### PR TITLE
Drop type parameters from all four spec kinds

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BernoulliPassRate.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BernoulliPassRate.java
@@ -40,14 +40,14 @@ public final class BernoulliPassRate<OT> implements Criterion<OT, PassRateStatis
     private final double threshold;
     private final ThresholdOrigin origin;
     private final double confidence;
-    private final Supplier<MeasureSpec<?, ?, ?>> baselineSupplier;
+    private final Supplier<MeasureSpec> baselineSupplier;
 
     private BernoulliPassRate(
             Mode mode,
             double threshold,
             ThresholdOrigin origin,
             double confidence,
-            Supplier<MeasureSpec<?, ?, ?>> baselineSupplier) {
+            Supplier<MeasureSpec> baselineSupplier) {
         this.mode = mode;
         this.threshold = threshold;
         this.origin = origin;
@@ -77,7 +77,7 @@ public final class BernoulliPassRate<OT> implements Criterion<OT, PassRateStatis
     }
 
     public static <OT> BernoulliPassRate<OT> empiricalFrom(
-            Supplier<MeasureSpec<?, ?, ?>> baseline) {
+            Supplier<MeasureSpec> baseline) {
         Objects.requireNonNull(baseline, "baseline");
         return new BernoulliPassRate<>(
                 Mode.EMPIRICAL_PINNED, Double.NaN, ThresholdOrigin.EMPIRICAL,
@@ -104,7 +104,7 @@ public final class BernoulliPassRate<OT> implements Criterion<OT, PassRateStatis
      * framework consults this at spec-conclude time to route a
      * pinned baseline into the evaluation context.
      */
-    public Optional<Supplier<MeasureSpec<?, ?, ?>>> baselineSupplier() {
+    public Optional<Supplier<MeasureSpec>> baselineSupplier() {
         return Optional.ofNullable(baselineSupplier);
     }
 

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ExploreSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ExploreSpec.java
@@ -28,7 +28,13 @@ import org.javai.punit.api.typed.UseCase;
  * spec itself carries only the varied factor list and the experiment
  * id.
  */
-public final class ExploreSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
+public final class ExploreSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT> {
+
+    @Override
+    public <R> R dispatch(Dispatcher<R> dispatcher) {
+        return dispatcher.apply(this);
+    }
+
 
     private final Sampling<FT, IT, OT> shape;
     private final List<FT> factors;

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ExploreSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ExploreSpec.java
@@ -18,79 +18,93 @@ import org.javai.punit.api.typed.Sampling;
 import org.javai.punit.api.typed.UseCase;
 
 /**
- * A grid-of-configurations experiment: runs {@code shape.samples()}
- * samples against each factor bundle in {@link #factors()} and records
+ * A grid-of-configurations experiment: runs {@code sampling.samples()}
+ * samples against each factor bundle in the explored grid and records
  * the per-config outcome.
  *
  * <p>Constructed via {@link #exploring(Sampling)}. All sample-
- * production knobs (use case factory, inputs, sample count, budgets,
- * exception policy) live on the {@link Sampling}; the explore
- * spec itself carries only the varied factor list and the experiment
- * id.
+ * production knobs live on the {@link Sampling}; the explore spec
+ * itself carries only the varied factor list and the experiment id.
+ *
+ * <p>The public class carries no type parameters — composition-time
+ * type safety lives on the typed {@link Builder}, and the engine
+ * recovers the typed view via {@link Spec#dispatch(Dispatcher)}.
  */
-public final class ExploreSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT> {
+public final class ExploreSpec implements Spec {
 
-    @Override
-    public <R> R dispatch(Dispatcher<R> dispatcher) {
-        return dispatcher.apply(this);
-    }
+    private final Internal<?, ?, ?> internal;
 
-
-    private final Sampling<FT, IT, OT> shape;
-    private final List<FT> factors;
-    private final String experimentId;
-
-    private final Map<FT, SampleSummary<OT>> perConfig = new LinkedHashMap<>();
-
-    private ExploreSpec(Builder<FT, IT, OT> b) {
-        this.shape = b.shape;
-        this.factors = b.factors;
-        this.experimentId = b.experimentId != null
-                ? b.experimentId
-                : "explore-" + Instant.now().toEpochMilli();
+    private ExploreSpec(Internal<?, ?, ?> internal) {
+        this.internal = internal;
     }
 
     /** Entry point — compose an explore experiment over a Sampling. */
-    public static <FT, IT, OT> Builder<FT, IT, OT> exploring(Sampling<FT, IT, OT> shape) {
-        return new Builder<>(Objects.requireNonNull(shape, "shape"));
+    public static <FT, IT, OT> Builder<FT, IT, OT> exploring(Sampling<FT, IT, OT> sampling) {
+        return new Builder<>(Objects.requireNonNull(sampling, "sampling"));
     }
 
-    public Sampling<FT, IT, OT> shape() { return shape; }
-    public List<FT> factors() { return factors; }
-    public String experimentId() { return experimentId; }
-
-    /** Convenience delegate to {@code shape().samples()}. */
-    public int samplesPerConfig() { return shape.samples(); }
-
-    @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
-        return shape.useCaseFactory();
+    @Override
+    public <R> R dispatch(Dispatcher<R> dispatcher) {
+        return doDispatch(internal, dispatcher);
     }
 
-    @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
-        List<Configuration<FT, IT, OT>> configs = new ArrayList<>(factors.size());
-        for (FT ft : factors) {
-            configs.add(Configuration.of(ft, shape.inputs(), shape.samples()));
+    private static <FT, IT, OT, R> R doDispatch(Internal<FT, IT, OT> typed, Dispatcher<R> d) {
+        return d.apply(typed);
+    }
+
+    // ── Public scalar accessors (no type parameters) ───────────────
+
+    public String experimentId() { return internal.experimentId; }
+    public int samplesPerConfig() { return internal.shape.samples(); }
+
+    // ── Typed internal delegate (engine-facing) ─────────────────────
+
+    private static final class Internal<FT, IT, OT> implements TypedSpec<FT, IT, OT> {
+
+        private final Sampling<FT, IT, OT> shape;
+        private final List<FT> factors;
+        private final String experimentId;
+
+        private final Map<FT, SampleSummary<OT>> perConfig = new LinkedHashMap<>();
+
+        private Internal(Builder<FT, IT, OT> b) {
+            this.shape = b.shape;
+            this.factors = b.factors;
+            this.experimentId = b.experimentId != null
+                    ? b.experimentId
+                    : "explore-" + Instant.now().toEpochMilli();
         }
-        return configs.iterator();
-    }
 
-    @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
-        perConfig.put(config.factors(), summary);
-    }
+        @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
+            return shape.useCaseFactory();
+        }
 
-    @Override public EngineResult conclude() {
-        Path dir = Paths.get("explorations", experimentId);
-        String message = "explore artefact (stage 2 placeholder); configurations="
-                + perConfig.size();
-        return new ExperimentResult(message, dir);
-    }
+        @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
+            List<Configuration<FT, IT, OT>> configs = new ArrayList<>(factors.size());
+            for (FT ft : factors) {
+                configs.add(Configuration.of(ft, shape.inputs(), shape.samples()));
+            }
+            return configs.iterator();
+        }
 
-    @Override public Optional<Duration> timeBudget() { return shape.timeBudget(); }
-    @Override public OptionalLong tokenBudget() { return shape.tokenBudget(); }
-    @Override public long tokenCharge() { return shape.tokenCharge(); }
-    @Override public BudgetExhaustionPolicy budgetPolicy() { return shape.budgetPolicy(); }
-    @Override public ExceptionPolicy exceptionPolicy() { return shape.exceptionPolicy(); }
-    @Override public int maxExampleFailures() { return shape.maxExampleFailures(); }
+        @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
+            perConfig.put(config.factors(), summary);
+        }
+
+        @Override public EngineResult conclude() {
+            Path dir = Paths.get("explorations", experimentId);
+            String message = "explore artefact (stage 2 placeholder); configurations="
+                    + perConfig.size();
+            return new ExperimentResult(message, dir);
+        }
+
+        @Override public Optional<Duration> timeBudget() { return shape.timeBudget(); }
+        @Override public OptionalLong tokenBudget() { return shape.tokenBudget(); }
+        @Override public long tokenCharge() { return shape.tokenCharge(); }
+        @Override public BudgetExhaustionPolicy budgetPolicy() { return shape.budgetPolicy(); }
+        @Override public ExceptionPolicy exceptionPolicy() { return shape.exceptionPolicy(); }
+        @Override public int maxExampleFailures() { return shape.maxExampleFailures(); }
+    }
 
     public static final class Builder<FT, IT, OT> {
 
@@ -122,11 +136,11 @@ public final class ExploreSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT
             return this;
         }
 
-        public ExploreSpec<FT, IT, OT> build() {
+        public ExploreSpec build() {
             if (factors == null) {
                 throw new IllegalStateException("factors is required — call .factors(...)");
             }
-            return new ExploreSpec<>(this);
+            return new ExploreSpec(new Internal<>(this));
         }
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/MeasureSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/MeasureSpec.java
@@ -22,42 +22,21 @@ import org.javai.punit.api.typed.ValueMatcher;
  *
  * <p>Constructed via {@link #measuring(Sampling, Object)}. The
  * {@link Sampling} carries the factor-free sample-production
- * parameters (use case factory, inputs, sample count, budgets,
- * exception policy); the second argument is the factor bundle the
- * measure runs against. The measure spec itself carries only the
+ * parameters; the second argument is the factor bundle the measure
+ * runs against. The measure spec itself carries only the
  * measure-specific overlay (experiment id, expected outputs for
  * instance conformance, matcher, baseline expiration window).
  *
- * <p>Stage 2 implements the spec surface and strategy-method dispatch;
- * artefact serialisation to YAML lands in Stage 4, at which point
- * {@link #conclude()} becomes load-bearing. For now it returns an
- * {@link ExperimentResult} with a placeholder message and the path
- * where the baseline <em>would</em> be written.
+ * <p>The public class carries no type parameters — composition-time
+ * type safety lives on the typed {@link Builder}, and the engine
+ * recovers the typed view via {@link Spec#dispatch(Dispatcher)}.
  */
-public final class MeasureSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT> {
+public final class MeasureSpec implements Spec {
 
-    @Override
-    public <R> R dispatch(Dispatcher<R> dispatcher) {
-        return dispatcher.apply(this);
-    }
+    private final Internal<?, ?, ?> internal;
 
-
-    private final Sampling<FT, IT, OT> sampling;
-    private final FT factors;
-    private final List<OT> expectedOutputs;
-    private final Optional<ValueMatcher<OT>> matcher;
-    private final String experimentId;
-    private final Optional<Integer> expiresInDays;
-
-    private Optional<SampleSummary<OT>> lastSummary = Optional.empty();
-
-    private MeasureSpec(Builder<FT, IT, OT> b) {
-        this.sampling = b.sampling;
-        this.factors = b.factors;
-        this.expectedOutputs = b.expected;
-        this.matcher = Optional.ofNullable(b.matcher);
-        this.experimentId = b.experimentId != null ? b.experimentId : defaultExperimentId();
-        this.expiresInDays = Optional.ofNullable(b.expiresInDays);
+    private MeasureSpec(Internal<?, ?, ?> internal) {
+        this.internal = internal;
     }
 
     /**
@@ -71,80 +50,86 @@ public final class MeasureSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT
                 Objects.requireNonNull(factors, "factors"));
     }
 
-    // ── Overlay accessors ───────────────────────────────────────────
-
-    /** The factor-free sampling backing this measure. */
-    public Sampling<FT, IT, OT> sampling() {
-        return sampling;
+    @Override
+    public <R> R dispatch(Dispatcher<R> dispatcher) {
+        return doDispatch(internal, dispatcher);
     }
 
-    /** The factor bundle this measure runs against. */
-    public FT factors() {
-        return factors;
+    private static <FT, IT, OT, R> R doDispatch(Internal<FT, IT, OT> typed, Dispatcher<R> d) {
+        return d.apply(typed);
     }
 
-    /** The optional expected-output list for instance-conformance checking. */
-    public Optional<List<OT>> expectedOutputs() {
-        return expectedOutputs.isEmpty() ? Optional.empty() : Optional.of(expectedOutputs);
-    }
+    // ── Public scalar accessors (no type parameters) ───────────────
 
-    /** Optional baseline validity window in days. */
-    public Optional<Integer> expiresInDays() {
-        return expiresInDays;
-    }
-
-    /** The experiment id written into the baseline YAML metadata. */
-    public String experimentId() {
-        return experimentId;
-    }
-
-    // ── Spec — run-loop delegates to the sampling ─────
-
-    @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
-        return sampling.useCaseFactory();
-    }
-
-    @Override public Optional<ValueMatcher<OT>> matcher() {
-        return matcher;
-    }
-
-    @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
-        return List.of(new Configuration<>(
-                factors, sampling.inputs(), expectedOutputs, sampling.samples())).iterator();
-    }
-
-    @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
-        this.lastSummary = Optional.of(summary);
-    }
-
-    @Override public EngineResult conclude() {
-        FactorBundle bundle = FactorBundle.of(factors);
-        Path path = defaultBaselinePath(experimentId, bundle);
-        String message = "measure baseline (stage 2 placeholder — serialisation lands in stage 4); "
-                + "samples=" + lastSummary.map(SampleSummary::total).orElse(0)
-                + ", passRate=" + lastSummary.map(s -> String.format("%.3f", s.passRate())).orElse("n/a");
-        return new ExperimentResult(message, path);
-    }
-
-    @Override public Optional<Duration> timeBudget() { return sampling.timeBudget(); }
-    @Override public OptionalLong tokenBudget() { return sampling.tokenBudget(); }
-    @Override public long tokenCharge() { return sampling.tokenCharge(); }
-    @Override public BudgetExhaustionPolicy budgetPolicy() { return sampling.budgetPolicy(); }
-    @Override public ExceptionPolicy exceptionPolicy() { return sampling.exceptionPolicy(); }
-    @Override public int maxExampleFailures() { return sampling.maxExampleFailures(); }
-
-    // ── Convenience delegates ───────────────────────────────────────
-
-    public int samples() { return sampling.samples(); }
-    public List<IT> inputs() { return sampling.inputs(); }
+    public int samples() { return internal.sampling.samples(); }
+    public String experimentId() { return internal.experimentId; }
+    public Optional<Integer> expiresInDays() { return internal.expiresInDays; }
 
     /**
      * The summary of the most recent run, if any — useful for engine
      * integration tests asserting on termination reason, latency
-     * result, or failure counts without wrapping the spec.
+     * result, or failure counts without wrapping the spec. Returns a
+     * wildcard-typed summary; tests that need typed access can cast
+     * at the assertion site or reach the typed view via dispatch.
      */
-    public Optional<SampleSummary<OT>> lastSummary() {
-        return lastSummary;
+    public Optional<SampleSummary<?>> lastSummary() {
+        return Optional.ofNullable(internal.lastSummary.orElse(null));
+    }
+
+    // ── Typed internal delegate (engine-facing) ─────────────────────
+
+    private static final class Internal<FT, IT, OT> implements TypedSpec<FT, IT, OT> {
+
+        private final Sampling<FT, IT, OT> sampling;
+        private final FT factors;
+        private final List<OT> expectedOutputs;
+        private final Optional<ValueMatcher<OT>> matcher;
+        private final String experimentId;
+        private final Optional<Integer> expiresInDays;
+
+        private Optional<SampleSummary<OT>> lastSummary = Optional.empty();
+
+        private Internal(Builder<FT, IT, OT> b) {
+            this.sampling = b.sampling;
+            this.factors = b.factors;
+            this.expectedOutputs = b.expected;
+            this.matcher = Optional.ofNullable(b.matcher);
+            this.experimentId = b.experimentId != null ? b.experimentId : defaultExperimentId();
+            this.expiresInDays = Optional.ofNullable(b.expiresInDays);
+        }
+
+        @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
+            return sampling.useCaseFactory();
+        }
+
+        @Override public Optional<ValueMatcher<OT>> matcher() {
+            return matcher;
+        }
+
+        @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
+            return List.of(new Configuration<>(
+                    factors, sampling.inputs(), expectedOutputs, sampling.samples())).iterator();
+        }
+
+        @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
+            this.lastSummary = Optional.of(summary);
+        }
+
+        @Override public EngineResult conclude() {
+            FactorBundle bundle = FactorBundle.of(factors);
+            Path path = defaultBaselinePath(experimentId, bundle);
+            String message = "measure baseline (stage 2 placeholder — serialisation lands in stage 4); "
+                    + "samples=" + lastSummary.map(SampleSummary::total).orElse(0)
+                    + ", passRate=" + lastSummary.map(s -> String.format("%.3f", s.passRate())).orElse("n/a");
+            return new ExperimentResult(message, path);
+        }
+
+        @Override public Optional<Duration> timeBudget() { return sampling.timeBudget(); }
+        @Override public OptionalLong tokenBudget() { return sampling.tokenBudget(); }
+        @Override public long tokenCharge() { return sampling.tokenCharge(); }
+        @Override public BudgetExhaustionPolicy budgetPolicy() { return sampling.budgetPolicy(); }
+        @Override public ExceptionPolicy exceptionPolicy() { return sampling.exceptionPolicy(); }
+        @Override public int maxExampleFailures() { return sampling.maxExampleFailures(); }
     }
 
     static Path defaultBaselinePath(String experimentId, FactorBundle bundle) {
@@ -217,7 +202,7 @@ public final class MeasureSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT
             return this;
         }
 
-        public MeasureSpec<FT, IT, OT> build() {
+        public MeasureSpec build() {
             if (!expected.isEmpty() && expected.size() != sampling.inputs().size()) {
                 throw new IllegalStateException(
                         "expectedOutputs (" + expected.size() + ") and sampling.inputs() ("
@@ -226,7 +211,7 @@ public final class MeasureSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT
             if (!expected.isEmpty() && matcher == null) {
                 matcher = ValueMatcher.equality();
             }
-            return new MeasureSpec<>(this);
+            return new MeasureSpec(new Internal<>(this));
         }
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/MeasureSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/MeasureSpec.java
@@ -34,7 +34,13 @@ import org.javai.punit.api.typed.ValueMatcher;
  * {@link ExperimentResult} with a placeholder message and the path
  * where the baseline <em>would</em> be written.
  */
-public final class MeasureSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
+public final class MeasureSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT> {
+
+    @Override
+    public <R> R dispatch(Dispatcher<R> dispatcher) {
+        return dispatcher.apply(this);
+    }
+
 
     private final Sampling<FT, IT, OT> sampling;
     private final FT factors;

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
@@ -42,7 +42,13 @@ import org.javai.punit.api.typed.spec.FactorMutator.IterationResult;
  * direction enum. The two methods are mutually exclusive at the API
  * level: one of them must be called and the last one wins.
  */
-public final class OptimizeSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
+public final class OptimizeSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT> {
+
+    @Override
+    public <R> R dispatch(Dispatcher<R> dispatcher) {
+        return dispatcher.apply(this);
+    }
+
 
     private final Sampling<FT, IT, OT> shape;
     private final FT initialFactors;

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/OptimizeSpec.java
@@ -20,7 +20,7 @@ import org.javai.punit.api.typed.spec.FactorMutator.IterationResult;
 
 /**
  * An iterative factor-space search. Each iteration runs
- * {@code shape.samples()} samples under the current factor bundle,
+ * {@code sampling.samples()} samples under the current factor bundle,
  * scores the outcome, and asks the {@link FactorMutator} for the
  * next factor record. The iterator stops when:
  *
@@ -32,158 +32,172 @@ import org.javai.punit.api.typed.spec.FactorMutator.IterationResult;
  * </ul>
  *
  * <p>Constructed via {@link #optimizing(Sampling)}. All sample-
- * production knobs (use case factory, inputs, sample count, budgets,
- * exception policy) live on the {@link Sampling}; the optimize
- * spec carries only the search-specific knobs.
+ * production knobs live on the {@link Sampling}; the optimize spec
+ * carries only the search-specific knobs.
  *
  * <p>The optimisation direction is expressed by which builder method
  * the author calls — {@link Builder#maximize(Scorer)} or
  * {@link Builder#minimize(Scorer)} — rather than by a separate
  * direction enum. The two methods are mutually exclusive at the API
  * level: one of them must be called and the last one wins.
+ *
+ * <p>The public class carries no type parameters — composition-time
+ * type safety lives on the typed {@link Builder}, and the engine
+ * recovers the typed view via {@link Spec#dispatch(Dispatcher)}.
  */
-public final class OptimizeSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, OT> {
+public final class OptimizeSpec implements Spec {
 
-    @Override
-    public <R> R dispatch(Dispatcher<R> dispatcher) {
-        return dispatcher.apply(this);
-    }
+    private final Internal<?, ?, ?> internal;
 
-
-    private final Sampling<FT, IT, OT> shape;
-    private final FT initialFactors;
-    private final FactorMutator<FT> mutator;
-    private final Scorer scorer;
-    private final boolean maximizing;
-    private final int maxIterations;
-    private final int noImprovementWindow;
-    private final String experimentId;
-
-    private final List<IterationResult<FT>> history = new ArrayList<>();
-
-    private OptimizeSpec(Builder<FT, IT, OT> b) {
-        this.shape = b.shape;
-        this.initialFactors = b.initialFactors;
-        this.mutator = b.mutator;
-        this.scorer = b.scorer;
-        this.maximizing = b.maximizing;
-        this.maxIterations = b.maxIterations;
-        this.noImprovementWindow = b.noImprovementWindow;
-        this.experimentId = b.experimentId != null
-                ? b.experimentId
-                : "optimize-" + Instant.now().toEpochMilli();
+    private OptimizeSpec(Internal<?, ?, ?> internal) {
+        this.internal = internal;
     }
 
     /** Entry point — compose an optimize experiment over a Sampling. */
-    public static <FT, IT, OT> Builder<FT, IT, OT> optimizing(Sampling<FT, IT, OT> shape) {
-        return new Builder<>(Objects.requireNonNull(shape, "shape"));
+    public static <FT, IT, OT> Builder<FT, IT, OT> optimizing(Sampling<FT, IT, OT> sampling) {
+        return new Builder<>(Objects.requireNonNull(sampling, "sampling"));
     }
 
-    public Sampling<FT, IT, OT> shape() { return shape; }
-    public FT initialFactors() { return initialFactors; }
-    public int maxIterations() { return maxIterations; }
-    public int noImprovementWindow() { return noImprovementWindow; }
-    public String experimentId() { return experimentId; }
-
-    /** {@code true} if the spec is maximising the score, {@code false} if minimising. */
-    public boolean isMaximizing() { return maximizing; }
-
-    /** Convenience delegate to {@code shape().samples()}. */
-    public int samplesPerIteration() { return shape.samples(); }
-
-    @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
-        return shape.useCaseFactory();
+    @Override
+    public <R> R dispatch(Dispatcher<R> dispatcher) {
+        return doDispatch(internal, dispatcher);
     }
 
-    @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
-        return new AdaptiveIterator();
+    private static <FT, IT, OT, R> R doDispatch(Internal<FT, IT, OT> typed, Dispatcher<R> d) {
+        return d.apply(typed);
     }
 
-    @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
-        double score = scorer.score(summary);
-        history.add(new IterationResult<>(config.factors(), score));
+    // ── Public scalar accessors (no type parameters) ───────────────
+
+    public int maxIterations() { return internal.maxIterations; }
+    public int noImprovementWindow() { return internal.noImprovementWindow; }
+    public String experimentId() { return internal.experimentId; }
+    public boolean isMaximizing() { return internal.maximizing; }
+    public int samplesPerIteration() { return internal.shape.samples(); }
+
+    /** The iteration history — wildcard-typed at the public surface. */
+    public List<IterationResult<?>> history() {
+        return List.copyOf(internal.history);
     }
 
-    @Override public EngineResult conclude() {
-        IterationResult<FT> best = bestSoFar();
-        Path dir = Paths.get("optimizations", experimentId);
-        String message = "optimize artefact (stage 2 placeholder); iterations="
-                + history.size()
-                + (best == null ? "" : ", bestScore=" + String.format("%.3f", best.score()));
-        return new ExperimentResult(message, dir);
-    }
+    // ── Typed internal delegate (engine-facing) ─────────────────────
 
-    public List<IterationResult<FT>> history() {
-        return Collections.unmodifiableList(history);
-    }
+    private static final class Internal<FT, IT, OT> implements TypedSpec<FT, IT, OT> {
 
-    @Override public Optional<Duration> timeBudget() { return shape.timeBudget(); }
-    @Override public OptionalLong tokenBudget() { return shape.tokenBudget(); }
-    @Override public long tokenCharge() { return shape.tokenCharge(); }
-    @Override public BudgetExhaustionPolicy budgetPolicy() { return shape.budgetPolicy(); }
-    @Override public ExceptionPolicy exceptionPolicy() { return shape.exceptionPolicy(); }
-    @Override public int maxExampleFailures() { return shape.maxExampleFailures(); }
+        private final Sampling<FT, IT, OT> shape;
+        private final FT initialFactors;
+        private final FactorMutator<FT> mutator;
+        private final Scorer scorer;
+        private final boolean maximizing;
+        private final int maxIterations;
+        private final int noImprovementWindow;
+        private final String experimentId;
 
-    private IterationResult<FT> bestSoFar() {
-        IterationResult<FT> best = null;
-        for (IterationResult<FT> r : history) {
-            if (best == null || isBetter(r.score(), best.score())) {
-                best = r;
-            }
-        }
-        return best;
-    }
+        private final List<IterationResult<FT>> history = new ArrayList<>();
 
-    private boolean isBetter(double a, double b) {
-        return maximizing ? a > b : a < b;
-    }
-
-    private final class AdaptiveIterator implements Iterator<Configuration<FT, IT, OT>> {
-
-        private FT next = initialFactors;
-        private int issued = 0;
-        private int iterationsSinceImprovement = 0;
-        private double bestScoreSeen = Double.NaN;
-
-        @Override public boolean hasNext() {
-            refresh();
-            return next != null;
+        private Internal(Builder<FT, IT, OT> b) {
+            this.shape = b.shape;
+            this.initialFactors = b.initialFactors;
+            this.mutator = b.mutator;
+            this.scorer = b.scorer;
+            this.maximizing = b.maximizing;
+            this.maxIterations = b.maxIterations;
+            this.noImprovementWindow = b.noImprovementWindow;
+            this.experimentId = b.experimentId != null
+                    ? b.experimentId
+                    : "optimize-" + Instant.now().toEpochMilli();
         }
 
-        @Override public Configuration<FT, IT, OT> next() {
-            refresh();
-            if (next == null) {
-                throw new NoSuchElementException();
-            }
-            FT factors = next;
-            next = null;
-            issued++;
-            return Configuration.of(factors, shape.inputs(), shape.samples());
+        @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
+            return shape.useCaseFactory();
         }
 
-        private void refresh() {
-            if (next != null) {
-                return;
-            }
-            if (issued >= maxIterations) {
-                return;
-            }
-            if (!history.isEmpty()) {
-                IterationResult<FT> last = history.get(history.size() - 1);
-                if (Double.isNaN(bestScoreSeen)
-                        || isBetter(last.score(), bestScoreSeen)) {
-                    bestScoreSeen = last.score();
-                    iterationsSinceImprovement = 0;
-                } else {
-                    iterationsSinceImprovement++;
+        @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
+            return new AdaptiveIterator();
+        }
+
+        @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
+            double score = scorer.score(summary);
+            history.add(new IterationResult<>(config.factors(), score));
+        }
+
+        @Override public EngineResult conclude() {
+            IterationResult<FT> best = bestSoFar();
+            Path dir = Paths.get("optimizations", experimentId);
+            String message = "optimize artefact (stage 2 placeholder); iterations="
+                    + history.size()
+                    + (best == null ? "" : ", bestScore=" + String.format("%.3f", best.score()));
+            return new ExperimentResult(message, dir);
+        }
+
+        @Override public Optional<Duration> timeBudget() { return shape.timeBudget(); }
+        @Override public OptionalLong tokenBudget() { return shape.tokenBudget(); }
+        @Override public long tokenCharge() { return shape.tokenCharge(); }
+        @Override public BudgetExhaustionPolicy budgetPolicy() { return shape.budgetPolicy(); }
+        @Override public ExceptionPolicy exceptionPolicy() { return shape.exceptionPolicy(); }
+        @Override public int maxExampleFailures() { return shape.maxExampleFailures(); }
+
+        private IterationResult<FT> bestSoFar() {
+            IterationResult<FT> best = null;
+            for (IterationResult<FT> r : history) {
+                if (best == null || isBetter(r.score(), best.score())) {
+                    best = r;
                 }
-                if (iterationsSinceImprovement >= noImprovementWindow) {
+            }
+            return best;
+        }
+
+        private boolean isBetter(double a, double b) {
+            return maximizing ? a > b : a < b;
+        }
+
+        private final class AdaptiveIterator implements Iterator<Configuration<FT, IT, OT>> {
+
+            private FT next = initialFactors;
+            private int issued = 0;
+            private int iterationsSinceImprovement = 0;
+            private double bestScoreSeen = Double.NaN;
+
+            @Override public boolean hasNext() {
+                refresh();
+                return next != null;
+            }
+
+            @Override public Configuration<FT, IT, OT> next() {
+                refresh();
+                if (next == null) {
+                    throw new NoSuchElementException();
+                }
+                FT factors = next;
+                next = null;
+                issued++;
+                return Configuration.of(factors, shape.inputs(), shape.samples());
+            }
+
+            private void refresh() {
+                if (next != null) {
                     return;
                 }
-                FT current = last.factors();
-                FT candidate = mutator.next(current,
-                        Collections.unmodifiableList(history));
-                next = candidate;
+                if (issued >= maxIterations) {
+                    return;
+                }
+                if (!history.isEmpty()) {
+                    IterationResult<FT> last = history.get(history.size() - 1);
+                    if (Double.isNaN(bestScoreSeen)
+                            || isBetter(last.score(), bestScoreSeen)) {
+                        bestScoreSeen = last.score();
+                        iterationsSinceImprovement = 0;
+                    } else {
+                        iterationsSinceImprovement++;
+                    }
+                    if (iterationsSinceImprovement >= noImprovementWindow) {
+                        return;
+                    }
+                    FT current = last.factors();
+                    FT candidate = mutator.next(current,
+                            Collections.unmodifiableList(history));
+                    next = candidate;
+                }
             }
         }
     }
@@ -261,7 +275,7 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, O
             return this;
         }
 
-        public OptimizeSpec<FT, IT, OT> build() {
+        public OptimizeSpec build() {
             if (initialFactors == null) {
                 throw new IllegalStateException("initialFactors is required");
             }
@@ -272,7 +286,7 @@ public final class OptimizeSpec<FT, IT, OT> implements Spec, TypedSpec<FT, IT, O
                 throw new IllegalStateException(
                         "scorer is required — call .maximize(...) or .minimize(...)");
             }
-            return new OptimizeSpec<>(this);
+            return new OptimizeSpec(new Internal<>(this));
         }
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/PercentileLatency.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/PercentileLatency.java
@@ -44,14 +44,14 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
     private final LatencySpec declaredSpec;
     private final ThresholdOrigin origin;
     private final EnumSet<PercentileKey> assertedPercentiles;
-    private final Supplier<MeasureSpec<?, ?, ?>> baselineSupplier;
+    private final Supplier<MeasureSpec> baselineSupplier;
 
     private PercentileLatency(
             Mode mode,
             LatencySpec declaredSpec,
             ThresholdOrigin origin,
             EnumSet<PercentileKey> assertedPercentiles,
-            Supplier<MeasureSpec<?, ?, ?>> baselineSupplier) {
+            Supplier<MeasureSpec> baselineSupplier) {
         this.mode = mode;
         this.declaredSpec = declaredSpec;
         this.origin = origin;
@@ -84,7 +84,7 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
     }
 
     public static <OT> PercentileLatency<OT> empiricalFrom(
-            Supplier<MeasureSpec<?, ?, ?>> baseline,
+            Supplier<MeasureSpec> baseline,
             PercentileKey first,
             PercentileKey... rest) {
         Objects.requireNonNull(baseline, "baseline");
@@ -94,7 +94,7 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
     }
 
     /** The baseline supplier when pinned; empty otherwise. */
-    public Optional<Supplier<MeasureSpec<?, ?, ?>>> baselineSupplier() {
+    public Optional<Supplier<MeasureSpec>> baselineSupplier() {
         return Optional.ofNullable(baselineSupplier);
     }
 

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpec.java
@@ -28,25 +28,16 @@ import org.javai.punit.api.typed.UseCase;
  * The combined verdict is {@link Verdict#compose(List)}'d from the
  * REQUIRED subset.
  *
- * <p>Stage 3.5 ships the structural refactor; the framework's baseline
- * resolver is a stub that always returns empty, so empirical criteria
- * yield {@link Verdict#INCONCLUSIVE} with a diagnostic. The real
- * resolver and Wilson-score-aware comparisons land in Stage 4.
+ * <p>The public class carries no type parameters — composition-time
+ * type safety lives on the typed {@link Builder}, and the engine
+ * recovers the typed view via {@link Spec#dispatch(Dispatcher)}.
  */
-public final class ProbabilisticTestSpec<FT, IT, OT> implements Spec<FT, IT, OT> {
+public final class ProbabilisticTestSpec implements Spec {
 
-    private final Sampling<FT, IT, OT> sampling;
-    private final FT factors;
-    private final List<Registered<OT>> registered;
-    private final TestIntent intent;
+    private final Internal<?, ?, ?> internal;
 
-    private SampleSummary<OT> summary;
-
-    private ProbabilisticTestSpec(Builder<FT, IT, OT> b) {
-        this.sampling = b.sampling;
-        this.factors = b.factors;
-        this.registered = List.copyOf(b.registered);
-        this.intent = b.intent;
+    private ProbabilisticTestSpec(Internal<?, ?, ?> internal) {
+        this.internal = internal;
     }
 
     /**
@@ -60,76 +51,95 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements Spec<FT, IT, OT>
                 Objects.requireNonNull(factors, "factors"));
     }
 
-    public Sampling<FT, IT, OT> sampling() { return sampling; }
-    public FT factors() { return factors; }
-    public int samples() { return sampling.samples(); }
+    /** Sample count for this test, taken from its sampling. */
+    public int samples() { return internal.sampling.samples(); }
 
     /**
      * The test's declared intent. {@link TestIntent#VERIFICATION} (default)
-     * claims evidential status — the framework will refuse to run a
-     * configuration too small to support a verification-grade verdict
-     * once feasibility checking lands. {@link TestIntent#SMOKE} is a
-     * sentinel-grade lightweight check; verdicts under SMOKE carry an
-     * explicit "not sized for verification" caveat.
+     * claims evidential status; {@link TestIntent#SMOKE} is a
+     * sentinel-grade lightweight check.
      */
-    public TestIntent intent() { return intent; }
+    public TestIntent intent() { return internal.intent; }
 
-    @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
-        return sampling.useCaseFactory();
+    @Override
+    public <R> R dispatch(Dispatcher<R> dispatcher) {
+        return doDispatch(internal, dispatcher);
     }
 
-    @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
-        return List.of(Configuration.<FT, IT, OT>of(factors, sampling.inputs(), sampling.samples()))
-                .iterator();
+    private static <FT, IT, OT, R> R doDispatch(Internal<FT, IT, OT> typed, Dispatcher<R> d) {
+        return d.apply(typed);
     }
 
-    @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
-        this.summary = summary;
-    }
+    // ── Typed internal delegate (engine-facing) ─────────────────────
 
-    @Override public EngineResult conclude() {
-        SampleSummary<OT> s = summary != null
-                ? summary
-                : SampleSummary.from(List.of(), Duration.ZERO);
-        FactorBundle factorBundle = FactorBundle.of(factors);
+    private static final class Internal<FT, IT, OT> implements TypedSpec<FT, IT, OT> {
 
-        List<EvaluatedCriterion> evaluated = new ArrayList<>(registered.size());
-        for (Registered<OT> entry : registered) {
-            CriterionResult result = evaluate(entry.criterion(), s, factorBundle);
-            evaluated.add(new EvaluatedCriterion(result, entry.role()));
+        private final Sampling<FT, IT, OT> sampling;
+        private final FT factors;
+        private final List<Registered<OT>> registered;
+        private final TestIntent intent;
+
+        private SampleSummary<OT> summary;
+
+        private Internal(Builder<FT, IT, OT> b) {
+            this.sampling = b.sampling;
+            this.factors = b.factors;
+            this.registered = List.copyOf(b.registered);
+            this.intent = b.intent;
         }
 
-        Verdict composed = Verdict.compose(evaluated);
-        List<String> warnings = new ArrayList<>();
-        warnings.add("baseline resolver is a Stage-3.5 stub — empirical criteria "
-                + "yield INCONCLUSIVE until Stage 4 lands real resolution");
+        @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
+            return sampling.useCaseFactory();
+        }
 
-        return new ProbabilisticTestResult(composed, factorBundle, evaluated, intent, warnings);
+        @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
+            return List.of(Configuration.<FT, IT, OT>of(factors, sampling.inputs(), sampling.samples()))
+                    .iterator();
+        }
+
+        @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
+            this.summary = summary;
+        }
+
+        @Override public EngineResult conclude() {
+            SampleSummary<OT> s = summary != null
+                    ? summary
+                    : SampleSummary.from(List.of(), Duration.ZERO);
+            FactorBundle factorBundle = FactorBundle.of(factors);
+
+            List<EvaluatedCriterion> evaluated = new ArrayList<>(registered.size());
+            for (Registered<OT> entry : registered) {
+                CriterionResult result = evaluate(entry.criterion(), s, factorBundle);
+                evaluated.add(new EvaluatedCriterion(result, entry.role()));
+            }
+
+            Verdict composed = Verdict.compose(evaluated);
+            List<String> warnings = new ArrayList<>();
+            warnings.add("baseline resolver is a Stage-3.5 stub — empirical criteria "
+                    + "yield INCONCLUSIVE until Stage 4 lands real resolution");
+
+            return new ProbabilisticTestResult(composed, factorBundle, evaluated, intent, warnings);
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private CriterionResult evaluate(
+                Criterion<OT, ?> criterion, SampleSummary<OT> s, FactorBundle factorBundle) {
+            Criterion raw = criterion;
+            EvaluationContext ctx = new EvaluationContext<OT, BaselineStatistics>() {
+                @Override public SampleSummary<OT> summary() { return s; }
+                @Override public Optional<BaselineStatistics> baseline() { return Optional.empty(); }
+                @Override public FactorBundle factors() { return factorBundle; }
+            };
+            return (CriterionResult) raw.evaluate(ctx);
+        }
+
+        @Override public Optional<Duration> timeBudget() { return sampling.timeBudget(); }
+        @Override public OptionalLong tokenBudget() { return sampling.tokenBudget(); }
+        @Override public long tokenCharge() { return sampling.tokenCharge(); }
+        @Override public BudgetExhaustionPolicy budgetPolicy() { return sampling.budgetPolicy(); }
+        @Override public ExceptionPolicy exceptionPolicy() { return sampling.exceptionPolicy(); }
+        @Override public int maxExampleFailures() { return sampling.maxExampleFailures(); }
     }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private CriterionResult evaluate(
-            Criterion<OT, ?> criterion, SampleSummary<OT> s, FactorBundle factorBundle) {
-        // Stage 3.5 stub baseline resolver: always empty. The criterion dispatches
-        // on its declared statisticsType() — the context's baseline is typed
-        // Optional<S> where S matches the criterion's parameter.
-        Criterion raw = criterion;
-        EvaluationContext ctx = new EvaluationContext<OT, BaselineStatistics>() {
-            @Override public SampleSummary<OT> summary() { return s; }
-            @Override public Optional<BaselineStatistics> baseline() { return Optional.empty(); }
-            @Override public FactorBundle factors() { return factorBundle; }
-        };
-        return (CriterionResult) raw.evaluate(ctx);
-    }
-
-    // ── Spec pass-throughs to the sampling ────────────
-
-    @Override public Optional<Duration> timeBudget() { return sampling.timeBudget(); }
-    @Override public OptionalLong tokenBudget() { return sampling.tokenBudget(); }
-    @Override public long tokenCharge() { return sampling.tokenCharge(); }
-    @Override public BudgetExhaustionPolicy budgetPolicy() { return sampling.budgetPolicy(); }
-    @Override public ExceptionPolicy exceptionPolicy() { return sampling.exceptionPolicy(); }
-    @Override public int maxExampleFailures() { return sampling.maxExampleFailures(); }
 
     // ── Builder ──────────────────────────────────────────────────────
 
@@ -162,17 +172,16 @@ public final class ProbabilisticTestSpec<FT, IT, OT> implements Spec<FT, IT, OT>
         /**
          * Declares the test's intent. Defaults to
          * {@link TestIntent#VERIFICATION}. Authors of sentinel-grade
-         * smoke checks against external providers (where the
-         * sample-size cost would be prohibitive for a verification
-         * claim) opt into {@link TestIntent#SMOKE} explicitly.
+         * smoke checks against external providers opt into
+         * {@link TestIntent#SMOKE} explicitly.
          */
         public Builder<FT, IT, OT> intent(TestIntent intent) {
             this.intent = Objects.requireNonNull(intent, "intent");
             return this;
         }
 
-        public ProbabilisticTestSpec<FT, IT, OT> build() {
-            return new ProbabilisticTestSpec<>(this);
+        public ProbabilisticTestSpec build() {
+            return new ProbabilisticTestSpec(new Internal<>(this));
         }
     }
 

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Spec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Spec.java
@@ -1,100 +1,39 @@
 package org.javai.punit.api.typed.spec;
 
-import java.time.Duration;
-import java.util.Iterator;
-import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.function.Function;
-
-import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.ValueMatcher;
-
 /**
- * Strategy contract the engine dispatches through.
+ * The user-facing strategy interface every spec kind implements.
  *
- * <p>Per {@code DES-SPEC-AS-STRATEGY.md}:
- * <ul>
- *   <li>{@link #configurations()} yields a finite, reproducible
- *       iterator of run-units.</li>
- *   <li>{@link #useCaseFactory()} supplies the constructor the engine
- *       invokes once per configuration.</li>
- *   <li>{@link #matcher()} supplies the instance-conformance
- *       matcher; present when the spec was built with
- *       {@code .expectations(...)}, empty otherwise.</li>
- *   <li>{@link #consume(Configuration, SampleSummary) consume(cfg, summary)}
- *       receives the per-configuration aggregate; the spec accumulates
- *       what it needs for {@link #conclude()}.</li>
- *   <li>{@link #conclude()} produces the
- *       {@link EngineResult} — a verdict for a probabilistic test,
- *       an artefact description for an experiment.</li>
- * </ul>
+ * <p>Sealed over the four spec families — measure, explore, optimize,
+ * probabilistic test. Carries <strong>no</strong> type parameters at
+ * the user-facing level: the typed work happens inside each spec via
+ * an internal {@link TypedSpec} delegate, reached through
+ * {@link #dispatch(Dispatcher)}. The dispatch pattern lets the engine
+ * recover the typed view without unchecked casts — Java captures the
+ * wildcards on the internal delegate into the generic method on the
+ * dispatcher.
  *
- * <p>The engine must not branch on the concrete subtype. The sealed
- * {@code permits} clause exists for tool-side exhaustive matching
- * (reporters, doc generators) — the engine itself treats the spec
- * polymorphically.
+ * <p>The user touches this interface only as a return type from
+ * {@code @ProbabilisticTest} / {@code @Experiment} methods; the
+ * dispatch mechanism is engine-internal.
  *
- * @param <FT> the factor record type
- * @param <IT> the per-sample input type
- * @param <OT> the per-sample outcome value type
+ * @see TypedSpec
  */
-public sealed interface Spec<FT, IT, OT>
+public sealed interface Spec
         permits MeasureSpec, ExploreSpec, OptimizeSpec, ProbabilisticTestSpec {
 
-    Iterator<Configuration<FT, IT, OT>> configurations();
-
-    Function<FT, UseCase<FT, IT, OT>> useCaseFactory();
+    /**
+     * Engine entry point — dispatches to a typed view of this spec.
+     * Authors do not call this directly.
+     */
+    <R> R dispatch(Dispatcher<R> dispatcher);
 
     /**
-     * @return the spec's instance-conformance matcher, when the spec
-     *         was built with {@code .expectations(...)}; empty
-     *         otherwise. The engine consults this only when the
-     *         current {@link Configuration} has non-empty
-     *         {@code expected} values.
+     * Engine-facing visitor over the typed view of a spec. The
+     * {@link #apply} method is generic over the spec's
+     * {@code <FT, IT, OT>}, allowing implementations (the engine, in
+     * practice) to remain fully type-safe.
      */
-    default Optional<ValueMatcher<OT>> matcher() {
-        return Optional.empty();
+    interface Dispatcher<R> {
+        <FT, IT, OT> R apply(TypedSpec<FT, IT, OT> typed);
     }
-
-    void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary);
-
-    EngineResult conclude();
-
-    // ── Stage-3 resource-control / latency accessors ────────────────
-
-    /**
-     * Wall-clock budget the engine honours when sampling this spec.
-     * Empty = no limit.
-     */
-    default Optional<Duration> timeBudget() { return Optional.empty(); }
-
-    /** Token budget the engine honours when sampling this spec. Empty = no limit. */
-    default OptionalLong tokenBudget() { return OptionalLong.empty(); }
-
-    /**
-     * Static per-sample token charge added to the token tally in
-     * addition to whatever the use case reports via
-     * {@link org.javai.punit.api.typed.UseCaseOutcome#tokens()}.
-     */
-    default long tokenCharge() { return 0L; }
-
-    /** What the engine does when a budget exhausts early. */
-    default BudgetExhaustionPolicy budgetPolicy() {
-        return BudgetExhaustionPolicy.FAIL;
-    }
-
-    /**
-     * How the engine treats a thrown exception from
-     * {@link UseCase#apply(Object)}.
-     */
-    default ExceptionPolicy exceptionPolicy() {
-        return ExceptionPolicy.ABORT_TEST;
-    }
-
-    /**
-     * Upper bound on the number of detailed failing outcomes retained
-     * for diagnostics. Counting is never affected; only example
-     * retention is capped.
-     */
-    default int maxExampleFailures() { return 10; }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/TypedSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/TypedSpec.java
@@ -1,0 +1,49 @@
+package org.javai.punit.api.typed.spec;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.Function;
+
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.ValueMatcher;
+
+/**
+ * Engine-facing strategy contract carrying the typed methods the
+ * engine programs against. Authors do not implement this interface;
+ * it is reached only via {@link Spec#dispatch(Spec.Dispatcher)} and
+ * exists so the engine can stay fully type-safe while the public
+ * spec types ({@link ProbabilisticTestSpec} et al.) carry no
+ * type parameters.
+ *
+ * <p>Each public spec class holds an internal instance of this
+ * interface and exposes it to the engine through the dispatch
+ * pattern, capturing {@code <FT, IT, OT>} from a wildcard reference
+ * into a generic method invocation.
+ *
+ * @param <FT> the factor record type
+ * @param <IT> the per-sample input type
+ * @param <OT> the per-sample outcome value type
+ */
+public interface TypedSpec<FT, IT, OT> {
+
+    Iterator<Configuration<FT, IT, OT>> configurations();
+
+    Function<FT, UseCase<FT, IT, OT>> useCaseFactory();
+
+    default Optional<ValueMatcher<OT>> matcher() {
+        return Optional.empty();
+    }
+
+    void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary);
+
+    EngineResult conclude();
+
+    default Optional<Duration> timeBudget() { return Optional.empty(); }
+    default OptionalLong tokenBudget() { return OptionalLong.empty(); }
+    default long tokenCharge() { return 0L; }
+    default BudgetExhaustionPolicy budgetPolicy() { return BudgetExhaustionPolicy.FAIL; }
+    default ExceptionPolicy exceptionPolicy() { return ExceptionPolicy.ABORT_TEST; }
+    default int maxExampleFailures() { return 10; }
+}

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/BernoulliPassRateTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/BernoulliPassRateTest.java
@@ -157,7 +157,7 @@ class BernoulliPassRateTest {
     @Test
     @DisplayName("empiricalFrom() exposes the supplier for framework routing")
     void empiricalFromExposesSupplier() {
-        java.util.function.Supplier<MeasureSpec<?, ?, ?>> supplier = () -> null;
+        java.util.function.Supplier<MeasureSpec> supplier = () -> null;
 
         BernoulliPassRate<String> criterion = BernoulliPassRate.empiricalFrom(supplier);
 

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/PercentileLatencyTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/PercentileLatencyTest.java
@@ -163,7 +163,7 @@ class PercentileLatencyTest {
     @Test
     @DisplayName("empiricalFrom() exposes the supplier for framework routing")
     void empiricalFromExposesSupplier() {
-        java.util.function.Supplier<MeasureSpec<?, ?, ?>> supplier = () -> null;
+        java.util.function.Supplier<MeasureSpec> supplier = () -> null;
 
         PercentileLatency<String> criterion = PercentileLatency.empiricalFrom(
                 supplier, PercentileKey.P95);

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpecIntentTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/ProbabilisticTestSpecIntentTest.java
@@ -30,7 +30,7 @@ class ProbabilisticTestSpecIntentTest {
     @Test
     @DisplayName("default intent is VERIFICATION")
     void defaultIntentIsVerification() {
-        ProbabilisticTestSpec<Factors, String, String> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling(), new Factors("m"))
                 .build();
 
@@ -40,7 +40,7 @@ class ProbabilisticTestSpecIntentTest {
     @Test
     @DisplayName(".intent(SMOKE) overrides the default")
     void intentSmokeOverridesDefault() {
-        ProbabilisticTestSpec<Factors, String, String> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling(), new Factors("m"))
                 .intent(TestIntent.SMOKE)
                 .build();
@@ -51,7 +51,7 @@ class ProbabilisticTestSpecIntentTest {
     @Test
     @DisplayName(".intent(VERIFICATION) is permitted (idempotent with default)")
     void intentVerificationIsPermitted() {
-        ProbabilisticTestSpec<Factors, String, String> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling(), new Factors("m"))
                 .intent(TestIntent.VERIFICATION)
                 .build();

--- a/punit-core/src/main/java/org/javai/punit/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/Engine.java
@@ -20,6 +20,7 @@ import org.javai.punit.api.typed.spec.SampleObserver;
 import org.javai.punit.api.typed.spec.SampleSummary;
 import org.javai.punit.api.typed.spec.Trial;
 import org.javai.punit.api.typed.spec.Spec;
+import org.javai.punit.api.typed.spec.TypedSpec;
 
 /**
  * The one engine, shared by every spec flavour.
@@ -54,8 +55,17 @@ public final class Engine {
         this.executor = Objects.requireNonNull(executor, "executor");
     }
 
-    public <FT, IT, OT> EngineResult run(Spec<FT, IT, OT> spec) {
+    public EngineResult run(Spec spec) {
         Objects.requireNonNull(spec, "spec");
+        return spec.dispatch(new Spec.Dispatcher<EngineResult>() {
+            @Override
+            public <FT, IT, OT> EngineResult apply(TypedSpec<FT, IT, OT> typed) {
+                return runTyped(typed);
+            }
+        });
+    }
+
+    private <FT, IT, OT> EngineResult runTyped(TypedSpec<FT, IT, OT> spec) {
         Iterator<Configuration<FT, IT, OT>> it = spec.configurations();
         int cycleStart = 0;
         while (it.hasNext()) {
@@ -69,7 +79,7 @@ public final class Engine {
     }
 
     private <FT, IT, OT> SampleSummary<OT> runConfig(
-            Spec<FT, IT, OT> spec,
+            TypedSpec<FT, IT, OT> spec,
             UseCase<FT, IT, OT> useCase,
             Configuration<FT, IT, OT> cfg,
             int cycleStart) {

--- a/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
+++ b/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
@@ -77,8 +77,8 @@ public final class PowerAnalysis {
      *                                  {@code rate - mde ≤ 0} or
      *                                  {@code rate + mde ≥ 1})
      */
-    public static <FT, IT, OT> int sampleSize(
-            Supplier<MeasureSpec<FT, IT, OT>> baseline,
+    public static int sampleSize(
+            Supplier<MeasureSpec> baseline,
             double mde,
             double power) {
         Objects.requireNonNull(baseline, "baseline");
@@ -88,7 +88,7 @@ public final class PowerAnalysis {
         // real baseline-producing method and not a thunk that will blow up
         // at evaluate-time. The returned MeasureSpec is unused under the
         // Stage-3.5 placeholder; Stage 4 reads its observed rate.
-        MeasureSpec<FT, IT, OT> resolved = Objects.requireNonNull(
+        MeasureSpec resolved = Objects.requireNonNull(
                 baseline.get(),
                 "baseline supplier returned null");
 

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -54,7 +54,7 @@ class EngineIntegrationTest {
                 .inputs("a", "bb", "ccc")
                 .samples(9)
                 .build();
-        MeasureSpec<LlmFactors, String, Integer> spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
 
         EngineResult outcome = new Engine().run(spec);
 
@@ -145,7 +145,7 @@ class EngineIntegrationTest {
                 .inputs(1, 2, 3)
                 .samples(5)
                 .build();
-        MeasureSpec<LlmFactors, Integer, Boolean> spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
 
         assertThatThrownBy(() -> new Engine().run(spec))
                 .isInstanceOf(IllegalStateException.class)
@@ -168,7 +168,7 @@ class EngineIntegrationTest {
                 .inputs("a", "b")
                 .samples(4)
                 .build();
-        MeasureSpec<LlmFactors, String, String> spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.0))
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.0))
                 .expectedOutputs("A", "Q") // match, mismatch
                 .build();
 
@@ -203,7 +203,7 @@ class EngineIntegrationTest {
                 .inputs("HELLO", "WORLD")
                 .samples(2)
                 .build();
-        MeasureSpec<LlmFactors, String, String> spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.0))
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.0))
                 .expectedOutputs("hello", "world")
                 .matcher(caseInsensitive)
                 .build();
@@ -250,7 +250,7 @@ class EngineIntegrationTest {
                 .inputs("a", "bb", "ccc")
                 .samples(7)
                 .build();
-        MeasureSpec<LlmFactors, String, Integer> spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.0)).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.0)).build();
 
         new Engine().run(spec);
         var summary = spec.lastSummary().orElseThrow();
@@ -284,7 +284,7 @@ class EngineIntegrationTest {
                 .inputs("a", "b")
                 .samples(3)
                 .build();
-        ExploreSpec<LlmFactors, String, Integer> spec = ExploreSpec.exploring(shape)
+        ExploreSpec spec = ExploreSpec.exploring(shape)
                 .factors(
                         new LlmFactors("gpt-4o", 0.0),
                         new LlmFactors("gpt-4o", 0.5),
@@ -316,7 +316,7 @@ class EngineIntegrationTest {
                 current.temperature() >= 0.95
                         ? null
                         : new LlmFactors(current.model(), current.temperature() + 0.1);
-        OptimizeSpec<LlmFactors, String, Integer> spec = OptimizeSpec.optimizing(shape)
+        OptimizeSpec spec = OptimizeSpec.optimizing(shape)
                 .initialFactors(new LlmFactors("gpt-4o", 0.0))
                 .mutator(mutator)
                 .maximize(s -> 1.0 / (1.0 + s.failures()))
@@ -368,7 +368,7 @@ class EngineIntegrationTest {
                 .inputs("x", "y", "z")
                 .samples(7)
                 .build();
-        MeasureSpec<LlmFactors, String, Integer> spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
         new Engine().run(spec);
         return observed;
     }

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -73,7 +73,7 @@ class EngineIntegrationTest {
                 .inputs(1, 2, 3)
                 .samples(30)
                 .build();
-        ProbabilisticTestSpec<LlmFactors, Integer, Boolean> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling, new LlmFactors("gpt-4o", 0.3))
                 .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
                 .build();
@@ -99,7 +99,7 @@ class EngineIntegrationTest {
                 .inputs(1, 2, 3)
                 .samples(15)
                 .build();
-        ProbabilisticTestSpec<LlmFactors, Integer, Boolean> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling, new LlmFactors("gpt-4o", 0.3))
                 .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLO))
                 .build();
@@ -121,7 +121,7 @@ class EngineIntegrationTest {
                 .inputs(1, 2, 3)
                 .samples(20)
                 .build();
-        ProbabilisticTestSpec<LlmFactors, Integer, Boolean> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling, new LlmFactors("gpt-4o", 0.3))
                 .criterion(BernoulliPassRate.<Boolean>empirical())
                 .build();
@@ -337,11 +337,11 @@ class EngineIntegrationTest {
                 .inputs(1, 2, 3)
                 .samples(10)
                 .build();
-        ProbabilisticTestSpec<LlmFactors, Integer, Boolean> verification = ProbabilisticTestSpec
+        ProbabilisticTestSpec verification = ProbabilisticTestSpec
                 .testing(sampling, new LlmFactors("gpt-4o", 0.0))
                 .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
                 .build();
-        ProbabilisticTestSpec<LlmFactors, Integer, Boolean> smoke = ProbabilisticTestSpec
+        ProbabilisticTestSpec smoke = ProbabilisticTestSpec
                 .testing(sampling, new LlmFactors("gpt-4o", 0.0))
                 .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
                 .intent(TestIntent.SMOKE)

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -366,7 +366,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .inputs(1)
                 .samples(5)
                 .build();
-        ProbabilisticTestSpec<Factors, Integer, Boolean> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling, new Factors("m"))
                 .criterion(PercentileLatency.<Boolean>meeting(
                         LatencySpec.builder().p50Millis(10L).build(),
@@ -399,7 +399,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .samples(5)
                 .build();
 
-        ProbabilisticTestSpec<Factors, Integer, Boolean> both = ProbabilisticTestSpec
+        ProbabilisticTestSpec both = ProbabilisticTestSpec
                 .testing(sampling, new Factors("m"))
                 .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
                 .criterion(PercentileLatency.<Boolean>meeting(
@@ -426,7 +426,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .inputs(1)
                 .samples(5)
                 .build();
-        ProbabilisticTestSpec<Factors, Integer, Boolean> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling, new Factors("m"))
                 .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
                 .reportOnly(PercentileLatency.<Boolean>meeting(
@@ -458,7 +458,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .inputs(1)
                 .samples(5)
                 .build();
-        ProbabilisticTestSpec<Factors, Integer, Boolean> spec = ProbabilisticTestSpec
+        ProbabilisticTestSpec spec = ProbabilisticTestSpec
                 .testing(sampling, new Factors("m"))
                 .criterion(PercentileLatency.<Boolean>meeting(
                         LatencySpec.builder().p50Millis(100L).build(),

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -88,10 +88,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .samples(1000)
                 .timeBudget(Duration.ofMillis(500))
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         new Engine().run(spec);
-        SampleSummary<Integer> summary = spec.lastSummary().orElseThrow();
+        var summary = spec.lastSummary().orElseThrow();
 
         assertThat(summary.total()).isLessThanOrEqualTo(7);
         assertThat(summary.terminationReason()).isEqualTo(TerminationReason.TIME_BUDGET);
@@ -121,10 +121,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .tokenBudget(250)
                 .tokenCharge(100)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         new Engine().run(spec);
-        SampleSummary<Integer> summary = spec.lastSummary().orElseThrow();
+        var summary = spec.lastSummary().orElseThrow();
 
         assertThat(summary.total()).isEqualTo(2);
         assertThat(summary.tokensConsumed()).isEqualTo(200L);
@@ -148,10 +148,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .samples(5)
                 .tokenCharge(50)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         new Engine().run(spec);
-        SampleSummary<Integer> summary = spec.lastSummary().orElseThrow();
+        var summary = spec.lastSummary().orElseThrow();
 
         assertThat(summary.total()).isEqualTo(5);
         assertThat(summary.tokensConsumed()).isEqualTo(50L * 5);
@@ -171,10 +171,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .timeBudget(Duration.ofMillis(200))
                 .onBudgetExhausted(BudgetExhaustionPolicy.PASS_INCOMPLETE)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         new Engine().run(spec);
-        SampleSummary<Integer> summary = spec.lastSummary().orElseThrow();
+        var summary = spec.lastSummary().orElseThrow();
 
         assertThat(summary.terminatedEarly()).isTrue();
         assertThat(summary.total()).isBetween(2, 7);
@@ -200,7 +200,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .inputs(1)
                 .samples(5)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         long t0 = System.nanoTime();
         new Engine().run(spec);
@@ -231,7 +231,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .inputs(1)
                 .samples(3)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         long t0 = System.nanoTime();
         new Engine().run(spec);
@@ -263,10 +263,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .samples(10)
                 .onException(ExceptionPolicy.FAIL_SAMPLE)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         new Engine().run(spec);
-        SampleSummary<Integer> summary = spec.lastSummary().orElseThrow();
+        var summary = spec.lastSummary().orElseThrow();
 
         assertThat(summary.total()).isEqualTo(10);
         assertThat(summary.successes()).isEqualTo(5);
@@ -287,7 +287,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .inputs(1)
                 .samples(5)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         assertThatThrownBy(() -> new Engine().run(spec))
                 .isInstanceOf(IllegalStateException.class)
@@ -311,10 +311,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .samples(50)
                 .maxExampleFailures(3)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         new Engine().run(spec);
-        SampleSummary<Integer> summary = spec.lastSummary().orElseThrow();
+        var summary = spec.lastSummary().orElseThrow();
 
         assertThat(summary.total()).isEqualTo(50);
         assertThat(summary.failures()).isEqualTo(50);
@@ -336,10 +336,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
                 .inputs(1)
                 .samples(5)
                 .build();
-        MeasureSpec<Factors, Integer, Integer> spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
+        MeasureSpec spec = MeasureSpec.measuring(sampling, new Factors("m")).build();
 
         new Engine().run(spec);
-        SampleSummary<Integer> summary = spec.lastSummary().orElseThrow();
+        var summary = spec.lastSummary().orElseThrow();
         var lr = summary.latencyResult();
         // Nearest-rank: p50 index = ceil(0.5*5)-1 = 2 -> 30ms; p90 = ceil(4.5)-1 = 4 -> 50ms.
         assertThat(lr.sampleCount()).isEqualTo(5);

--- a/punit-core/src/test/java/org/javai/punit/power/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/power/PowerAnalysisTest.java
@@ -22,7 +22,7 @@ class PowerAnalysisTest {
         @Override public UseCaseOutcome<String> apply(String input) { return UseCaseOutcome.ok(input); }
     };
 
-    private static Supplier<MeasureSpec<Factors, String, String>> baseline() {
+    private static Supplier<MeasureSpec> baseline() {
         return () -> {
             Sampling<Factors, String, String> sampling = Sampling
                     .<Factors, String, String>builder()
@@ -117,7 +117,7 @@ class PowerAnalysisTest {
     @DisplayName("invokes the baseline supplier exactly once")
     void invokesSupplierOnce() {
         int[] callCount = {0};
-        Supplier<MeasureSpec<Factors, String, String>> counting = () -> {
+        Supplier<MeasureSpec> counting = () -> {
             callCount[0]++;
             return baseline().get();
         };


### PR DESCRIPTION
## What changes for authors

Before:
\`\`\`java
@ProbabilisticTest
ProbabilisticTestSpec<ShoppingBasketFactors, String, Response>
        shoppingMeetsBaseline() { ... }

@Experiment
MeasureSpec<ShoppingBasketFactors, String, Response>
        shoppingBaseline() { ... }

@Experiment
ExploreSpec<ShoppingBasketFactors, String, Response>
        shoppingGrid() { ... }

@Experiment
OptimizeSpec<ShoppingBasketFactors, String, Response>
        shoppingTune() { ... }
\`\`\`

After:
\`\`\`java
@ProbabilisticTest
ProbabilisticTestSpec shoppingMeetsBaseline() { ... }

@Experiment
MeasureSpec shoppingBaseline() { ... }

@Experiment
ExploreSpec shoppingGrid() { ... }

@Experiment
OptimizeSpec shoppingTune() { ... }
\`\`\`

The bodies are unchanged. Builders stay generic — \`.criterion(Criterion<OT, ?>)\` still rejects wrong-\`OT\` criteria at compile time. Composition-time type safety is fully preserved.

## What changes internally

- \`Spec\` is non-generic + sealed with one dispatch method: \`<R> R dispatch(Dispatcher<R>)\`.
- New \`TypedSpec<FT, IT, OT>\` interface carries the engine-facing typed methods.
- All four concrete specs (\`ProbabilisticTestSpec\`, \`MeasureSpec\`, \`ExploreSpec\`, \`OptimizeSpec\`) are non-generic public; each holds a \`TypedSpec<?, ?, ?>\` internal delegate as a static inner \`Internal\` class.
- \`dispatch()\` routes through a static generic helper that captures the wildcards into fresh type variables — no unchecked casts, no \`@SuppressWarnings\`.
- \`Engine.run(Spec)\` dispatches into a private generic \`runTyped(TypedSpec<FT, IT, OT>)\` helper.

## Public-surface trade-offs

| Accessor | Before | After |
|---|---|---|
| \`MeasureSpec.lastSummary()\` | \`Optional<SampleSummary<OT>>\` | \`Optional<SampleSummary<?>>\` |
| \`OptimizeSpec.history()\` | \`List<IterationResult<FT>>\` | \`List<IterationResult<?>>\` |
| \`MeasureSpec.sampling()\`, \`.factors()\`, \`.expectedOutputs()\`, \`.inputs()\` | typed accessors | dropped (not externally called) |
| \`ExploreSpec.shape()\`, \`.factors()\` | typed accessors | dropped (not externally called) |
| \`OptimizeSpec.shape()\`, \`.initialFactors()\` | typed accessors | dropped (not externally called) |

Engine integration tests that previously declared \`SampleSummary<Integer> summary = spec.lastSummary().orElseThrow()\` now use \`var summary = ...\`. All existing assertions (\`summary.total()\`, \`summary.terminationReason()\`, AssertJ's \`isEqualTo\`) work unchanged on the wildcard-typed summary.

## Cascade

\`PowerAnalysis.sampleSize\`, \`BernoulliPassRate.empiricalFrom\`, \`PercentileLatency.empiricalFrom\` all dropped now-phantom \`<FT, IT, OT>\` from their \`Supplier<MeasureSpec<...>>\` signatures. Test callers update trivially.

## Test plan

- [x] \`./gradlew build\` passes
- [x] All existing engine integration tests pass against the new shape
- [x] Authoring tests pass with un-parameterised declarations

## Doc follow-up (separate orchestrator commits)

The catalog \`java.md\` files for PT01–PT03, EX01–EX03 still show typed return types in their authoring patterns. They'll need updating after this lands — kept out of this PR to keep the diff focused on the surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)