### PR TITLE
Refactor ExperimentExtension using Strategy pattern

### DIFF
--- a/src/main/java/org/javai/punit/experiment/engine/ExperimentConfig.java
+++ b/src/main/java/org/javai/punit/experiment/engine/ExperimentConfig.java
@@ -1,0 +1,76 @@
+package org.javai.punit.experiment.engine;
+
+import org.javai.punit.api.ExperimentMode;
+import org.javai.punit.experiment.explore.ExploreConfig;
+import org.javai.punit.experiment.measure.MeasureConfig;
+import org.javai.punit.experiment.optimize.OptimizeConfig;
+
+/**
+ * Base interface for experiment configuration.
+ *
+ * <p>Each experiment mode provides its own implementation with mode-specific fields.
+ *
+ * <h2>Implementations</h2>
+ * <ul>
+ *   <li>{@link MeasureConfig} - Configuration for @MeasureExperiment</li>
+ *   <li>{@link ExploreConfig} - Configuration for @ExploreExperiment</li>
+ *   <li>{@link OptimizeConfig} - Configuration for @OptimizeExperiment</li>
+ * </ul>
+ *
+ * <p>Note: This interface is not sealed because Java requires sealed interfaces
+ * and their permitted implementations to be in the same package (without JPMS modules).
+ * The implementations are nonetheless restricted to the three mode packages.
+ */
+public interface ExperimentConfig {
+
+    /**
+     * The experiment mode.
+     *
+     * @return the mode (MEASURE, EXPLORE, or OPTIMIZE)
+     */
+    ExperimentMode mode();
+
+    /**
+     * The use case class being tested.
+     *
+     * @return the use case class
+     */
+    Class<?> useCaseClass();
+
+    /**
+     * Resolved use case identifier.
+     *
+     * <p>Resolved from the use case class via {@code @UseCase} annotation
+     * or simple class name.
+     *
+     * @return the use case ID
+     */
+    String useCaseId();
+
+    /**
+     * Time budget in milliseconds.
+     *
+     * <p>0 means unlimited.
+     *
+     * @return the time budget in milliseconds
+     */
+    long timeBudgetMs();
+
+    /**
+     * Token budget for LLM calls.
+     *
+     * <p>0 means unlimited.
+     *
+     * @return the token budget
+     */
+    long tokenBudget();
+
+    /**
+     * Experiment identifier for output naming.
+     *
+     * <p>Used in output file paths and reports.
+     *
+     * @return the experiment ID, or empty string if not specified
+     */
+    String experimentId();
+}

--- a/src/main/java/org/javai/punit/experiment/engine/ExperimentExtension.java
+++ b/src/main/java/org/javai/punit/experiment/engine/ExperimentExtension.java
@@ -1,125 +1,128 @@
 package org.javai.punit.experiment.engine;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-import org.javai.punit.api.DiffableContentProvider;
-import org.javai.punit.api.ExperimentMode;
-import org.javai.punit.api.ExploreExperiment;
-import org.javai.punit.api.Factor;
-import org.javai.punit.api.FactorArguments;
-import org.javai.punit.api.FactorSource;
-import org.javai.punit.api.FactorValues;
-import org.javai.punit.api.MeasureExperiment;
-import org.javai.punit.api.OptimizeExperiment;
-import org.javai.punit.api.Pacing;
-import org.javai.punit.api.ResultCaptor;
-import org.javai.punit.api.UseCase;
-import org.javai.punit.api.UseCaseContext;
-import org.javai.punit.api.UseCaseProvider;
+import org.javai.punit.experiment.explore.ExploreStrategy;
+import org.javai.punit.experiment.measure.MeasureStrategy;
+import org.javai.punit.experiment.optimize.OptimizeStrategy;
 import org.javai.punit.ptest.engine.PacingConfiguration;
 import org.javai.punit.ptest.engine.PacingReporter;
 import org.javai.punit.ptest.engine.PacingResolver;
-import org.javai.punit.engine.covariate.BaselineFileNamer;
-import org.javai.punit.engine.covariate.CovariateProfileResolver;
-import org.javai.punit.engine.covariate.DefaultCovariateResolutionContext;
-import org.javai.punit.engine.covariate.FootprintComputer;
-import org.javai.punit.engine.covariate.UseCaseCovariateExtractor;
-import org.javai.punit.experiment.model.DefaultUseCaseContext;
-import org.javai.punit.experiment.model.EmpiricalBaseline;
-import org.javai.punit.experiment.model.ResultProjection;
-import org.javai.punit.model.CovariateDeclaration;
-import org.javai.punit.model.CovariateProfile;
-import org.javai.punit.model.CriterionOutcome;
-import org.javai.punit.model.UseCaseCriteria;
-import org.javai.punit.model.UseCaseResult;
-import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 
 /**
- * JUnit 5 extension that drives experiment execution.
+ * JUnit 5 extension that coordinates experiment execution.
  *
- * <p>This extension:
+ * <p>This class is intentionally thin - it detects which mode annotation is present,
+ * delegates to the corresponding strategy, and manages shared infrastructure (pacing).
+ * Mode-specific logic lives in the strategy implementations:
  * <ul>
- *   <li>Injects {@link ResultCaptor} into experiment methods</li>
- *   <li>Executes experiment methods repeatedly as samples</li>
- *   <li>Aggregates results from the captor</li>
- *   <li>Generates empirical baselines</li>
+ *   <li>{@link MeasureStrategy} - Handles @MeasureExperiment</li>
+ *   <li>{@link ExploreStrategy} - Handles @ExploreExperiment</li>
+ *   <li>{@link OptimizeStrategy} - Handles @OptimizeExperiment</li>
  * </ul>
  *
  * <h2>Architecture</h2>
- * <p>The new architecture uses a method-execution model:
+ * <p>The extension uses the Strategy pattern to keep mode-specific logic encapsulated.
+ * Each strategy knows how to:
  * <ol>
- *   <li>The experiment method receives a {@link ResultCaptor} parameter</li>
- *   <li>The method executes and calls the use case</li>
- *   <li>The method records the result via {@code captor.record(result)}</li>
- *   <li>The extension aggregates results after each method execution</li>
+ *   <li>Parse its annotation into a configuration</li>
+ *   <li>Generate invocation contexts (the sample stream)</li>
+ *   <li>Intercept and execute each sample</li>
+ *   <li>Generate mode-specific output</li>
  * </ol>
- *
- * <h2>Example</h2>
- * <pre>{@code
- * @Experiment(useCase = ShoppingUseCase.class, samples = 1000)
- * void measureSearchBaseline(ShoppingUseCase useCase, ResultCaptor captor) {
- *     captor.record(useCase.searchProducts("headphones", context));
- * }
- * }</pre>
  */
-public class ExperimentExtension implements TestTemplateInvocationContextProvider, 
+public class ExperimentExtension implements TestTemplateInvocationContextProvider,
         InvocationInterceptor {
-    
-    private static final ExtensionContext.Namespace NAMESPACE = 
-        ExtensionContext.Namespace.create(ExperimentExtension.class);
-    
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create("org.javai.punit.experiment");
+
+    private static final List<ExperimentModeStrategy> STRATEGIES = List.of(
+            new MeasureStrategy(),
+            new ExploreStrategy(),
+            new OptimizeStrategy()
+    );
+
     @Override
     public boolean supportsTestTemplate(ExtensionContext context) {
         return context.getTestMethod()
-            .map(m -> m.isAnnotationPresent(MeasureExperiment.class) ||
-                      m.isAnnotationPresent(ExploreExperiment.class) ||
-                      m.isAnnotationPresent(OptimizeExperiment.class))
-            .orElse(false);
+                .map(m -> STRATEGIES.stream().anyMatch(s -> s.supports(m)))
+                .orElse(false);
     }
-    
+
     @Override
-    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+            ExtensionContext context) {
+
         Method testMethod = context.getRequiredTestMethod();
+        ExperimentModeStrategy strategy = findStrategy(testMethod);
+
         ExtensionContext.Store store = context.getStore(NAMESPACE);
+        ExperimentConfig config = strategy.parseConfig(testMethod);
 
-        // Detect which annotation is present and extract configuration
-        ExperimentConfig config = resolveExperimentConfig(testMethod);
-
-        // Store common metadata
-        store.put("experimentConfig", config);
-        store.put("useCaseId", config.useCaseId());
-        store.put("useCaseClass", config.useCaseClass());
+        // Store shared state
+        store.put("strategy", strategy);
+        store.put("config", config);
         store.put("testMethod", testMethod);
         store.put("startTimeMs", System.currentTimeMillis());
-        store.put("contextBuilt", new AtomicBoolean(false));
+        store.put("useCaseId", config.useCaseId());
+        store.put("useCaseClass", config.useCaseClass());
 
-        // Resolve pacing configuration from @Pacing annotation
-        int totalSamples = computeTotalSamplesFromConfig(config, testMethod);
-        PacingConfiguration pacing = resolvePacingFromConfig(testMethod, totalSamples, config);
+        // Setup pacing (shared infrastructure)
+        int totalSamples = strategy.computeTotalSamples(config, testMethod);
+        setupPacing(testMethod, totalSamples, config, store);
+
+        return strategy.provideInvocationContexts(config, context, store);
+    }
+
+    @Override
+    public void interceptTestTemplateMethod(
+            Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext) throws Throwable {
+
+        // Use parent context's store since provideTestTemplateInvocationContexts stored data there
+        ExtensionContext parentContext = extensionContext.getParent().orElse(extensionContext);
+        ExtensionContext.Store store = parentContext.getStore(NAMESPACE);
+
+        ExperimentModeStrategy strategy = store.get("strategy", ExperimentModeStrategy.class);
+
+        // Apply pacing delay (shared infrastructure)
+        applyPacingDelay(store);
+
+        strategy.intercept(invocation, invocationContext, extensionContext, store);
+    }
+
+    /**
+     * Finds the strategy that supports the given test method.
+     */
+    private ExperimentModeStrategy findStrategy(Method testMethod) {
+        return STRATEGIES.stream()
+                .filter(s -> s.supports(testMethod))
+                .findFirst()
+                .orElseThrow(() -> new ExtensionConfigurationException(
+                        "No strategy found for method: " + testMethod.getName() +
+                                ". Method must be annotated with @MeasureExperiment, " +
+                                "@ExploreExperiment, or @OptimizeExperiment."));
+    }
+
+    /**
+     * Sets up pacing configuration from @Pacing annotation.
+     */
+    private void setupPacing(Method testMethod, int totalSamples,
+                             ExperimentConfig config, ExtensionContext.Store store) {
+
+        PacingResolver resolver = new PacingResolver();
+        PacingConfiguration pacing = resolver.resolve(testMethod, totalSamples);
         store.put("pacing", pacing);
         store.put("globalSampleCounter", new AtomicInteger(0));
 
@@ -130,1445 +133,42 @@ public class ExperimentExtension implements TestTemplateInvocationContextProvide
             pacingReporter.printPreFlightReport(testName, totalSamples, pacing, Instant.now());
             pacingReporter.printFeasibilityWarning(pacing, config.timeBudgetMs(), totalSamples);
         }
