### PR TITLE
OptimizeSpec: collapse .scoredBy(s).toward(MAXIMIZE) to .maximize(s) / .minimize(s)

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Objective.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Objective.java
@@ -1,4 +1,0 @@
-package org.javai.punit.api.typed.spec;
-
-/** Optimisation direction: are we looking for a bigger score or a smaller one? */
-public enum Objective { MAXIMIZE, MINIMIZE }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
@@ -35,6 +35,12 @@ import org.javai.punit.api.typed.spec.FactorMutator.IterationResult;
  * production knobs (use case factory, inputs, sample count, budgets,
  * exception policy) live on the {@link Sampling}; the optimize
  * spec carries only the search-specific knobs.
+ *
+ * <p>The optimisation direction is expressed by which builder method
+ * the author calls — {@link Builder#maximize(Scorer)} or
+ * {@link Builder#minimize(Scorer)} — rather than by a separate
+ * direction enum. The two methods are mutually exclusive at the API
+ * level: one of them must be called and the last one wins.
  */
 public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
 
@@ -42,7 +48,7 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
     private final FT initialFactors;
     private final FactorMutator<FT> mutator;
     private final Scorer scorer;
-    private final Objective objective;
+    private final boolean maximizing;
     private final int maxIterations;
     private final int noImprovementWindow;
     private final String experimentId;
@@ -54,7 +60,7 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
         this.initialFactors = b.initialFactors;
         this.mutator = b.mutator;
         this.scorer = b.scorer;
-        this.objective = b.objective;
+        this.maximizing = b.maximizing;
         this.maxIterations = b.maxIterations;
         this.noImprovementWindow = b.noImprovementWindow;
         this.experimentId = b.experimentId != null
@@ -72,6 +78,9 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
     public int maxIterations() { return maxIterations; }
     public int noImprovementWindow() { return noImprovementWindow; }
     public String experimentId() { return experimentId; }
+
+    /** {@code true} if the spec is maximising the score, {@code false} if minimising. */
+    public boolean isMaximizing() { return maximizing; }
 
     /** Convenience delegate to {@code shape().samples()}. */
     public int samplesPerIteration() { return shape.samples(); }
@@ -120,7 +129,7 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
     }
 
     private boolean isBetter(double a, double b) {
-        return objective == Objective.MAXIMIZE ? a > b : a < b;
+        return maximizing ? a > b : a < b;
     }
 
     private final class AdaptiveIterator implements Iterator<Configuration<FT, IT, OT>> {
@@ -179,7 +188,8 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
         private FT initialFactors;
         private FactorMutator<FT> mutator;
         private Scorer scorer;
-        private Objective objective = Objective.MAXIMIZE;
+        private boolean maximizing;
+        private boolean directionSet;
         private int maxIterations = 20;
         private int noImprovementWindow = 5;
         private String experimentId;
@@ -198,15 +208,29 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
             return this;
         }
 
-        /** The reducer that collapses an iteration's sample summary to a comparable score. */
-        public Builder<FT, IT, OT> scoredBy(Scorer s) {
-            this.scorer = Objects.requireNonNull(s, "scorer");
+        /**
+         * Sets the scorer and declares the optimisation direction as
+         * "maximise the score." Mutually exclusive with
+         * {@link #minimize(Scorer)} — the last one called wins. One
+         * of {@code maximize} / {@code minimize} is required.
+         */
+        public Builder<FT, IT, OT> maximize(Scorer scorer) {
+            this.scorer = Objects.requireNonNull(scorer, "scorer");
+            this.maximizing = true;
+            this.directionSet = true;
             return this;
         }
 
-        /** The optimisation direction. */
-        public Builder<FT, IT, OT> toward(Objective o) {
-            this.objective = Objects.requireNonNull(o, "objective");
+        /**
+         * Sets the scorer and declares the optimisation direction as
+         * "minimise the score." Mutually exclusive with
+         * {@link #maximize(Scorer)} — the last one called wins. One
+         * of {@code maximize} / {@code minimize} is required.
+         */
+        public Builder<FT, IT, OT> minimize(Scorer scorer) {
+            this.scorer = Objects.requireNonNull(scorer, "scorer");
+            this.maximizing = false;
+            this.directionSet = true;
             return this;
         }
 
@@ -238,8 +262,9 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
             if (mutator == null) {
                 throw new IllegalStateException("mutator is required");
             }
-            if (scorer == null) {
-                throw new IllegalStateException("scorer is required — call .scoredBy(...)");
+            if (!directionSet) {
+                throw new IllegalStateException(
+                        "scorer is required — call .maximize(...) or .minimize(...)");
             }
             return new OptimizeSpec<>(this);
         }

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -16,7 +16,6 @@ import org.javai.punit.api.typed.spec.EngineResult;
 import org.javai.punit.api.typed.spec.ExperimentResult;
 import org.javai.punit.api.typed.spec.ExploreSpec;
 import org.javai.punit.api.typed.spec.FactorMutator;
-import org.javai.punit.api.typed.spec.Objective;
 import org.javai.punit.api.typed.spec.OptimizeSpec;
 import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
 import org.javai.punit.api.typed.spec.MeasureSpec;
@@ -320,8 +319,7 @@ class EngineIntegrationTest {
         OptimizeSpec<LlmFactors, String, Integer> spec = OptimizeSpec.optimizing(shape)
                 .initialFactors(new LlmFactors("gpt-4o", 0.0))
                 .mutator(mutator)
-                .scoredBy(s -> 1.0 / (1.0 + s.failures()))
-                .toward(Objective.MAXIMIZE)
+                .maximize(s -> 1.0 / (1.0 + s.failures()))
                 .maxIterations(5)
                 .noImprovementWindow(10)
                 .build();


### PR DESCRIPTION
## Summary

Collapses the two-call optimization-direction declaration into a single fluent call.

Before:
```java
.scoredBy(s -> ...)
.toward(Objective.MAXIMIZE)
```

After:
```java
.maximize(s -> ...)
// or
.minimize(s -> ...)
```

The `Objective` enum is retired entirely — direction now lives in which builder method the author calls. The two methods are mutually exclusive at the API level (last one called wins; one of them is required).

## Rationale

Caught during the migration-preview DX critique against punitexamples. The `.scoredBy(...)` + `.toward(...)` pair was redundant ceremony — the scorer always carries direction semantically, and forcing the author to declare it on a separate call buys nothing. Collapsing it removes one builder line per optimization spec and one enum from the public surface.

This is the first of a sequence of small DX surgeries identified in the migration preview's open observations list (see \`docs/MIGRATION-PREVIEW-PUNITEXAMPLES.md\`).

## Changes

- \`OptimizeSpec.Builder\`: replace \`.scoredBy(Scorer).toward(Objective)\` with \`.maximize(Scorer)\` / \`.minimize(Scorer)\`.
- \`Objective.java\`: deleted.
- \`EngineIntegrationTest\`: update call sites.

## Test plan

- [x] \`./gradlew build\` passes
- [x] All existing OptimizeSpec tests pass against the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)