### PR TITLE
refactor: extract invocation context classes (Phase 8)

### DIFF
--- a/src/main/java/org/javai/punit/ptest/engine/ProbabilisticTestExtension.java
+++ b/src/main/java/org/javai/punit/ptest/engine/ProbabilisticTestExtension.java
@@ -977,43 +977,4 @@ public class ProbabilisticTestExtension implements
 	}
 
 	// ========== Inner Classes ==========
-
-	/**
-	 * Invocation context for a single sample execution.
-	 * Provides ParameterResolver for TokenChargeRecorder injection.
-	 */
-	private record ProbabilisticTestInvocationContext(
-			int sampleIndex,
-			int totalSamples,
-			DefaultTokenChargeRecorder tokenRecorder) implements TestTemplateInvocationContext {
-
-		@Override
-		public String getDisplayName(int invocationIndex) {
-			return String.format("Sample %d/%d", sampleIndex, totalSamples);
-		}
-
-		@Override
-		public List<Extension> getAdditionalExtensions() {
-			if (tokenRecorder != null) {
-				return List.of(new TokenChargeRecorderParameterResolver(tokenRecorder));
-			}
-			return Collections.emptyList();
-		}
-	}
-
-	/**
-	 * ParameterResolver for injecting TokenChargeRecorder into test methods.
-	 */
-	private record TokenChargeRecorderParameterResolver(TokenChargeRecorder recorder) implements ParameterResolver {
-
-		@Override
-		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-			return TokenChargeRecorder.class.isAssignableFrom(parameterContext.getParameter().getType());
-		}
-
-		@Override
-		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-			return recorder;
-		}
-	}
 }

--- a/src/main/java/org/javai/punit/ptest/engine/ProbabilisticTestInvocationContext.java
+++ b/src/main/java/org/javai/punit/ptest/engine/ProbabilisticTestInvocationContext.java
@@ -1,0 +1,69 @@
+package org.javai.punit.ptest.engine;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.javai.punit.api.TokenChargeRecorder;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Invocation context for a single sample execution in a probabilistic test.
+ *
+ * <p>This context provides:
+ * <ul>
+ *   <li>A display name showing the sample index (e.g., "Sample 1/100")</li>
+ *   <li>Optional TokenChargeRecorder injection for dynamic token tracking</li>
+ * </ul>
+ *
+ * <p>Package-private: internal implementation detail of the test extension.
+ *
+ * @param sampleIndex The 1-based index of this sample
+ * @param totalSamples The total number of samples to be executed
+ * @param tokenRecorder The token recorder for this sample (null if not using dynamic tokens)
+ */
+record ProbabilisticTestInvocationContext(
+        int sampleIndex,
+        int totalSamples,
+        DefaultTokenChargeRecorder tokenRecorder) implements TestTemplateInvocationContext {
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return String.format("Sample %d/%d", sampleIndex, totalSamples);
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        if (tokenRecorder != null) {
+            return List.of(new TokenChargeRecorderParameterResolver(tokenRecorder));
+        }
+        return Collections.emptyList();
+    }
+}
+
+/**
+ * ParameterResolver for injecting TokenChargeRecorder into test methods.
+ *
+ * <p>This resolver enables test methods to receive a {@link TokenChargeRecorder}
+ * parameter for recording token consumption during sample execution.
+ *
+ * <p>Package-private: internal implementation detail of the test extension.
+ *
+ * @param recorder The token charge recorder to inject
+ */
+record TokenChargeRecorderParameterResolver(TokenChargeRecorder recorder) implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return TokenChargeRecorder.class.isAssignableFrom(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return recorder;
+    }
+}
+


### PR DESCRIPTION
## Summary

Extract invocation context records to their own file as the final phase of the `ProbabilisticTestExtension` refactoring.

## Changes

**New File: `ProbabilisticTestInvocationContext.java`**
- `ProbabilisticTestInvocationContext`: JUnit 5 invocation context for sample execution
  - Provides display names ("Sample 1/100")
  - Optionally adds TokenChargeRecorder parameter resolver
- `TokenChargeRecorderParameterResolver`: Injects TokenChargeRecorder into test methods
- Comprehensive Javadoc documentation

## Final Metrics

| Phase | Component | Lines Removed | PR |
|-------|-----------|---------------|-----|
| 1 | FinalConfigurationLogger | ~50 | #7 |
| 2 | SampleFailureFormatter | ~40 | #8 |
| 3 | BudgetOrchestrator | ~120 | #9 |
| 4 | SampleExecutor | ~70 | #10 |
| 5 | BaselineSelectionOrchestrator | ~168 | #11 |
| 6 | ResultPublisher | ~214 | #12 |
| 7 | TestConfiguration | ~113 | #13 |
| 8 | InvocationContext | ~39 | #14 |

**Total: `ProbabilisticTestExtension` reduced from 1744 → 980 lines (44% reduction)**

## Testing

All existing tests pass.