-
-        // Dispatch based on experiment mode
-        return switch (config.mode()) {
-            case MEASURE -> provideMeasureInvocationContextsFromConfig(config, store);
-            case EXPLORE -> provideExploreInvocationContextsFromConfig(context, testMethod, config, store);
-            case OPTIMIZE -> provideOptimizeInvocationContexts(context, testMethod, config, store);
-        };
-    }
-
-    /**
-     * Unified configuration extracted from any experiment annotation.
-     */
-    private record ExperimentConfig(
-            ExperimentMode mode,
-            Class<?> useCaseClass,
-            String useCaseId,
-            int samples,
-            int samplesPerConfig,
-            long timeBudgetMs,
-            long tokenBudget,
-            String experimentId,
-            int expiresInDays,
-            // OPTIMIZE-specific
-            String treatmentFactor,
-            Class<?> scorerClass,
-            Class<?> mutatorClass,
-            String objective,
-            int samplesPerIteration,
-            int maxIterations,
-            int noImprovementWindow
-    ) {}
-
-    /**
-     * Resolves experiment configuration from whichever annotation is present.
-     */
-    private ExperimentConfig resolveExperimentConfig(Method testMethod) {
-        // Check for new annotations first
-        MeasureExperiment measure = testMethod.getAnnotation(MeasureExperiment.class);
-        if (measure != null) {
-            Class<?> useCaseClass = measure.useCase();
-            String useCaseId = resolveUseCaseIdFromClass(useCaseClass);
-            return new ExperimentConfig(
-                ExperimentMode.MEASURE,
-                useCaseClass,
-                useCaseId,
-                measure.samples(),
-                0, // samplesPerConfig not used in MEASURE
-                measure.timeBudgetMs(),
-                measure.tokenBudget(),
-                measure.experimentId(),
-                measure.expiresInDays(),
-                null, null, null, null, 0, 0, 0 // OPTIMIZE fields
-            );
-        }
-
-        ExploreExperiment explore = testMethod.getAnnotation(ExploreExperiment.class);
-        if (explore != null) {
-            Class<?> useCaseClass = explore.useCase();
-            String useCaseId = resolveUseCaseIdFromClass(useCaseClass);
-            return new ExperimentConfig(
-                ExperimentMode.EXPLORE,
-                useCaseClass,
-                useCaseId,
-                0, // samples not used in EXPLORE
-                explore.samplesPerConfig(),
-                explore.timeBudgetMs(),
-                explore.tokenBudget(),
-                explore.experimentId(),
-                explore.expiresInDays(),
-                null, null, null, null, 0, 0, 0 // OPTIMIZE fields
-            );
-        }
-
-        OptimizeExperiment optimize = testMethod.getAnnotation(OptimizeExperiment.class);
-        if (optimize != null) {
-            Class<?> useCaseClass = optimize.useCase();
-            String useCaseId = resolveUseCaseIdFromClass(useCaseClass);
-            return new ExperimentConfig(
-                ExperimentMode.OPTIMIZE,
-                useCaseClass,
-                useCaseId,
-                0, 0, // samples/samplesPerConfig not used directly
-                optimize.timeBudgetMs(),
-                optimize.tokenBudget(),
-                optimize.experimentId(),
-                0, // expiresInDays not used in OPTIMIZE
-                optimize.treatmentFactor(),
-                optimize.scorer(),
-                optimize.mutator(),
-                optimize.objective().name(),
-                optimize.samplesPerIteration(),
-                optimize.maxIterations(),
-                optimize.noImprovementWindow()
-            );
-        }
-
-        throw new ExtensionConfigurationException(
-            "Method must be annotated with @MeasureExperiment, @ExploreExperiment, or @OptimizeExperiment");
-    }
-
-    /**
-     * Resolves use case ID from class reference.
-     */
-    private String resolveUseCaseIdFromClass(Class<?> useCaseClass) {
-        if (useCaseClass == null || useCaseClass == Void.class) {
-            throw new ExtensionConfigurationException(
-                "Experiment must specify useCase class");
-        }
-        return UseCaseProvider.resolveId(useCaseClass);
-    }
-
-    /**
-     * Computes total samples from ExperimentConfig.
-     */
-    private int computeTotalSamplesFromConfig(ExperimentConfig config, Method testMethod) {
-        return switch (config.mode()) {
-            case MEASURE -> config.mode().getEffectiveSampleSize(config.samples());
-            case EXPLORE -> {
-                int samplesPerConfig = config.mode().getEffectiveSampleSize(config.samplesPerConfig());
-                yield samplesPerConfig; // Conservative estimate
-            }
-            case OPTIMIZE -> config.samplesPerIteration() * config.maxIterations();
-        };
-    }
-
-    /**
-     * Resolves pacing configuration from ExperimentConfig.
-     */
-    private PacingConfiguration resolvePacingFromConfig(Method testMethod, int samples, ExperimentConfig config) {
-        PacingResolver resolver = new PacingResolver();
-        return resolver.resolve(testMethod, samples);
-    }
-
-    /**
-     * Provides invocation contexts for @MeasureExperiment using ExperimentConfig.
-     */
-    @SuppressWarnings("unchecked")
-    private Stream<TestTemplateInvocationContext> provideMeasureInvocationContextsFromConfig(
-            ExperimentConfig config, ExtensionContext.Store store) {
-
-        int samples = config.mode().getEffectiveSampleSize(config.samples());
-        String useCaseId = config.useCaseId();
-
-        // Create single aggregator
-        ExperimentResultAggregator aggregator = new ExperimentResultAggregator(useCaseId, samples);
-        store.put("aggregator", aggregator);
-
-        AtomicBoolean terminated = new AtomicBoolean(false);
-        AtomicInteger currentSample = new AtomicInteger(0);
-        store.put("terminated", terminated);
-        store.put("currentSample", currentSample);
-        store.put("mode", ExperimentMode.MEASURE);
-
-        // Check for @FactorSource annotation - if present, use cycling factors
-        Method testMethod = store.get("testMethod", Method.class);
-        FactorSource factorSource = testMethod != null ? testMethod.getAnnotation(FactorSource.class) : null;
-
-        if (factorSource != null) {
-            return provideMeasureWithFactorsInvocationContextsFromConfig(
-                testMethod, factorSource, samples, useCaseId, store, aggregator, terminated);
-        }
-
-        // No factor source - simple sample stream
-        return Stream.iterate(1, i -> i + 1)
-            .limit(samples)
-            .takeWhile(i -> !terminated.get())
-            .map(i -> new MeasureInvocationContext(i, samples, useCaseId, new ResultCaptor()));
-    }
-
-    /**
-     * Provides invocation contexts for @MeasureExperiment with factor source using ExperimentConfig.
-     */
-    @SuppressWarnings("unchecked")
-    private Stream<TestTemplateInvocationContext> provideMeasureWithFactorsInvocationContextsFromConfig(
-            Method testMethod, FactorSource factorSource, int samples, String useCaseId,
-            ExtensionContext.Store store, ExperimentResultAggregator aggregator, AtomicBoolean terminated) {
-
-        // Delegate to existing implementation
-        return provideMeasureWithFactorsInvocationContexts(
-            testMethod, factorSource, samples, useCaseId, store, aggregator, terminated);
-    }
-
-    /**
-     * Provides invocation contexts for @ExploreExperiment using ExperimentConfig.
-     */
-    @SuppressWarnings("unchecked")
-    private Stream<TestTemplateInvocationContext> provideExploreInvocationContextsFromConfig(
-            ExtensionContext context, Method testMethod, ExperimentConfig config,
-            ExtensionContext.Store store) {
-
-        int samplesPerConfig = config.mode().getEffectiveSampleSize(config.samplesPerConfig());
-        String useCaseId = config.useCaseId();
-
-        // Find @FactorSource annotation
-        FactorSource factorSource = testMethod.getAnnotation(FactorSource.class);
-        if (factorSource == null) {
-            // Warn: EXPLORE without factors is equivalent to MEASURE
-            context.publishReportEntry("punit.warning",
-                "EXPLORE without @FactorSource is equivalent to MEASURE. " +
-                "Consider adding @FactorSource or using @MeasureExperiment.");
-
-            store.put("mode", ExperimentMode.EXPLORE);
-            ExperimentResultAggregator aggregator = new ExperimentResultAggregator(useCaseId, samplesPerConfig);
-            store.put("aggregator", aggregator);
-            store.put("terminated", new AtomicBoolean(false));
-            store.put("currentSample", new AtomicInteger(0));
-
-            return Stream.iterate(1, i -> i + 1)
-                .limit(samplesPerConfig)
-                .map(i -> new MeasureInvocationContext(i, samplesPerConfig, useCaseId, new ResultCaptor()));
-        }
-
-        // Find factor method
-        String methodName = factorSource.value();
-        Stream<FactorArguments> factorCombinations;
-        try {
-            Method sourceMethod = testMethod.getDeclaringClass().getDeclaredMethod(methodName);
-            sourceMethod.setAccessible(true);
-            factorCombinations = (Stream<FactorArguments>) sourceMethod.invoke(null);
-        } catch (Exception e) {
-            throw new ExtensionConfigurationException(
-                "Cannot invoke @FactorSource method '" + methodName + "': " + e.getMessage(), e);
-        }
-
-        // Collect all configurations first
-        List<FactorArguments> argsList = factorCombinations.toList();
-
-        // Get factor names
-        List<FactorInfo> factorInfos = extractFactorInfos(testMethod, factorSource, argsList);
-
-        // Store explore-mode metadata
-        store.put("mode", ExperimentMode.EXPLORE);
-        store.put("factorInfos", factorInfos);
-        store.put("configAggregators", new LinkedHashMap<String, ExperimentResultAggregator>());
-        store.put("terminated", new AtomicBoolean(false));
-
-        // Generate invocation contexts for all configs × samples
-        List<ExploreInvocationContext> invocations = new ArrayList<>();
-
-        for (int configIndex = 0; configIndex < argsList.size(); configIndex++) {
-            FactorArguments args = argsList.get(configIndex);
-            Object[] factorValues = args.get();
-
-            String configName = buildConfigName(factorInfos, factorValues);
-
-            ExperimentResultAggregator configAggregator =
-                new ExperimentResultAggregator(useCaseId + "/" + configName, samplesPerConfig);
-            ((Map<String, ExperimentResultAggregator>) store.get("configAggregators", Map.class))
-                .put(configName, configAggregator);
-
-            for (int sample = 1; sample <= samplesPerConfig; sample++) {
-                invocations.add(new ExploreInvocationContext(
-                    sample, samplesPerConfig, configIndex + 1, argsList.size(),
-                    useCaseId, configName, factorValues, factorInfos, new ResultCaptor()
-                ));
-            }
-        }
-
-        return invocations.stream().map(c -> (TestTemplateInvocationContext) c);
-    }
-
-    /**
-     * Provides invocation contexts for @OptimizeExperiment.
-     *
-     * <p>@OptimizeExperiment uses a lazy iteration model: samples are generated on-demand
-     * as the optimization progresses. Each iteration runs samplesPerIteration samples,
-     * then the mutator generates a new treatment factor value for the next iteration.
-     */
-    private Stream<TestTemplateInvocationContext> provideOptimizeInvocationContexts(
-            ExtensionContext context, Method testMethod, ExperimentConfig config,
-            ExtensionContext.Store store) {
-
-        store.put("mode", ExperimentMode.OPTIMIZE);
-        store.put("terminated", new AtomicBoolean(false));
-
-        // TODO: Implement @OptimizeExperiment invocation context generation
-        // This will use a custom Spliterator for lazy iteration
-        throw new UnsupportedOperationException(
-            "@OptimizeExperiment is not yet fully implemented. Phase 6 in progress.");
     }
 
     /**
      * Applies pacing delay between samples.
      *
      * <p>Uses a global sample counter to ensure continuous pacing across all samples,
-     * including across configuration boundaries in @ExploreExperiment. This prevents rate
-     * limit violations when many configs have few samples each.
-     *
-     * <p>The first sample (globalSampleCounter == 1) has no delay.
-     *
-     * @param store the extension context store containing pacing configuration
+     * including across configuration boundaries in @ExploreExperiment.
      */
     private void applyPacingDelay(ExtensionContext.Store store) {
         PacingConfiguration pacing = store.get("pacing", PacingConfiguration.class);
         if (pacing == null || !pacing.hasPacing()) {
             return;
         }
-        
+
         AtomicInteger globalSampleCounter = store.get("globalSampleCounter", AtomicInteger.class);
         if (globalSampleCounter == null) {
             return;
         }
-        
+
         int globalSample = globalSampleCounter.incrementAndGet();
-        
+
         // Skip delay for first sample
         if (globalSample <= 1) {
             return;
         }
-        
+
         long delayMs = pacing.effectiveMinDelayMs();
         if (delayMs <= 0) {
             return;
         }
-        
+
         try {
             Thread.sleep(delayMs);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             // Don't fail the experiment, just continue
-        }
-    }
-    /**
-     * Provides invocation contexts for @MeasureExperiment with factor source (cycling).
-     */
-    @SuppressWarnings("unchecked")
-    private Stream<TestTemplateInvocationContext> provideMeasureWithFactorsInvocationContexts(
-            Method testMethod, FactorSource factorSource, int samples, String useCaseId,
-            ExtensionContext.Store store, ExperimentResultAggregator aggregator, AtomicBoolean terminated) {
-        
-        // Resolve the factor source
-        String sourceReference = factorSource.value();
-        Stream<FactorArguments> factorStream;
-        try {
-            if (sourceReference.contains("#")) {
-                // Cross-class reference
-                String[] parts = sourceReference.split("#", 2);
-                String className = parts[0];
-                String methodName = parts[1];
-                Class<?> targetClass = resolveClass(className, testMethod.getDeclaringClass());
-                Method sourceMethod = targetClass.getDeclaredMethod(methodName);
-                factorStream = getFactorArguments(sourceMethod, sourceReference);
-            } else {
-                // Same-class reference
-                Method sourceMethod = testMethod.getDeclaringClass().getDeclaredMethod(sourceReference);
-                factorStream = getFactorArguments(sourceMethod, sourceReference);
-            }
-        } catch (NoSuchMethodException | IllegalAccessException | java.lang.reflect.InvocationTargetException e) {
-            throw new ExtensionConfigurationException(
-                "Cannot invoke @FactorSource method '" + sourceReference + "': " + e.getMessage(), e);
-        }
-        
-        // Materialize factors for cycling
-        List<FactorArguments> factorsList = factorStream.toList();
-        if (factorsList.isEmpty()) {
-            throw new ExtensionConfigurationException(
-                "Factor source '" + sourceReference + "' returned no factors");
-        }
-        
-        // Extract factor names from the first FactorArguments
-        List<FactorInfo> factorInfos = extractFactorInfosFromArguments(testMethod, factorsList.get(0));
-        store.put("factorInfos", factorInfos);
-        
-        // Generate sample stream with cycling factors
-        return Stream.iterate(1, i -> i + 1)
-            .limit(samples)
-            .takeWhile(i -> !terminated.get())
-            .map(i -> {
-                // Cycling: factor index = (sample - 1) % factorCount
-                int factorIndex = (i - 1) % factorsList.size();
-                FactorArguments args = factorsList.get(factorIndex);
-                Object[] factorValues = extractFactorValues(args, factorInfos);
-                return new MeasureWithFactorsInvocationContext(
-                    i, samples, useCaseId, new ResultCaptor(), factorValues, factorInfos);
-            });
-    }
-
-    private Stream<FactorArguments> getFactorArguments(Method sourceMethod, String sourceReference)
-            throws InvocationTargetException, IllegalAccessException {
-        sourceMethod.setAccessible(true);
-        Object result = sourceMethod.invoke(null);
-        if (result instanceof Stream) {
-            return (Stream<FactorArguments>) result;
-        } else if (result instanceof java.util.Collection) {
-            return ((Collection<FactorArguments>) result).stream();
-        } else {
-            throw new ExtensionConfigurationException(
-                    "Factor source method must return Stream or Collection: " + sourceReference);
-        }
-    }
-
-    /**
-     * Extracts factor info from FactorArguments and method parameters.
-     */
-    private List<FactorInfo> extractFactorInfosFromArguments(Method testMethod, FactorArguments firstArgs) {
-        List<FactorInfo> infos = new ArrayList<>();
-        
-        // Try to get names from FactorArguments
-        String[] argNames = firstArgs.names();
-        if (argNames != null) {
-            for (int i = 0; i < argNames.length; i++) {
-                // FactorInfo(parameterIndex, name, filePrefix, type)
-                infos.add(new FactorInfo(i, argNames[i], argNames[i], Object.class));
-            }
-        } else {
-            // Fall back to @Factor annotations on method parameters
-            int factorIndex = 0;
-            for (java.lang.reflect.Parameter param : testMethod.getParameters()) {
-                Factor factor = param.getAnnotation(Factor.class);
-                if (factor != null) {
-                    infos.add(new FactorInfo(factorIndex++, factor.value(), factor.value(), param.getType()));
-                }
-            }
-        }
-        
-        return infos;
-    }
-    
-    /**
-     * Extracts factor values in the order matching factorInfos.
-     */
-    private Object[] extractFactorValues(FactorArguments args, List<FactorInfo> factorInfos) {
-        Object[] values = new Object[factorInfos.size()];
-        String[] argNames = args.names();
-        
-        for (int i = 0; i < factorInfos.size(); i++) {
-            FactorInfo info = factorInfos.get(i);
-            if (argNames != null) {
-                // Find by name
-                for (int j = 0; j < argNames.length; j++) {
-                    if (argNames[j].equals(info.name())) {
-                        values[i] = args.get(j);
-                        break;
-                    }
-                }
-            } else {
-                // Use positional index
-                values[i] = args.get(info.parameterIndex());
-            }
-        }
-        
-        return values;
-    }
-    
-    /**
-     * Resolves a class from a simple or fully qualified name.
-     * Tries sibling packages (e.g., from .experiment to .usecase) for convenience.
-     */
-    private Class<?> resolveClass(String className, Class<?> contextClass) {
-        String packageName = contextClass.getPackageName();
-        
-        // 1. Try same package
-        try {
-            return Class.forName(packageName + "." + className);
-        } catch (ClassNotFoundException ignored) {
-        }
-        
-        // 2. Try fully qualified name
-        try {
-            return Class.forName(className);
-        } catch (ClassNotFoundException ignored) {
-        }
-        
-        // 3. Try sibling packages (e.g., from .experiment to .usecase)
-        int lastDot = packageName.lastIndexOf('.');
-        if (lastDot > 0) {
-            String parentPackage = packageName.substring(0, lastDot);
-            
-            for (String sibling : new String[]{"usecase", "model", "domain", "service", "api", "core"}) {
-                try {
-                    return Class.forName(parentPackage + "." + sibling + "." + className);
-                } catch (ClassNotFoundException ignored) {
-                }
-            }
-            
-            // Try parent package directly
-            try {
-                return Class.forName(parentPackage + "." + className);
-            } catch (ClassNotFoundException ignored) {
-            }
-        }
-        
-        throw new ExtensionConfigurationException(
-            "Cannot resolve class '" + className + "' from context " + contextClass.getName() +
-            ". Try using the fully qualified class name.");
-    }
-
-    /**
-     * Extracts factor information for file naming.
-     *
-     * <p>Priority:
-     * <ol>
-     *   <li>Names embedded in {@link FactorArguments} (best DX - names with values)</li>
-     *   <li>{@code @FactorSource(factors = {...})} annotation</li>
-     *   <li>{@code @Factor} annotations on method parameters</li>
-     * </ol>
-     */
-    private List<FactorInfo> extractFactorInfos(Method method, FactorSource factorSource, 
-                                                 List<FactorArguments> argsList) {
-        // 1. Prefer names embedded in FactorArguments (best DX)
-        if (!argsList.isEmpty() && argsList.get(0).hasNames()) {
-            String[] names = argsList.get(0).names();
-            List<FactorInfo> factorInfos = new ArrayList<>();
-            for (int i = 0; i < names.length; i++) {
-                factorInfos.add(new FactorInfo(i, names[i], names[i], Object.class));
-            }
-            return factorInfos;
-        }
-        
-        // 2. Factor names from @FactorSource annotation
-        String[] factorNames = factorSource.factors();
-        if (factorNames.length > 0) {
-            List<FactorInfo> factorInfos = new ArrayList<>();
-            for (int i = 0; i < factorNames.length; i++) {
-                String name = factorNames[i];
-                factorInfos.add(new FactorInfo(i, name, name, Object.class));
-            }
-            return factorInfos;
-        }
-        
-        // 3. Fall back to @Factor annotations on method parameters
-        List<FactorInfo> factorInfos = getFactorInfos(method);
-
-        return factorInfos;
-    }
-
-    private static List<FactorInfo> getFactorInfos(Method method) {
-        List<FactorInfo> factorInfos = new ArrayList<>();
-        Parameter[] parameters = method.getParameters();
-
-        for (int i = 0; i < parameters.length; i++) {
-            Factor factor = parameters[i].getAnnotation(Factor.class);
-            if (factor != null) {
-                String name = factor.value();
-                String filePrefix = factor.filePrefix().isEmpty() ? name : factor.filePrefix();
-                factorInfos.add(new FactorInfo(i, name, filePrefix, parameters[i].getType()));
-            }
-        }
-        return factorInfos;
-    }
-
-    /**
-     * Builds a configuration name from factor values for file naming.
-     *
-     * <p>Assumes @Factor-annotated parameters are at the start of the method
-     * parameter list and in the same order as FactorArguments values.
-     */
-    private String buildConfigName(List<FactorInfo> factorInfos, Object[] values) {
-        StringBuilder sb = new StringBuilder();
-        
-        // Use whichever is smaller - factorInfos or values
-        int count = Math.min(factorInfos.size(), values.length);
-        
-        for (int i = 0; i < count; i++) {
-            if (i > 0) sb.append("_");
-            FactorInfo info = factorInfos.get(i);
-            Object value = values[i];
-            String valueStr = formatFactorValue(value);
-            sb.append(info.filePrefix()).append("-").append(valueStr);
-        }
-        
-        // If there are more values than factorInfos, add generic names
-        for (int i = count; i < values.length; i++) {
-            if (!sb.isEmpty()) sb.append("_");
-            String valueStr = formatFactorValue(values[i]);
-            sb.append("f").append(i).append("-").append(valueStr);
-        }
-        
-        return sb.toString();
-    }
-    
-    /**
-     * Formats a factor value for use in file names.
-     */
-    private String formatFactorValue(Object value) {
-        if (value == null) return "null";
-        String str = value.toString();
-        // Clean up for file system compatibility
-        return str.replace(" ", "_")
-                  .replace("/", "-")
-                  .replace("\\", "-")
-                  .replace(":", "-")
-                  .replaceAll("[^a-zA-Z0-9._-]", "");
-    }
-    
-    /**
-     * Info about a factor parameter.
-     */
-    record FactorInfo(int parameterIndex, String name, String filePrefix, Class<?> type) {}
-    
-    // ═══════════════════════════════════════════════════════════════════════════
-    // INVOCATION INTERCEPTOR - Executes experiment and captures results
-    // ═══════════════════════════════════════════════════════════════════════════
-    
-    @Override
-    public void interceptTestTemplateMethod(
-            Invocation<Void> invocation,
-            ReflectiveInvocationContext<Method> invocationContext,
-            ExtensionContext extensionContext) throws Throwable {
-        
-        // Use parent context's store since provideTestTemplateInvocationContexts stored data there
-        ExtensionContext parentContext = extensionContext.getParent().orElse(extensionContext);
-        ExtensionContext.Store store = parentContext.getStore(NAMESPACE);
-        
-        ExperimentMode mode = store.get("mode", ExperimentMode.class);
-        if (mode == null) mode = ExperimentMode.MEASURE;
-        
-        if (mode == ExperimentMode.EXPLORE) {
-            interceptExploreMethod(invocation, invocationContext, extensionContext, store);
-        } else {
-            interceptMeasureMethod(invocation, extensionContext, store);
-        }
-    }
-    
-    /**
-     * Intercepts @MeasureExperiment experiment execution.
-     */
-    @SuppressWarnings("unchecked")
-    private void interceptMeasureMethod(
-            Invocation<Void> invocation,
-            ExtensionContext extensionContext,
-            ExtensionContext.Store store) throws Throwable {
-
-        // Build context on first invocation
-        AtomicBoolean contextBuilt = store.get("contextBuilt", AtomicBoolean.class);
-        if (contextBuilt != null && !contextBuilt.get()) {
-            Method testMethod = store.get("testMethod", Method.class);
-            UseCaseContext useCaseContext = buildContext(testMethod);
-            store.put("useCaseContext", useCaseContext);
-            contextBuilt.set(true);
-        }
-
-        ExperimentResultAggregator aggregator = store.get("aggregator", ExperimentResultAggregator.class);
-        ExperimentConfig config = store.get("experimentConfig", ExperimentConfig.class);
-        AtomicBoolean terminated = store.get("terminated", AtomicBoolean.class);
-        AtomicInteger currentSample = store.get("currentSample", AtomicInteger.class);
-        Long startTimeMs = store.get("startTimeMs", Long.class);
-
-        long timeBudgetMs = config.timeBudgetMs();
-        long tokenBudget = config.tokenBudget();
-        int samples = config.samples();
-        ExperimentMode mode = config.mode();
-
-        int sample = currentSample.incrementAndGet();
-
-        // Apply pacing delay (continuous across all samples, skip first)
-        applyPacingDelay(store);
-
-        // Check time budget
-        if (timeBudgetMs > 0) {
-            long elapsed = System.currentTimeMillis() - startTimeMs;
-            if (elapsed >= timeBudgetMs) {
-                terminated.set(true);
-                aggregator.setTerminated("TIME_BUDGET_EXHAUSTED",
-                    "Time budget of " + timeBudgetMs + "ms exceeded");
-                invocation.skip();
-                checkAndGenerateSpec(extensionContext, store);
-                return;
-            }
-        }
-
-        // Check token budget
-        if (tokenBudget > 0 && aggregator.getTotalTokens() >= tokenBudget) {
-            terminated.set(true);
-            aggregator.setTerminated("TOKEN_BUDGET_EXHAUSTED",
-                "Token budget of " + tokenBudget + " exceeded");
-            invocation.skip();
-            checkAndGenerateSpec(extensionContext, store);
-            return;
-        }
-
-        // Get captor from the current invocation context's store
-        ExtensionContext.Store invocationStore = extensionContext.getStore(NAMESPACE);
-        ResultCaptor captor = invocationStore.get("captor", ResultCaptor.class);
-
-        try {
-            invocation.proceed();
-            recordResult(captor, aggregator);
-        } catch (Throwable e) {
-            aggregator.recordException(e);
-        }
-
-        // Report progress
-        int effectiveSamples = mode.getEffectiveSampleSize(samples);
-        reportProgress(extensionContext, aggregator, sample, effectiveSamples);
-
-        // Check if this is the last sample
-        if (sample >= effectiveSamples || terminated.get()) {
-            if (!terminated.get()) {
-                aggregator.setCompleted();
-            }
-            generateSpecOnce(extensionContext, store);
-        }
-    }
-    
-    /**
-     * Intercepts @ExploreExperiment experiment execution.
-     */
-    @SuppressWarnings("unchecked")
-    private void interceptExploreMethod(
-            Invocation<Void> invocation,
-            ReflectiveInvocationContext<Method> invocationContext,
-            ExtensionContext extensionContext,
-            ExtensionContext.Store store) throws Throwable {
-
-        ExperimentConfig config = store.get("experimentConfig", ExperimentConfig.class);
-        AtomicBoolean terminated = store.get("terminated", AtomicBoolean.class);
-        Map<String, ExperimentResultAggregator> configAggregators =
-            store.get("configAggregators", Map.class);
-        List<FactorInfo> factorInfos = store.get("factorInfos", List.class);
-
-        int samplesPerConfig = config.mode().getEffectiveSampleSize(config.samplesPerConfig());
-
-        // Apply pacing delay (continuous across all samples, skip first)
-        applyPacingDelay(store);
-
-        // Get explore invocation context info from extension context store
-        ExtensionContext.Store invocationStore = extensionContext.getStore(NAMESPACE);
-        ResultCaptor captor = invocationStore.get("captor", ResultCaptor.class);
-        String configName = invocationStore.get("configName", String.class);
-        int sampleInConfig = invocationStore.get("sampleInConfig", Integer.class);
-        Object[] factorValues = invocationStore.get("factorValues", Object[].class);
-
-        ExperimentResultAggregator aggregator = configAggregators.get(configName);
-        if (aggregator == null) {
-            throw new ExtensionConfigurationException(
-                "No aggregator found for configuration: " + configName);
-        }
-
-        // Set factor values on the UseCaseProvider BEFORE the method executes
-        Optional<UseCaseProvider> providerOpt = findUseCaseProvider(extensionContext);
-        providerOpt.ifPresent(provider -> {
-            if (factorValues != null) {
-                List<String> factorNames = factorInfos.stream()
-                    .map(FactorInfo::name)
-                    .toList();
-                provider.setCurrentFactorValues(factorValues, factorNames);
-            }
-        });
-
-        // Get use case class for projection settings
-        Class<?> useCaseClass = store.get("useCaseClass", Class.class);
-        ResultProjectionBuilder projectionBuilder = createProjectionBuilder(useCaseClass, providerOpt.orElse(null));
-
-        try {
-            invocation.proceed();
-            recordResult(captor, aggregator);
-
-            // Build result projection for @ExploreExperiment
-            if (captor != null && captor.hasResult()) {
-                ResultProjection projection = projectionBuilder.build(
-                    sampleInConfig - 1, // 0-based index
-                    captor.getResult()
-                );
-                aggregator.addResultProjection(projection);
-            }
-        } catch (Throwable e) {
-            aggregator.recordException(e);
-
-            // Build error projection for @ExploreExperiment
-            ResultProjection projection = projectionBuilder.buildError(
-                sampleInConfig - 1,
-                System.currentTimeMillis() - store.get("startTimeMs", Long.class),
-                e
-            );
-            aggregator.addResultProjection(projection);
-        }
-
-        // Report progress for this config
-        extensionContext.publishReportEntry("punit.mode", "EXPLORE");
-        extensionContext.publishReportEntry("punit.config", configName);
-        extensionContext.publishReportEntry("punit.sample", sampleInConfig + "/" + samplesPerConfig);
-        extensionContext.publishReportEntry("punit.successRate",
-            String.format("%.2f%%", aggregator.getObservedSuccessRate() * 100));
-
-        // Check if this is the last sample for this config
-        if (sampleInConfig >= samplesPerConfig) {
-            aggregator.setCompleted();
-            generateExploreSpec(extensionContext, store, configName, aggregator);
-        }
-    }
-    
-    /**
-     * Records the result from the captor into the aggregator.
-     *
-     * <p>Success is determined in priority order:
-     * <ol>
-     *   <li>If criteria are recorded, use {@code criteria.allPassed()}</li>
-     *   <li>Otherwise, fall back to legacy {@code determineSuccess()} heuristics</li>
-     * </ol>
-     */
-    private void recordResult(ResultCaptor captor, ExperimentResultAggregator aggregator) {
-        if (captor != null && captor.hasResult()) {
-            UseCaseResult result = captor.getResult();
-            
-            // Determine success: prefer criteria if available
-            boolean success;
-            if (captor.hasCriteria()) {
-                // Use criteria to determine success (the correct approach)
-                success = captor.getCriteria().allPassed();
-                // Also record criteria for per-criterion stats
-                aggregator.recordCriteria(captor.getCriteria());
-            } else {
-                // Legacy fallback: infer success from result values
-                success = determineSuccess(result);
-            }
-            
-            if (success) {
-                aggregator.recordSuccess(result);
-            } else {
-                String failureCategory = determineFailureCategory(result, captor.getCriteria());
-                aggregator.recordFailure(result, failureCategory);
-            }
-        } else if (captor != null && captor.hasException()) {
-            aggregator.recordException(captor.getException());
-        } else {
-            aggregator.recordSuccess(UseCaseResult.builder().value("recorded", false).build());
-        }
-    }
-    
-    // ═══════════════════════════════════════════════════════════════════════════
-    // CONTEXT BUILDING
-    // ═══════════════════════════════════════════════════════════════════════════
-    
-    @SuppressWarnings("unused")
-    private UseCaseContext buildContext(Method method) {
-        // Context is now managed by the experiment method body and UseCaseProvider
-        // This method returns an empty context for baseline metadata purposes
-        return DefaultUseCaseContext.builder().build();
-    }
-    
-    // ═══════════════════════════════════════════════════════════════════════════
-    // RESULT PROJECTION
-    // ═══════════════════════════════════════════════════════════════════════════
-    
-    /**
-     * Creates a ResultProjectionBuilder based on use case annotation and provider.
-     *
-     * @param useCaseClass the use case class (may be null or Void.class)
-     * @param provider the UseCaseProvider (may be null)
-     * @return a configured ResultProjectionBuilder
-     */
-    private ResultProjectionBuilder createProjectionBuilder(Class<?> useCaseClass, UseCaseProvider provider) {
-        int maxDiffableLines = 5; // default
-        int maxLineLength = 60;   // default
-        DiffableContentProvider customProvider = null;
-        
-        // Get settings from @UseCase annotation if available
-        if (useCaseClass != null && useCaseClass != Void.class) {
-            UseCase annotation = useCaseClass.getAnnotation(UseCase.class);
-            if (annotation != null) {
-                maxDiffableLines = annotation.maxDiffableLines();
-                maxLineLength = annotation.diffableContentMaxLineLength();
-            }
-            
-            // Check if use case instance implements DiffableContentProvider
-            if (provider != null) {
-                Object instance = provider.getCurrentInstance(useCaseClass);
-                if (instance instanceof DiffableContentProvider dcp) {
-                    customProvider = dcp;
-                }
-            }
-        }
-        
-        return new ResultProjectionBuilder(maxDiffableLines, maxLineLength, customProvider);
-    }
-    
-    // ═══════════════════════════════════════════════════════════════════════════
-    // RESULT DETERMINATION
-    // ═══════════════════════════════════════════════════════════════════════════
-    
-    private boolean determineSuccess(UseCaseResult result) {
-        // Check for common success indicators (in priority order)
-        if (result.hasValue("success")) {
-            return result.getBoolean("success", false);
-        }
-        if (result.hasValue("isSuccess")) {
-            return result.getBoolean("isSuccess", false);
-        }
-        if (result.hasValue("passed")) {
-            return result.getBoolean("passed", false);
-        }
-        if (result.hasValue("isValid")) {
-            return result.getBoolean("isValid", false);
-        }
-        if (result.hasValue("isValidJson")) {
-            return result.getBoolean("isValidJson", false);
-        }
-        if (result.hasValue("error")) {
-            return result.getValue("error", Object.class).isEmpty();
-        }
-        
-        // Default to success if no failure indicators
-        return true;
-    }
-    
-    private String determineFailureCategory(UseCaseResult result, UseCaseCriteria criteria) {
-        // If criteria are available, derive failure category from first failed criterion
-        if (criteria != null) {
-            for (CriterionOutcome outcome : criteria.evaluate()) {
-                if (!outcome.passed()) {
-                    return outcome.description();
-                }
-            }
-        }
-        
-        // Legacy: check for common failure category indicators in result
-        if (result.hasValue("failureCategory")) {
-            return result.getString("failureCategory", "unknown");
-        }
-        if (result.hasValue("errorType")) {
-            return result.getString("errorType", "unknown");
-        }
-        if (result.hasValue("errorCode")) {
-            return result.getString("errorCode", "unknown");
-        }
-        return "unknown";
-    }
-    
-    // ═══════════════════════════════════════════════════════════════════════════
-    // PROGRESS & BASELINE GENERATION
-    // ═══════════════════════════════════════════════════════════════════════════
-    
-    private void reportProgress(ExtensionContext context, ExperimentResultAggregator aggregator, 
-                               int currentSample, int totalSamples) {
-        // Report via JUnit TestReporter if available
-        context.publishReportEntry("punit.mode", "EXPERIMENT");
-        context.publishReportEntry("punit.sample", currentSample + "/" + totalSamples);
-        context.publishReportEntry("punit.successRate", 
-            String.format("%.2f%%", aggregator.getObservedSuccessRate() * 100));
-    }
-    
-    private void checkAndGenerateSpec(ExtensionContext context, ExtensionContext.Store store) {
-        ExperimentResultAggregator aggregator = store.get("aggregator", ExperimentResultAggregator.class);
-        if (aggregator.getSamplesExecuted() > 0) {
-            generateSpecOnce(context, store);
-        }
-    }
-
-    /**
-     * Generates the spec file exactly once per experiment run.
-     *
-     * <p>Uses a guard flag in the store to ensure that even if this method
-     * is called multiple times (e.g., from different threads in parallel
-     * execution or from different code paths), only one spec file is generated.
-     *
-     * <p><b>Thread Safety:</b> Uses {@code getOrComputeIfAbsent} for atomic
-     * initialization of the guard flag, combined with {@code compareAndSet}
-     * for atomic state transition. This ensures exactly-once semantics even
-     * under concurrent access.
-     */
-    private void generateSpecOnce(ExtensionContext context, ExtensionContext.Store store) {
-        // Thread-safe lazy initialization using getOrComputeIfAbsent
-        // This ensures all threads see the SAME AtomicBoolean instance
-        AtomicBoolean specGenerated = store.getOrComputeIfAbsent(
-            "specGenerated",
-            key -> new AtomicBoolean(false),
-            AtomicBoolean.class
-        );
-        
-        // Atomically check-and-set to ensure only one thread executes generateSpec
-        if (specGenerated.compareAndSet(false, true)) {
-            generateSpec(context, store);
-        }
-    }
-    
-    private void generateSpec(ExtensionContext context, ExtensionContext.Store store) {
-        ExperimentResultAggregator aggregator = store.get("aggregator", ExperimentResultAggregator.class);
-        UseCaseContext useCaseContext = store.get("useCaseContext", UseCaseContext.class);
-        ExperimentConfig config = store.get("experimentConfig", ExperimentConfig.class);
-        Class<?> useCaseClass = store.get("useCaseClass", Class.class);
-        String useCaseId = aggregator.getUseCaseId();
-
-        int expiresInDays = config.expiresInDays();
-        
-        // Emit informational note if no expiration is set
-        if (expiresInDays == 0) {
-            context.publishReportEntry("punit.info.expiration",
-                "Consider setting expiresInDays to track baseline freshness");
-        }
-        
-        // Resolve covariates from use case class
-        String footprint = null;
-        CovariateProfile covariateProfile = null;
-        
-        if (useCaseClass != null && useCaseClass != Void.class) {
-            UseCaseCovariateExtractor extractor = new UseCaseCovariateExtractor();
-            CovariateDeclaration declaration = extractor.extractDeclaration(useCaseClass);
-            
-            if (!declaration.isEmpty()) {
-                // Resolve covariate values using experiment timing
-                Long startTimeMs = store.get("startTimeMs", Long.class);
-                Instant startTime = startTimeMs != null 
-                    ? Instant.ofEpochMilli(startTimeMs)
-                    : Instant.now().minusSeconds(60); // fallback
-                Instant endTime = aggregator.getEndTime();
-                
-                // Get use case instance from provider for @CovariateSource resolution
-                Object useCaseInstance = null;
-                Optional<UseCaseProvider> providerOpt = findUseCaseProvider(context);
-                if (providerOpt.isPresent()) {
-                    useCaseInstance = providerOpt.get().getCurrentInstance(useCaseClass);
-                }
-                
-                DefaultCovariateResolutionContext resolutionContext = 
-                    DefaultCovariateResolutionContext.builder()
-                        .experimentTiming(startTime, endTime)
-                        .useCaseInstance(useCaseInstance)
-                        .build();
-                
-                CovariateProfileResolver resolver = new CovariateProfileResolver();
-                covariateProfile = resolver.resolve(declaration, resolutionContext);
-                
-                // Compute footprint
-                FootprintComputer footprintComputer = new FootprintComputer();
-                footprint = footprintComputer.computeFootprint(useCaseId, declaration);
-                
-                context.publishReportEntry("punit.covariates.count", 
-                    String.valueOf(covariateProfile.size()));
-            }
-        }
-        
-        EmpiricalBaselineGenerator generator = new EmpiricalBaselineGenerator();
-        EmpiricalBaseline baseline = generator.generate(
-            aggregator,
-            context.getTestClass().orElse(null),
-            context.getTestMethod().orElse(null),
-            useCaseContext,
-            expiresInDays,
-            footprint,
-            covariateProfile
-        );
-        
-        // Write spec to file (in src/test/resources/punit/specs/)
-        try {
-            Path outputPath = resolveMeasureOutputPath(useCaseId, footprint, covariateProfile);
-            BaselineWriter writer = new BaselineWriter();
-            writer.write(baseline, outputPath);
-            
-            context.publishReportEntry("punit.spec.outputPath", outputPath.toString());
-        } catch (IOException e) {
-            context.publishReportEntry("punit.spec.error", e.getMessage());
-        }
-        
-        // Publish final report
-        publishFinalReport(context, aggregator);
-    }
-    
-    /**
-     * Generates a spec for a single configuration in @ExploreExperiment.
-     */
-    private void generateExploreSpec(
-            ExtensionContext context,
-            ExtensionContext.Store store,
-            String configName,
-            ExperimentResultAggregator aggregator) {
-
-        UseCaseContext useCaseContext = store.get("useCaseContext", UseCaseContext.class);
-        if (useCaseContext == null) {
-            useCaseContext = DefaultUseCaseContext.builder().build();
-        }
-
-        ExperimentConfig config = store.get("experimentConfig", ExperimentConfig.class);
-        String useCaseId = store.get("useCaseId", String.class);
-        int expiresInDays = config.expiresInDays();
-        
-        EmpiricalBaselineGenerator generator = new EmpiricalBaselineGenerator();
-        EmpiricalBaseline baseline = generator.generate(
-            aggregator,
-            context.getTestClass().orElse(null),
-            context.getTestMethod().orElse(null),
-            useCaseContext,
-            expiresInDays
-        );
-        
-        // Write spec to config-specific file (in explorations/)
-        try {
-            Path outputPath = resolveExploreOutputPath(useCaseId, configName);
-            BaselineWriter writer = new BaselineWriter();
-            writer.write(baseline, outputPath);
-            
-            context.publishReportEntry("punit.spec.outputPath", outputPath.toString());
-            context.publishReportEntry("punit.config.complete", configName);
-        } catch (IOException e) {
-            context.publishReportEntry("punit.spec.error", 
-                "Config " + configName + ": " + e.getMessage());
-        }
-        
-        // Publish report for this config
-        context.publishReportEntry("punit.config.successRate", 
-            String.format("%s: %.4f", configName, aggregator.getObservedSuccessRate()));
-    }
-    
-    /**
-     * Default output directory for @MeasureExperiment specs.
-     */
-    private static final String DEFAULT_SPECS_DIR = "src/test/resources/punit/specs";
-    
-    /**
-     * Default output directory for @ExploreExperiment specs.
-     */
-    private static final String DEFAULT_EXPLORATIONS_DIR = "src/test/resources/punit/explorations";
-    
-    /**
-     * Resolves the output path for @MeasureExperiment (single configuration).
-     *
-     * <p>Output: {@code src/test/resources/punit/specs/{UseCaseName}-{footprint}[-{covHashes}].yaml}
-     *
-     * @param useCaseId the use case identifier
-     * @param footprint the footprint hash (may be null)
-     * @param covariateProfile the covariate profile (may be null)
-     * @return the output path
-     */
-    private Path resolveMeasureOutputPath(String useCaseId, String footprint, CovariateProfile covariateProfile) 
-            throws IOException {
-        
-        String filename;
-        if (footprint != null && !footprint.isEmpty()) {
-            // Use BaselineFileNamer for covariate-aware naming
-            BaselineFileNamer namer = new BaselineFileNamer();
-            CovariateProfile profile = covariateProfile != null ? covariateProfile : CovariateProfile.empty();
-            filename = namer.generateFilename(useCaseId, footprint, profile);
-        } else {
-            // Legacy naming for baselines without covariates
-            filename = useCaseId.replace('.', '-') + ".yaml";
-        }
-        
-        // Check for system property override (set by Gradle task)
-        String outputDirOverride = System.getProperty("punit.specs.outputDir");
-        Path baseDir;
-        if (outputDirOverride != null && !outputDirOverride.isEmpty()) {
-            baseDir = Paths.get(outputDirOverride);
-        } else {
-            baseDir = Paths.get(DEFAULT_SPECS_DIR);
-        }
-        
-        Files.createDirectories(baseDir);
-        return baseDir.resolve(filename);
-    }
-    
-    /**
-     * Resolves the output path for @ExploreExperiment (multiple configurations).
-     *
-     * <p>Structure:
-     * <pre>
-     * src/test/resources/punit/explorations/
-     * └── ShoppingUseCase/              # Directory for use case
-     *     ├── model-gpt-4_temp-0.0.yaml
-     *     └── model-gpt-4_temp-0.7.yaml
-     * </pre>
-     */
-    private Path resolveExploreOutputPath(String useCaseId, String configName)
-            throws IOException {
-        
-        String filename = configName + ".yaml";
-        
-        // Check for system property override (set by Gradle task)
-        String outputDirOverride = System.getProperty("punit.explorations.outputDir");
-        Path baseDir;
-        if (outputDirOverride != null && !outputDirOverride.isEmpty()) {
-            baseDir = Paths.get(outputDirOverride);
-        } else {
-            baseDir = Paths.get(DEFAULT_EXPLORATIONS_DIR);
-        }
-        
-        // Create subdirectory for use case
-        Path useCaseDir = baseDir.resolve(useCaseId.replace('.', '-'));
-        Files.createDirectories(useCaseDir);
-        
-        return useCaseDir.resolve(filename);
-    }
-    
-    private void publishFinalReport(ExtensionContext context, ExperimentResultAggregator aggregator) {
-        context.publishReportEntry("punit.experiment.complete", "true");
-        context.publishReportEntry("punit.useCaseId", aggregator.getUseCaseId());
-        context.publishReportEntry("punit.samplesExecuted", 
-            String.valueOf(aggregator.getSamplesExecuted()));
-        context.publishReportEntry("punit.successRate", 
-            String.format("%.4f", aggregator.getObservedSuccessRate()));
-        context.publishReportEntry("punit.standardError",
-            String.format("%.4f", aggregator.getStandardError()));
-        context.publishReportEntry("punit.terminationReason", 
-            aggregator.getTerminationReason());
-        context.publishReportEntry("punit.elapsedMs", 
-            String.valueOf(aggregator.getElapsedMs()));
-        context.publishReportEntry("punit.totalTokens",
-            String.valueOf(aggregator.getTotalTokens()));
-    }
-
-    /**
-     * Invocation context for @MeasureExperiment (single configuration, no factors).
-     */
-    private record MeasureInvocationContext(int sampleNumber, int totalSamples,
-                                               String useCaseId, ResultCaptor captor) 
-            implements TestTemplateInvocationContext {
-
-        @Override
-        public String getDisplayName(int invocationIndex) {
-            return String.format("[%s] sample %d/%d", useCaseId, sampleNumber, totalSamples);
-        }
-
-        @Override
-        public List<Extension> getAdditionalExtensions() {
-            return List.of(new CaptorParameterResolver(captor, null, 0));
-        }
-    }
-    
-    /**
-     * Invocation context for @MeasureExperiment with factor source (cycling).
-     *
-     * <p>Provides factor values that cycle through the factor source entries.
-     * With samples=1000 and 10 factor entries, each factor is used ~100 times.
-     */
-    private record MeasureWithFactorsInvocationContext(
-            int sampleNumber, int totalSamples,
-            String useCaseId, ResultCaptor captor,
-            Object[] factorValues, List<FactorInfo> factorInfos) 
-            implements TestTemplateInvocationContext {
-
-        @Override
-        public String getDisplayName(int invocationIndex) {
-            return String.format("[%s] sample %d/%d", useCaseId, sampleNumber, totalSamples);
-        }
-
-        @Override
-        public List<Extension> getAdditionalExtensions() {
-            List<Extension> extensions = new ArrayList<>();
-            extensions.add(new CaptorParameterResolver(captor, null, sampleNumber, factorValues));
-            extensions.add(new FactorParameterResolver(factorValues, factorInfos));
-            extensions.add(new FactorValuesResolver(factorValues, factorInfos));
-            return extensions;
-        }
-    }
-    
-    /**
-     * Invocation context for @ExploreExperiment (multiple configurations).
-     */
-    private record ExploreInvocationContext(
-            int sampleInConfig, int samplesPerConfig,
-            int configIndex, int totalConfigs,
-            String useCaseId, String configName,
-            Object[] factorValues, List<FactorInfo> factorInfos,
-            ResultCaptor captor) 
-            implements TestTemplateInvocationContext {
-
-        @Override
-        public String getDisplayName(int invocationIndex) {
-            return String.format("[%s] config %d/%d (%s) sample %d/%d", 
-                useCaseId, configIndex, totalConfigs, configName, sampleInConfig, samplesPerConfig);
-        }
-
-        @Override
-        public List<Extension> getAdditionalExtensions() {
-            List<Extension> extensions = new ArrayList<>();
-            // IMPORTANT: FactorValuesInitializer must be first to set factor values 
-            // on UseCaseProvider BEFORE any parameter resolution happens
-            extensions.add(new FactorValuesInitializer(factorValues, factorInfos));
-            extensions.add(new CaptorParameterResolver(captor, configName, sampleInConfig, factorValues));
-            extensions.add(new FactorParameterResolver(factorValues, factorInfos));
-            extensions.add(new FactorValuesResolver(factorValues, factorInfos));
-            return extensions;
-        }
-    }
-    
-    /**
-     * Initializes factor values on the UseCaseProvider BEFORE parameter resolution
-     * and clears them AFTER the test completes.
-     *
-     * <p>This is critical for auto-wired use case injection: the provider needs to know
-     * the current factor values when resolving the use case parameter, which happens
-     * before the test method is invoked (and before interceptTestTemplateMethod).
-     */
-    private static class FactorValuesInitializer implements 
-            org.junit.jupiter.api.extension.BeforeEachCallback,
-            org.junit.jupiter.api.extension.AfterEachCallback {
-        private final Object[] factorValues;
-        private final List<FactorInfo> factorInfos;
-        
-        FactorValuesInitializer(Object[] factorValues, List<FactorInfo> factorInfos) {
-            this.factorValues = factorValues;
-            this.factorInfos = factorInfos;
-        }
-        
-        @Override
-        public void beforeEach(ExtensionContext context) {
-            // Find the UseCaseProvider and set factor values
-            findProvider(context).ifPresent(provider -> {
-                if (factorValues != null) {
-                    List<String> factorNames = factorInfos.stream()
-                        .map(FactorInfo::name)
-                        .toList();
-                    provider.setCurrentFactorValues(factorValues, factorNames);
-                }
-            });
-        }
-        
-        @Override
-        public void afterEach(ExtensionContext context) {
-            // Clear factor values after the test completes
-            findProvider(context).ifPresent(UseCaseProvider::clearCurrentFactorValues);
-        }
-        
-        private Optional<UseCaseProvider> findProvider(ExtensionContext context) {
-            Object testInstance = context.getRequiredTestInstance();
-            for (java.lang.reflect.Field field : testInstance.getClass().getDeclaredFields()) {
-                if (UseCaseProvider.class.isAssignableFrom(field.getType())) {
-                    field.setAccessible(true);
-                    try {
-                        return Optional.of((UseCaseProvider) field.get(testInstance));
-                    } catch (IllegalAccessException e) {
-                        // Continue searching
-                    }
-                }
-            }
-            return Optional.empty();
-        }
-    }
-    
-    /**
-     * Parameter resolver that provides FactorValues for accessing factor data by name.
-     */
-    private static class FactorValuesResolver implements ParameterResolver {
-        private final Object[] factorValues;
-        private final List<FactorInfo> factorInfos;
-        
-        FactorValuesResolver(Object[] factorValues, List<FactorInfo> factorInfos) {
-            this.factorValues = factorValues;
-            this.factorInfos = factorInfos;
-        }
-        
-        @Override
-        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-            return parameterContext.getParameter().getType() == FactorValues.class;
-        }
-        
-        @Override
-        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-            List<String> names = factorInfos.stream()
-                .map(FactorInfo::name)
-                .toList();
-            return new FactorValues(factorValues, names);
-        }
-    }
-    
-    /**
-     * Parameter resolver that provides the ResultCaptor for the current invocation.
-     */
-    private static class CaptorParameterResolver implements ParameterResolver {
-        private final ResultCaptor captor;
-        private final String configName;
-        private final int sampleInConfig;
-        private final Object[] factorValues;
-        
-        CaptorParameterResolver(ResultCaptor captor, String configName, int sampleInConfig) {
-            this(captor, configName, sampleInConfig, null);
-        }
-        
-        CaptorParameterResolver(ResultCaptor captor, String configName, int sampleInConfig, Object[] factorValues) {
-            this.captor = captor;
-            this.configName = configName;
-            this.sampleInConfig = sampleInConfig;
-            this.factorValues = factorValues;
-        }
-        
-        @Override
-        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) 
-                throws ParameterResolutionException {
-            return parameterContext.getParameter().getType() == ResultCaptor.class;
-        }
-        
-        @Override
-        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) 
-                throws ParameterResolutionException {
-            // Store in the extension context so the interceptor can access it
-            ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
-            store.put("captor", captor);
-            if (configName != null) {
-                store.put("configName", configName);
-                store.put("sampleInConfig", sampleInConfig);
-            }
-            if (factorValues != null) {
-                store.put("factorValues", factorValues);
-            }
-            return captor;
-        }
-    }
-    
-    /**
-     * Finds the UseCaseProvider in the test instance.
-     */
-    private Optional<UseCaseProvider> findUseCaseProvider(ExtensionContext context) {
-        Object testInstance = context.getRequiredTestInstance();
-        for (java.lang.reflect.Field field : testInstance.getClass().getDeclaredFields()) {
-            if (UseCaseProvider.class.isAssignableFrom(field.getType())) {
-                field.setAccessible(true);
-                try {
-                    return Optional.of((UseCaseProvider) field.get(testInstance));
-                } catch (IllegalAccessException e) {
-                    // Continue searching
-                }
-            }
-        }
-        return Optional.empty();
-    }
-    
-    /**
-     * Parameter resolver that provides factor values for @ExploreExperiment.
-     */
-    private static class FactorParameterResolver implements ParameterResolver {
-        private final Object[] factorValues;
-        private final List<FactorInfo> factorInfos;
-        
-        FactorParameterResolver(Object[] factorValues, List<FactorInfo> factorInfos) {
-            this.factorValues = factorValues;
-            this.factorInfos = factorInfos;
-        }
-        
-        @Override
-        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) 
-                throws ParameterResolutionException {
-            // Check if this parameter has a @Factor annotation
-            return parameterContext.getParameter().isAnnotationPresent(Factor.class);
-        }
-        
-        @Override
-        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) 
-                throws ParameterResolutionException {
-            Factor factor = parameterContext.getParameter().getAnnotation(Factor.class);
-            String factorName = factor.value();
-            
-            // Find the matching factor value
-            for (int i = 0; i < factorInfos.size(); i++) {
-                if (factorInfos.get(i).name().equals(factorName)) {
-                    return factorValues[i];
-                }
-            }
-            
-            throw new ParameterResolutionException(
-                "No factor value found for @Factor(\"" + factorName + "\")");
         }
     }
 }

