### PR TITLE
ProbabilisticTestSpec.Builder.intent(TestIntent) — restore declared intent

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
@@ -3,6 +3,7 @@ package org.javai.punit.api.typed.spec;
 import java.util.List;
 import java.util.Objects;
 
+import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.typed.FactorBundle;
 
 /**
@@ -17,21 +18,30 @@ import org.javai.punit.api.typed.FactorBundle;
  * {@link #verdict()} is {@link Verdict#compose(List) Verdict.compose}'d
  * from the REQUIRED subset.
  *
+ * <p>{@link #intent()} carries the test's declared intent through to
+ * reporting so that sentinel-grade smoke verdicts can be flagged with
+ * an explicit caveat ("not sized for verification") and so that the
+ * future feasibility-check machinery can decide whether a verification
+ * claim is statistically supportable for the chosen sample size.
+ *
  * @param verdict          the composed PASS / FAIL / INCONCLUSIVE
  * @param factors          the factor bundle observed
  * @param criterionResults the full ordered list of evaluated criteria
+ * @param intent           the test's declared intent (VERIFICATION / SMOKE)
  * @param warnings         free-form warnings (e.g. "statistics wiring pending")
  */
 public record ProbabilisticTestResult(
         Verdict verdict,
         FactorBundle factors,
         List<EvaluatedCriterion> criterionResults,
+        TestIntent intent,
         List<String> warnings) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
         Objects.requireNonNull(factors, "factors");
         Objects.requireNonNull(criterionResults, "criterionResults");
+        Objects.requireNonNull(intent, "intent");
         Objects.requireNonNull(warnings, "warnings");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpec.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Function;
 
+import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.Sampling;
 import org.javai.punit.api.typed.UseCase;
@@ -37,6 +38,7 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSp
     private final Sampling<FT, IT, OT> sampling;
     private final FT factors;
     private final List<Registered<OT>> registered;
+    private final TestIntent intent;
 
     private SampleSummary<OT> summary;
 
@@ -44,6 +46,7 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSp
         this.sampling = b.sampling;
         this.factors = b.factors;
         this.registered = List.copyOf(b.registered);
+        this.intent = b.intent;
     }
 
     /**
@@ -60,6 +63,16 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSp
     public Sampling<FT, IT, OT> sampling() { return sampling; }
     public FT factors() { return factors; }
     public int samples() { return sampling.samples(); }
+
+    /**
+     * The test's declared intent. {@link TestIntent#VERIFICATION} (default)
+     * claims evidential status — the framework will refuse to run a
+     * configuration too small to support a verification-grade verdict
+     * once feasibility checking lands. {@link TestIntent#SMOKE} is a
+     * sentinel-grade lightweight check; verdicts under SMOKE carry an
+     * explicit "not sized for verification" caveat.
+     */
+    public TestIntent intent() { return intent; }
 
     @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
         return sampling.useCaseFactory();
@@ -91,7 +104,7 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSp
         warnings.add("baseline resolver is a Stage-3.5 stub — empirical criteria "
                 + "yield INCONCLUSIVE until Stage 4 lands real resolution");
 
-        return new ProbabilisticTestResult(composed, factorBundle, evaluated, warnings);
+        return new ProbabilisticTestResult(composed, factorBundle, evaluated, intent, warnings);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -125,6 +138,7 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSp
         private final Sampling<FT, IT, OT> sampling;
         private final FT factors;
         private final List<Registered<OT>> registered = new ArrayList<>();
