### PR TITLE
Rename DataGenerationSpec to Spec

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Configuration.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Configuration.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * One run-unit as surfaced by {@link DataGenerationSpec#configurations()}: the factor
+ * One run-unit as surfaced by {@link Spec#configurations()}: the factor
  * values to instantiate the use case with, the inputs to cycle through,
  * optionally a parallel list of expected values (instance-conformance
  * checking), and how many samples to execute.

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/EngineResult.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/EngineResult.java
@@ -1,7 +1,7 @@
 package org.javai.punit.api.typed.spec;
 
 /**
- * The value produced by {@link DataGenerationSpec#conclude()}. Sealed with two
+ * The value produced by {@link Spec#conclude()}. Sealed with two
  * variants: a probabilistic test concludes with a
  * {@link ProbabilisticTestResult}; an experiment concludes with an
  * {@link ExperimentResult}.

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ExploreSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ExploreSpec.java
@@ -28,7 +28,7 @@ import org.javai.punit.api.typed.UseCase;
  * spec itself carries only the varied factor list and the experiment
  * id.
  */
-public final class ExploreSpec<FT, IT, OT> implements DataGenerationSpec<FT, IT, OT> {
+public final class ExploreSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
 
     private final Sampling<FT, IT, OT> shape;
     private final List<FT> factors;

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/MeasureSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/MeasureSpec.java
@@ -34,7 +34,7 @@ import org.javai.punit.api.typed.ValueMatcher;
  * {@link ExperimentResult} with a placeholder message and the path
  * where the baseline <em>would</em> be written.
  */
-public final class MeasureSpec<FT, IT, OT> implements DataGenerationSpec<FT, IT, OT> {
+public final class MeasureSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
 
     private final Sampling<FT, IT, OT> sampling;
     private final FT factors;
@@ -92,7 +92,7 @@ public final class MeasureSpec<FT, IT, OT> implements DataGenerationSpec<FT, IT,
         return experimentId;
     }
 
-    // ── DataGenerationSpec — run-loop delegates to the sampling ─────
+    // ── Spec — run-loop delegates to the sampling ─────
 
     @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
         return sampling.useCaseFactory();

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
@@ -36,7 +36,7 @@ import org.javai.punit.api.typed.spec.FactorMutator.IterationResult;
  * exception policy) live on the {@link Sampling}; the optimize
  * spec carries only the search-specific knobs.
  */
-public final class OptimizeSpec<FT, IT, OT> implements DataGenerationSpec<FT, IT, OT> {
+public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
 
     private final Sampling<FT, IT, OT> shape;
     private final FT initialFactors;

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpec.java
@@ -33,7 +33,7 @@ import org.javai.punit.api.typed.UseCase;
  * yield {@link Verdict#INCONCLUSIVE} with a diagnostic. The real
  * resolver and Wilson-score-aware comparisons land in Stage 4.
  */
-public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSpec<FT, IT, OT> {
+public final class ProbabilisticTestSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
 
     private final Sampling<FT, IT, OT> sampling;
     private final FT factors;
@@ -122,7 +122,7 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements DataGenerationSp
         return (CriterionResult) raw.evaluate(ctx);
     }
 
-    // ── DataGenerationSpec pass-throughs to the sampling ────────────
+    // ── Spec pass-throughs to the sampling ────────────
 
     @Override public Optional<Duration> timeBudget() { return sampling.timeBudget(); }
     @Override public OptionalLong tokenBudget() { return sampling.tokenBudget(); }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ResourceControls.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ResourceControls.java
@@ -16,7 +16,7 @@ import java.util.OptionalLong;
  * duplicate the field declarations and validation across four spec
  * builders, each spec keeps a single {@code ResourceControls}
  * instance and delegates the corresponding
- * {@link DataGenerationSpec} interface accessors to its fields.
+ * {@link Spec} interface accessors to its fields.
  *
  * <p>Evaluation-time thresholds (latency percentiles, functional
  * pass-rate) are <em>not</em> resource controls — they judge the

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleSummary.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleSummary.java
@@ -9,7 +9,7 @@ import org.javai.punit.api.typed.UseCaseOutcome;
 
 /**
  * Per-configuration aggregate of observed samples. Produced by the
- * engine, consumed by the spec via {@link DataGenerationSpec#consume(Configuration, SampleSummary)}.
+ * engine, consumed by the spec via {@link Spec#consume(Configuration, SampleSummary)}.
  *
  * <p>{@link #outcomes()} holds the (optionally capped) list of
  * per-sample outcomes; the success / failure counts and token totals

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Spec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Spec.java
@@ -38,7 +38,7 @@ import org.javai.punit.api.typed.ValueMatcher;
  * @param <IT> the per-sample input type
  * @param <OT> the per-sample outcome value type
  */
-public sealed interface DataGenerationSpec<FT, IT, OT>
+public sealed interface Spec<FT, IT, OT>
         permits MeasureSpec, ExploreSpec, OptimizeSpec, ProbabilisticTestSpec {
 
     Iterator<Configuration<FT, IT, OT>> configurations();

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/TerminationReason.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/TerminationReason.java
@@ -4,7 +4,7 @@ package org.javai.punit.api.typed.spec;
  * Why a configuration's sample loop stopped.
  *
  * <p>Attached to {@link SampleSummary} so the spec's
- * {@link DataGenerationSpec#consume(Configuration, SampleSummary)} callback and the
+ * {@link Spec#consume(Configuration, SampleSummary)} callback and the
  * downstream reporters can distinguish a naturally-completed run from
  * one that exhausted a budget early.
  */

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Verdict.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Verdict.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 /**
  * Three-state statistical verdict returned by a
- * {@link ProbabilisticTestSpec}'s {@link DataGenerationSpec#conclude() conclude()}
+ * {@link ProbabilisticTestSpec}'s {@link Spec#conclude() conclude()}
  * call.
  *
  * <p>Kept distinct from the legacy

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/package-info.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/package-info.java
@@ -6,18 +6,18 @@
  * {@link org.javai.punit.api.typed.spec.ExploreSpec},
  * {@link org.javai.punit.api.typed.spec.OptimizeSpec},
  * {@link org.javai.punit.api.typed.spec.ProbabilisticTestSpec}) implements
- * {@link org.javai.punit.api.typed.spec.DataGenerationSpec}. The engine iterates
- * {@link org.javai.punit.api.typed.spec.DataGenerationSpec#configurations()},
+ * {@link org.javai.punit.api.typed.spec.Spec}. The engine iterates
+ * {@link org.javai.punit.api.typed.spec.Spec#configurations()},
  * samples each configuration through a
  * {@link org.javai.punit.api.typed.spec.SampleExecutor}, hands the
  * resulting {@link org.javai.punit.api.typed.spec.SampleSummary} back to
- * {@link org.javai.punit.api.typed.spec.DataGenerationSpec#consume(Configuration, SampleSummary)
+ * {@link org.javai.punit.api.typed.spec.Spec#consume(Configuration, SampleSummary)
  * spec.consume(...)}, and finishes by invoking
- * {@link org.javai.punit.api.typed.spec.DataGenerationSpec#conclude() spec.conclude()}
+ * {@link org.javai.punit.api.typed.spec.Spec#conclude() spec.conclude()}
  * — which yields a {@link org.javai.punit.api.typed.spec.EngineResult}.
  *
  * <p>The engine never inspects the concrete spec subtype. All
  * flavour-specific behaviour reaches the engine through the strategy
- * methods on {@code DataGenerationSpec}.
+ * methods on {@code Spec}.
  */
 package org.javai.punit.api.typed.spec;

--- a/punit-core/src/main/java/org/javai/punit/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/Engine.java
@@ -19,17 +19,17 @@ import org.javai.punit.api.typed.spec.SampleExecutor;
 import org.javai.punit.api.typed.spec.SampleObserver;
 import org.javai.punit.api.typed.spec.SampleSummary;
 import org.javai.punit.api.typed.spec.Trial;
-import org.javai.punit.api.typed.spec.DataGenerationSpec;
+import org.javai.punit.api.typed.spec.Spec;
 
 /**
  * The one engine, shared by every spec flavour.
  *
  * <p>The engine iterates
- * {@link DataGenerationSpec#configurations() spec.configurations()}, samples each
+ * {@link Spec#configurations() spec.configurations()}, samples each
  * configuration through a {@link SampleExecutor}, hands the resulting
  * {@link SampleSummary} to
- * {@link DataGenerationSpec#consume(Configuration, SampleSummary) spec.consume(...)},
- * and finally invokes {@link DataGenerationSpec#conclude() spec.conclude()} to
+ * {@link Spec#consume(Configuration, SampleSummary) spec.consume(...)},
+ * and finally invokes {@link Spec#conclude() spec.conclude()} to
  * obtain the run's {@link EngineResult}.
  *
  * <p>Resource controls declared on the spec (time budget, token
@@ -54,7 +54,7 @@ public final class Engine {
         this.executor = Objects.requireNonNull(executor, "executor");
     }
 
-    public <FT, IT, OT> EngineResult run(DataGenerationSpec<FT, IT, OT> spec) {
+    public <FT, IT, OT> EngineResult run(Spec<FT, IT, OT> spec) {
         Objects.requireNonNull(spec, "spec");
         Iterator<Configuration<FT, IT, OT>> it = spec.configurations();
         int cycleStart = 0;
@@ -69,7 +69,7 @@ public final class Engine {
     }
 
     private <FT, IT, OT> SampleSummary<OT> runConfig(
-            DataGenerationSpec<FT, IT, OT> spec,
+            Spec<FT, IT, OT> spec,
             UseCase<FT, IT, OT> useCase,
             Configuration<FT, IT, OT> cfg,
             int cycleStart) {

--- a/punit-core/src/main/java/org/javai/punit/engine/package-info.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/package-info.java
@@ -3,7 +3,7 @@
  *
  * <p>One {@link org.javai.punit.engine.Engine} drives every spec
  * flavour through the strategy methods declared on
- * {@link org.javai.punit.api.typed.spec.DataGenerationSpec}. Samples are invoked
+ * {@link org.javai.punit.api.typed.spec.Spec}. Samples are invoked
  * through a
  * {@link org.javai.punit.api.typed.spec.SampleExecutor} — today the
  * shipped implementation is

--- a/punit-core/src/test/java/org/javai/punit/architecture/TypedEngineArchitectureTest.java
+++ b/punit-core/src/test/java/org/javai/punit/architecture/TypedEngineArchitectureTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
  * <p>The core guarantee this stage locks in: the engine does not
  * branch on spec subtype. It reaches flavour-specific behaviour only
  * through the strategy methods on
- * {@code org.javai.punit.api.typed.spec.DataGenerationSpec}.
+ * {@code org.javai.punit.api.typed.spec.Spec}.
  */
 @DisplayName("typed engine architecture rules")
 class TypedEngineArchitectureTest {
@@ -32,7 +32,7 @@ class TypedEngineArchitectureTest {
     }
 
     @Test
-    @DisplayName("engine must not import concrete DataGenerationSpec subtypes")
+    @DisplayName("engine must not import concrete Spec subtypes")
     void engineMustNotImportConcreteSpecs() {
         ArchRule rule = noClasses()
                 .that().resideInAPackage("org.javai.punit.engine..")
@@ -48,7 +48,7 @@ class TypedEngineArchitectureTest {
                 .orShould().dependOnClassesThat()
                 .haveFullyQualifiedName(
                         "org.javai.punit.api.typed.spec.ProbabilisticTestSpec")
-                .because("engine must dispatch through the DataGenerationSpec strategy interface, "
+                .because("engine must dispatch through the Spec strategy interface, "
                         + "never instanceof / switch on subtype");
         rule.check(engineClasses);
     }


### PR DESCRIPTION
## Summary

The `DataGeneration` prefix on the strategy interface referred to a value type that retired in PR #56 when the factor-binding step collapsed into spec entry-point arguments. With that referent gone, `DataGenerationSpec` reads as *"spec for the data-generation activity"* — supportable but not earned. A newcomer who searches for `DataGeneration` finds nothing and has to infer the historical reading.

`Spec` is the simpler name. Each implementing class is `*Spec` (`MeasureSpec`, `ExploreSpec`, `OptimizeSpec`, `ProbabilisticTestSpec`); the parent interface being `Spec` makes the inheritance read straight — *"MeasureSpec is a Spec"* — instead of the non-sequitur *"MeasureSpec is a DataGenerationSpec."*

## Changes

```java
public sealed interface Spec<FT, IT, OT>
        permits MeasureSpec, ExploreSpec, OptimizeSpec, ProbabilisticTestSpec { ... }

public final class Engine {
    public <FT, IT, OT> EngineResult run(Spec<FT, IT, OT> spec) { ... }
}
```

15 files touched: the interface itself, the four implementing classes' `implements` clauses, the engine signature, ArchUnit rules, package-info, and javadoc cross-references. Pure rename, mechanical.

## Considered alternatives

- `EngineSpec` — honest about the dispatch role but adds an engine-internal flavour to a type that lives on `punit-api` precisely so authors don't see engine vocabulary.
- `SamplingSpec` — collides conceptually with the `Sampling` value type renamed in PR #56.
- Keep `DataGenerationSpec` — the activity-oriented re-reading lands cleanly enough, but the cost of accepting a name whose intended referent no longer exists is paid by every newcomer who searches for `DataGeneration` and finds nothing.

## Trade-off accepted

The fully-qualified name is `org.javai.punit.api.typed.spec.Spec` — the simple name echoes the package's last segment. Authors rarely import the parent type directly (they import the concrete spec types), and Java handles the overlap without ambiguity.

## Test plan

- [x] `./gradlew test` green
- [x] Zero residual `DataGenerationSpec` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)