### PR TITLE
Doc reframe: Sampling as the integrity mechanism for empirical pairing

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
@@ -15,13 +15,36 @@ import org.javai.punit.api.typed.spec.ExceptionPolicy;
  * the input cycle, the sample count, and the sample-loop governors
  * (budgets, exception policy, failure-retention cap).
  *
- * <p>A {@code Sampling} does <strong>not</strong> carry a factors
- * instance. Factors are supplied at the spec entry point that
- * consumes the sampling — {@code Experiment.measuring(sampling, factors)}
- * for a measure, {@code ProbabilisticTest.testing(sampling, factors)}
- * for the paired test, and so on. This deferred binding is what lets
- * one helper feed a measure / probabilistic-test pair (same factors
- * at both call sites) or an explore / optimize (varying factors).
+ * <h2>Sampling is the integrity mechanism for the empirical pair
+ * pattern</h2>
+ *
+ * <p>The headline use of {@code Sampling} is to be authored once,
+ * in a helper method, and consumed by both a measure baseline and
+ * the probabilistic test paired against it. <strong>That sharing is
+ * not just a code-reuse convenience — it is the framework's
+ * structural guarantee that the empirical comparison is
+ * meaningful.</strong>
+ *
+ * <p>An empirical probabilistic test asks: <em>has the service's
+ * pass rate degraded from the rate the baseline measured?</em> For
+ * that question to be statistically coherent, the test and the
+ * baseline must be drawn from the same sampling population — same
+ * use case, same input list, same factors, same sample-loop
+ * governors. Anything that differs between them confounds the
+ * comparison. By passing the same {@code Sampling} value into both
+ * the measure and the test, Java's reference semantics enforce that
+ * sameness at compile time. The pairing is structural, not a
+ * brittle prose convention.
+ *
+ * <p>A {@code Sampling} does not carry a factors instance — factors
+ * are supplied at the spec entry point that consumes the sampling
+ * ({@code Experiment.measuring(sampling, factors)},
+ * {@code ProbabilisticTest.testing(sampling, factors)}, etc.). For
+ * the measure / test pair, both call sites pass the same factors;
+ * the framework's empirical-baseline resolver then matches the
+ * test's factors against the measure's stored baseline (CR02).
+ *
+ * <h2>The pair pattern at the call site</h2>
  *
  * <pre>{@code
  * private Sampling<F, I, O> sampling(int samples) {
@@ -36,6 +59,16 @@ import org.javai.punit.api.typed.spec.ExceptionPolicy;
  *             .criterion(BernoulliPassRate.empirical())
  *             .build();
  * }
+ * }</pre>
+ *
+ * <p>Same {@code sampling(...)} helper, same {@code factors},
+ * differing only in the sample count and the criterion overlay.
+ * The <em>same Sampling, same factors</em> shape is the contract
+ * the empirical baseline resolver depends on.
+ *
+ * <h2>Other consumers</h2>
+ *
+ * <pre>{@code
  * @PunitExperiment Experiment compare() {
  *     return Experiment.exploring(sampling(50)).grid(a, b, c).build();
  * }
@@ -45,7 +78,15 @@ import org.javai.punit.api.typed.spec.ExceptionPolicy;
  * }
  * }</pre>
  *
