### PR TITLE
Inline-sampling form with empirical-test guard

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BernoulliPassRate.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BernoulliPassRate.java
@@ -119,6 +119,11 @@ public final class BernoulliPassRate<OT> implements Criterion<OT, PassRateStatis
     }
 
     @Override
+    public boolean isEmpirical() {
+        return mode != Mode.CONTRACTUAL;
+    }
+
+    @Override
     public CriterionResult evaluate(EvaluationContext<OT, PassRateStatistics> ctx) {
         Objects.requireNonNull(ctx, "ctx");
         SampleSummary<OT> summary = ctx.summary();

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Criterion.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Criterion.java
@@ -39,4 +39,22 @@ public interface Criterion<OT, S extends BaselineStatistics> {
      * no side effects.
      */
     CriterionResult evaluate(EvaluationContext<OT, S> ctx);
+
+    /**
+     * @return {@code true} if the criterion's evaluation depends on a
+     *         resolved baseline (an empirical claim against measured
+     *         data); {@code false} for contractual claims with no
+     *         baseline dependency. Default: {@code false}.
+     *
+     * <p>The framework consults this at build time to gate the
+     * inline-sampling form on probabilistic tests: an empirical
+     * criterion requires a {@link Sampling} value shared with the
+     * paired measure (the structural integrity guarantee for the
+     * empirical comparison), so the inline form — which constructs
+     * a fresh {@link Sampling} per spec — is rejected with a
+     * diagnostic teaching the helper-extraction pattern.
+     */
+    default boolean isEmpirical() {
+        return false;
+    }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
@@ -101,6 +101,45 @@ public final class Experiment implements Spec {
         return new OptimizeBuilder<>(Objects.requireNonNull(sampling, "sampling"));
     }
 
+    // ── Inline-sampling entry points (one-off authoring) ────────────
+    //
+    // Each inline form accepts a use-case factory in place of a Sampling.
+    // The returned builder accumulates sampling-level state (inputs,
+    // samples, governors) alongside the spec-overlay state, synthesising
+    // a Sampling at .build() time.
+    //
+    // Inline form is for one-off authoring (no reuse). The integrity
+    // guarantee that comes from sharing a Sampling value across a
+    // measure / probabilistic-test pair is unavailable in the inline
+    // form — measures, explores, and optimizes are unaffected (no
+    // pairing); empirical probabilistic tests are rejected at .build()
+    // with a diagnostic teaching the helper-extraction pattern.
+
+    /**
+     * Inline-sampling form of {@link #measuring(Sampling, Object)}.
+     * Sampling parameters are supplied through the returned builder.
+     */
+    public static <FT, IT, OT> InlineMeasureBuilder<FT, IT, OT> measuring(
+            Function<FT, UseCase<FT, IT, OT>> useCaseFactory, FT factors) {
+        return new InlineMeasureBuilder<>(
+                Objects.requireNonNull(useCaseFactory, "useCaseFactory"),
+                Objects.requireNonNull(factors, "factors"));
+    }
+
+    /** Inline-sampling form of {@link #exploring(Sampling)}. */
+    public static <FT, IT, OT> InlineExploreBuilder<FT, IT, OT> exploring(
+            Function<FT, UseCase<FT, IT, OT>> useCaseFactory) {
+        return new InlineExploreBuilder<>(
+                Objects.requireNonNull(useCaseFactory, "useCaseFactory"));
+    }
+
+    /** Inline-sampling form of {@link #optimizing(Sampling)}. */
+    public static <FT, IT, OT> InlineOptimizeBuilder<FT, IT, OT> optimizing(
+            Function<FT, UseCase<FT, IT, OT>> useCaseFactory) {
+        return new InlineOptimizeBuilder<>(
+                Objects.requireNonNull(useCaseFactory, "useCaseFactory"));
+    }
+
     // ── Public scalar accessors ─────────────────────────────────────
 
     public Kind kind() { return kind; }
@@ -541,6 +580,401 @@ public final class Experiment implements Spec {
                         "scorer is required — call .maximize(...) or .minimize(...)");
             }
             return new Experiment(Kind.OPTIMIZE, new OptimizeInternal<>(this));
+        }
+    }
+
+    // ── Inline builders ─────────────────────────────────────────────
+
+    /**
+     * Carries the sampling-level state (use case factory, inputs,
+     * samples, governors) shared by all inline experiment builders.
+     * Subclasses add the kind-specific overlay state.
+     */
+    private static class InlineSamplingState<FT, IT, OT> {
+
+        final Function<FT, UseCase<FT, IT, OT>> useCaseFactory;
+        List<IT> inputs;
+        int samples = 1000;
+        Optional<Duration> timeBudget = Optional.empty();
+        OptionalLong tokenBudget = OptionalLong.empty();
+        long tokenCharge = 0L;
+        BudgetExhaustionPolicy budgetPolicy = BudgetExhaustionPolicy.FAIL;
+        ExceptionPolicy exceptionPolicy = ExceptionPolicy.ABORT_TEST;
+        int maxExampleFailures = 10;
+
+        InlineSamplingState(Function<FT, UseCase<FT, IT, OT>> useCaseFactory) {
+            this.useCaseFactory = useCaseFactory;
+        }
+
+        Sampling<FT, IT, OT> toSampling() {
+            if (inputs == null) {
+                throw new IllegalStateException(
+                        "inputs is required — call .inputs(...) before .build()");
+            }
+            Sampling.Builder<FT, IT, OT> b = Sampling.<FT, IT, OT>builder()
+                    .useCaseFactory(useCaseFactory)
+                    .inputs(inputs)
+                    .samples(samples);
+            timeBudget.ifPresent(b::timeBudget);
+            tokenBudget.ifPresent(b::tokenBudget);
+            if (tokenCharge > 0L) {
+                b.tokenCharge(tokenCharge);
+            }
+            b.onBudgetExhausted(budgetPolicy);
+            b.onException(exceptionPolicy);
+            b.maxExampleFailures(maxExampleFailures);
+            return b.build();
+        }
+    }
+
+    public static final class InlineMeasureBuilder<FT, IT, OT> {
+
+        private final InlineSamplingState<FT, IT, OT> sampling;
+        private final FT factors;
+        private List<OT> expected = List.of();
+        private ValueMatcher<OT> matcher;
+        private String experimentId;
+        private Integer expiresInDays;
+
+        private InlineMeasureBuilder(Function<FT, UseCase<FT, IT, OT>> useCaseFactory, FT factors) {
+            this.sampling = new InlineSamplingState<>(useCaseFactory);
+            this.factors = factors;
+        }
+
+        // Sampling-level setters
+        public InlineMeasureBuilder<FT, IT, OT> inputs(List<IT> inputs) {
+            Objects.requireNonNull(inputs, "inputs");
+            if (inputs.isEmpty()) {
+                throw new IllegalArgumentException("inputs must be non-empty");
+            }
+            sampling.inputs = List.copyOf(inputs);
+            return this;
+        }
+
+        @SafeVarargs
+        public final InlineMeasureBuilder<FT, IT, OT> inputs(IT... inputs) {
+            return inputs(List.of(Objects.requireNonNull(inputs, "inputs")));
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> samples(int samples) {
+            if (samples < 1) {
+                throw new IllegalArgumentException("samples must be >= 1, got " + samples);
+            }
+            sampling.samples = samples;
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> timeBudget(Duration budget) {
+            Objects.requireNonNull(budget, "timeBudget");
+            sampling.timeBudget = Optional.of(budget);
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> tokenBudget(long tokens) {
+            sampling.tokenBudget = OptionalLong.of(tokens);
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> tokenCharge(long tokens) {
+            sampling.tokenCharge = tokens;
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> onBudgetExhausted(BudgetExhaustionPolicy policy) {
+            sampling.budgetPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> onException(ExceptionPolicy policy) {
+            sampling.exceptionPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> maxExampleFailures(int cap) {
+            sampling.maxExampleFailures = cap;
+            return this;
+        }
+
+        // Measure-overlay setters
+        public InlineMeasureBuilder<FT, IT, OT> experimentId(String id) {
+            this.experimentId = Objects.requireNonNull(id, "experimentId");
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> expectedOutputs(List<OT> outputs) {
+            this.expected = List.copyOf(Objects.requireNonNull(outputs, "outputs"));
+            return this;
+        }
+
+        @SafeVarargs
+        public final InlineMeasureBuilder<FT, IT, OT> expectedOutputs(OT... outputs) {
+            return expectedOutputs(List.of(outputs));
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> matcher(ValueMatcher<OT> matcher) {
+            this.matcher = Objects.requireNonNull(matcher, "matcher");
+            return this;
+        }
+
+        public InlineMeasureBuilder<FT, IT, OT> expiresInDays(int days) {
+            if (days < 0) {
+                throw new IllegalArgumentException("expiresInDays must be non-negative, got " + days);
+            }
+            this.expiresInDays = days;
+            return this;
+        }
+
+        public Experiment build() {
+            MeasureBuilder<FT, IT, OT> delegate = new MeasureBuilder<>(
+                    sampling.toSampling(), factors);
+            if (experimentId != null) {
+                delegate.experimentId(experimentId);
+            }
+            if (!expected.isEmpty()) {
+                delegate.expectedOutputs(expected);
+            }
+            if (matcher != null) {
+                delegate.matcher(matcher);
+            }
+            if (expiresInDays != null) {
+                delegate.expiresInDays(expiresInDays);
+            }
+            return delegate.build();
+        }
+    }
+
+    public static final class InlineExploreBuilder<FT, IT, OT> {
+
+        private final InlineSamplingState<FT, IT, OT> sampling;
+        private List<FT> grid;
+        private String experimentId;
+
+        private InlineExploreBuilder(Function<FT, UseCase<FT, IT, OT>> useCaseFactory) {
+            this.sampling = new InlineSamplingState<>(useCaseFactory);
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> inputs(List<IT> inputs) {
+            Objects.requireNonNull(inputs, "inputs");
+            if (inputs.isEmpty()) {
+                throw new IllegalArgumentException("inputs must be non-empty");
+            }
+            sampling.inputs = List.copyOf(inputs);
+            return this;
+        }
+
+        @SafeVarargs
+        public final InlineExploreBuilder<FT, IT, OT> inputs(IT... inputs) {
+            return inputs(List.of(Objects.requireNonNull(inputs, "inputs")));
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> samples(int samples) {
+            if (samples < 1) {
+                throw new IllegalArgumentException("samples must be >= 1, got " + samples);
+            }
+            sampling.samples = samples;
+            return this;
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> timeBudget(Duration budget) {
+            sampling.timeBudget = Optional.of(Objects.requireNonNull(budget, "timeBudget"));
+            return this;
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> tokenBudget(long tokens) {
+            sampling.tokenBudget = OptionalLong.of(tokens);
+            return this;
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> tokenCharge(long tokens) {
+            sampling.tokenCharge = tokens;
+            return this;
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> onBudgetExhausted(BudgetExhaustionPolicy policy) {
+            sampling.budgetPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> onException(ExceptionPolicy policy) {
+            sampling.exceptionPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> maxExampleFailures(int cap) {
+            sampling.maxExampleFailures = cap;
+            return this;
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> grid(List<FT> grid) {
+            Objects.requireNonNull(grid, "grid");
+            if (grid.isEmpty()) {
+                throw new IllegalArgumentException("grid must be non-empty");
+            }
+            this.grid = List.copyOf(grid);
+            return this;
+        }
+
+        @SafeVarargs
+        public final InlineExploreBuilder<FT, IT, OT> grid(FT... grid) {
+            return grid(List.of(Objects.requireNonNull(grid, "grid")));
+        }
+
+        public InlineExploreBuilder<FT, IT, OT> experimentId(String id) {
+            this.experimentId = Objects.requireNonNull(id, "experimentId");
+            return this;
+        }
+
+        public Experiment build() {
+            if (grid == null) {
+                throw new IllegalStateException("grid is required — call .grid(...)");
+            }
+            ExploreBuilder<FT, IT, OT> delegate = new ExploreBuilder<>(sampling.toSampling())
+                    .grid(grid);
+            if (experimentId != null) {
+                delegate.experimentId(experimentId);
+            }
+            return delegate.build();
+        }
+    }
+
+    public static final class InlineOptimizeBuilder<FT, IT, OT> {
+
+        private final InlineSamplingState<FT, IT, OT> sampling;
+        private FT initialFactors;
+        private FactorsStepper<FT> stepper;
+        private Scorer scorer;
+        private boolean maximizing;
+        private boolean directionSet;
+        private int maxIterations = 20;
+        private int noImprovementWindow = 5;
+        private String experimentId;
+
+        private InlineOptimizeBuilder(Function<FT, UseCase<FT, IT, OT>> useCaseFactory) {
+            this.sampling = new InlineSamplingState<>(useCaseFactory);
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> inputs(List<IT> inputs) {
+            Objects.requireNonNull(inputs, "inputs");
+            if (inputs.isEmpty()) {
+                throw new IllegalArgumentException("inputs must be non-empty");
+            }
+            sampling.inputs = List.copyOf(inputs);
+            return this;
+        }
+
+        @SafeVarargs
+        public final InlineOptimizeBuilder<FT, IT, OT> inputs(IT... inputs) {
+            return inputs(List.of(Objects.requireNonNull(inputs, "inputs")));
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> samples(int samples) {
+            if (samples < 1) {
+                throw new IllegalArgumentException("samples must be >= 1, got " + samples);
+            }
+            sampling.samples = samples;
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> timeBudget(Duration budget) {
+            sampling.timeBudget = Optional.of(Objects.requireNonNull(budget, "timeBudget"));
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> tokenBudget(long tokens) {
+            sampling.tokenBudget = OptionalLong.of(tokens);
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> tokenCharge(long tokens) {
+            sampling.tokenCharge = tokens;
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> onBudgetExhausted(BudgetExhaustionPolicy policy) {
+            sampling.budgetPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> onException(ExceptionPolicy policy) {
+            sampling.exceptionPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> maxExampleFailures(int cap) {
+            sampling.maxExampleFailures = cap;
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> initialFactors(FT factors) {
+            this.initialFactors = Objects.requireNonNull(factors, "initialFactors");
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> stepper(FactorsStepper<FT> s) {
+            this.stepper = Objects.requireNonNull(s, "stepper");
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> maximize(Scorer scorer) {
+            this.scorer = Objects.requireNonNull(scorer, "scorer");
+            this.maximizing = true;
+            this.directionSet = true;
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> minimize(Scorer scorer) {
+            this.scorer = Objects.requireNonNull(scorer, "scorer");
+            this.maximizing = false;
+            this.directionSet = true;
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> maxIterations(int n) {
+            if (n < 1) {
+                throw new IllegalArgumentException("maxIterations must be >= 1");
+            }
+            this.maxIterations = n;
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> noImprovementWindow(int n) {
+            if (n < 1) {
+                throw new IllegalArgumentException("noImprovementWindow must be >= 1");
+            }
+            this.noImprovementWindow = n;
+            return this;
+        }
+
+        public InlineOptimizeBuilder<FT, IT, OT> experimentId(String id) {
+            this.experimentId = Objects.requireNonNull(id, "experimentId");
+            return this;
+        }
+
+        public Experiment build() {
+            if (initialFactors == null) {
+                throw new IllegalStateException("initialFactors is required");
+            }
+            if (stepper == null) {
+                throw new IllegalStateException("stepper is required");
+            }
+            if (!directionSet) {
+                throw new IllegalStateException(
+                        "scorer is required — call .maximize(...) or .minimize(...)");
+            }
+            OptimizeBuilder<FT, IT, OT> delegate = new OptimizeBuilder<>(sampling.toSampling())
+                    .initialFactors(initialFactors)
+                    .stepper(stepper)
+                    .maxIterations(maxIterations)
+                    .noImprovementWindow(noImprovementWindow);
+            if (maximizing) {
+                delegate.maximize(scorer);
+            } else {
+                delegate.minimize(scorer);
+            }
+            if (experimentId != null) {
+                delegate.experimentId(experimentId);
+            }
+            return delegate.build();
         }
     }
 

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/PercentileLatency.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/PercentileLatency.java
@@ -109,6 +109,11 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
     }
 
     @Override
+    public boolean isEmpirical() {
+        return mode != Mode.CONTRACTUAL;
+    }
+
+    @Override
     public CriterionResult evaluate(EvaluationContext<OT, LatencyStatistics> ctx) {
         Objects.requireNonNull(ctx, "ctx");
         SampleSummary<OT> summary = ctx.summary();

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -82,6 +82,33 @@ public final class ProbabilisticTest implements Spec {
                 Objects.requireNonNull(factors, "factors"));
     }
 
+    /**
+     * Inline-sampling form of {@link #testing(Sampling, Object)}.
+     * Sampling parameters are supplied through the returned builder.
+     *
+     * <p>For a probabilistic test with a <strong>contractual</strong>
+     * criterion (e.g., {@link BernoulliPassRate#meeting(double, org.javai.punit.api.ThresholdOrigin)}),
+     * the inline form is equivalent to constructing a fresh
+     * {@link Sampling} per spec — there is no baseline pairing to
+     * preserve, so no integrity guarantee at risk.
+     *
+     * <p>For a probabilistic test with an <strong>empirical</strong>
+     * criterion ({@code BernoulliPassRate.empirical()} /
+     * {@code .empiricalFrom(...)}), the inline form is rejected at
+     * {@code .build()} time. An empirical comparison requires the
+     * test and the baseline measure to draw from the same sampling
+     * population; that integrity guarantee comes from sharing a
+     * {@link Sampling} value with the paired measure, which the
+     * inline form cannot provide. The diagnostic teaches the
+     * helper-extraction pattern.
+     */
+    public static <FT, IT, OT> InlineBuilder<FT, IT, OT> testing(
+            Function<FT, UseCase<FT, IT, OT>> useCaseFactory, FT factors) {
+        return new InlineBuilder<>(
+                Objects.requireNonNull(useCaseFactory, "useCaseFactory"),
+                Objects.requireNonNull(factors, "factors"));
+    }
+
     /** Sample count for this test, taken from its sampling. */
     public int samples() { return internal.sampling.samples(); }
 
@@ -217,4 +244,160 @@ public final class ProbabilisticTest implements Spec {
     }
 
     private record Registered<OT>(Criterion<OT, ?> criterion, CriterionRole role) {}
+
+    // ── Inline-sampling builder ─────────────────────────────────────
+
+    /**
+     * Inline-form builder. Accumulates sampling-level state alongside
+     * the test-overlay state; synthesises a {@link Sampling} at
+     * {@link #build()} time. Rejects empirical criteria at build time
+     * with a diagnostic teaching the helper-extraction pattern.
+     */
+    public static final class InlineBuilder<FT, IT, OT> {
+
+        private final Function<FT, UseCase<FT, IT, OT>> useCaseFactory;
+        private final FT factors;
+        private List<IT> inputs;
+        private int samples = 1000;
+        private Optional<Duration> timeBudget = Optional.empty();
+        private OptionalLong tokenBudget = OptionalLong.empty();
+        private long tokenCharge = 0L;
+        private BudgetExhaustionPolicy budgetPolicy = BudgetExhaustionPolicy.FAIL;
+        private ExceptionPolicy exceptionPolicy = ExceptionPolicy.ABORT_TEST;
+        private int maxExampleFailures = 10;
+        private final List<Registered<OT>> registered = new ArrayList<>();
+        private TestIntent intent = TestIntent.VERIFICATION;
+
+        private InlineBuilder(Function<FT, UseCase<FT, IT, OT>> useCaseFactory, FT factors) {
+            this.useCaseFactory = useCaseFactory;
+            this.factors = factors;
+        }
+
+        public InlineBuilder<FT, IT, OT> inputs(List<IT> inputs) {
+            Objects.requireNonNull(inputs, "inputs");
+            if (inputs.isEmpty()) {
+                throw new IllegalArgumentException("inputs must be non-empty");
+            }
+            this.inputs = List.copyOf(inputs);
+            return this;
+        }
+
+        @SafeVarargs
+        public final InlineBuilder<FT, IT, OT> inputs(IT... inputs) {
+            return inputs(List.of(Objects.requireNonNull(inputs, "inputs")));
+        }
+
+        public InlineBuilder<FT, IT, OT> samples(int samples) {
+            if (samples < 1) {
+                throw new IllegalArgumentException("samples must be >= 1, got " + samples);
+            }
+            this.samples = samples;
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> timeBudget(Duration budget) {
+            this.timeBudget = Optional.of(Objects.requireNonNull(budget, "timeBudget"));
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> tokenBudget(long tokens) {
+            this.tokenBudget = OptionalLong.of(tokens);
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> tokenCharge(long tokens) {
+            this.tokenCharge = tokens;
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> onBudgetExhausted(BudgetExhaustionPolicy policy) {
+            this.budgetPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> onException(ExceptionPolicy policy) {
+            this.exceptionPolicy = Objects.requireNonNull(policy, "policy");
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> maxExampleFailures(int cap) {
+            this.maxExampleFailures = cap;
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> criterion(Criterion<OT, ?> criterion) {
+            Objects.requireNonNull(criterion, "criterion");
+            registered.add(new Registered<>(criterion, CriterionRole.REQUIRED));
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> reportOnly(Criterion<OT, ?> criterion) {
+            Objects.requireNonNull(criterion, "criterion");
+            registered.add(new Registered<>(criterion, CriterionRole.REPORT_ONLY));
+            return this;
+        }
+
+        public InlineBuilder<FT, IT, OT> intent(TestIntent intent) {
+            this.intent = Objects.requireNonNull(intent, "intent");
+            return this;
+        }
+
+        public ProbabilisticTest build() {
+            // Empirical-criterion guard. The integrity guarantee for an
+            // empirical comparison comes from sharing a Sampling value
+            // with the paired measure; the inline form constructs a
+            // fresh Sampling per spec and cannot provide that guarantee.
+            for (Registered<OT> r : registered) {
+                if (r.criterion().isEmpirical()) {
+                    throw new IllegalStateException(
+                            "An empirical criterion (" + r.criterion().name() + ") requires "
+                                    + "the probabilistic test to share a Sampling with its "
+                                    + "baseline measure. The inline ProbabilisticTest.testing("
+                                    + "useCaseFactory, factors) form cannot guarantee that "
+                                    + "structural pairing.\n\n"
+                                    + "Extract the sampling as a helper and use the "
+                                    + "Sampling-bound entry point at both call sites:\n"
+                                    + "    private Sampling<F, I, O> sampling(int samples) {\n"
+                                    + "        return Sampling.of(useCaseFactory, samples, inputs);\n"
+                                    + "    }\n"
+                                    + "    @PunitExperiment Experiment baseline() {\n"
+                                    + "        return Experiment.measuring(sampling(1000), factors).build();\n"
+                                    + "    }\n"
+                                    + "    @PunitTest ProbabilisticTest meets() {\n"
+                                    + "        return ProbabilisticTest.testing(sampling(100), factors)\n"
+                                    + "                .criterion(BernoulliPassRate.empirical())\n"
+                                    + "                .build();\n"
+                                    + "    }");
+                }
+            }
+            if (inputs == null) {
+                throw new IllegalStateException(
+                        "inputs is required — call .inputs(...) before .build()");
+            }
+            Sampling.Builder<FT, IT, OT> sb = Sampling.<FT, IT, OT>builder()
+                    .useCaseFactory(useCaseFactory)
+                    .inputs(inputs)
+                    .samples(samples);
+            timeBudget.ifPresent(sb::timeBudget);
+            tokenBudget.ifPresent(sb::tokenBudget);
+            if (tokenCharge > 0L) {
+                sb.tokenCharge(tokenCharge);
+            }
+            sb.onBudgetExhausted(budgetPolicy);
+            sb.onException(exceptionPolicy);
+            sb.maxExampleFailures(maxExampleFailures);
+            Sampling<FT, IT, OT> sampling = sb.build();
+
+            Builder<FT, IT, OT> delegate = new Builder<>(sampling, factors);
+            delegate.intent(intent);
+            for (Registered<OT> r : registered) {
+                if (r.role() == CriterionRole.REQUIRED) {
+                    delegate.criterion(r.criterion());
+                } else {
+                    delegate.reportOnly(r.criterion());
+                }
+            }
+            return delegate.build();
+        }
+    }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/InlineSamplingFormTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/InlineSamplingFormTest.java
@@ -1,0 +1,134 @@
+package org.javai.punit.api.typed.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Inline-sampling form")
+class InlineSamplingFormTest {
+
+    record Factors(String label) {}
+
+    private static final UseCase<Factors, String, String> ECHO = new UseCase<>() {
+        @Override public UseCaseOutcome<String> apply(String input) { return UseCaseOutcome.ok(input); }
+    };
+
+    @Test
+    @DisplayName("Experiment.measuring(useCase, factors) builds a measure with inline sampling")
+    void measureInlineForm() {
+        Experiment spec = Experiment.measuring(f -> ECHO, new Factors("m"))
+                .inputs("a", "b", "c")
+                .samples(50)
+                .experimentId("inline-measure")
+                .build();
+
+        assertThat(spec.kind()).isEqualTo(Experiment.Kind.MEASURE);
+        assertThat(spec.samples()).isEqualTo(50);
+        assertThat(spec.experimentId()).isEqualTo("inline-measure");
+    }
+
+    @Test
+    @DisplayName("Experiment.exploring(useCase) builds an explore with inline sampling")
+    void exploreInlineForm() {
+        Experiment spec = Experiment.exploring((Factors f) -> ECHO)
+                .inputs("a", "b")
+                .samples(10)
+                .grid(new Factors("v1"), new Factors("v2"), new Factors("v3"))
+                .build();
+
+        assertThat(spec.kind()).isEqualTo(Experiment.Kind.EXPLORE);
+        assertThat(spec.samples()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Experiment.optimizing(useCase) builds an optimize with inline sampling")
+    void optimizeInlineForm() {
+        Experiment spec = Experiment.optimizing((Factors f) -> ECHO)
+                .inputs("a")
+                .samples(5)
+                .initialFactors(new Factors("seed"))
+                .stepper((current, history) -> history.size() >= 3 ? null : new Factors(current.label() + "+"))
+                .maximize(s -> 1.0)
+                .maxIterations(5)
+                .build();
+
+        assertThat(spec.kind()).isEqualTo(Experiment.Kind.OPTIMIZE);
+        assertThat(spec.samples()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("inline measure rejects null factory at the entry point")
+    void measureInlineRejectsNullFactory() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> Experiment.measuring((java.util.function.Function<Factors, UseCase<Factors, String, String>>) null,
+                        new Factors("m")));
+    }
+
+    @Test
+    @DisplayName("inline measure requires inputs at .build()")
+    void measureInlineRequiresInputs() {
+        var builder = Experiment.measuring((Factors f) -> ECHO, new Factors("m"));
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(builder::build)
+                .withMessageContaining("inputs");
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest.testing(useCase, factors) inline form works for contractual criteria")
+    void contractualInlineFormBuilds() {
+        ProbabilisticTest spec = ProbabilisticTest.testing((Factors f) -> ECHO, new Factors("m"))
+                .inputs("a", "b")
+                .samples(20)
+                .criterion(BernoulliPassRate.<String>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+
+        assertThat(spec.samples()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest.testing inline form rejects empirical criteria with a teaching diagnostic")
+    void empiricalInlineFormIsRejected() {
+        var builder = ProbabilisticTest.testing((Factors f) -> ECHO, new Factors("m"))
+                .inputs("a", "b")
+                .samples(20)
+                .criterion(BernoulliPassRate.<String>empirical());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(builder::build)
+                .withMessageContaining("empirical")
+                .withMessageContaining("Sampling")
+                .withMessageContaining("baseline measure")
+                .withMessageContaining("private Sampling");
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest inline form rejects empirical criteria registered as report-only too")
+    void empiricalReportOnlyInlineFormIsRejected() {
+        var builder = ProbabilisticTest.testing((Factors f) -> ECHO, new Factors("m"))
+                .inputs("a", "b")
+                .samples(20)
+                .criterion(BernoulliPassRate.<String>meeting(0.5, ThresholdOrigin.SLA))
+                .reportOnly(BernoulliPassRate.<String>empirical());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(builder::build)
+                .withMessageContaining("empirical");
+    }
+
+    @Test
+    @DisplayName("Sampling-bound ProbabilisticTest path still accepts empirical criteria — the guard is inline-only")
+    void samplingBoundEmpiricalIsAccepted() {
+        var sampling = org.javai.punit.api.typed.Sampling.of(
+                (Factors f) -> ECHO, 20, "a", "b");
+        ProbabilisticTest spec = ProbabilisticTest.testing(sampling, new Factors("m"))
+                .criterion(BernoulliPassRate.<String>empirical())
+                .build();
+
+        assertThat(spec.samples()).isEqualTo(20);
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline-form entry points on \`Experiment\` and \`ProbabilisticTest\` for one-off authoring — sampling parameters live on the spec's builder, no separate \`Sampling\` helper needed. Closes the "first-experiment authoring overhead" top-tier DX item from the migration preview.

## What's new

Four overloaded entry points, distinguished from the existing Sampling-bound ones by the first argument type (\`Function\` vs \`Sampling\`):

\`\`\`java
Experiment.measuring(Function<FT, UseCase<FT,IT,OT>>, FT factors)   // → InlineMeasureBuilder
Experiment.exploring(Function<FT, UseCase<FT,IT,OT>>)               // → InlineExploreBuilder
Experiment.optimizing(Function<FT, UseCase<FT,IT,OT>>)              // → InlineOptimizeBuilder
ProbabilisticTest.testing(Function<FT, UseCase<FT,IT,OT>>, FT)      // → InlineBuilder
\`\`\`

Each Inline*Builder accumulates sampling-level state (\`inputs\`, \`samples\`, governors) alongside the spec-overlay state. At \`.build()\` the builder synthesises a \`Sampling\` internally and delegates to the existing Sampling-bound builder for spec construction — single source of truth for spec logic.

## Reading at the call site

\`\`\`java
// Inline measure (one-off)
@PunitExperiment Experiment shoppingBaseline() {
    return Experiment.measuring(f -> new ShoppingBasketUseCase(f), GPT_4O)
            .inputs("Add 2 apples", "Remove the milk")
            .samples(1000)
            .experimentId("baseline-v1")
            .build();
}

// Inline contractual test (one-off)
@PunitTest ProbabilisticTest paymentMeetsSla() {
    return ProbabilisticTest.testing(f -> new PaymentGatewayUseCase(f), STANDARD)
            .inputs(new ChargeRequest("tok_visa", 1999L))
            .samples(50)
            .criterion(BernoulliPassRate.meeting(0.99, ThresholdOrigin.SLA))
            .build();
}
\`\`\`

For multi-consumer authoring (a measure and a paired test), the existing \`Sampling\`-bound shape remains the right tool — and is the *only* legal shape for empirical pair patterns.

## Empirical-criterion guard

The inline form's structural risk is that it constructs a fresh \`Sampling\` per spec, so two specs (a measure and an empirical test) cannot share a \`Sampling\` reference even when the author intends a pair. That breaks the integrity guarantee the empirical baseline resolver depends on (codified in DG01 README and \`Sampling\` javadoc per PR #64).

\`ProbabilisticTest.InlineBuilder.build()\` therefore checks every registered criterion (REQUIRED and REPORT_ONLY alike): if any returns \`isEmpirical() == true\`, \`.build()\` throws an \`IllegalStateException\` whose message names the offending criterion and walks the author through the helper-extraction pattern with a worked example.

The Sampling-bound entry point is unaffected — empirical criteria there are still composed normally.

## API addition: \`Criterion.isEmpirical()\`

Small additive change to the \`Criterion\` interface:

\`\`\`java
default boolean isEmpirical() { return false; }
\`\`\`

\`BernoulliPassRate\` and \`PercentileLatency\` override it to return \`mode != CONTRACTUAL\`. Future criterion kinds inherit the default; criteria that depend on baseline data override.

## Test plan

- [x] \`./gradlew build\` passes (39 actionable tasks; full suite green)
- [x] New \`InlineSamplingFormTest\` (9 tests) covers:
  - Each inline form builds the right \`Experiment.Kind\` / runs end-to-end
  - \`.inputs(...)\` required at build time
  - Contractual ProbabilisticTest inline form builds
  - Empirical ProbabilisticTest inline form rejected (REQUIRED criterion)
  - Empirical reportOnly ProbabilisticTest inline form rejected
  - Sampling-bound empirical path remains unaffected (the guard is inline-only)

## Sequencing

This is **piece 2** of three pieces motivated by recent design dialogue:

- Piece 1 (PR #64, merged): doc reframe — \`Sampling\` as the integrity mechanism for empirical pairing.
- **Piece 2 (this PR): inline-sampling form with empirical-test guard.**
- Piece 3 (queued): evaluate-time sample-size constraint (\`test_N ≤ baseline_N\`) inside empirical criteria.
- Piece 4 (queued, design captured in \`docs/DES-INPUTS-IDENTITY-SUPPLIER.md\`): \`InputSupplier\` for cross-process input identity.

## Doc follow-up

Catalog updates (the inline form will appear in EX01-EX03 and PT01-PT13 \`java.md\` examples; migration preview's open-work-set updates) land as a separate orchestrator commit on \`refactor/compositional-design\` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)