--- a/src/main/java/org/javai/punit/experiment/engine/ExperimentModeStrategy.java
+++ b/src/main/java/org/javai/punit/experiment/engine/ExperimentModeStrategy.java
@@ -1,0 +1,107 @@
+package org.javai.punit.experiment.engine;
+
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Strategy interface for handling a specific experiment mode.
+ *
+ * <p>Each experiment mode (MEASURE, EXPLORE, OPTIMIZE) provides an implementation
+ * that encapsulates all mode-specific behavior:
+ * <ul>
+ *   <li>Parsing its annotation into a configuration</li>
+ *   <li>Generating invocation contexts (the sample stream)</li>
+ *   <li>Intercepting and executing each sample</li>
+ *   <li>Generating mode-specific output (specs, optimization history, etc.)</li>
+ * </ul>
+ *
+ * <p>This pattern keeps {@link ExperimentExtension} thin and mode-agnostic.
+ * The extension simply detects which annotation is present, finds the corresponding
+ * strategy, and delegates all mode-specific work.
+ *
+ * <h2>Implementations</h2>
+ * <ul>
+ *   <li>{@code MeasureStrategy} - Handles @MeasureExperiment</li>
+ *   <li>{@code ExploreStrategy} - Handles @ExploreExperiment</li>
+ *   <li>{@code OptimizeStrategy} - Handles @OptimizeExperiment</li>
+ * </ul>
+ */
+public interface ExperimentModeStrategy {
+
+    /**
+     * Check if this strategy handles the given test method.
+     *
+     * <p>Typically checks for the presence of the mode's annotation
+     * (e.g., @MeasureExperiment for MeasureStrategy).
+     *
+     * @param testMethod the test method to check
+     * @return true if this strategy's annotation is present
+     */
+    boolean supports(Method testMethod);
+
+    /**
+     * Parse the experiment annotation into a mode-specific configuration.
+     *
+     * @param testMethod the annotated test method
+     * @return the parsed configuration (a subtype of {@link ExperimentConfig})
+     * @throws org.junit.jupiter.api.extension.ExtensionConfigurationException
+     *         if the annotation is invalid or missing required attributes
+     */
+    ExperimentConfig parseConfig(Method testMethod);
+
+    /**
+     * Provide the stream of invocation contexts for this experiment.
+     *
+     * <p>Each invocation context represents one sample execution. The stream
+     * may be finite (e.g., MEASURE with fixed sample count) or lazy
+     * (e.g., OPTIMIZE with dynamic iteration).
+     *
+     * @param config the parsed configuration
+     * @param context the JUnit extension context
+     * @param store the extension store for shared state
+     * @return stream of invocation contexts (one per sample)
+     */
+    Stream<TestTemplateInvocationContext> provideInvocationContexts(
+            ExperimentConfig config,
+            ExtensionContext context,
+            ExtensionContext.Store store);
+
+    /**
+     * Intercept and execute a single sample.
+     *
+     * <p>Called for each invocation context. Responsible for:
+     * <ul>
+     *   <li>Checking budget constraints (time, tokens)</li>
+     *   <li>Proceeding with or skipping the invocation</li>
+     *   <li>Recording results to aggregators</li>
+     *   <li>Generating output when complete</li>
+     * </ul>
+     *
+     * @param invocation the JUnit invocation to proceed or skip
+     * @param invocationContext reflective context for the method
+     * @param extensionContext the JUnit extension context
+     * @param store the extension store for shared state
+     * @throws Throwable if the test method throws
+     */
+    void intercept(
+            InvocationInterceptor.Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext,
+            ExtensionContext.Store store) throws Throwable;
+
+    /**
+     * Compute the total number of samples for pacing calculation.
+     *
+     * <p>Used by the extension to configure pacing before samples execute.
+     * For OPTIMIZE mode, this may be an estimate (samplesPerIteration × maxIterations).
+     *
+     * @param config the parsed configuration
+     * @param testMethod the test method (may have @FactorSource for EXPLORE)
+     * @return estimated total samples
+     */
+    int computeTotalSamples(ExperimentConfig config, Method testMethod);
+}