- * <p>Two construction paths:
+ * <p>Explore and optimize use the same Sampling-then-factors-vary
+ * shape, with factors generated either from a grid or by an
+ * iterative stepper. The "Sampling stays constant; factors vary"
+ * principle is what makes the per-configuration comparison
+ * meaningful — same as the measure ↔ test pairing, scaled out to
+ * many configurations.
+ *
+ * <h2>Two construction paths</h2>
+ *
  * <ul>
  *   <li>{@link #of(Function, int, List) Sampling.of(useCase, samples, inputs)}
  *       — compact form for the common case. Defaults applied for all

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
@@ -66,8 +66,13 @@ public final class Experiment implements Spec {
     // ── Static factories ─────────────────────────────────────────────
 
     /**
-     * Compose a measure experiment over a factor-free
-     * {@link Sampling} and the factor bundle the measure runs against.
+     * Compose a measure experiment over a {@link Sampling} and the
+     * factors the measure runs against. The same {@link Sampling}
+     * value can be passed to {@link ProbabilisticTest#testing} to
+     * pair the measure with an empirical test — Java's reference
+     * semantics enforce that both operate on the same sampling
+     * population, the structural guarantee the empirical comparison
+     * depends on.
      */
     public static <FT, IT, OT> MeasureBuilder<FT, IT, OT> measuring(
             Sampling<FT, IT, OT> sampling, FT factors) {
@@ -78,7 +83,8 @@ public final class Experiment implements Spec {
 
     /**
      * Compose an explore experiment over a {@link Sampling}; the
-     * factor grid is supplied through the returned builder.
+     * grid of factors instances is supplied through the returned
+     * builder.
      */
     public static <FT, IT, OT> ExploreBuilder<FT, IT, OT> exploring(
             Sampling<FT, IT, OT> sampling) {

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -41,8 +41,39 @@ public final class ProbabilisticTest implements Spec {
     }
 
     /**
-     * Entry point — compose a probabilistic test over a factor-free
-     * {@link Sampling} and the factor bundle it should run against.
+     * Entry point — compose a probabilistic test over a
+     * {@link Sampling} and the factors it should run against.
+     *
+     * <p>For an empirical test (criterion built via
+     * {@link BernoulliPassRate#empirical()} or {@code .empiricalFrom(...)}),
+     * the {@code Sampling} passed here must be the <em>same value</em>
+     * passed to the paired measure's
+     * {@link Experiment#measuring(Sampling, Object) Experiment.measuring(...)}.
+     * The shared reference is what guarantees the test and the
+     * baseline are drawn from the same sampling population — same
+     * use case, same input list, same governors. Without that
+     * sameness, the empirical comparison is statistically
+     * incoherent.
+     *
+     * <p>Authoring pattern: extract the {@code Sampling} into a
+     * helper method shared between the measure and the test:
+     *
+     * <pre>{@code
+     * private Sampling<F, I, O> sampling(int samples) { ... }
+     *
+     * @PunitExperiment Experiment baseline() {
+     *     return Experiment.measuring(sampling(1000), factors).build();
+     * }
+     * @PunitTest ProbabilisticTest meets() {
+     *     return ProbabilisticTest.testing(sampling(100), factors)
+     *             .criterion(BernoulliPassRate.empirical())
+     *             .build();
+     * }
+     * }</pre>
+     *
+     * <p>Same {@code factors} at both call sites; same helper
+     * supplying the {@code Sampling}; only the sample count and the
+     * criterion overlay differ.
      */
     public static <FT, IT, OT> Builder<FT, IT, OT> testing(
             Sampling<FT, IT, OT> sampling, FT factors) {


### PR DESCRIPTION
## Summary

Doc-only. No API surface changes; no runtime semantics changes. Three javadoc rewrites landing the design intent that the Sampling type's load-bearing role is *correctness*, not just *reuse*.

## Why

The Sampling type was originally framed as a code-reuse helper. Re-reading the surface during recent DX iteration makes clear that its load-bearing role is structural integrity:

> When the same \`Sampling\` value is passed into both a measure baseline and the probabilistic test paired against it, Java's reference semantics enforce that both operate on the same sampling population — same use case, same input list, same governors. Without that sameness, the empirical comparison is statistically incoherent.

The compositional split's headline reason was reuse; the load-bearing reason is correctness. The doc now leads with the load-bearing reason.

## What changed

- \`Sampling.java\` class-level javadoc now leads with *"Sampling is the integrity mechanism for the empirical pair pattern"* and names the *"same Sampling, same factors"* contract explicitly. The legacy "factor-free Sampling" framing is gone (it was already mostly cleaned up in PR #63 but a residual reference remained); the new prose names the actual mechanic — deferred factors-binding plus structural sameness via shared Sampling reference.
- \`Experiment.measuring(...)\` javadoc references the pairing guarantee.
- \`Experiment.exploring(...)\` javadoc cleaned of "factor grid" (now "grid of factors instances", matching PR #63 vocabulary).
- \`ProbabilisticTest.testing(...)\` javadoc gets a substantive expansion: spells out the empirical-pair contract, walks through the helper-extraction pattern, frames the "same factors, same Sampling, only sample count and criterion vary" shape as what the empirical baseline resolver depends on.

## Why now (and why this PR is doc-only)

This commit is the precursor to a forthcoming change that will add an inline-sampling form on the spec entry points, restricted to cases where the empirical-pair guarantee doesn't apply (measures, contractual tests). The reframed doc is the design intent that subsequent change will reference. Landing it first means the design point is codified before any code change can drift from it.

## Test plan

- [x] \`./gradlew build\` passes (39 actionable tasks; full test suite green)
- [x] No source changes outside javadoc — no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)