+        private TestIntent intent = TestIntent.VERIFICATION;
 
         private Builder(Sampling<FT, IT, OT> sampling, FT factors) {
             this.sampling = sampling;
@@ -142,6 +156,18 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSp
         public Builder<FT, IT, OT> reportOnly(Criterion<OT, ?> criterion) {
             Objects.requireNonNull(criterion, "criterion");
             registered.add(new Registered<>(criterion, CriterionRole.REPORT_ONLY));
+            return this;
+        }
+
+        /**
+         * Declares the test's intent. Defaults to
+         * {@link TestIntent#VERIFICATION}. Authors of sentinel-grade
+         * smoke checks against external providers (where the
+         * sample-size cost would be prohibitive for a verification
+         * claim) opt into {@link TestIntent#SMOKE} explicitly.
+         */
+        public Builder<FT, IT, OT> intent(TestIntent intent) {
+            this.intent = Objects.requireNonNull(intent, "intent");
             return this;
         }
 

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpecIntentTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpecIntentTest.java
@@ -1,0 +1,68 @@
+package org.javai.punit.api.typed.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ProbabilisticTestSpec intent")
+class ProbabilisticTestSpecIntentTest {
+
+    record Factors(String label) {}
+
+    private static final UseCase<Factors, String, String> ECHO = new UseCase<>() {
+        @Override public UseCaseOutcome<String> apply(String input) { return UseCaseOutcome.ok(input); }
+    };
+
+    private static Sampling<Factors, String, String> sampling() {
+        return Sampling.<Factors, String, String>builder()
+                .useCaseFactory(f -> ECHO)
+                .inputs("a")
+                .samples(10)
+                .build();
+    }
+
+    @Test
+    @DisplayName("default intent is VERIFICATION")
+    void defaultIntentIsVerification() {
+        ProbabilisticTestSpec<Factors, String, String> spec = ProbabilisticTestSpec
+                .testing(sampling(), new Factors("m"))
+                .build();
+
+        assertThat(spec.intent()).isEqualTo(TestIntent.VERIFICATION);
+    }
+
+    @Test
+    @DisplayName(".intent(SMOKE) overrides the default")
+    void intentSmokeOverridesDefault() {
+        ProbabilisticTestSpec<Factors, String, String> spec = ProbabilisticTestSpec
+                .testing(sampling(), new Factors("m"))
+                .intent(TestIntent.SMOKE)
+                .build();
+
+        assertThat(spec.intent()).isEqualTo(TestIntent.SMOKE);
+    }
+
+    @Test
+    @DisplayName(".intent(VERIFICATION) is permitted (idempotent with default)")
+    void intentVerificationIsPermitted() {
+        ProbabilisticTestSpec<Factors, String, String> spec = ProbabilisticTestSpec
+                .testing(sampling(), new Factors("m"))
+                .intent(TestIntent.VERIFICATION)
+                .build();
+
+        assertThat(spec.intent()).isEqualTo(TestIntent.VERIFICATION);
+    }
+
+    @Test
+    @DisplayName(".intent(null) is rejected")
+    void intentNullIsRejected() {
+        var builder = ProbabilisticTestSpec.testing(sampling(), new Factors("m"));
+        assertThatNullPointerException().isThrownBy(() -> builder.intent(null));
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.typed.Sampling;
 import org.javai.punit.api.typed.UseCase;
@@ -327,6 +328,32 @@ class EngineIntegrationTest {
 
         new Engine().run(spec);
         assertThat(spec.history()).hasSize(5);
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTestSpec threads its declared intent through to the result")
+    void intentThreadsThroughToResult() {
+        Sampling<LlmFactors, Integer, Boolean> sampling = Sampling
+                .<LlmFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> new AlwaysPassesUseCase())
+                .inputs(1, 2, 3)
+                .samples(10)
+                .build();
+        ProbabilisticTestSpec<LlmFactors, Integer, Boolean> verification = ProbabilisticTestSpec
+                .testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+        ProbabilisticTestSpec<LlmFactors, Integer, Boolean> smoke = ProbabilisticTestSpec
+                .testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
+                .intent(TestIntent.SMOKE)
+                .build();
+
+        var verResult = (ProbabilisticTestResult) new Engine().run(verification);
+        var smkResult = (ProbabilisticTestResult) new Engine().run(smoke);
+
+        assertThat(verResult.intent()).isEqualTo(TestIntent.VERIFICATION);
+        assertThat(smkResult.intent()).isEqualTo(TestIntent.SMOKE);
     }
 
     private List<String> runAndRecord() {


### PR DESCRIPTION
## Summary

Restores the per-spec intent declaration that the Stage 3.5 reshape silently retired alongside the rest of `ProbabilisticTestSpec`'s pre-compositional fluent surface (`.threshold`, `.confidence`, `.minDetectableEffect`, `.power`, `.latency`, `.assertOn`). Those retirements were correct — the concerns moved to criteria or to criterion roles — but `.intent(...)` had nowhere else to go: intent is a property of the test's *claim*, not of any single criterion (a test with five criteria still has one intent), and not of the sampling (intent is about how the result should be interpreted, not how samples are produced).

The omission left the new API unable to express `TestIntent.SMOKE`, which is not metadata — it changes framework behaviour:

- `VERIFICATION` (default) fails fast as `MISCONFIGURED` on undersized N (Stage 5 wires this).
- `SMOKE` permits undersized configurations and emits explicit *"not sized for verification"* caveats.

Without a way to declare smoke, authors of sentinel-grade checks against expensive external providers (payment gateways, third-party LLMs) had no path that didn't claim verification status they couldn't statistically support.

## Changes

- `ProbabilisticTestSpec.Builder.intent(TestIntent)` — new builder method, default `VERIFICATION`, smoke is opt-in.
- `ProbabilisticTestSpec.intent()` — accessor on the spec.
- `ProbabilisticTestResult.intent` — fifth component; threads through so reporters and the future feasibility-check machinery can read the test's declared intent.

## Author surface

```java
@ProbabilisticTest
ProbabilisticTestSpec<…> paymentMeetsSla() {
    return ProbabilisticTestSpec.testing(sampling(100), factors)
            .criterion(BernoulliPassRate.meeting(0.99, ThresholdOrigin.SLA))
            .intent(TestIntent.SMOKE)               // sentinel against external provider
            .build();
}
```

## Test plan

- [x] `./gradlew test` green
- [x] `ProbabilisticTestSpecIntentTest` covers default, override, null rejection
- [x] `EngineIntegrationTest.intentThreadsThroughToResult` confirms intent appears in `ProbabilisticTestResult`

## Out of scope

- The feasibility check that consumes intent (refuse to run a verification-grade test with an undersized N) lives on the Stage 5 path along with the rest of the JUnit extension wiring.
- The reporter caveat ("sample not sized for verification") emitted under SMOKE is a Stage 7 / RP07 concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)