### PR TITLE
Sampling.of(...) — compact factory for the 80% case

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
@@ -25,24 +25,36 @@ import org.javai.punit.api.typed.spec.ExceptionPolicy;
  * reused across all four spec kinds:
  *
  * <pre>{@code
- * private Sampling<F, I, O> sampling(int samples) { ... }
+ * private Sampling<F, I, O> sampling(int samples) {
+ *     return Sampling.of(f -> new MyUseCase(f), samples, input1, input2);
+ * }
  *
- * @Experiment        MeasureSpec<F, I, O> baseline() {
+ * @Experiment        MeasureSpec baseline() {
  *     return MeasureSpec.measuring(sampling(1000), factors).build();
  * }
- * @ProbabilisticTest ProbabilisticTestSpec<F, I, O> meets() {
+ * @ProbabilisticTest ProbabilisticTestSpec meets() {
  *     return ProbabilisticTestSpec.testing(sampling(100), factors)
  *             .criterion(BernoulliPassRate.empirical())
  *             .build();
  * }
- * @Experiment        ExploreSpec<F, I, O> compare() {
+ * @Experiment        ExploreSpec compare() {
  *     return ExploreSpec.exploring(sampling(50)).factors(a, b, c).build();
  * }
- * @Experiment        OptimizeSpec<F, I, O> tune() {
+ * @Experiment        OptimizeSpec tune() {
  *     return OptimizeSpec.optimizing(sampling(20))
- *             .initialFactors(f0).mutator(...).scoredBy(...).toward(...).build();
+ *             .initialFactors(f0).mutator(...).maximize(...).build();
  * }
  * }</pre>
+ *
+ * <p>Two construction paths:
+ * <ul>
+ *   <li>{@link #of(Function, int, List) Sampling.of(useCase, samples, inputs)}
+ *       — compact form for the common case. Defaults applied for all
+ *       optional knobs (no budgets, {@code FAIL} on exhaustion,
+ *       {@code ABORT_TEST} on exception, {@code maxExampleFailures = 10}).</li>
+ *   <li>{@link #builder()} — full control over budgets, policies, and
+ *       failure-retention. The 20% case.</li>
+ * </ul>
  */
 public final class Sampling<FT, IT, OT> {
 
@@ -70,6 +82,49 @@ public final class Sampling<FT, IT, OT> {
 
     public static <FT, IT, OT> Builder<FT, IT, OT> builder() {
         return new Builder<>();
+    }
+
+    /**
+     * Compact form for the common case — three required values, all
+     * optional knobs (budgets, exception policy, failure-retention cap)
+     * left at their defaults. Equivalent to:
+     *
+     * <pre>{@code
+     * Sampling.<FT, IT, OT>builder()
+     *         .useCaseFactory(useCaseFactory)
+     *         .inputs(inputs)
+     *         .samples(samples)
+     *         .build();
+     * }</pre>
+     *
+     * <p>For samplings that need a time / token budget, a non-default
+     * exception policy, or a custom failure-retention cap, use the
+     * full {@link #builder()} form. The two paths are bit-for-bit
+     * equivalent at the data level — {@code of(...)} simply skips the
+     * builder ceremony for the 80% case.
+     */
+    public static <FT, IT, OT> Sampling<FT, IT, OT> of(
+            Function<FT, UseCase<FT, IT, OT>> useCaseFactory,
+            int samples,
+            List<IT> inputs) {
+        return Sampling.<FT, IT, OT>builder()
+                .useCaseFactory(useCaseFactory)
+                .inputs(inputs)
+                .samples(samples)
+                .build();
+    }
+
+    /**
+     * Varargs form of {@link #of(Function, int, List)} — convenient
+     * when the inputs are inline literals.
+     */
+    @SafeVarargs
+    public static <FT, IT, OT> Sampling<FT, IT, OT> of(
+            Function<FT, UseCase<FT, IT, OT>> useCaseFactory,
+            int samples,
+            IT... inputs) {
+        Objects.requireNonNull(inputs, "inputs");
+        return of(useCaseFactory, samples, List.of(inputs));
     }
 
     public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {

--- a/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
@@ -165,4 +165,51 @@ class SamplingTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> sampling.samples(0));
     }
+
+    // ── Sampling.of(...) compact form ──────────────────────────────
+
+    @Test
+    @DisplayName("Sampling.of(factory, samples, List) builds with defaults for optional knobs")
+    void ofWithList() {
+        Sampling<Factors, String, String> sampling = Sampling.of(
+                EchoUseCase::new,
+                250,
+                java.util.List.of("alpha", "beta", "gamma"));
+
+        assertThat(sampling.samples()).isEqualTo(250);
+        assertThat(sampling.inputs()).containsExactly("alpha", "beta", "gamma");
+        assertThat(sampling.timeBudget()).isEmpty();
+        assertThat(sampling.tokenBudget()).isEmpty();
+        assertThat(sampling.tokenCharge()).isEqualTo(0L);
+        assertThat(sampling.budgetPolicy()).isEqualTo(BudgetExhaustionPolicy.FAIL);
+        assertThat(sampling.exceptionPolicy()).isEqualTo(ExceptionPolicy.ABORT_TEST);
+        assertThat(sampling.maxExampleFailures()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Sampling.of(factory, samples, IT...) varargs form is equivalent to the List form")
+    void ofWithVarargs() {
+        Sampling<Factors, String, String> a = Sampling.of(
+                EchoUseCase::new, 100, "x", "y");
+        Sampling<Factors, String, String> b = Sampling.of(
+                EchoUseCase::new, 100, java.util.List.of("x", "y"));
+
+        assertThat(a.inputs()).isEqualTo(b.inputs());
+        assertThat(a.samples()).isEqualTo(b.samples());
+    }
+
+    @Test
+    @DisplayName("Sampling.of(...) rejects non-positive samples — same contract as the builder")
+    void ofRejectsNonPositiveSamples() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Sampling.of(EchoUseCase::new, 0, "x"));
+    }
+
+    @Test
+    @DisplayName("Sampling.of(...) rejects empty inputs — same contract as the builder")
+    void ofRejectsEmptyInputs() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Sampling.<Factors, String, String>of(
+                        EchoUseCase::new, 100, java.util.List.of()));
+    }
 }


### PR DESCRIPTION
## Summary

Adds a static factory \`Sampling.of(useCaseFactory, samples, inputs)\` for the common case where authors don't need budgets, policies, or failure-retention caps.

The shape:
\`\`\`java
public static <FT, IT, OT> Sampling<FT, IT, OT> of(
    Function<FT, UseCase<FT, IT, OT>> useCaseFactory,
    int samples,
    List<IT> inputs);

@SafeVarargs
public static <FT, IT, OT> Sampling<FT, IT, OT> of(
    Function<FT, UseCase<FT, IT, OT>> useCaseFactory,
    int samples,
    IT... inputs);
\`\`\`

Both delegate to the existing \`Sampling.builder()\` under the hood — defaults applied for every optional knob. Bit-for-bit equivalent at the data level. Authors recognise the pattern from \`List.of(...)\` / \`Map.of(...)\`.

## Why

Before:
\`\`\`java
private Sampling<ShoppingFactors, String, ShoppingResponse> sampling(int samples) {
    return Sampling.<ShoppingFactors, String, ShoppingResponse>builder()
            .useCaseFactory(f -> new ShoppingBasketUseCase(f))
            .inputs("Add 2 apples", "Remove the milk")
            .samples(samples)
            .build();
}
\`\`\`
7 lines, two type-parameter triples, builder ceremony around 3 required values.

After:
\`\`\`java
private Sampling<ShoppingFactors, String, ShoppingResponse> sampling(int samples) {
    return Sampling.of(
            f -> new ShoppingBasketUseCase(f),
            samples,
            "Add 2 apples", "Remove the milk");
}
\`\`\`
4 lines, one type-parameter triple (on the return type, where it's load-bearing), no \`.builder()\`, no \`.build()\`.

For samplings that need a budget or non-default policy, \`Sampling.builder()\` is unchanged — the 20% case pays exactly what it pays today.

## Two-tier discipline

The two-tier promise decays if the simple form grows. The discipline:

> **\`of(...)\` keeps exactly the three-required-arg signatures forever.** Anything more — a budget, a policy, a charge — sends authors to the builder.

That's the rule that keeps this from becoming a lattice of factories.

## Context

This addresses one of the top-tier DX observations from \`docs/MIGRATION-PREVIEW-PUNITEXAMPLES.md\` — and by doing so, retires the "boilerplate has roughly doubled" claim it sat under, which an honest line count had already shown to be overstated. The migration preview is updated in a companion orchestrator commit on \`refactor/compositional-design\` (\`4d27ff6\`).

## Test plan

- [x] \`./gradlew build\` passes
- [x] New \`SamplingTest\` cases cover: build with defaults, varargs/List equivalence, sample-count and input validation parity with the builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)