--- a/src/main/java/org/javai/punit/experiment/engine/shared/CaptorParameterResolver.java
+++ b/src/main/java/org/javai/punit/experiment/engine/shared/CaptorParameterResolver.java
@@ -1,0 +1,65 @@
+package org.javai.punit.experiment.engine.shared;
+
+import org.javai.punit.api.ResultCaptor;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * Parameter resolver that provides the {@link ResultCaptor} for the current invocation.
+ *
+ * <p>Also stores metadata in the extension context store for access by the interceptor:
+ * <ul>
+ *   <li>{@code captor} - the ResultCaptor instance</li>
+ *   <li>{@code configName} - the configuration name (for EXPLORE mode)</li>
+ *   <li>{@code sampleInConfig} - the sample number within the configuration</li>
+ *   <li>{@code factorValues} - the factor values (if present)</li>
+ * </ul>
+ */
+public class CaptorParameterResolver implements ParameterResolver {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create("org.javai.punit.experiment");
+
+    private final ResultCaptor captor;
+    private final String configName;
+    private final int sampleInConfig;
+    private final Object[] factorValues;
+
+    public CaptorParameterResolver(ResultCaptor captor, String configName, int sampleInConfig) {
+        this(captor, configName, sampleInConfig, null);
+    }
+
+    public CaptorParameterResolver(ResultCaptor captor, String configName,
+                                   int sampleInConfig, Object[] factorValues) {
+        this.captor = captor;
+        this.configName = configName;
+        this.sampleInConfig = sampleInConfig;
+        this.factorValues = factorValues;
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext,
+                                     ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == ResultCaptor.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext,
+                                   ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        // Store in the extension context so the interceptor can access it
+        ExtensionContext.Store store = extensionContext.getStore(NAMESPACE);
+        store.put("captor", captor);
+        if (configName != null) {
+            store.put("configName", configName);
+            store.put("sampleInConfig", sampleInConfig);
+        }
+        if (factorValues != null) {
+            store.put("factorValues", factorValues);
+        }
+        return captor;
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/engine/shared/FactorInfo.java
+++ b/src/main/java/org/javai/punit/experiment/engine/shared/FactorInfo.java
@@ -1,0 +1,19 @@
+package org.javai.punit.experiment.engine.shared;
+
+/**
+ * Information about a factor parameter.
+ *
+ * <p>Used for factor resolution and file naming in MEASURE and EXPLORE modes.
+ *
+ * @param parameterIndex index of this factor in the parameter list
+ * @param name logical name of the factor
+ * @param filePrefix prefix to use in output file names
+ * @param type the Java type of the factor
+ */
+public record FactorInfo(
+        int parameterIndex,
+        String name,
+        String filePrefix,
+        Class<?> type
+) {
+}

--- a/src/main/java/org/javai/punit/experiment/engine/shared/FactorParameterResolver.java
+++ b/src/main/java/org/javai/punit/experiment/engine/shared/FactorParameterResolver.java
@@ -1,0 +1,50 @@
+package org.javai.punit.experiment.engine.shared;
+
+import java.util.List;
+import org.javai.punit.api.Factor;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * Parameter resolver that provides factor values for @Factor-annotated parameters.
+ *
+ * <p>Matches factor values to parameters by the factor name specified in the
+ * @Factor annotation.
+ */
+public class FactorParameterResolver implements ParameterResolver {
+
+    private final Object[] factorValues;
+    private final List<FactorInfo> factorInfos;
+
+    public FactorParameterResolver(Object[] factorValues, List<FactorInfo> factorInfos) {
+        this.factorValues = factorValues;
+        this.factorInfos = factorInfos;
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext,
+                                     ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return parameterContext.getParameter().isAnnotationPresent(Factor.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext,
+                                   ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        Factor factor = parameterContext.getParameter().getAnnotation(Factor.class);
+        String factorName = factor.value();
+
+        // Find the matching factor value
+        for (int i = 0; i < factorInfos.size(); i++) {
+            if (factorInfos.get(i).name().equals(factorName)) {
+                return factorValues[i];
+            }
+        }
+
+        throw new ParameterResolutionException(
+                "No factor value found for @Factor(\"" + factorName + "\")");
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/engine/shared/FactorResolver.java
+++ b/src/main/java/org/javai/punit/experiment/engine/shared/FactorResolver.java
@@ -1,0 +1,274 @@
+package org.javai.punit.experiment.engine.shared;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.javai.punit.api.Factor;
+import org.javai.punit.api.FactorArguments;
+import org.javai.punit.api.FactorSource;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+
+/**
+ * Resolves factor information from annotations and method parameters.
+ *
+ * <p>Used by both MEASURE and EXPLORE modes for factor handling.
+ */
+public final class FactorResolver {
+
+    private FactorResolver() {
+        // Utility class
+    }
+
+    /**
+     * Resolves factor arguments from the @FactorSource annotation.
+     *
+     * @param testMethod the test method
+     * @param factorSource the @FactorSource annotation
+     * @return list of factor arguments
+     */
+    @SuppressWarnings("unchecked")
+    public static List<FactorArguments> resolveFactorArguments(
+            Method testMethod, FactorSource factorSource) {
+
+        String sourceReference = factorSource.value();
+
+        try {
+            Stream<FactorArguments> factorStream;
+
+            if (sourceReference.contains("#")) {
+                // Cross-class reference
+                String[] parts = sourceReference.split("#", 2);
+                String className = parts[0];
+                String methodName = parts[1];
+                Class<?> targetClass = resolveClass(className, testMethod.getDeclaringClass());
+                Method sourceMethod = targetClass.getDeclaredMethod(methodName);
+                factorStream = invokeFactorSource(sourceMethod, sourceReference);
+            } else {
+                // Same-class reference
+                Method sourceMethod = testMethod.getDeclaringClass().getDeclaredMethod(sourceReference);
+                factorStream = invokeFactorSource(sourceMethod, sourceReference);
+            }
+
+            return factorStream.toList();
+
+        } catch (NoSuchMethodException e) {
+            throw new ExtensionConfigurationException(
+                    "Cannot find @FactorSource method '" + sourceReference + "'", e);
+        } catch (Exception e) {
+            throw new ExtensionConfigurationException(
+                    "Cannot invoke @FactorSource method '" + sourceReference + "': " + e.getMessage(), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Stream<FactorArguments> invokeFactorSource(Method sourceMethod, String sourceReference)
+            throws Exception {
+        sourceMethod.setAccessible(true);
+        Object result = sourceMethod.invoke(null);
+
+        if (result instanceof Stream) {
+            return (Stream<FactorArguments>) result;
+        } else if (result instanceof Collection) {
+            return ((Collection<FactorArguments>) result).stream();
+        } else {
+            throw new ExtensionConfigurationException(
+                    "Factor source method must return Stream or Collection: " + sourceReference);
+        }
+    }
+
+    /**
+     * Extracts factor info from FactorArguments and method parameters.
+     *
+     * @param testMethod the test method
+     * @param firstArgs the first FactorArguments (for extracting names)
+     * @return list of factor info
+     */
+    public static List<FactorInfo> extractFactorInfosFromArguments(
+            Method testMethod, FactorArguments firstArgs) {
+
+        List<FactorInfo> infos = new ArrayList<>();
+
+        // Try to get names from FactorArguments
+        String[] argNames = firstArgs.names();
+        if (argNames != null) {
+            for (int i = 0; i < argNames.length; i++) {
+                infos.add(new FactorInfo(i, argNames[i], argNames[i], Object.class));
+            }
+        } else {
+            // Fall back to @Factor annotations on method parameters
+            int factorIndex = 0;
+            for (Parameter param : testMethod.getParameters()) {
+                Factor factor = param.getAnnotation(Factor.class);
+                if (factor != null) {
+                    infos.add(new FactorInfo(factorIndex++, factor.value(), factor.value(), param.getType()));
+                }
+            }
+        }
+
+        return infos;
+    }
+
+    /**
+     * Extracts factor info from @FactorSource annotation and arguments.
+     *
+     * <p>Priority:
+     * <ol>
+     *   <li>Names embedded in {@link FactorArguments} (best DX - names with values)</li>
+     *   <li>{@code @FactorSource(factors = {...})} annotation</li>
+     *   <li>{@code @Factor} annotations on method parameters</li>
+     * </ol>
+     */
+    public static List<FactorInfo> extractFactorInfos(
+            Method method, FactorSource factorSource, List<FactorArguments> argsList) {
+
+        // 1. Prefer names embedded in FactorArguments
+        if (!argsList.isEmpty() && argsList.get(0).hasNames()) {
+            String[] names = argsList.get(0).names();
+            List<FactorInfo> factorInfos = new ArrayList<>();
+            for (int i = 0; i < names.length; i++) {
+                factorInfos.add(new FactorInfo(i, names[i], names[i], Object.class));
+            }
+            return factorInfos;
+        }
+
+        // 2. Factor names from @FactorSource annotation
+        String[] factorNames = factorSource.factors();
+        if (factorNames.length > 0) {
+            List<FactorInfo> factorInfos = new ArrayList<>();
+            for (int i = 0; i < factorNames.length; i++) {
+                factorInfos.add(new FactorInfo(i, factorNames[i], factorNames[i], Object.class));
+            }
+            return factorInfos;
+        }
+
+        // 3. Fall back to @Factor annotations on method parameters
+        return getFactorInfosFromParameters(method);
+    }
+
+    /**
+     * Extracts factor infos from @Factor-annotated method parameters.
+     */
+    public static List<FactorInfo> getFactorInfosFromParameters(Method method) {
+        List<FactorInfo> factorInfos = new ArrayList<>();
+        Parameter[] parameters = method.getParameters();
+
+        for (int i = 0; i < parameters.length; i++) {
+            Factor factor = parameters[i].getAnnotation(Factor.class);
+            if (factor != null) {
+                String name = factor.value();
+                String filePrefix = factor.filePrefix().isEmpty() ? name : factor.filePrefix();
+                factorInfos.add(new FactorInfo(i, name, filePrefix, parameters[i].getType()));
+            }
+        }
+        return factorInfos;
+    }
+
+    /**
+     * Extracts factor values in the order matching factorInfos.
+     */
+    public static Object[] extractFactorValues(FactorArguments args, List<FactorInfo> factorInfos) {
+        Object[] values = new Object[factorInfos.size()];
+        String[] argNames = args.names();
+
+        for (int i = 0; i < factorInfos.size(); i++) {
+            FactorInfo info = factorInfos.get(i);
+            if (argNames != null) {
+                // Find by name
+                for (int j = 0; j < argNames.length; j++) {
+                    if (argNames[j].equals(info.name())) {
+                        values[i] = args.get(j);
+                        break;
+                    }
+                }
+            } else {
+                // Use positional index
+                values[i] = args.get(info.parameterIndex());
+            }
+        }
+
+        return values;
+    }
+
+    /**
+     * Builds a configuration name from factor values for file naming.
+     */
+    public static String buildConfigName(List<FactorInfo> factorInfos, Object[] values) {
+        StringBuilder sb = new StringBuilder();
+
+        int count = Math.min(factorInfos.size(), values.length);
+
+        for (int i = 0; i < count; i++) {
+            if (i > 0) sb.append("_");
+            FactorInfo info = factorInfos.get(i);
+            Object value = values[i];
+            String valueStr = formatFactorValue(value);
+            sb.append(info.filePrefix()).append("-").append(valueStr);
+        }
+
+        // If there are more values than factorInfos, add generic names
+        for (int i = count; i < values.length; i++) {
+            if (!sb.isEmpty()) sb.append("_");
+            String valueStr = formatFactorValue(values[i]);
+            sb.append("f").append(i).append("-").append(valueStr);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Formats a factor value for use in file names.
+     */
+    public static String formatFactorValue(Object value) {
+        if (value == null) return "null";
+        String str = value.toString();
+        return str.replace(" ", "_")
+                .replace("/", "-")
+                .replace("\\", "-")
+                .replace(":", "-")
+                .replaceAll("[^a-zA-Z0-9._-]", "");
+    }
+
+    /**
+     * Resolves a class from a simple or fully qualified name.
+     */
+    public static Class<?> resolveClass(String className, Class<?> contextClass) {
+        String packageName = contextClass.getPackageName();
+
+        // 1. Try same package
+        try {
+            return Class.forName(packageName + "." + className);
+        } catch (ClassNotFoundException ignored) {
+        }
+
+        // 2. Try fully qualified name
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException ignored) {
+        }
+
+        // 3. Try sibling packages
+        int lastDot = packageName.lastIndexOf('.');
+        if (lastDot > 0) {
+            String parentPackage = packageName.substring(0, lastDot);
+
+            for (String sibling : new String[]{"usecase", "model", "domain", "service", "api", "core"}) {
+                try {
+                    return Class.forName(parentPackage + "." + sibling + "." + className);
+                } catch (ClassNotFoundException ignored) {
+                }
+            }
+
+            try {
+                return Class.forName(parentPackage + "." + className);
+            } catch (ClassNotFoundException ignored) {
+            }
+        }
+
+        throw new ExtensionConfigurationException(
+                "Cannot resolve class '" + className + "' from context " + contextClass.getName() +
+                        ". Try using the fully qualified class name.");
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/engine/shared/FactorValuesInitializer.java
+++ b/src/main/java/org/javai/punit/experiment/engine/shared/FactorValuesInitializer.java
@@ -1,0 +1,59 @@
+package org.javai.punit.experiment.engine.shared;
+
+import java.util.List;
+import java.util.Optional;
+import org.javai.punit.api.UseCaseProvider;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Initializes factor values on the UseCaseProvider BEFORE parameter resolution
+ * and clears them AFTER the test completes.
+ *
+ * <p>This is critical for auto-wired use case injection: the provider needs to know
+ * the current factor values when resolving the use case parameter, which happens
+ * before the test method is invoked (and before interceptTestTemplateMethod).
+ */
+public class FactorValuesInitializer implements BeforeEachCallback, AfterEachCallback {
+
+    private final Object[] factorValues;
+    private final List<FactorInfo> factorInfos;
+
+    public FactorValuesInitializer(Object[] factorValues, List<FactorInfo> factorInfos) {
+        this.factorValues = factorValues;
+        this.factorInfos = factorInfos;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        findProvider(context).ifPresent(provider -> {
+            if (factorValues != null) {
+                List<String> factorNames = factorInfos.stream()
+                        .map(FactorInfo::name)
+                        .toList();
+                provider.setCurrentFactorValues(factorValues, factorNames);
+            }
+        });
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        findProvider(context).ifPresent(UseCaseProvider::clearCurrentFactorValues);
+    }
+
+    private Optional<UseCaseProvider> findProvider(ExtensionContext context) {
+        Object testInstance = context.getRequiredTestInstance();
+        for (java.lang.reflect.Field field : testInstance.getClass().getDeclaredFields()) {
+            if (UseCaseProvider.class.isAssignableFrom(field.getType())) {
+                field.setAccessible(true);
+                try {
+                    return Optional.of((UseCaseProvider) field.get(testInstance));
+                } catch (IllegalAccessException e) {
+                    // Continue searching
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/engine/shared/FactorValuesResolver.java
+++ b/src/main/java/org/javai/punit/experiment/engine/shared/FactorValuesResolver.java
@@ -1,0 +1,38 @@
+package org.javai.punit.experiment.engine.shared;
+
+import java.util.List;
+import org.javai.punit.api.FactorValues;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * Parameter resolver that provides {@link FactorValues} for accessing factor data by name.
+ *
+ * <p>FactorValues provides a map-like interface to access factor values during test execution.
+ */
+public class FactorValuesResolver implements ParameterResolver {
+
+    private final Object[] factorValues;
+    private final List<FactorInfo> factorInfos;
+
+    public FactorValuesResolver(Object[] factorValues, List<FactorInfo> factorInfos) {
+        this.factorValues = factorValues;
+        this.factorInfos = factorInfos;
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext,
+                                     ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType() == FactorValues.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext,
+                                   ExtensionContext extensionContext) {
+        List<String> names = factorInfos.stream()
+                .map(FactorInfo::name)
+                .toList();
+        return new FactorValues(factorValues, names);
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/engine/shared/ResultRecorder.java
+++ b/src/main/java/org/javai/punit/experiment/engine/shared/ResultRecorder.java
@@ -1,0 +1,107 @@
+package org.javai.punit.experiment.engine.shared;
+
+import org.javai.punit.api.ResultCaptor;
+import org.javai.punit.experiment.engine.ExperimentResultAggregator;
+import org.javai.punit.model.CriterionOutcome;
+import org.javai.punit.model.UseCaseCriteria;
+import org.javai.punit.model.UseCaseResult;
+
+/**
+ * Records results from a ResultCaptor into an ExperimentResultAggregator.
+ *
+ * <p>Handles success/failure determination and failure categorization.
+ */
+public final class ResultRecorder {
+
+    private ResultRecorder() {
+        // Utility class
+    }
+
+    /**
+     * Records the result from the captor into the aggregator.
+     *
+     * <p>Success is determined in priority order:
+     * <ol>
+     *   <li>If criteria are recorded, use {@code criteria.allPassed()}</li>
+     *   <li>Otherwise, fall back to legacy heuristics</li>
+     * </ol>
+     */
+    public static void recordResult(ResultCaptor captor, ExperimentResultAggregator aggregator) {
+        if (captor != null && captor.hasResult()) {
+            UseCaseResult result = captor.getResult();
+
+            // Determine success: prefer criteria if available
+            boolean success;
+            if (captor.hasCriteria()) {
+                success = captor.getCriteria().allPassed();
+                aggregator.recordCriteria(captor.getCriteria());
+            } else {
+                success = determineSuccess(result);
+            }
+
+            if (success) {
+                aggregator.recordSuccess(result);
+            } else {
+                String failureCategory = determineFailureCategory(result, captor.getCriteria());
+                aggregator.recordFailure(result, failureCategory);
+            }
+        } else if (captor != null && captor.hasException()) {
+            aggregator.recordException(captor.getException());
+        } else {
+            aggregator.recordSuccess(UseCaseResult.builder().value("recorded", false).build());
+        }
+    }
+
+    /**
+     * Determines success from common result indicators.
+     */
+    private static boolean determineSuccess(UseCaseResult result) {
+        if (result.hasValue("success")) {
+            return result.getBoolean("success", false);
+        }
+        if (result.hasValue("isSuccess")) {
+            return result.getBoolean("isSuccess", false);
+        }
+        if (result.hasValue("passed")) {
+            return result.getBoolean("passed", false);
+        }
+        if (result.hasValue("isValid")) {
+            return result.getBoolean("isValid", false);
+        }
+        if (result.hasValue("isValidJson")) {
+            return result.getBoolean("isValidJson", false);
+        }
+        if (result.hasValue("error")) {
+            return result.getValue("error", Object.class).isEmpty();
+        }
+
+        // Default to success if no failure indicators
+        return true;
+    }
+
+    /**
+     * Determines the failure category from criteria or result.
+     */
+    private static String determineFailureCategory(UseCaseResult result, UseCaseCriteria criteria) {
+        // If criteria are available, derive failure category from first failed criterion
+        if (criteria != null) {
+            for (CriterionOutcome outcome : criteria.evaluate()) {
+                if (!outcome.passed()) {
+                    return outcome.description();
+                }
+            }
+        }
+
+        // Legacy: check for common failure category indicators in result
+        if (result.hasValue("failureCategory")) {
+            return result.getString("failureCategory", "unknown");
+        }
+        if (result.hasValue("errorType")) {
+            return result.getString("errorType", "unknown");
+        }
+        if (result.hasValue("errorCode")) {
+            return result.getString("errorCode", "unknown");
+        }
+        return "unknown";
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/explore/ExploreConfig.java
+++ b/src/main/java/org/javai/punit/experiment/explore/ExploreConfig.java
@@ -1,0 +1,44 @@
+package org.javai.punit.experiment.explore;
+
+import org.javai.punit.api.ExperimentMode;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+
+/**
+ * Configuration for @ExploreExperiment.
+ *
+ * <p>EXPLORE mode compares multiple configurations to understand factor effects.
+ * It runs a small number of samples per configuration (default 1) and generates
+ * separate spec files for each configuration, enabling comparison via diff.
+ *
+ * @param useCaseClass the use case class to test
+ * @param useCaseId resolved use case identifier
+ * @param samplesPerConfig samples to run per factor configuration
+ * @param timeBudgetMs time budget in milliseconds (0 = unlimited)
+ * @param tokenBudget token budget (0 = unlimited)
+ * @param experimentId experiment identifier for output naming
+ * @param expiresInDays baseline expiration in days (0 = no expiration tracking)
+ */
+public record ExploreConfig(
+        Class<?> useCaseClass,
+        String useCaseId,
+        int samplesPerConfig,
+        long timeBudgetMs,
+        long tokenBudget,
+        String experimentId,
+        int expiresInDays
+) implements ExperimentConfig {
+
+    @Override
+    public ExperimentMode mode() {
+        return ExperimentMode.EXPLORE;
+    }
+
+    /**
+     * Returns the effective samples per config, using the mode default if not specified.
+     *
+     * @return the effective samples per configuration
+     */
+    public int effectiveSamplesPerConfig() {
+        return mode().getEffectiveSampleSize(samplesPerConfig);
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/explore/ExploreInvocationContext.java
+++ b/src/main/java/org/javai/punit/experiment/explore/ExploreInvocationContext.java
@@ -1,0 +1,49 @@
+package org.javai.punit.experiment.explore;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.javai.punit.api.ResultCaptor;
+import org.javai.punit.experiment.engine.shared.CaptorParameterResolver;
+import org.javai.punit.experiment.engine.shared.FactorInfo;
+import org.javai.punit.experiment.engine.shared.FactorParameterResolver;
+import org.javai.punit.experiment.engine.shared.FactorValuesInitializer;
+import org.javai.punit.experiment.engine.shared.FactorValuesResolver;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Invocation context for @ExploreExperiment (multiple configurations).
+ *
+ * <p>Each invocation represents a single sample within a specific factor configuration.
+ * EXPLORE mode generates one spec file per configuration.
+ */
+public record ExploreInvocationContext(
+        int sampleInConfig,
+        int samplesPerConfig,
+        int configIndex,
+        int totalConfigs,
+        String useCaseId,
+        String configName,
+        Object[] factorValues,
+        List<FactorInfo> factorInfos,
+        ResultCaptor captor
+) implements TestTemplateInvocationContext {
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return String.format("[%s] config %d/%d (%s) sample %d/%d",
+                useCaseId, configIndex, totalConfigs, configName, sampleInConfig, samplesPerConfig);
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        List<Extension> extensions = new ArrayList<>();
+        // IMPORTANT: FactorValuesInitializer must be first to set factor values
+        // on UseCaseProvider BEFORE any parameter resolution happens
+        extensions.add(new FactorValuesInitializer(factorValues, factorInfos));
+        extensions.add(new CaptorParameterResolver(captor, configName, sampleInConfig, factorValues));
+        extensions.add(new FactorParameterResolver(factorValues, factorInfos));
+        extensions.add(new FactorValuesResolver(factorValues, factorInfos));
+        return extensions;
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/explore/ExploreSpecGenerator.java
+++ b/src/main/java/org/javai/punit/experiment/explore/ExploreSpecGenerator.java
@@ -1,0 +1,90 @@
+package org.javai.punit.experiment.explore;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.javai.punit.experiment.engine.BaselineWriter;
+import org.javai.punit.experiment.engine.EmpiricalBaselineGenerator;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+import org.javai.punit.experiment.engine.ExperimentResultAggregator;
+import org.javai.punit.experiment.model.DefaultUseCaseContext;
+import org.javai.punit.experiment.model.EmpiricalBaseline;
+import org.javai.punit.api.UseCaseContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Generates spec files for @ExploreExperiment configurations.
+ *
+ * <p>Output structure:
+ * <pre>
+ * src/test/resources/punit/explorations/
+ * └── {UseCaseId}/
+ *     ├── model-gpt-4_temp-0.0.yaml
+ *     └── model-gpt-4_temp-0.7.yaml
+ * </pre>
+ */
+public class ExploreSpecGenerator {
+
+    private static final String DEFAULT_EXPLORATIONS_DIR = "src/test/resources/punit/explorations";
+
+    /**
+     * Generates a spec file for a single configuration.
+     */
+    public void generateSpec(
+            ExtensionContext context,
+            ExtensionContext.Store store,
+            String configName,
+            ExperimentResultAggregator aggregator) {
+
+        ExploreConfig config = (ExploreConfig) store.get("config", ExperimentConfig.class);
+        String useCaseId = config.useCaseId();
+        int expiresInDays = config.expiresInDays();
+
+        UseCaseContext useCaseContext = DefaultUseCaseContext.builder().build();
+
+        EmpiricalBaselineGenerator generator = new EmpiricalBaselineGenerator();
+        EmpiricalBaseline baseline = generator.generate(
+                aggregator,
+                context.getTestClass().orElse(null),
+                context.getTestMethod().orElse(null),
+                useCaseContext,
+                expiresInDays
+        );
+
+        // Write spec to config-specific file
+        try {
+            Path outputPath = resolveOutputPath(useCaseId, configName);
+            BaselineWriter writer = new BaselineWriter();
+            writer.write(baseline, outputPath);
+
+            context.publishReportEntry("punit.spec.outputPath", outputPath.toString());
+            context.publishReportEntry("punit.config.complete", configName);
+        } catch (IOException e) {
+            context.publishReportEntry("punit.spec.error",
+                    "Config " + configName + ": " + e.getMessage());
+        }
+
+        // Publish report for this config
+        context.publishReportEntry("punit.config.successRate",
+                String.format("%s: %.4f", configName, aggregator.getObservedSuccessRate()));
+    }
+
+    private Path resolveOutputPath(String useCaseId, String configName) throws IOException {
+        String filename = configName + ".yaml";
+
+        String outputDirOverride = System.getProperty("punit.explorations.outputDir");
+        Path baseDir;
+        if (outputDirOverride != null && !outputDirOverride.isEmpty()) {
+            baseDir = Paths.get(outputDirOverride);
+        } else {
+            baseDir = Paths.get(DEFAULT_EXPLORATIONS_DIR);
+        }
+
+        // Create subdirectory for use case
+        Path useCaseDir = baseDir.resolve(useCaseId.replace('.', '-'));
+        Files.createDirectories(useCaseDir);
+
+        return useCaseDir.resolve(filename);
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/explore/ExploreStrategy.java
+++ b/src/main/java/org/javai/punit/experiment/explore/ExploreStrategy.java
@@ -1,0 +1,292 @@
+package org.javai.punit.experiment.explore;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.javai.punit.api.DiffableContentProvider;
+import org.javai.punit.api.ExperimentMode;
+import org.javai.punit.api.ExploreExperiment;
+import org.javai.punit.api.FactorArguments;
+import org.javai.punit.api.FactorSource;
+import org.javai.punit.api.ResultCaptor;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.api.UseCaseProvider;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+import org.javai.punit.experiment.engine.ExperimentModeStrategy;
+import org.javai.punit.experiment.engine.ExperimentResultAggregator;
+import org.javai.punit.experiment.engine.ResultProjectionBuilder;
+import org.javai.punit.experiment.engine.shared.FactorInfo;
+import org.javai.punit.experiment.engine.shared.FactorResolver;
+import org.javai.punit.experiment.engine.shared.ResultRecorder;
+import org.javai.punit.experiment.model.ResultProjection;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Strategy for handling @ExploreExperiment.
+ *
+ * <p>EXPLORE mode compares multiple configurations to understand factor effects.
+ * It runs a small number of samples per configuration (default 1) and generates
+ * separate spec files for each configuration, enabling comparison via diff.
+ */
+public class ExploreStrategy implements ExperimentModeStrategy {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create("org.javai.punit.experiment");
+
+    @Override
+    public boolean supports(Method testMethod) {
+        return testMethod.isAnnotationPresent(ExploreExperiment.class);
+    }
+
+    @Override
+    public ExperimentConfig parseConfig(Method testMethod) {
+        ExploreExperiment annotation = testMethod.getAnnotation(ExploreExperiment.class);
+        if (annotation == null) {
+            throw new ExtensionConfigurationException(
+                    "Method must be annotated with @ExploreExperiment");
+        }
+
+        Class<?> useCaseClass = annotation.useCase();
+        String useCaseId = UseCaseProvider.resolveId(useCaseClass);
+
+        return new ExploreConfig(
+                useCaseClass,
+                useCaseId,
+                annotation.samplesPerConfig(),
+                annotation.timeBudgetMs(),
+                annotation.tokenBudget(),
+                annotation.experimentId(),
+                annotation.expiresInDays()
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Stream<TestTemplateInvocationContext> provideInvocationContexts(
+            ExperimentConfig config,
+            ExtensionContext context,
+            ExtensionContext.Store store) {
+
+        ExploreConfig exploreConfig = (ExploreConfig) config;
+        int samplesPerConfig = exploreConfig.effectiveSamplesPerConfig();
+        String useCaseId = exploreConfig.useCaseId();
+
+        Method testMethod = context.getRequiredTestMethod();
+        FactorSource factorSource = testMethod.getAnnotation(FactorSource.class);
+
+        if (factorSource == null) {
+            // Warn: EXPLORE without factors is equivalent to MEASURE
+            context.publishReportEntry("punit.warning",
+                    "EXPLORE without @FactorSource is equivalent to MEASURE. " +
+                            "Consider adding @FactorSource or using @MeasureExperiment.");
+
+            return provideSimpleInvocationContexts(exploreConfig, store);
+        }
+
+        // Resolve factor combinations
+        List<FactorArguments> argsList = FactorResolver.resolveFactorArguments(testMethod, factorSource);
+        List<FactorInfo> factorInfos = FactorResolver.extractFactorInfos(testMethod, factorSource, argsList);
+
+        // Store explore-mode metadata
+        store.put("mode", ExperimentMode.EXPLORE);
+        store.put("factorInfos", factorInfos);
+        store.put("configAggregators", new LinkedHashMap<String, ExperimentResultAggregator>());
+        store.put("terminated", new AtomicBoolean(false));
+
+        // Generate invocation contexts for all configs × samples
+        List<ExploreInvocationContext> invocations = new ArrayList<>();
+
+        for (int configIndex = 0; configIndex < argsList.size(); configIndex++) {
+            FactorArguments args = argsList.get(configIndex);
+            Object[] factorValues = args.get();
+
+            String configName = FactorResolver.buildConfigName(factorInfos, factorValues);
+
+            ExperimentResultAggregator configAggregator =
+                    new ExperimentResultAggregator(useCaseId + "/" + configName, samplesPerConfig);
+            ((Map<String, ExperimentResultAggregator>) store.get("configAggregators", Map.class))
+                    .put(configName, configAggregator);
+
+            for (int sample = 1; sample <= samplesPerConfig; sample++) {
+                invocations.add(new ExploreInvocationContext(
+                        sample, samplesPerConfig, configIndex + 1, argsList.size(),
+                        useCaseId, configName, factorValues, factorInfos, new ResultCaptor()
+                ));
+            }
+        }
+
+        return invocations.stream().map(c -> (TestTemplateInvocationContext) c);
+    }
+
+    private Stream<TestTemplateInvocationContext> provideSimpleInvocationContexts(
+            ExploreConfig config, ExtensionContext.Store store) {
+
+        int samplesPerConfig = config.effectiveSamplesPerConfig();
+        String useCaseId = config.useCaseId();
+
+        store.put("mode", ExperimentMode.EXPLORE);
+        ExperimentResultAggregator aggregator = new ExperimentResultAggregator(useCaseId, samplesPerConfig);
+        store.put("aggregator", aggregator);
+        store.put("terminated", new AtomicBoolean(false));
+
+        return Stream.iterate(1, i -> i + 1)
+                .limit(samplesPerConfig)
+                .map(i -> new org.javai.punit.experiment.measure.MeasureInvocationContext(
+                        i, samplesPerConfig, useCaseId, new ResultCaptor()));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void intercept(
+            InvocationInterceptor.Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext,
+            ExtensionContext.Store store) throws Throwable {
+
+        ExploreConfig config = (ExploreConfig) store.get("config", ExperimentConfig.class);
+        Map<String, ExperimentResultAggregator> configAggregators =
+                store.get("configAggregators", Map.class);
+        List<FactorInfo> factorInfos = store.get("factorInfos", List.class);
+
+        int samplesPerConfig = config.effectiveSamplesPerConfig();
+
+        // Get explore invocation context info from extension context store
+        ExtensionContext.Store invocationStore = extensionContext.getStore(NAMESPACE);
+        ResultCaptor captor = invocationStore.get("captor", ResultCaptor.class);
+        String configName = invocationStore.get("configName", String.class);
+        Integer sampleInConfig = invocationStore.get("sampleInConfig", Integer.class);
+        Object[] factorValues = invocationStore.get("factorValues", Object[].class);
+
+        // Handle simple mode (no factors)
+        if (configAggregators == null) {
+            ExperimentResultAggregator aggregator = store.get("aggregator", ExperimentResultAggregator.class);
+            try {
+                invocation.proceed();
+                ResultRecorder.recordResult(captor, aggregator);
+            } catch (Throwable e) {
+                aggregator.recordException(e);
+            }
+            return;
+        }
+
+        ExperimentResultAggregator aggregator = configAggregators.get(configName);
+        if (aggregator == null) {
+            throw new ExtensionConfigurationException(
+                    "No aggregator found for configuration: " + configName);
+        }
+
+        // Set factor values on the UseCaseProvider
+        Optional<UseCaseProvider> providerOpt = findUseCaseProvider(extensionContext);
+        providerOpt.ifPresent(provider -> {
+            if (factorValues != null && factorInfos != null) {
+                List<String> factorNames = factorInfos.stream()
+                        .map(FactorInfo::name)
+                        .toList();
+                provider.setCurrentFactorValues(factorValues, factorNames);
+            }
+        });
+
+        // Get use case class for projection settings
+        Class<?> useCaseClass = config.useCaseClass();
+        ResultProjectionBuilder projectionBuilder = createProjectionBuilder(useCaseClass, providerOpt.orElse(null));
+
+        try {
+            invocation.proceed();
+            ResultRecorder.recordResult(captor, aggregator);
+
+            // Build result projection
+            if (captor != null && captor.hasResult()) {
+                ResultProjection projection = projectionBuilder.build(
+                        sampleInConfig - 1,
+                        captor.getResult()
+                );
+                aggregator.addResultProjection(projection);
+            }
+        } catch (Throwable e) {
+            aggregator.recordException(e);
+
+            Long startTimeMs = store.get("startTimeMs", Long.class);
+            ResultProjection projection = projectionBuilder.buildError(
+                    sampleInConfig - 1,
+                    System.currentTimeMillis() - startTimeMs,
+                    e
+            );
+            aggregator.addResultProjection(projection);
+        }
+
+        // Report progress for this config
+        extensionContext.publishReportEntry("punit.mode", "EXPLORE");
+        extensionContext.publishReportEntry("punit.config", configName);
+        extensionContext.publishReportEntry("punit.sample", sampleInConfig + "/" + samplesPerConfig);
+        extensionContext.publishReportEntry("punit.successRate",
+                String.format("%.2f%%", aggregator.getObservedSuccessRate() * 100));
+
+        // Check if this is the last sample for this config
+        if (sampleInConfig >= samplesPerConfig) {
+            aggregator.setCompleted();
+            ExploreSpecGenerator generator = new ExploreSpecGenerator();
+            generator.generateSpec(extensionContext, store, configName, aggregator);
+        }
+    }
+
+    @Override
+    public int computeTotalSamples(ExperimentConfig config, Method testMethod) {
+        ExploreConfig exploreConfig = (ExploreConfig) config;
+        int samplesPerConfig = exploreConfig.effectiveSamplesPerConfig();
+
+        FactorSource factorSource = testMethod.getAnnotation(FactorSource.class);
+        if (factorSource == null) {
+            return samplesPerConfig;
+        }
+
+        List<FactorArguments> argsList = FactorResolver.resolveFactorArguments(testMethod, factorSource);
+        return samplesPerConfig * argsList.size();
+    }
+
+    private ResultProjectionBuilder createProjectionBuilder(Class<?> useCaseClass, UseCaseProvider provider) {
+        int maxDiffableLines = 5;
+        int maxLineLength = 60;
+        DiffableContentProvider customProvider = null;
+
+        if (useCaseClass != null && useCaseClass != Void.class) {
+            UseCase annotation = useCaseClass.getAnnotation(UseCase.class);
+            if (annotation != null) {
+                maxDiffableLines = annotation.maxDiffableLines();
+                maxLineLength = annotation.diffableContentMaxLineLength();
+            }
+
+            if (provider != null) {
+                Object instance = provider.getCurrentInstance(useCaseClass);
+                if (instance instanceof DiffableContentProvider dcp) {
+                    customProvider = dcp;
+                }
+            }
+        }
+
+        return new ResultProjectionBuilder(maxDiffableLines, maxLineLength, customProvider);
+    }
+
+    private Optional<UseCaseProvider> findUseCaseProvider(ExtensionContext context) {
+        Object testInstance = context.getRequiredTestInstance();
+        for (java.lang.reflect.Field field : testInstance.getClass().getDeclaredFields()) {
+            if (UseCaseProvider.class.isAssignableFrom(field.getType())) {
+                field.setAccessible(true);
+                try {
+                    return Optional.of((UseCaseProvider) field.get(testInstance));
+                } catch (IllegalAccessException e) {
+                    // Continue searching
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/measure/MeasureConfig.java
+++ b/src/main/java/org/javai/punit/experiment/measure/MeasureConfig.java
@@ -1,0 +1,43 @@
+package org.javai.punit.experiment.measure;
+
+import org.javai.punit.api.ExperimentMode;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+
+/**
+ * Configuration for @MeasureExperiment.
+ *
+ * <p>MEASURE mode establishes reliable statistics for a single configuration
+ * by running many samples (default 1000) and generating an empirical spec.
+ *
+ * @param useCaseClass the use case class to test
+ * @param useCaseId resolved use case identifier
+ * @param samples number of samples to execute
+ * @param timeBudgetMs time budget in milliseconds (0 = unlimited)
+ * @param tokenBudget token budget (0 = unlimited)
+ * @param experimentId experiment identifier for output naming
+ * @param expiresInDays baseline expiration in days (0 = no expiration tracking)
+ */
+public record MeasureConfig(
+        Class<?> useCaseClass,
+        String useCaseId,
+        int samples,
+        long timeBudgetMs,
+        long tokenBudget,
+        String experimentId,
+        int expiresInDays
+) implements ExperimentConfig {
+
+    @Override
+    public ExperimentMode mode() {
+        return ExperimentMode.MEASURE;
+    }
+
+    /**
+     * Returns the effective sample count, using the mode default if not specified.
+     *
+     * @return the effective sample count
+     */
+    public int effectiveSamples() {
+        return mode().getEffectiveSampleSize(samples);
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/measure/MeasureInvocationContext.java
+++ b/src/main/java/org/javai/punit/experiment/measure/MeasureInvocationContext.java
@@ -1,0 +1,31 @@
+package org.javai.punit.experiment.measure;
+
+import java.util.List;
+import org.javai.punit.api.ResultCaptor;
+import org.javai.punit.experiment.engine.shared.CaptorParameterResolver;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Invocation context for @MeasureExperiment without factors.
+ *
+ * <p>Represents a single sample execution in MEASURE mode when no @FactorSource
+ * is present. Each invocation receives a fresh {@link ResultCaptor}.
+ */
+public record MeasureInvocationContext(
+        int sampleNumber,
+        int totalSamples,
+        String useCaseId,
+        ResultCaptor captor
+) implements TestTemplateInvocationContext {
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return String.format("[%s] sample %d/%d", useCaseId, sampleNumber, totalSamples);
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return List.of(new CaptorParameterResolver(captor, null, sampleNumber));
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/measure/MeasureSpecGenerator.java
+++ b/src/main/java/org/javai/punit/experiment/measure/MeasureSpecGenerator.java
@@ -1,0 +1,174 @@
+package org.javai.punit.experiment.measure;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Optional;
+import org.javai.punit.api.UseCaseProvider;
+import org.javai.punit.engine.covariate.BaselineFileNamer;
+import org.javai.punit.engine.covariate.CovariateProfileResolver;
+import org.javai.punit.engine.covariate.DefaultCovariateResolutionContext;
+import org.javai.punit.engine.covariate.FootprintComputer;
+import org.javai.punit.engine.covariate.UseCaseCovariateExtractor;
+import org.javai.punit.experiment.engine.BaselineWriter;
+import org.javai.punit.experiment.engine.EmpiricalBaselineGenerator;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+import org.javai.punit.experiment.engine.ExperimentResultAggregator;
+import org.javai.punit.experiment.model.DefaultUseCaseContext;
+import org.javai.punit.experiment.model.EmpiricalBaseline;
+import org.javai.punit.model.CovariateDeclaration;
+import org.javai.punit.model.CovariateProfile;
+import org.javai.punit.api.UseCaseContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Generates empirical spec files for @MeasureExperiment.
+ *
+ * <p>Output: {@code src/test/resources/punit/specs/{UseCaseName}-{footprint}[-{covHashes}].yaml}
+ */
+public class MeasureSpecGenerator {
+
+    private static final String DEFAULT_SPECS_DIR = "src/test/resources/punit/specs";
+
+    /**
+     * Generates the spec file for a completed MEASURE experiment.
+     */
+    public void generateSpec(ExtensionContext context, ExtensionContext.Store store) {
+        ExperimentResultAggregator aggregator = store.get("aggregator", ExperimentResultAggregator.class);
+        MeasureConfig config = (MeasureConfig) store.get("config", ExperimentConfig.class);
+        Class<?> useCaseClass = config.useCaseClass();
+        String useCaseId = aggregator.getUseCaseId();
+
+        int expiresInDays = config.expiresInDays();
+
+        // Emit informational note if no expiration is set
+        if (expiresInDays == 0) {
+            context.publishReportEntry("punit.info.expiration",
+                    "Consider setting expiresInDays to track baseline freshness");
+        }
+
+        // Resolve covariates from use case class
+        String footprint = null;
+        CovariateProfile covariateProfile = null;
+
+        if (useCaseClass != null && useCaseClass != Void.class) {
+            UseCaseCovariateExtractor extractor = new UseCaseCovariateExtractor();
+            CovariateDeclaration declaration = extractor.extractDeclaration(useCaseClass);
+
+            if (!declaration.isEmpty()) {
+                Long startTimeMs = store.get("startTimeMs", Long.class);
+                Instant startTime = startTimeMs != null
+                        ? Instant.ofEpochMilli(startTimeMs)
+                        : Instant.now().minusSeconds(60);
+                Instant endTime = aggregator.getEndTime();
+
+                // Get use case instance for @CovariateSource resolution
+                Object useCaseInstance = null;
+                Optional<UseCaseProvider> providerOpt = findUseCaseProvider(context);
+                if (providerOpt.isPresent()) {
+                    useCaseInstance = providerOpt.get().getCurrentInstance(useCaseClass);
+                }
+
+                DefaultCovariateResolutionContext resolutionContext =
+                        DefaultCovariateResolutionContext.builder()
+                                .experimentTiming(startTime, endTime)
+                                .useCaseInstance(useCaseInstance)
+                                .build();
+
+                CovariateProfileResolver resolver = new CovariateProfileResolver();
+                covariateProfile = resolver.resolve(declaration, resolutionContext);
+
+                FootprintComputer footprintComputer = new FootprintComputer();
+                footprint = footprintComputer.computeFootprint(useCaseId, declaration);
+
+                context.publishReportEntry("punit.covariates.count",
+                        String.valueOf(covariateProfile.size()));
+            }
+        }
+
+        UseCaseContext useCaseContext = DefaultUseCaseContext.builder().build();
+
+        EmpiricalBaselineGenerator generator = new EmpiricalBaselineGenerator();
+        EmpiricalBaseline baseline = generator.generate(
+                aggregator,
+                context.getTestClass().orElse(null),
+                context.getTestMethod().orElse(null),
+                useCaseContext,
+                expiresInDays,
+                footprint,
+                covariateProfile
+        );
+
+        // Write spec to file
+        try {
+            Path outputPath = resolveOutputPath(useCaseId, footprint, covariateProfile);
+            BaselineWriter writer = new BaselineWriter();
+            writer.write(baseline, outputPath);
+
+            context.publishReportEntry("punit.spec.outputPath", outputPath.toString());
+        } catch (IOException e) {
+            context.publishReportEntry("punit.spec.error", e.getMessage());
+        }
+
+        // Publish final report
+        publishFinalReport(context, aggregator);
+    }
+
+    private Path resolveOutputPath(String useCaseId, String footprint, CovariateProfile covariateProfile)
+            throws IOException {
+
+        String filename;
+        if (footprint != null && !footprint.isEmpty()) {
+            BaselineFileNamer namer = new BaselineFileNamer();
+            CovariateProfile profile = covariateProfile != null ? covariateProfile : CovariateProfile.empty();
+            filename = namer.generateFilename(useCaseId, footprint, profile);
+        } else {
+            filename = useCaseId.replace('.', '-') + ".yaml";
+        }
+
+        String outputDirOverride = System.getProperty("punit.specs.outputDir");
+        Path baseDir;
+        if (outputDirOverride != null && !outputDirOverride.isEmpty()) {
+            baseDir = Paths.get(outputDirOverride);
+        } else {
+            baseDir = Paths.get(DEFAULT_SPECS_DIR);
+        }
+
+        Files.createDirectories(baseDir);
+        return baseDir.resolve(filename);
+    }
+
+    private void publishFinalReport(ExtensionContext context, ExperimentResultAggregator aggregator) {
+        context.publishReportEntry("punit.experiment.complete", "true");
+        context.publishReportEntry("punit.useCaseId", aggregator.getUseCaseId());
+        context.publishReportEntry("punit.samplesExecuted",
+                String.valueOf(aggregator.getSamplesExecuted()));
+        context.publishReportEntry("punit.successRate",
+                String.format("%.4f", aggregator.getObservedSuccessRate()));
+        context.publishReportEntry("punit.standardError",
+                String.format("%.4f", aggregator.getStandardError()));
+        context.publishReportEntry("punit.terminationReason",
+                aggregator.getTerminationReason());
+        context.publishReportEntry("punit.elapsedMs",
+                String.valueOf(aggregator.getElapsedMs()));
+        context.publishReportEntry("punit.totalTokens",
+                String.valueOf(aggregator.getTotalTokens()));
+    }
+
+    private Optional<UseCaseProvider> findUseCaseProvider(ExtensionContext context) {
+        Object testInstance = context.getRequiredTestInstance();
+        for (java.lang.reflect.Field field : testInstance.getClass().getDeclaredFields()) {
+            if (UseCaseProvider.class.isAssignableFrom(field.getType())) {
+                field.setAccessible(true);
+                try {
+                    return Optional.of((UseCaseProvider) field.get(testInstance));
+                } catch (IllegalAccessException e) {
+                    // Continue searching
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/measure/MeasureStrategy.java
+++ b/src/main/java/org/javai/punit/experiment/measure/MeasureStrategy.java
@@ -1,0 +1,227 @@
+package org.javai.punit.experiment.measure;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.javai.punit.api.ExperimentMode;
+import org.javai.punit.api.FactorArguments;
+import org.javai.punit.api.FactorSource;
+import org.javai.punit.api.MeasureExperiment;
+import org.javai.punit.api.ResultCaptor;
+import org.javai.punit.api.UseCaseProvider;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+import org.javai.punit.experiment.engine.ExperimentModeStrategy;
+import org.javai.punit.experiment.engine.ExperimentResultAggregator;
+import org.javai.punit.experiment.engine.shared.FactorInfo;
+import org.javai.punit.experiment.engine.shared.FactorResolver;
+import org.javai.punit.experiment.engine.shared.ResultRecorder;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Strategy for handling @MeasureExperiment.
+ *
+ * <p>MEASURE mode establishes reliable statistics for a single configuration
+ * by running many samples (default 1000) and generating an empirical spec.
+ */
+public class MeasureStrategy implements ExperimentModeStrategy {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create("org.javai.punit.experiment");
+
+    @Override
+    public boolean supports(Method testMethod) {
+        return testMethod.isAnnotationPresent(MeasureExperiment.class);
+    }
+
+    @Override
+    public ExperimentConfig parseConfig(Method testMethod) {
+        MeasureExperiment annotation = testMethod.getAnnotation(MeasureExperiment.class);
+        if (annotation == null) {
+            throw new ExtensionConfigurationException(
+                    "Method must be annotated with @MeasureExperiment");
+        }
+
+        Class<?> useCaseClass = annotation.useCase();
+        String useCaseId = UseCaseProvider.resolveId(useCaseClass);
+
+        return new MeasureConfig(
+                useCaseClass,
+                useCaseId,
+                annotation.samples(),
+                annotation.timeBudgetMs(),
+                annotation.tokenBudget(),
+                annotation.experimentId(),
+                annotation.expiresInDays()
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Stream<TestTemplateInvocationContext> provideInvocationContexts(
+            ExperimentConfig config,
+            ExtensionContext context,
+            ExtensionContext.Store store) {
+
+        MeasureConfig measureConfig = (MeasureConfig) config;
+        int samples = measureConfig.effectiveSamples();
+        String useCaseId = measureConfig.useCaseId();
+
+        // Create aggregator
+        ExperimentResultAggregator aggregator = new ExperimentResultAggregator(useCaseId, samples);
+        store.put("aggregator", aggregator);
+
+        AtomicBoolean terminated = new AtomicBoolean(false);
+        AtomicInteger currentSample = new AtomicInteger(0);
+        store.put("terminated", terminated);
+        store.put("currentSample", currentSample);
+        store.put("mode", ExperimentMode.MEASURE);
+
+        // Check for @FactorSource annotation
+        Method testMethod = context.getRequiredTestMethod();
+        FactorSource factorSource = testMethod.getAnnotation(FactorSource.class);
+
+        if (factorSource != null) {
+            return provideWithFactorsInvocationContexts(
+                    testMethod, factorSource, samples, useCaseId, store, terminated);
+        }
+
+        // No factor source - simple sample stream
+        return Stream.iterate(1, i -> i + 1)
+                .limit(samples)
+                .takeWhile(i -> !terminated.get())
+                .map(i -> new MeasureInvocationContext(i, samples, useCaseId, new ResultCaptor()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Stream<TestTemplateInvocationContext> provideWithFactorsInvocationContexts(
+            Method testMethod,
+            FactorSource factorSource,
+            int samples,
+            String useCaseId,
+            ExtensionContext.Store store,
+            AtomicBoolean terminated) {
+
+        // Resolve factor stream
+        List<FactorArguments> factorsList = FactorResolver.resolveFactorArguments(
+                testMethod, factorSource);
+
+        if (factorsList.isEmpty()) {
+            throw new ExtensionConfigurationException(
+                    "Factor source '" + factorSource.value() + "' returned no factors");
+        }
+
+        // Extract factor names from first FactorArguments
+        List<FactorInfo> factorInfos = FactorResolver.extractFactorInfosFromArguments(
+                testMethod, factorsList.get(0));
+        store.put("factorInfos", factorInfos);
+
+        // Generate sample stream with cycling factors
+        return Stream.iterate(1, i -> i + 1)
+                .limit(samples)
+                .takeWhile(i -> !terminated.get())
+                .map(i -> {
+                    int factorIndex = (i - 1) % factorsList.size();
+                    FactorArguments args = factorsList.get(factorIndex);
+                    Object[] factorValues = FactorResolver.extractFactorValues(args, factorInfos);
+                    return new MeasureWithFactorsInvocationContext(
+                            i, samples, useCaseId, new ResultCaptor(), factorValues, factorInfos);
+                });
+    }
+
+    @Override
+    public void intercept(
+            InvocationInterceptor.Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext,
+            ExtensionContext.Store store) throws Throwable {
+
+        MeasureConfig config = (MeasureConfig) store.get("config", ExperimentConfig.class);
+        ExperimentResultAggregator aggregator = store.get("aggregator", ExperimentResultAggregator.class);
+        AtomicBoolean terminated = store.get("terminated", AtomicBoolean.class);
+        AtomicInteger currentSample = store.get("currentSample", AtomicInteger.class);
+        Long startTimeMs = store.get("startTimeMs", Long.class);
+
+        int sample = currentSample.incrementAndGet();
+        int effectiveSamples = config.effectiveSamples();
+
+        // Check time budget
+        if (config.timeBudgetMs() > 0) {
+            long elapsed = System.currentTimeMillis() - startTimeMs;
+            if (elapsed >= config.timeBudgetMs()) {
+                terminated.set(true);
+                aggregator.setTerminated("TIME_BUDGET_EXHAUSTED",
+                        "Time budget of " + config.timeBudgetMs() + "ms exceeded");
+                invocation.skip();
+                generateSpecIfNeeded(extensionContext, store);
+                return;
+            }
+        }
+
+        // Check token budget
+        if (config.tokenBudget() > 0 && aggregator.getTotalTokens() >= config.tokenBudget()) {
+            terminated.set(true);
+            aggregator.setTerminated("TOKEN_BUDGET_EXHAUSTED",
+                    "Token budget of " + config.tokenBudget() + " exceeded");
+            invocation.skip();
+            generateSpecIfNeeded(extensionContext, store);
+            return;
+        }
+
+        // Get captor from invocation context store
+        ExtensionContext.Store invocationStore = extensionContext.getStore(NAMESPACE);
+        ResultCaptor captor = invocationStore.get("captor", ResultCaptor.class);
+
+        try {
+            invocation.proceed();
+            ResultRecorder.recordResult(captor, aggregator);
+        } catch (Throwable e) {
+            aggregator.recordException(e);
+        }
+
+        // Report progress
+        reportProgress(extensionContext, aggregator, sample, effectiveSamples);
+
+        // Check if this is the last sample
+        if (sample >= effectiveSamples || terminated.get()) {
+            if (!terminated.get()) {
+                aggregator.setCompleted();
+            }
+            generateSpecIfNeeded(extensionContext, store);
+        }
+    }
+
+    @Override
+    public int computeTotalSamples(ExperimentConfig config, Method testMethod) {
+        MeasureConfig measureConfig = (MeasureConfig) config;
+        return measureConfig.effectiveSamples();
+    }
+
+    private void reportProgress(ExtensionContext context, ExperimentResultAggregator aggregator,
+                                int currentSample, int totalSamples) {
+        context.publishReportEntry("punit.mode", "MEASURE");
+        context.publishReportEntry("punit.sample", currentSample + "/" + totalSamples);
+        context.publishReportEntry("punit.successRate",
+                String.format("%.2f%%", aggregator.getObservedSuccessRate() * 100));
+    }
+
+    private void generateSpecIfNeeded(ExtensionContext context, ExtensionContext.Store store) {
+        AtomicBoolean specGenerated = store.getOrComputeIfAbsent(
+                "specGenerated",
+                key -> new AtomicBoolean(false),
+                AtomicBoolean.class
+        );
+
+        if (specGenerated.compareAndSet(false, true)) {
+            MeasureSpecGenerator generator = new MeasureSpecGenerator();
+            generator.generateSpec(context, store);
+        }
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/measure/MeasureWithFactorsInvocationContext.java
+++ b/src/main/java/org/javai/punit/experiment/measure/MeasureWithFactorsInvocationContext.java
@@ -1,0 +1,41 @@
+package org.javai.punit.experiment.measure;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.javai.punit.api.ResultCaptor;
+import org.javai.punit.experiment.engine.shared.CaptorParameterResolver;
+import org.javai.punit.experiment.engine.shared.FactorInfo;
+import org.javai.punit.experiment.engine.shared.FactorParameterResolver;
+import org.javai.punit.experiment.engine.shared.FactorValuesResolver;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Invocation context for @MeasureExperiment with factor source (cycling).
+ *
+ * <p>Provides factor values that cycle through the factor source entries.
+ * With samples=1000 and 10 factor entries, each factor is used ~100 times.
+ */
+public record MeasureWithFactorsInvocationContext(
+        int sampleNumber,
+        int totalSamples,
+        String useCaseId,
+        ResultCaptor captor,
+        Object[] factorValues,
+        List<FactorInfo> factorInfos
+) implements TestTemplateInvocationContext {
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return String.format("[%s] sample %d/%d", useCaseId, sampleNumber, totalSamples);
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        List<Extension> extensions = new ArrayList<>();
+        extensions.add(new CaptorParameterResolver(captor, null, sampleNumber, factorValues));
+        extensions.add(new FactorParameterResolver(factorValues, factorInfos));
+        extensions.add(new FactorValuesResolver(factorValues, factorInfos));
+        return extensions;
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/optimize/OptimizeConfig.java
+++ b/src/main/java/org/javai/punit/experiment/optimize/OptimizeConfig.java
@@ -1,0 +1,58 @@
+package org.javai.punit.experiment.optimize;
+
+import org.javai.punit.api.ExperimentMode;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+
+/**
+ * Configuration for @OptimizeExperiment.
+ *
+ * <p>OPTIMIZE mode iteratively refines a single treatment factor to find its
+ * optimal value. It runs multiple samples per iteration, scores each iteration,
+ * and mutates the treatment factor until termination conditions are met.
+ *
+ * <p>This config holds the annotation-parsed values (class references).
+ * The {@link OptimizationConfig} class holds the runtime objects (instantiated
+ * scorer, mutator, etc.) for the {@link OptimizationOrchestrator}.
+ *
+ * @param useCaseClass the use case class to test
+ * @param useCaseId resolved use case identifier
+ * @param treatmentFactor name of the factor to optimize
+ * @param scorerClass scorer class for evaluating iterations
+ * @param mutatorClass mutator class for generating new factor values
+ * @param objective optimization objective (MAXIMIZE or MINIMIZE)
+ * @param samplesPerIteration samples to run per iteration
+ * @param maxIterations maximum iterations before termination
+ * @param noImprovementWindow iterations without improvement before termination
+ * @param timeBudgetMs time budget in milliseconds (0 = unlimited)
+ * @param tokenBudget token budget (0 = unlimited)
+ * @param experimentId experiment identifier for output naming
+ */
+public record OptimizeConfig(
+        Class<?> useCaseClass,
+        String useCaseId,
+        String treatmentFactor,
+        Class<? extends Scorer<OptimizationIterationAggregate>> scorerClass,
+        Class<? extends FactorMutator<?>> mutatorClass,
+        OptimizationObjective objective,
+        int samplesPerIteration,
+        int maxIterations,
+        int noImprovementWindow,
+        long timeBudgetMs,
+        long tokenBudget,
+        String experimentId
+) implements ExperimentConfig {
+
+    @Override
+    public ExperimentMode mode() {
+        return ExperimentMode.OPTIMIZE;
+    }
+
+    /**
+     * Computes the maximum possible samples across all iterations.
+     *
+     * @return samplesPerIteration × maxIterations
+     */
+    public int maxTotalSamples() {
+        return samplesPerIteration * maxIterations;
+    }
+}

--- a/src/main/java/org/javai/punit/experiment/optimize/OptimizeStrategy.java
+++ b/src/main/java/org/javai/punit/experiment/optimize/OptimizeStrategy.java
@@ -1,0 +1,99 @@
+package org.javai.punit.experiment.optimize;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.javai.punit.api.ExperimentMode;
+import org.javai.punit.api.OptimizeExperiment;
+import org.javai.punit.api.UseCaseProvider;
+import org.javai.punit.experiment.engine.ExperimentConfig;
+import org.javai.punit.experiment.engine.ExperimentModeStrategy;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+/**
+ * Strategy for handling @OptimizeExperiment.
+ *
+ * <p>OPTIMIZE mode iteratively refines a single treatment factor to find its
+ * optimal value. It runs multiple samples per iteration, scores each iteration,
+ * and mutates the treatment factor until termination conditions are met.
+ *
+ * <p>Note: Full implementation is in progress. This strategy currently throws
+ * UnsupportedOperationException for invocation context generation.
+ */
+public class OptimizeStrategy implements ExperimentModeStrategy {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create("org.javai.punit.experiment");
+
+    @Override
+    public boolean supports(Method testMethod) {
+        return testMethod.isAnnotationPresent(OptimizeExperiment.class);
+    }
+
+    @Override
+    public ExperimentConfig parseConfig(Method testMethod) {
+        OptimizeExperiment annotation = testMethod.getAnnotation(OptimizeExperiment.class);
+        if (annotation == null) {
+            throw new ExtensionConfigurationException(
+                    "Method must be annotated with @OptimizeExperiment");
+        }
+
+        Class<?> useCaseClass = annotation.useCase();
+        String useCaseId = UseCaseProvider.resolveId(useCaseClass);
+
+        return new OptimizeConfig(
+                useCaseClass,
+                useCaseId,
+                annotation.treatmentFactor(),
+                annotation.scorer(),
+                annotation.mutator(),
+                annotation.objective(),
+                annotation.samplesPerIteration(),
+                annotation.maxIterations(),
+                annotation.noImprovementWindow(),
+                annotation.timeBudgetMs(),
+                annotation.tokenBudget(),
+                annotation.experimentId()
+        );
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideInvocationContexts(
+            ExperimentConfig config,
+            ExtensionContext context,
+            ExtensionContext.Store store) {
+
+        OptimizeConfig optimizeConfig = (OptimizeConfig) config;
+
+        store.put("mode", ExperimentMode.OPTIMIZE);
+        store.put("terminated", new AtomicBoolean(false));
+
+        // TODO: Implement @OptimizeExperiment invocation context generation
+        // This will use a custom Spliterator for lazy iteration
+        throw new UnsupportedOperationException(
+                "@OptimizeExperiment is not yet fully implemented. " +
+                        "Use the OptimizationOrchestrator directly for now.");
+    }
+
+    @Override
+    public void intercept(
+            InvocationInterceptor.Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext,
+            ExtensionContext.Store store) throws Throwable {
+
+        // TODO: Implement @OptimizeExperiment interception
+        throw new UnsupportedOperationException(
+                "@OptimizeExperiment interception is not yet implemented.");
+    }
+
+    @Override
+    public int computeTotalSamples(ExperimentConfig config, Method testMethod) {
+        OptimizeConfig optimizeConfig = (OptimizeConfig) config;
+        return optimizeConfig.maxTotalSamples();
+    }
+}


### PR DESCRIPTION
## Summary

Major refactoring of `ExperimentExtension` to reduce complexity and improve maintainability:

- **Before**: 1,575 lines with intermingled mode-specific logic
- **After**: 174 lines - a thin coordinator that delegates to strategies

### Architecture Changes

- Introduced `ExperimentConfig` interface with mode-specific implementations (`MeasureConfig`, `ExploreConfig`, `OptimizeConfig`)
- Introduced `ExperimentModeStrategy` interface with three implementations
- Created symmetric package structure: `experiment.measure`, `experiment.explore`, `experiment.optimize`
- Extracted shared helpers to `experiment.engine.shared`

### New Files

| Package | Files |
|---------|-------|
| `experiment.engine` | `ExperimentConfig.java`, `ExperimentModeStrategy.java` |
| `experiment.engine.shared` | `FactorResolver`, `ResultRecorder`, parameter resolvers |
| `experiment.measure` | `MeasureConfig`, `MeasureStrategy`, `MeasureInvocationContext`, `MeasureSpecGenerator` |
| `experiment.explore` | `ExploreConfig`, `ExploreStrategy`, `ExploreInvocationContext`, `ExploreSpecGenerator` |
| `experiment.optimize` | `OptimizeConfig`, `OptimizeStrategy` |

## Test plan

- [x] Compilation passes
- [x] All experiment-related tests pass
- [x] Pacing integration tests pass
- [ ] Manual verification of MEASURE mode
- [ ] Manual verification of EXPLORE mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)