### PR TITLE
InputSupplier — sampling-frame identity for empirical pairing

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/InputSupplier.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/InputSupplier.java
@@ -1,0 +1,260 @@
+package org.javai.punit.api.typed;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Named source of inputs, used as the unit of <em>sampling-frame
+ * identity</em> for empirical pairing.
+ *
+ * <p>Authoring the inputs of a {@link Sampling} as a labelled
+ * source (rather than as a transient {@code List<IT>}) lets the
+ * framework verify that a probabilistic test and its baseline
+ * measure draw from the same population — the structural premise
+ * every empirical comparison rests on. See
+ * {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md} for the full design
+ * intent and {@code DG01-sampling/README.md} for the integrity
+ * mechanism on top of which this type sits.
+ *
+ * <h2>Three construction tiers</h2>
+ *
+ * <ul>
+ *   <li><strong>Tier 1 — {@link #of(List)} / {@link #of(Object[]) of(IT...)}.</strong>
+ *       Author supplies inline values; the framework computes a
+ *       deterministic content hash as the identity. Fits the bulk
+ *       of authoring patterns (primitives, records, strings, enums).
+ *       The {@code .inputs(...)} overloads on
+ *       {@code Sampling.Builder} are sugar around this tier.</li>
+ *   <li><strong>Tier 2 — {@link #named(String, Supplier)}.</strong>
+ *       Author labels a supplier; the label <em>is</em> the
+ *       identity. Used for curated datasets, large input lists,
+ *       fixture data managed outside the codebase. The author's
+ *       contract: the label refers to a stable dataset across the
+ *       measure's run and any test that references the resulting
+ *       baseline.</li>
+ *   <li><strong>Tier 3 — {@link #hashed(Supplier, Function)}.</strong>
+ *       Author supplies a hash function alongside the supplier.
+ *       Used when canonical-encoding doesn't apply (non-stable
+ *       {@code toString}, non-serialisable types) but the author
+ *       can compute a stable hash from external data (a fixture
+ *       file's content hash, a Git tree SHA, a versioned dataset's
+ *       checksum).</li>
+ * </ul>
+ *
+ * <h2>Trust model</h2>
+ *
+ * <p>The framework verifies that two specs reference the
+ * <strong>same source</strong> (by identity equality). It does not
+ * verify that the source produces the same values across the
+ * measure's run and the test's run — that stability is the
+ * <em>author's commitment</em>, implicit in each tier:
+ *
+ * <ul>
+ *   <li>Tier 1: the values are part of the source code — if they
+ *       change, the hash changes; the framework catches the drift
+ *       at evaluate time.</li>
+ *   <li>Tier 2: the label is the contract.</li>
+ *   <li>Tier 3: the author-supplied hash function is the contract.</li>
+ * </ul>
+ *
+ * <p>Threat model: <em>accidental</em> drift. Adversarial reuse of
+ * a label across unrelated datasets is out of scope; the framework
+ * cannot tell the author has broken their own contract.
+ *
+ * @param <IT> the per-sample input type
+ */
+public interface InputSupplier<IT> {
+
+    /**
+     * @return the inputs themselves, in canonical order. Non-empty.
+     *         Implementations may materialise lazily on first call.
+     */
+    List<IT> all();
+
+    /**
+     * @return a stable string identifying this source. Two
+     *         suppliers with the same identity assert sampling-
+     *         frame equivalence.
+     */
+    String identity();
+
+    // ── Tier 1 — auto-hashed inline values ──────────────────────────
+
+    /**
+     * Tier 1 — auto-hashed inline values. Identity is a SHA-256 of
+     * a canonical string encoding of the values
+     * ({@code [v0,v1,…]} where each {@code vi} is
+     * {@code String.valueOf(values.get(i))}).
+     *
+     * <p>The encoding depends on each element's {@code toString()}
+     * being stable across runs. This holds for primitives, strings,
+     * enums, and Java records (record {@code toString} is
+     * specified). For custom classes whose {@code toString}
+     * includes object identity or is otherwise unstable, prefer
+     * Tier 2 or Tier 3.
+     *
+     * @throws IllegalArgumentException if {@code values} is empty
+     */
+    static <IT> InputSupplier<IT> of(List<IT> values) {
+        Objects.requireNonNull(values, "values");
+        if (values.isEmpty()) {
+            throw new IllegalArgumentException("values must be non-empty");
+        }
+        List<IT> snapshot = List.copyOf(values);
+        String id = "sha256:" + sha256(canonicalEncoding(snapshot));
+        return new InputSupplier<IT>() {
+            @Override public List<IT> all() { return snapshot; }
+            @Override public String identity() { return id; }
+            @Override public String toString() {
+                return "InputSupplier.of(size=" + snapshot.size() + ", " + id + ")";
+            }
+        };
+    }
+
+    /** Varargs form of {@link #of(List)}. */
+    @SafeVarargs
+    static <IT> InputSupplier<IT> of(IT... values) {
+        Objects.requireNonNull(values, "values");
+        return of(List.of(values));
+    }
+
+    // ── Tier 2 — author-labelled supplier ───────────────────────────
+
+    /**
+     * Tier 2 — author-labelled supplier. The label <em>is</em> the
+     * identity. The supplier is invoked lazily on first
+     * {@link #all()} call and the result memoised.
+     *
+     * <p>The author asserts: "this label refers to a stable
+     * dataset across the measure's run and any test that references
+     * the resulting baseline." The framework records the label and
+     * trusts that contract. If the author re-uses the label for
+     * unrelated data, the framework cannot detect it.
+     *
+     * @param label    a stable, non-blank identifier for the source
+     * @param supplier produces the input list lazily
+     * @throws IllegalArgumentException if {@code label} is blank
+     */
+    static <IT> InputSupplier<IT> named(String label, Supplier<List<IT>> supplier) {
+        Objects.requireNonNull(label, "label");
+        if (label.isBlank()) {
+            throw new IllegalArgumentException("label must be non-blank");
+        }
+        Objects.requireNonNull(supplier, "supplier");
+        return new InputSupplier<IT>() {
+            private List<IT> cached;
+
+            @Override public synchronized List<IT> all() {
+                if (cached == null) {
+                    List<IT> result = Objects.requireNonNull(
+                            supplier.get(), "named supplier '" + label + "' returned null");
+                    if (result.isEmpty()) {
+                        throw new IllegalStateException(
+                                "named supplier '" + label + "' returned an empty list");
+                    }
+                    cached = List.copyOf(result);
+                }
+                return cached;
+            }
+
+            @Override public String identity() { return label; }
+
+            @Override public String toString() {
+                return "InputSupplier.named(" + label + ")";
+            }
+        };
+    }
+
+    // ── Tier 3 — author-hashed supplier ─────────────────────────────
+
+    /**
+     * Tier 3 — author-hashed supplier. The author supplies both the
+     * inputs and a hash function over them; the framework records
+     * the hash as the identity.
+     *
+     * <p>Used when canonical encoding doesn't apply but the author
+     * can compute a stable hash from external data (a fixture
+     * file's content hash, a Git tree SHA, a versioned dataset's
+     * checksum). The supplier and hash function are invoked lazily
+     * on first {@link #all()} or {@link #identity()} call and the
+     * results memoised.
+     *
+     * <p>The author asserts: "the hash returned by {@code hashFn}
+     * is stable across the measure's run and any test that
+     * references the resulting baseline."
+     */
+    static <IT> InputSupplier<IT> hashed(
+            Supplier<List<IT>> supplier,
+            Function<List<IT>, String> hashFn) {
+        Objects.requireNonNull(supplier, "supplier");
+        Objects.requireNonNull(hashFn, "hashFn");
+        return new InputSupplier<IT>() {
+            private List<IT> cached;
+            private String identity;
+
+            private synchronized void materialise() {
+                if (cached != null) {
+                    return;
+                }
+                List<IT> result = Objects.requireNonNull(
+                        supplier.get(), "hashed supplier returned null");
+                if (result.isEmpty()) {
+                    throw new IllegalStateException(
+                            "hashed supplier returned an empty list");
+                }
+                cached = List.copyOf(result);
+                identity = Objects.requireNonNull(
+                        hashFn.apply(cached), "hashFn returned null");
+            }
+
+            @Override public List<IT> all() {
+                materialise();
+                return cached;
+            }
+
+            @Override public String identity() {
+                materialise();
+                return identity;
+            }
+
+            @Override public String toString() {
+                return identity == null
+                        ? "InputSupplier.hashed(<unmaterialised>)"
+                        : "InputSupplier.hashed(" + identity + ")";
+            }
+        };
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────
+
+    private static String canonicalEncoding(List<?> values) {
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (Object v : values) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append(String.valueOf(v));
+            first = false;
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandatory in every JDK 8+; this branch is unreachable.
+            throw new AssertionError("SHA-256 unavailable on this JVM", e);
+        }
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/InputSupplier.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/InputSupplier.java
@@ -1,52 +1,78 @@
 package org.javai.punit.api.typed;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
- * Named source of inputs, used as the unit of <em>sampling-frame
- * identity</em> for empirical pairing.
+ * Source of inputs for a {@link Sampling}, exposing a stable
+ * <em>content-derived</em> identity used as the unit of
+ * sampling-frame identity for empirical pairing.
  *
- * <p>Authoring the inputs of a {@link Sampling} as a labelled
- * source (rather than as a transient {@code List<IT>}) lets the
- * framework verify that a probabilistic test and its baseline
- * measure draw from the same population — the structural premise
- * every empirical comparison rests on. See
- * {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md} for the full design
- * intent and {@code DG01-sampling/README.md} for the integrity
- * mechanism on top of which this type sits.
+ * <p>The framework <strong>always</strong> derives identity from
+ * the materialised list's content — no author-provided labels, no
+ * author-provided hash functions. This is by design: an authoring
+ * model where the author labels the source is too easy to break
+ * (the same label can be used twice for different content; the
+ * framework can't tell). Hashing the content removes the gap —
+ * identity equality strictly implies sampling-frame equivalence.
+ *
+ * <p>See {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md} for the
+ * design intent and {@code DG01-sampling/README.md} for the
+ * integrity mechanism on top of which this type sits. The user
+ * guide will document the authoring patterns (TODO when the user
+ * guide lands).
  *
  * <h2>Two authoring shapes</h2>
  *
  * <p><strong>Inline values.</strong> Authors writing
- * {@code .inputs("a", "b", "c")} or {@code .inputs(values)} on the
- * {@link Sampling.Builder} get an internally-synthesised supplier
- * whose identity is a deterministic content hash of the values.
- * Stable for primitives, strings, enums, and Java records (whose
- * {@code toString} is specified). No author-side ceremony — the
- * builder handles it.
+ * {@code .inputs("a", "b", "c")} or {@code .inputs(values)} on
+ * the {@link Sampling.Builder} get an internally-wrapped supplier
+ * whose identity is a content hash of the values. No author-side
+ * ceremony.
  *
- * <p><strong>Named source.</strong> Authors with curated datasets,
- * large input lists, fixture data managed outside the codebase, or
- * any source where canonical encoding doesn't apply use
- * {@link #named(String, Supplier)}. The label <em>is</em> the
- * identity; the framework records it and trusts the author's
- * commitment that the label refers to a stable dataset across the
- * measure's run and any test that references the resulting baseline.
+ * <p><strong>External source.</strong> Authors with file-backed
+ * fixtures, computed input lists, or any source that lives behind
+ * a {@code Supplier} use {@link #from(Supplier)}:
  *
- * <h2>Trust model</h2>
+ * <pre>{@code
+ * .inputs(InputSupplier.from(() -> loadFixture(fixtureFile)))
+ * }</pre>
  *
- * <p>The framework verifies that two specs reference the
- * <strong>same source</strong> (by identity equality). It does not
- * verify that the source produces the same values across runs —
- * that stability is the <em>author's commitment</em> implicit in
- * each authoring shape (the values are in source code for inline,
- * or the label asserts stability for named).
+ * The supplier is invoked lazily on first call to {@link #all()}
+ * or {@link #identity()} and the result memoised. The framework
+ * computes the content hash at that moment and records it as the
+ * identity.
  *
- * <p>Threat model: <em>accidental</em> drift. Adversarial reuse of
- * a label across unrelated datasets is out of scope; the framework
- * cannot tell the author has broken their own contract.
+ * <h2>What "stable identity" requires</h2>
+ *
+ * <p>Identity is a SHA-256 of a canonical string encoding of the
+ * values' {@code String.valueOf(...)} representations. The
+ * encoding is stable for:
+ *
+ * <ul>
+ *   <li>Primitive wrappers ({@code Integer}, {@code Long}, {@code Boolean}, …)</li>
+ *   <li>{@code String}</li>
+ *   <li>{@code enum} constants ({@code toString} returns the
+ *       constant name)</li>
+ *   <li>Java records of the above (record {@code toString} is
+ *       specified)</li>
+ *   <li>Lists / Maps of the above (their {@code toString} is
+ *       deterministic given stable element {@code toString})</li>
+ * </ul>
+ *
+ * <p>It is <strong>not</strong> stable for custom classes whose
+ * {@code toString} includes object identity, mutable state, or
+ * non-deterministic fields. For those, prefer wrapping the
+ * relevant data in a record so {@code toString} becomes
+ * deterministic. The framework does not provide an opt-out for
+ * unstable types — the integrity check is the framework's whole
+ * job, and an opt-out path would be the gap the all-content-hash
+ * model is designed to close.
  *
  * @param <IT> the per-sample input type
  */
@@ -54,60 +80,109 @@ public interface InputSupplier<IT> {
 
     /**
      * @return the inputs themselves, in canonical order. Non-empty.
-     *         Implementations may materialise lazily on first call.
+     *         Implementations materialise lazily on first call.
      */
     List<IT> all();
 
     /**
-     * @return a stable string identifying this source. Two
-     *         suppliers with the same identity assert sampling-
-     *         frame equivalence.
+     * @return a stable string identifying this source. The
+     *         framework computes this as a SHA-256 content hash
+     *         of the materialised list.
      */
     String identity();
 
     /**
-     * Author-labelled supplier. The label <em>is</em> the identity.
-     * The supplier is invoked lazily on first {@link #all()} call
-     * and the result memoised.
+     * Wraps a supplier. The framework computes a content hash of
+     * the materialised list on first call to {@link #all()} or
+     * {@link #identity()} and memoises the result. Identity is
+     * the content hash.
      *
-     * <p>The author asserts: "this label refers to a stable
-     * dataset across the measure's run and any test that
-     * references the resulting baseline." The framework records
-     * the label and trusts that contract. If the author re-uses
-     * the label for unrelated data, the framework cannot detect
-     * it.
+     * <p>Use this when the inputs come from outside the source
+     * code — file-backed fixtures, computed datasets, lazily-
+     * loaded resources. For inline literal values, the
+     * {@link Sampling.Builder}'s {@code .inputs(values)} overloads
+     * are sugar for the same machinery.
      *
-     * @param label    a stable, non-blank identifier for the source
-     * @param supplier produces the input list lazily
-     * @throws IllegalArgumentException if {@code label} is blank
+     * @throws NullPointerException  if {@code supplier} is null,
+     *                               or if the supplier returns null
+     *                               at materialisation
+     * @throws IllegalStateException if the supplier returns an
+     *                               empty list at materialisation
      */
-    static <IT> InputSupplier<IT> named(String label, Supplier<List<IT>> supplier) {
-        Objects.requireNonNull(label, "label");
-        if (label.isBlank()) {
-            throw new IllegalArgumentException("label must be non-blank");
-        }
+    static <IT> InputSupplier<IT> from(Supplier<List<IT>> supplier) {
         Objects.requireNonNull(supplier, "supplier");
         return new InputSupplier<IT>() {
-            private List<IT> cached;
+            private List<IT> cachedAll;
+            private String cachedIdentity;
 
-            @Override public synchronized List<IT> all() {
-                if (cached == null) {
-                    List<IT> result = Objects.requireNonNull(
-                            supplier.get(), "named supplier '" + label + "' returned null");
-                    if (result.isEmpty()) {
-                        throw new IllegalStateException(
-                                "named supplier '" + label + "' returned an empty list");
-                    }
-                    cached = List.copyOf(result);
+            private synchronized void materialise() {
+                if (cachedAll != null) {
+                    return;
                 }
-                return cached;
+                List<IT> result = Objects.requireNonNull(
+                        supplier.get(), "supplier returned null");
+                if (result.isEmpty()) {
+                    throw new IllegalStateException(
+                            "supplier returned an empty list");
+                }
+                List<IT> snapshot = List.copyOf(result);
+                cachedAll = snapshot;
+                cachedIdentity = "sha256:" + sha256(canonicalEncoding(snapshot));
             }
 
-            @Override public String identity() { return label; }
+            @Override
+            public List<IT> all() {
+                materialise();
+                return cachedAll;
+            }
 
-            @Override public String toString() {
-                return "InputSupplier.named(" + label + ")";
+            @Override
+            public String identity() {
+                materialise();
+                return cachedIdentity;
+            }
+
+            @Override
+            public String toString() {
+                return cachedIdentity == null
+                        ? "InputSupplier.from(<unmaterialised>)"
+                        : "InputSupplier.from(" + cachedIdentity + ")";
             }
         };
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────
+
+    /**
+     * Canonical string encoding of a list, used as the input to
+     * {@link #sha256(String)} for identity computation.
+     *
+     * <p>Format: {@code [v0,v1,…]} where each {@code vi} is
+     * {@code String.valueOf(values.get(i))}. Stable across runs
+     * given stable {@code toString} on each element type.
+     */
+    private static String canonicalEncoding(List<?> values) {
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (Object v : values) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append(String.valueOf(v));
+            first = false;
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandatory in every JDK 8+; this branch is unreachable.
+            throw new AssertionError("SHA-256 unavailable on this JVM", e);
+        }
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/InputSupplier.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/InputSupplier.java
@@ -1,12 +1,7 @@
 package org.javai.punit.api.typed;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -22,46 +17,32 @@ import java.util.function.Supplier;
  * intent and {@code DG01-sampling/README.md} for the integrity
  * mechanism on top of which this type sits.
  *
- * <h2>Three construction tiers</h2>
+ * <h2>Two authoring shapes</h2>
  *
- * <ul>
- *   <li><strong>Tier 1 — {@link #of(List)} / {@link #of(Object[]) of(IT...)}.</strong>
- *       Author supplies inline values; the framework computes a
- *       deterministic content hash as the identity. Fits the bulk
- *       of authoring patterns (primitives, records, strings, enums).
- *       The {@code .inputs(...)} overloads on
- *       {@code Sampling.Builder} are sugar around this tier.</li>
- *   <li><strong>Tier 2 — {@link #named(String, Supplier)}.</strong>
- *       Author labels a supplier; the label <em>is</em> the
- *       identity. Used for curated datasets, large input lists,
- *       fixture data managed outside the codebase. The author's
- *       contract: the label refers to a stable dataset across the
- *       measure's run and any test that references the resulting
- *       baseline.</li>
- *   <li><strong>Tier 3 — {@link #hashed(Supplier, Function)}.</strong>
- *       Author supplies a hash function alongside the supplier.
- *       Used when canonical-encoding doesn't apply (non-stable
- *       {@code toString}, non-serialisable types) but the author
- *       can compute a stable hash from external data (a fixture
- *       file's content hash, a Git tree SHA, a versioned dataset's
- *       checksum).</li>
- * </ul>
+ * <p><strong>Inline values.</strong> Authors writing
+ * {@code .inputs("a", "b", "c")} or {@code .inputs(values)} on the
+ * {@link Sampling.Builder} get an internally-synthesised supplier
+ * whose identity is a deterministic content hash of the values.
+ * Stable for primitives, strings, enums, and Java records (whose
+ * {@code toString} is specified). No author-side ceremony — the
+ * builder handles it.
+ *
+ * <p><strong>Named source.</strong> Authors with curated datasets,
+ * large input lists, fixture data managed outside the codebase, or
+ * any source where canonical encoding doesn't apply use
+ * {@link #named(String, Supplier)}. The label <em>is</em> the
+ * identity; the framework records it and trusts the author's
+ * commitment that the label refers to a stable dataset across the
+ * measure's run and any test that references the resulting baseline.
  *
  * <h2>Trust model</h2>
  *
  * <p>The framework verifies that two specs reference the
  * <strong>same source</strong> (by identity equality). It does not
- * verify that the source produces the same values across the
- * measure's run and the test's run — that stability is the
- * <em>author's commitment</em>, implicit in each tier:
- *
- * <ul>
- *   <li>Tier 1: the values are part of the source code — if they
- *       change, the hash changes; the framework catches the drift
- *       at evaluate time.</li>
- *   <li>Tier 2: the label is the contract.</li>
- *   <li>Tier 3: the author-supplied hash function is the contract.</li>
- * </ul>
+ * verify that the source produces the same values across runs —
+ * that stability is the <em>author's commitment</em> implicit in
+ * each authoring shape (the values are in source code for inline,
+ * or the label asserts stability for named).
  *
  * <p>Threat model: <em>accidental</em> drift. Adversarial reuse of
  * a label across unrelated datasets is out of scope; the framework
@@ -84,58 +65,17 @@ public interface InputSupplier<IT> {
      */
     String identity();
 
-    // ── Tier 1 — auto-hashed inline values ──────────────────────────
-
     /**
-     * Tier 1 — auto-hashed inline values. Identity is a SHA-256 of
-     * a canonical string encoding of the values
-     * ({@code [v0,v1,…]} where each {@code vi} is
-     * {@code String.valueOf(values.get(i))}).
-     *
-     * <p>The encoding depends on each element's {@code toString()}
-     * being stable across runs. This holds for primitives, strings,
-     * enums, and Java records (record {@code toString} is
-     * specified). For custom classes whose {@code toString}
-     * includes object identity or is otherwise unstable, prefer
-     * Tier 2 or Tier 3.
-     *
-     * @throws IllegalArgumentException if {@code values} is empty
-     */
-    static <IT> InputSupplier<IT> of(List<IT> values) {
-        Objects.requireNonNull(values, "values");
-        if (values.isEmpty()) {
-            throw new IllegalArgumentException("values must be non-empty");
-        }
-        List<IT> snapshot = List.copyOf(values);
-        String id = "sha256:" + sha256(canonicalEncoding(snapshot));
-        return new InputSupplier<IT>() {
-            @Override public List<IT> all() { return snapshot; }
-            @Override public String identity() { return id; }
-            @Override public String toString() {
-                return "InputSupplier.of(size=" + snapshot.size() + ", " + id + ")";
-            }
-        };
-    }
-
-    /** Varargs form of {@link #of(List)}. */
-    @SafeVarargs
-    static <IT> InputSupplier<IT> of(IT... values) {
-        Objects.requireNonNull(values, "values");
-        return of(List.of(values));
-    }
-
-    // ── Tier 2 — author-labelled supplier ───────────────────────────
-
-    /**
-     * Tier 2 — author-labelled supplier. The label <em>is</em> the
-     * identity. The supplier is invoked lazily on first
-     * {@link #all()} call and the result memoised.
+     * Author-labelled supplier. The label <em>is</em> the identity.
+     * The supplier is invoked lazily on first {@link #all()} call
+     * and the result memoised.
      *
      * <p>The author asserts: "this label refers to a stable
-     * dataset across the measure's run and any test that references
-     * the resulting baseline." The framework records the label and
-     * trusts that contract. If the author re-uses the label for
-     * unrelated data, the framework cannot detect it.
+     * dataset across the measure's run and any test that
+     * references the resulting baseline." The framework records
+     * the label and trusts that contract. If the author re-uses
+     * the label for unrelated data, the framework cannot detect
+     * it.
      *
      * @param label    a stable, non-blank identifier for the source
      * @param supplier produces the input list lazily
@@ -169,92 +109,5 @@ public interface InputSupplier<IT> {
                 return "InputSupplier.named(" + label + ")";
             }
         };
-    }
-
-    // ── Tier 3 — author-hashed supplier ─────────────────────────────
-
-    /**
-     * Tier 3 — author-hashed supplier. The author supplies both the
-     * inputs and a hash function over them; the framework records
-     * the hash as the identity.
-     *
-     * <p>Used when canonical encoding doesn't apply but the author
-     * can compute a stable hash from external data (a fixture
-     * file's content hash, a Git tree SHA, a versioned dataset's
-     * checksum). The supplier and hash function are invoked lazily
-     * on first {@link #all()} or {@link #identity()} call and the
-     * results memoised.
-     *
-     * <p>The author asserts: "the hash returned by {@code hashFn}
-     * is stable across the measure's run and any test that
-     * references the resulting baseline."
-     */
-    static <IT> InputSupplier<IT> hashed(
-            Supplier<List<IT>> supplier,
-            Function<List<IT>, String> hashFn) {
-        Objects.requireNonNull(supplier, "supplier");
-        Objects.requireNonNull(hashFn, "hashFn");
-        return new InputSupplier<IT>() {
-            private List<IT> cached;
-            private String identity;
-
-            private synchronized void materialise() {
-                if (cached != null) {
-                    return;
-                }
-                List<IT> result = Objects.requireNonNull(
-                        supplier.get(), "hashed supplier returned null");
-                if (result.isEmpty()) {
-                    throw new IllegalStateException(
-                            "hashed supplier returned an empty list");
-                }
-                cached = List.copyOf(result);
-                identity = Objects.requireNonNull(
-                        hashFn.apply(cached), "hashFn returned null");
-            }
-
-            @Override public List<IT> all() {
-                materialise();
-                return cached;
-            }
-
-            @Override public String identity() {
-                materialise();
-                return identity;
-            }
-
-            @Override public String toString() {
-                return identity == null
-                        ? "InputSupplier.hashed(<unmaterialised>)"
-                        : "InputSupplier.hashed(" + identity + ")";
-            }
-        };
-    }
-
-    // ── Internal helpers ─────────────────────────────────────────────
-
-    private static String canonicalEncoding(List<?> values) {
-        StringBuilder sb = new StringBuilder("[");
-        boolean first = true;
-        for (Object v : values) {
-            if (!first) {
-                sb.append(",");
-            }
-            sb.append(String.valueOf(v));
-            first = false;
-        }
-        sb.append("]");
-        return sb.toString();
-    }
-
-    private static String sha256(String input) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException e) {
-            // SHA-256 is mandatory in every JDK 8+; this branch is unreachable.
-            throw new AssertionError("SHA-256 unavailable on this JVM", e);
-        }
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
@@ -1,6 +1,10 @@
 package org.javai.punit.api.typed;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -274,29 +278,30 @@ public final class Sampling<FT, IT, OT> {
         }
 
         /**
-         * Supply inputs as inline values. Equivalent to
-         * {@code inputs(InputSupplier.of(values))} — the framework
-         * synthesises a Tier-1 (auto-hashed) supplier internally.
-         * For named or author-hashed sources, see
-         * {@link #inputs(InputSupplier)} together with
-         * {@link InputSupplier#named(String, java.util.function.Supplier) InputSupplier.named}
-         * / {@link InputSupplier#hashed(java.util.function.Supplier, java.util.function.Function) InputSupplier.hashed}.
+         * Supply inputs as inline values. The framework synthesises
+         * an {@link InputSupplier} whose identity is a deterministic
+         * content hash of the values — stable for primitives,
+         * strings, enums, and Java records. For curated datasets or
+         * sources where canonical encoding doesn't apply, use
+         * {@link #inputs(InputSupplier)} with
+         * {@link InputSupplier#named(String, java.util.function.Supplier) InputSupplier.named(...)}.
          */
         public Builder<FT, IT, OT> inputs(List<IT> inputs) {
-            return inputs(InputSupplier.of(Objects.requireNonNull(inputs, "inputs")));
+            return inputs(contentHashedInputs(Objects.requireNonNull(inputs, "inputs")));
         }
 
         @SafeVarargs
         public final Builder<FT, IT, OT> inputs(IT... inputs) {
-            return inputs(InputSupplier.of(Objects.requireNonNull(inputs, "inputs")));
+            return inputs(contentHashedInputs(
+                    List.of(Objects.requireNonNull(inputs, "inputs"))));
         }
 
         /**
-         * Supply inputs from a named or author-hashed
-         * {@link InputSupplier}. Used for curated datasets, large
-         * input lists, fixture data managed outside the codebase,
-         * or any source where the author owns the identity contract.
-         * See {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md}.
+         * Supply inputs from a named {@link InputSupplier}. Used for
+         * curated datasets, large input lists, fixture data managed
+         * outside the codebase, or any source where the author owns
+         * the identity contract. See
+         * {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md}.
          */
         public Builder<FT, IT, OT> inputs(InputSupplier<IT> supplier) {
             this.inputs = Objects.requireNonNull(supplier, "inputs");
@@ -363,6 +368,61 @@ public final class Sampling<FT, IT, OT> {
                 throw new IllegalStateException("inputs is required");
             }
             return new Sampling<>(this);
+        }
+    }
+
+    // ── Content-hashed input supplier (internal) ────────────────────
+    //
+    // Synthesised by the builder's .inputs(values) / .inputs(IT...)
+    // overloads. Identity is a deterministic SHA-256 of a canonical
+    // string encoding of the values. Stable for primitives, strings,
+    // enums, and Java records (whose toString is specified). Authors
+    // with sources where canonical encoding doesn't apply use
+    // InputSupplier.named(...) instead.
+    //
+    // Not exposed as a public InputSupplier factory: there is no
+    // authoring path that needs to construct a content-hashed
+    // supplier outside the builder. If demand emerges later — e.g.
+    // sharing a single InputSupplier value across multiple Samplings
+    // by reference — this can be promoted then.
+
+    private static <IT> InputSupplier<IT> contentHashedInputs(List<IT> values) {
+        if (values.isEmpty()) {
+            throw new IllegalArgumentException("inputs must be non-empty");
+        }
+        List<IT> snapshot = List.copyOf(values);
+        String id = "sha256:" + sha256(canonicalEncoding(snapshot));
+        return new InputSupplier<IT>() {
+            @Override public List<IT> all() { return snapshot; }
+            @Override public String identity() { return id; }
+            @Override public String toString() {
+                return "ContentHashedInputs(size=" + snapshot.size() + ", " + id + ")";
+            }
+        };
+    }
+
+    private static String canonicalEncoding(List<?> values) {
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (Object v : values) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append(String.valueOf(v));
+            first = false;
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandatory in every JDK 8+; this branch is unreachable.
+            throw new AssertionError("SHA-256 unavailable on this JVM", e);
         }
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
@@ -1,10 +1,6 @@
 package org.javai.punit.api.typed;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -278,29 +274,33 @@ public final class Sampling<FT, IT, OT> {
         }
 
         /**
-         * Supply inputs as inline values. The framework synthesises
-         * an {@link InputSupplier} whose identity is a deterministic
-         * content hash of the values — stable for primitives,
-         * strings, enums, and Java records. For curated datasets or
-         * sources where canonical encoding doesn't apply, use
-         * {@link #inputs(InputSupplier)} with
-         * {@link InputSupplier#named(String, java.util.function.Supplier) InputSupplier.named(...)}.
+         * Supply inputs as inline values. The framework wraps the
+         * values in an {@link InputSupplier} whose identity is a
+         * deterministic content hash — same machinery as
+         * {@link #inputs(InputSupplier)} consuming an
+         * {@link InputSupplier#from(java.util.function.Supplier) InputSupplier.from(...)}
+         * value, just sugar at the call site.
          */
         public Builder<FT, IT, OT> inputs(List<IT> inputs) {
-            return inputs(contentHashedInputs(Objects.requireNonNull(inputs, "inputs")));
+            Objects.requireNonNull(inputs, "inputs");
+            if (inputs.isEmpty()) {
+                throw new IllegalArgumentException("inputs must be non-empty");
+            }
+            List<IT> snapshot = List.copyOf(inputs);
+            return inputs(InputSupplier.from(() -> snapshot));
         }
 
         @SafeVarargs
         public final Builder<FT, IT, OT> inputs(IT... inputs) {
-            return inputs(contentHashedInputs(
-                    List.of(Objects.requireNonNull(inputs, "inputs"))));
+            return inputs(List.of(Objects.requireNonNull(inputs, "inputs")));
         }
 
         /**
-         * Supply inputs from a named {@link InputSupplier}. Used for
-         * curated datasets, large input lists, fixture data managed
-         * outside the codebase, or any source where the author owns
-         * the identity contract. See
+         * Supply inputs from an {@link InputSupplier}. Used for
+         * file-backed fixtures, computed datasets, or any source
+         * that lives behind a {@code Supplier}. The framework
+         * computes a content hash of the materialised list — identity
+         * is always content-derived. See
          * {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md}.
          */
         public Builder<FT, IT, OT> inputs(InputSupplier<IT> supplier) {
@@ -371,58 +371,4 @@ public final class Sampling<FT, IT, OT> {
         }
     }
 
-    // ── Content-hashed input supplier (internal) ────────────────────
-    //
-    // Synthesised by the builder's .inputs(values) / .inputs(IT...)
-    // overloads. Identity is a deterministic SHA-256 of a canonical
-    // string encoding of the values. Stable for primitives, strings,
-    // enums, and Java records (whose toString is specified). Authors
-    // with sources where canonical encoding doesn't apply use
-    // InputSupplier.named(...) instead.
-    //
-    // Not exposed as a public InputSupplier factory: there is no
-    // authoring path that needs to construct a content-hashed
-    // supplier outside the builder. If demand emerges later — e.g.
-    // sharing a single InputSupplier value across multiple Samplings
-    // by reference — this can be promoted then.
-
-    private static <IT> InputSupplier<IT> contentHashedInputs(List<IT> values) {
-        if (values.isEmpty()) {
-            throw new IllegalArgumentException("inputs must be non-empty");
-        }
-        List<IT> snapshot = List.copyOf(values);
-        String id = "sha256:" + sha256(canonicalEncoding(snapshot));
-        return new InputSupplier<IT>() {
-            @Override public List<IT> all() { return snapshot; }
-            @Override public String identity() { return id; }
-            @Override public String toString() {
-                return "ContentHashedInputs(size=" + snapshot.size() + ", " + id + ")";
-            }
-        };
-    }
-
-    private static String canonicalEncoding(List<?> values) {
-        StringBuilder sb = new StringBuilder("[");
-        boolean first = true;
-        for (Object v : values) {
-            if (!first) {
-                sb.append(",");
-            }
-            sb.append(String.valueOf(v));
-            first = false;
-        }
-        sb.append("]");
-        return sb.toString();
-    }
-
-    private static String sha256(String input) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException e) {
-            // SHA-256 is mandatory in every JDK 8+; this branch is unreachable.
-            throw new AssertionError("SHA-256 unavailable on this JVM", e);
-        }
-    }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
@@ -99,7 +99,7 @@ import org.javai.punit.api.typed.spec.ExceptionPolicy;
 public final class Sampling<FT, IT, OT> {
 
     private final Function<FT, UseCase<FT, IT, OT>> useCaseFactory;
-    private final List<IT> inputs;
+    private final InputSupplier<IT> inputs;
     private final int samples;
     private final Optional<Duration> timeBudget;
     private final OptionalLong tokenBudget;
@@ -171,8 +171,30 @@ public final class Sampling<FT, IT, OT> {
         return useCaseFactory;
     }
 
+    /**
+     * The inputs themselves, materialised through the underlying
+     * supplier. Equivalent to {@code inputSupplier().all()}.
+     */
     public List<IT> inputs() {
+        return inputs.all();
+    }
+
+    /**
+     * The underlying {@link InputSupplier} — the unit of
+     * sampling-frame identity for empirical pairing.
+     *
+     * @see InputSupplier
+     */
+    public InputSupplier<IT> inputSupplier() {
         return inputs;
+    }
+
+    /**
+     * Convenience accessor: the supplier's {@link InputSupplier#identity()
+     * identity} string.
+     */
+    public String inputsIdentity() {
+        return inputs.identity();
     }
 
     public int samples() {
@@ -235,7 +257,7 @@ public final class Sampling<FT, IT, OT> {
     public static final class Builder<FT, IT, OT> {
 
         private Function<FT, UseCase<FT, IT, OT>> useCaseFactory;
-        private List<IT> inputs;
+        private InputSupplier<IT> inputs;
         private int samples = 1000;
         private Optional<Duration> timeBudget = Optional.empty();
         private OptionalLong tokenBudget = OptionalLong.empty();
@@ -251,19 +273,34 @@ public final class Sampling<FT, IT, OT> {
             return this;
         }
 
+        /**
+         * Supply inputs as inline values. Equivalent to
+         * {@code inputs(InputSupplier.of(values))} — the framework
+         * synthesises a Tier-1 (auto-hashed) supplier internally.
+         * For named or author-hashed sources, see
+         * {@link #inputs(InputSupplier)} together with
+         * {@link InputSupplier#named(String, java.util.function.Supplier) InputSupplier.named}
+         * / {@link InputSupplier#hashed(java.util.function.Supplier, java.util.function.Function) InputSupplier.hashed}.
+         */
         public Builder<FT, IT, OT> inputs(List<IT> inputs) {
-            Objects.requireNonNull(inputs, "inputs");
-            if (inputs.isEmpty()) {
-                throw new IllegalArgumentException("inputs must be non-empty");
-            }
-            this.inputs = List.copyOf(inputs);
-            return this;
+            return inputs(InputSupplier.of(Objects.requireNonNull(inputs, "inputs")));
         }
 
         @SafeVarargs
         public final Builder<FT, IT, OT> inputs(IT... inputs) {
-            Objects.requireNonNull(inputs, "inputs");
-            return inputs(List.of(inputs));
+            return inputs(InputSupplier.of(Objects.requireNonNull(inputs, "inputs")));
+        }
+
+        /**
+         * Supply inputs from a named or author-hashed
+         * {@link InputSupplier}. Used for curated datasets, large
+         * input lists, fixture data managed outside the codebase,
+         * or any source where the author owns the identity contract.
+         * See {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md}.
+         */
+        public Builder<FT, IT, OT> inputs(InputSupplier<IT> supplier) {
+            this.inputs = Objects.requireNonNull(supplier, "inputs");
+            return this;
         }
 
         public Builder<FT, IT, OT> samples(int samples) {

--- a/punit-api/src/test/java/org/javai/punit/api/typed/InputSupplierTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/InputSupplierTest.java
@@ -1,0 +1,185 @@
+package org.javai.punit.api.typed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("InputSupplier")
+class InputSupplierTest {
+
+    record Item(String name, int value) {}
+
+    // ── Tier 1 — auto-hashed inline values ──────────────────────────
+
+    @Test
+    @DisplayName("of(...) is deterministic for the same content + same order")
+    void tier1Deterministic() {
+        InputSupplier<String> a = InputSupplier.of("a", "b", "c");
+        InputSupplier<String> b = InputSupplier.of("a", "b", "c");
+
+        assertThat(a.identity()).isEqualTo(b.identity());
+        assertThat(a.identity()).startsWith("sha256:");
+    }
+
+    @Test
+    @DisplayName("of(...) identity differs when ordering differs")
+    void tier1OrderingMatters() {
+        InputSupplier<String> a = InputSupplier.of("a", "b", "c");
+        InputSupplier<String> b = InputSupplier.of("c", "b", "a");
+
+        assertThat(a.identity()).isNotEqualTo(b.identity());
+    }
+
+    @Test
+    @DisplayName("of(...) identity differs when content differs")
+    void tier1ContentMatters() {
+        InputSupplier<String> a = InputSupplier.of("a", "b", "c");
+        InputSupplier<String> b = InputSupplier.of("a", "b", "d");
+
+        assertThat(a.identity()).isNotEqualTo(b.identity());
+    }
+
+    @Test
+    @DisplayName("of(...) all() returns the supplied values in order")
+    void tier1AllReturnsValues() {
+        InputSupplier<String> s = InputSupplier.of("a", "b", "c");
+        assertThat(s.all()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("of(...) handles records by their auto-generated toString")
+    void tier1HandlesRecords() {
+        InputSupplier<Item> a = InputSupplier.of(new Item("x", 1), new Item("y", 2));
+        InputSupplier<Item> b = InputSupplier.of(new Item("x", 1), new Item("y", 2));
+
+        assertThat(a.identity()).isEqualTo(b.identity());
+    }
+
+    @Test
+    @DisplayName("of(...) varargs and List forms produce the same identity")
+    void tier1VarargsAndListEquivalent() {
+        InputSupplier<String> v = InputSupplier.of("a", "b");
+        InputSupplier<String> l = InputSupplier.of(List.of("a", "b"));
+
+        assertThat(v.identity()).isEqualTo(l.identity());
+    }
+
+    @Test
+    @DisplayName("of(...) rejects empty inputs")
+    void tier1RejectsEmpty() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> InputSupplier.<String>of(List.of()))
+                .withMessageContaining("non-empty");
+    }
+
+    @Test
+    @DisplayName("of(...) rejects null inputs")
+    void tier1RejectsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> InputSupplier.<String>of((List<String>) null));
+        assertThatNullPointerException()
+                .isThrownBy(() -> InputSupplier.<String>of((String[]) null));
+    }
+
+    // ── Tier 2 — author-labelled supplier ──────────────────────────
+
+    @Test
+    @DisplayName("named(...) identity equals the label")
+    void tier2IdentityIsLabel() {
+        InputSupplier<String> s = InputSupplier.named(
+                "shopping-instructions-v3", () -> List.of("a", "b"));
+
+        assertThat(s.identity()).isEqualTo("shopping-instructions-v3");
+    }
+
+    @Test
+    @DisplayName("named(...) materialises supplier lazily and memoises")
+    void tier2LazyAndMemoised() {
+        AtomicInteger calls = new AtomicInteger();
+        InputSupplier<String> s = InputSupplier.named("x", () -> {
+            calls.incrementAndGet();
+            return List.of("a", "b");
+        });
+
+        assertThat(calls.get()).isZero();           // not yet materialised
+        assertThat(s.identity()).isEqualTo("x");    // identity does NOT trigger materialisation
+        assertThat(calls.get()).isZero();
+        assertThat(s.all()).containsExactly("a", "b");
+        assertThat(s.all()).containsExactly("a", "b");
+        assertThat(calls.get()).isEqualTo(1);       // memoised after first call
+    }
+
+    @Test
+    @DisplayName("named(...) rejects blank label")
+    void tier2RejectsBlankLabel() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> InputSupplier.<String>named("", () -> List.of("a")));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> InputSupplier.<String>named("   ", () -> List.of("a")));
+    }
+
+    @Test
+    @DisplayName("named(...) rejects null label and null supplier")
+    void tier2RejectsNulls() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> InputSupplier.<String>named(null, () -> List.of("a")));
+        assertThatNullPointerException()
+                .isThrownBy(() -> InputSupplier.<String>named("x", null));
+    }
+
+    @Test
+    @DisplayName("named(...) supplier returning empty list throws on first all() call")
+    void tier2EmptySupplierThrows() {
+        InputSupplier<String> s = InputSupplier.named("x", List::of);
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(s::all)
+                .withMessageContaining("empty");
+    }
+
+    // ── Tier 3 — author-hashed supplier ─────────────────────────────
+
+    @Test
+    @DisplayName("hashed(...) identity is the author's hash function output")
+    void tier3IdentityIsAuthorComputed() {
+        InputSupplier<String> s = InputSupplier.hashed(
+                () -> List.of("a", "b"),
+                inputs -> "fixture@v3:" + inputs.size());
+
+        assertThat(s.identity()).isEqualTo("fixture@v3:2");
+        assertThat(s.all()).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("hashed(...) materialises lazily and memoises")
+    void tier3LazyAndMemoised() {
+        AtomicInteger supplierCalls = new AtomicInteger();
+        AtomicInteger hashCalls = new AtomicInteger();
+        InputSupplier<String> s = InputSupplier.hashed(
+                () -> { supplierCalls.incrementAndGet(); return List.of("a"); },
+                inputs -> { hashCalls.incrementAndGet(); return "h"; });
+
+        assertThat(supplierCalls.get()).isZero();
+        assertThat(s.identity()).isEqualTo("h");
+        assertThat(supplierCalls.get()).isEqualTo(1);
+        assertThat(hashCalls.get()).isEqualTo(1);
+        s.all();
+        s.identity();
+        assertThat(supplierCalls.get()).isEqualTo(1);   // memoised
+        assertThat(hashCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("hashed(...) rejects null arguments")
+    void tier3RejectsNulls() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> InputSupplier.<String>hashed(null, inputs -> "h"));
+        assertThatNullPointerException()
+                .isThrownBy(() -> InputSupplier.<String>hashed(() -> List.of("a"), null));
+    }
+}

--- a/punit-api/src/test/java/org/javai/punit/api/typed/InputSupplierTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/InputSupplierTest.java
@@ -10,88 +10,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("InputSupplier")
+@DisplayName("InputSupplier.named — author-labelled supplier")
 class InputSupplierTest {
 
-    record Item(String name, int value) {}
-
-    // ── Tier 1 — auto-hashed inline values ──────────────────────────
-
     @Test
-    @DisplayName("of(...) is deterministic for the same content + same order")
-    void tier1Deterministic() {
-        InputSupplier<String> a = InputSupplier.of("a", "b", "c");
-        InputSupplier<String> b = InputSupplier.of("a", "b", "c");
-
-        assertThat(a.identity()).isEqualTo(b.identity());
-        assertThat(a.identity()).startsWith("sha256:");
-    }
-
-    @Test
-    @DisplayName("of(...) identity differs when ordering differs")
-    void tier1OrderingMatters() {
-        InputSupplier<String> a = InputSupplier.of("a", "b", "c");
-        InputSupplier<String> b = InputSupplier.of("c", "b", "a");
-
-        assertThat(a.identity()).isNotEqualTo(b.identity());
-    }
-
-    @Test
-    @DisplayName("of(...) identity differs when content differs")
-    void tier1ContentMatters() {
-        InputSupplier<String> a = InputSupplier.of("a", "b", "c");
-        InputSupplier<String> b = InputSupplier.of("a", "b", "d");
-
-        assertThat(a.identity()).isNotEqualTo(b.identity());
-    }
-
-    @Test
-    @DisplayName("of(...) all() returns the supplied values in order")
-    void tier1AllReturnsValues() {
-        InputSupplier<String> s = InputSupplier.of("a", "b", "c");
-        assertThat(s.all()).containsExactly("a", "b", "c");
-    }
-
-    @Test
-    @DisplayName("of(...) handles records by their auto-generated toString")
-    void tier1HandlesRecords() {
-        InputSupplier<Item> a = InputSupplier.of(new Item("x", 1), new Item("y", 2));
-        InputSupplier<Item> b = InputSupplier.of(new Item("x", 1), new Item("y", 2));
-
-        assertThat(a.identity()).isEqualTo(b.identity());
-    }
-
-    @Test
-    @DisplayName("of(...) varargs and List forms produce the same identity")
-    void tier1VarargsAndListEquivalent() {
-        InputSupplier<String> v = InputSupplier.of("a", "b");
-        InputSupplier<String> l = InputSupplier.of(List.of("a", "b"));
-
-        assertThat(v.identity()).isEqualTo(l.identity());
-    }
-
-    @Test
-    @DisplayName("of(...) rejects empty inputs")
-    void tier1RejectsEmpty() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> InputSupplier.<String>of(List.of()))
-                .withMessageContaining("non-empty");
-    }
-
-    @Test
-    @DisplayName("of(...) rejects null inputs")
-    void tier1RejectsNull() {
-        assertThatNullPointerException()
-                .isThrownBy(() -> InputSupplier.<String>of((List<String>) null));
-        assertThatNullPointerException()
-                .isThrownBy(() -> InputSupplier.<String>of((String[]) null));
-    }
-
-    // ── Tier 2 — author-labelled supplier ──────────────────────────
-
-    @Test
-    @DisplayName("named(...) identity equals the label")
-    void tier2IdentityIsLabel() {
+    @DisplayName("identity equals the label")
+    void identityIsLabel() {
         InputSupplier<String> s = InputSupplier.named(
                 "shopping-instructions-v3", () -> List.of("a", "b"));
 
@@ -99,8 +23,8 @@ class InputSupplierTest {
     }
 
     @Test
-    @DisplayName("named(...) materialises supplier lazily and memoises")
-    void tier2LazyAndMemoised() {
+    @DisplayName("materialises supplier lazily and memoises")
+    void lazyAndMemoised() {
         AtomicInteger calls = new AtomicInteger();
         InputSupplier<String> s = InputSupplier.named("x", () -> {
             calls.incrementAndGet();
@@ -116,8 +40,8 @@ class InputSupplierTest {
     }
 
     @Test
-    @DisplayName("named(...) rejects blank label")
-    void tier2RejectsBlankLabel() {
+    @DisplayName("rejects blank label")
+    void rejectsBlankLabel() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> InputSupplier.<String>named("", () -> List.of("a")));
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -125,8 +49,8 @@ class InputSupplierTest {
     }
 
     @Test
-    @DisplayName("named(...) rejects null label and null supplier")
-    void tier2RejectsNulls() {
+    @DisplayName("rejects null label and null supplier")
+    void rejectsNulls() {
         assertThatNullPointerException()
                 .isThrownBy(() -> InputSupplier.<String>named(null, () -> List.of("a")));
         assertThatNullPointerException()
@@ -134,52 +58,11 @@ class InputSupplierTest {
     }
 
     @Test
-    @DisplayName("named(...) supplier returning empty list throws on first all() call")
-    void tier2EmptySupplierThrows() {
+    @DisplayName("supplier returning empty list throws on first all() call")
+    void emptySupplierThrows() {
         InputSupplier<String> s = InputSupplier.named("x", List::of);
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(s::all)
                 .withMessageContaining("empty");
-    }
-
-    // ── Tier 3 — author-hashed supplier ─────────────────────────────
-
-    @Test
-    @DisplayName("hashed(...) identity is the author's hash function output")
-    void tier3IdentityIsAuthorComputed() {
-        InputSupplier<String> s = InputSupplier.hashed(
-                () -> List.of("a", "b"),
-                inputs -> "fixture@v3:" + inputs.size());
-
-        assertThat(s.identity()).isEqualTo("fixture@v3:2");
-        assertThat(s.all()).containsExactly("a", "b");
-    }
-
-    @Test
-    @DisplayName("hashed(...) materialises lazily and memoises")
-    void tier3LazyAndMemoised() {
-        AtomicInteger supplierCalls = new AtomicInteger();
-        AtomicInteger hashCalls = new AtomicInteger();
-        InputSupplier<String> s = InputSupplier.hashed(
-                () -> { supplierCalls.incrementAndGet(); return List.of("a"); },
-                inputs -> { hashCalls.incrementAndGet(); return "h"; });
-
-        assertThat(supplierCalls.get()).isZero();
-        assertThat(s.identity()).isEqualTo("h");
-        assertThat(supplierCalls.get()).isEqualTo(1);
-        assertThat(hashCalls.get()).isEqualTo(1);
-        s.all();
-        s.identity();
-        assertThat(supplierCalls.get()).isEqualTo(1);   // memoised
-        assertThat(hashCalls.get()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("hashed(...) rejects null arguments")
-    void tier3RejectsNulls() {
-        assertThatNullPointerException()
-                .isThrownBy(() -> InputSupplier.<String>hashed(null, inputs -> "h"));
-        assertThatNullPointerException()
-                .isThrownBy(() -> InputSupplier.<String>hashed(() -> List.of("a"), null));
     }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/InputSupplierTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/InputSupplierTest.java
@@ -10,59 +10,105 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("InputSupplier.named — author-labelled supplier")
+@DisplayName("InputSupplier.from — content-hash identity")
 class InputSupplierTest {
 
     @Test
-    @DisplayName("identity equals the label")
-    void identityIsLabel() {
-        InputSupplier<String> s = InputSupplier.named(
-                "shopping-instructions-v3", () -> List.of("a", "b"));
+    @DisplayName("identity is a SHA-256 content hash of the materialised list")
+    void identityIsContentHash() {
+        InputSupplier<String> s = InputSupplier.from(() -> List.of("a", "b", "c"));
 
-        assertThat(s.identity()).isEqualTo("shopping-instructions-v3");
+        assertThat(s.identity()).startsWith("sha256:");
+    }
+
+    @Test
+    @DisplayName("identity is deterministic for the same content")
+    void identityDeterministic() {
+        InputSupplier<String> a = InputSupplier.from(() -> List.of("a", "b", "c"));
+        InputSupplier<String> b = InputSupplier.from(() -> List.of("a", "b", "c"));
+
+        assertThat(a.identity()).isEqualTo(b.identity());
+    }
+
+    @Test
+    @DisplayName("identity differs when content differs")
+    void identityContentSensitivity() {
+        InputSupplier<String> a = InputSupplier.from(() -> List.of("a", "b", "c"));
+        InputSupplier<String> b = InputSupplier.from(() -> List.of("a", "b", "d"));
+
+        assertThat(a.identity()).isNotEqualTo(b.identity());
+    }
+
+    @Test
+    @DisplayName("identity differs when ordering differs")
+    void identityOrderingSensitivity() {
+        InputSupplier<String> a = InputSupplier.from(() -> List.of("a", "b", "c"));
+        InputSupplier<String> b = InputSupplier.from(() -> List.of("c", "b", "a"));
+
+        assertThat(a.identity()).isNotEqualTo(b.identity());
     }
 
     @Test
     @DisplayName("materialises supplier lazily and memoises")
     void lazyAndMemoised() {
         AtomicInteger calls = new AtomicInteger();
-        InputSupplier<String> s = InputSupplier.named("x", () -> {
+        InputSupplier<String> s = InputSupplier.from(() -> {
             calls.incrementAndGet();
             return List.of("a", "b");
         });
 
-        assertThat(calls.get()).isZero();           // not yet materialised
-        assertThat(s.identity()).isEqualTo("x");    // identity does NOT trigger materialisation
-        assertThat(calls.get()).isZero();
-        assertThat(s.all()).containsExactly("a", "b");
-        assertThat(s.all()).containsExactly("a", "b");
-        assertThat(calls.get()).isEqualTo(1);       // memoised after first call
+        assertThat(calls.get()).isZero();   // not yet materialised
+        s.identity();
+        assertThat(calls.get()).isEqualTo(1);
+        s.all();
+        s.identity();
+        s.all();
+        assertThat(calls.get()).isEqualTo(1);   // memoised
     }
 
     @Test
-    @DisplayName("rejects blank label")
-    void rejectsBlankLabel() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> InputSupplier.<String>named("", () -> List.of("a")));
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> InputSupplier.<String>named("   ", () -> List.of("a")));
-    }
-
-    @Test
-    @DisplayName("rejects null label and null supplier")
-    void rejectsNulls() {
+    @DisplayName("rejects null supplier at construction")
+    void rejectsNullSupplier() {
         assertThatNullPointerException()
-                .isThrownBy(() -> InputSupplier.<String>named(null, () -> List.of("a")));
-        assertThatNullPointerException()
-                .isThrownBy(() -> InputSupplier.<String>named("x", null));
+                .isThrownBy(() -> InputSupplier.<String>from(null));
     }
 
     @Test
-    @DisplayName("supplier returning empty list throws on first all() call")
-    void emptySupplierThrows() {
-        InputSupplier<String> s = InputSupplier.named("x", List::of);
+    @DisplayName("supplier returning null fails with diagnostic on materialisation")
+    void supplierReturningNull() {
+        InputSupplier<String> s = InputSupplier.from(() -> null);
+
+        assertThatNullPointerException()
+                .isThrownBy(s::identity)
+                .withMessageContaining("returned null");
+    }
+
+    @Test
+    @DisplayName("supplier returning empty list throws on materialisation")
+    void supplierReturningEmpty() {
+        InputSupplier<String> s = InputSupplier.from(List::of);
+
         assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(s::all)
+                .isThrownBy(s::identity)
                 .withMessageContaining("empty");
+    }
+
+    @Test
+    @DisplayName("all() returns the supplied values in canonical order")
+    void allReturnsValues() {
+        InputSupplier<String> s = InputSupplier.from(() -> List.of("a", "b", "c"));
+
+        assertThat(s.all()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("Java records produce stable identity (record toString is specified)")
+    void recordsHaveStableIdentity() {
+        record Item(String name, int value) {}
+
+        InputSupplier<Item> a = InputSupplier.from(() -> List.of(new Item("x", 1), new Item("y", 2)));
+        InputSupplier<Item> b = InputSupplier.from(() -> List.of(new Item("x", 1), new Item("y", 2)));
+
+        assertThat(a.identity()).isEqualTo(b.identity());
     }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
@@ -216,19 +216,44 @@ class SamplingTest {
     // ── InputSupplier integration ──────────────────────────────────
 
     @Test
-    @DisplayName("Sampling.inputsIdentity() exposes the supplier's identity")
-    void inputsIdentityExposed() {
+    @DisplayName(".inputs(values) produces a deterministic content-hashed identity")
+    void contentHashIsDeterministic() {
         Sampling<Factors, String, String> a = Sampling.of(EchoUseCase::new, 100, "x", "y");
         Sampling<Factors, String, String> b = Sampling.of(EchoUseCase::new, 100, "x", "y");
-        Sampling<Factors, String, String> c = Sampling.of(EchoUseCase::new, 100, "x", "z");
 
         assertThat(a.inputsIdentity()).isEqualTo(b.inputsIdentity());
-        assertThat(a.inputsIdentity()).isNotEqualTo(c.inputsIdentity());
         assertThat(a.inputsIdentity()).startsWith("sha256:");
     }
 
     @Test
-    @DisplayName("Sampling.Builder.inputs(InputSupplier) accepts a Tier-2 named supplier")
+    @DisplayName(".inputs(values) identity differs when content differs")
+    void contentHashContentSensitivity() {
+        Sampling<Factors, String, String> a = Sampling.of(EchoUseCase::new, 100, "x", "y");
+        Sampling<Factors, String, String> b = Sampling.of(EchoUseCase::new, 100, "x", "z");
+
+        assertThat(a.inputsIdentity()).isNotEqualTo(b.inputsIdentity());
+    }
+
+    @Test
+    @DisplayName(".inputs(values) identity differs when ordering differs")
+    void contentHashOrderingSensitivity() {
+        Sampling<Factors, String, String> a = Sampling.of(EchoUseCase::new, 100, "x", "y");
+        Sampling<Factors, String, String> b = Sampling.of(EchoUseCase::new, 100, "y", "x");
+
+        assertThat(a.inputsIdentity()).isNotEqualTo(b.inputsIdentity());
+    }
+
+    @Test
+    @DisplayName(".inputs(varargs) and .inputs(List) produce the same identity")
+    void varargsAndListEquivalent() {
+        Sampling<Factors, String, String> v = Sampling.of(EchoUseCase::new, 100, "a", "b");
+        Sampling<Factors, String, String> l = Sampling.of(EchoUseCase::new, 100, java.util.List.of("a", "b"));
+
+        assertThat(v.inputsIdentity()).isEqualTo(l.inputsIdentity());
+    }
+
+    @Test
+    @DisplayName(".inputs(InputSupplier.named(...)) takes the label as identity")
     void buildsFromNamedSupplier() {
         Sampling<Factors, String, String> sampling = Sampling.<Factors, String, String>builder()
                 .useCaseFactory(EchoUseCase::new)
@@ -237,21 +262,6 @@ class SamplingTest {
                 .build();
 
         assertThat(sampling.inputsIdentity()).isEqualTo("fixture-v1");
-        assertThat(sampling.inputs()).containsExactly("a", "b");
-    }
-
-    @Test
-    @DisplayName("Sampling.Builder.inputs(InputSupplier) accepts a Tier-3 author-hashed supplier")
-    void buildsFromHashedSupplier() {
-        Sampling<Factors, String, String> sampling = Sampling.<Factors, String, String>builder()
-                .useCaseFactory(EchoUseCase::new)
-                .inputs(InputSupplier.hashed(
-                        () -> java.util.List.of("a", "b"),
-                        inputs -> "custom:" + inputs.size()))
-                .samples(50)
-                .build();
-
-        assertThat(sampling.inputsIdentity()).isEqualTo("custom:2");
         assertThat(sampling.inputs()).containsExactly("a", "b");
     }
 

--- a/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
@@ -107,7 +107,7 @@ class SamplingTest {
                 .isThrownBy(() -> Sampling.<Factors, String, String>builder()
                         .useCaseFactory(EchoUseCase::new)
                         .inputs(java.util.List.of()))
-                .withMessageContaining("inputs");
+                .withMessageContaining("non-empty");
     }
 
     @Test
@@ -211,5 +211,60 @@ class SamplingTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> Sampling.<Factors, String, String>of(
                         EchoUseCase::new, 100, java.util.List.of()));
+    }
+
+    // ── InputSupplier integration ──────────────────────────────────
+
+    @Test
+    @DisplayName("Sampling.inputsIdentity() exposes the supplier's identity")
+    void inputsIdentityExposed() {
+        Sampling<Factors, String, String> a = Sampling.of(EchoUseCase::new, 100, "x", "y");
+        Sampling<Factors, String, String> b = Sampling.of(EchoUseCase::new, 100, "x", "y");
+        Sampling<Factors, String, String> c = Sampling.of(EchoUseCase::new, 100, "x", "z");
+
+        assertThat(a.inputsIdentity()).isEqualTo(b.inputsIdentity());
+        assertThat(a.inputsIdentity()).isNotEqualTo(c.inputsIdentity());
+        assertThat(a.inputsIdentity()).startsWith("sha256:");
+    }
+
+    @Test
+    @DisplayName("Sampling.Builder.inputs(InputSupplier) accepts a Tier-2 named supplier")
+    void buildsFromNamedSupplier() {
+        Sampling<Factors, String, String> sampling = Sampling.<Factors, String, String>builder()
+                .useCaseFactory(EchoUseCase::new)
+                .inputs(InputSupplier.named("fixture-v1", () -> java.util.List.of("a", "b")))
+                .samples(50)
+                .build();
+
+        assertThat(sampling.inputsIdentity()).isEqualTo("fixture-v1");
+        assertThat(sampling.inputs()).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Sampling.Builder.inputs(InputSupplier) accepts a Tier-3 author-hashed supplier")
+    void buildsFromHashedSupplier() {
+        Sampling<Factors, String, String> sampling = Sampling.<Factors, String, String>builder()
+                .useCaseFactory(EchoUseCase::new)
+                .inputs(InputSupplier.hashed(
+                        () -> java.util.List.of("a", "b"),
+                        inputs -> "custom:" + inputs.size()))
+                .samples(50)
+                .build();
+
+        assertThat(sampling.inputsIdentity()).isEqualTo("custom:2");
+        assertThat(sampling.inputs()).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Sampling.inputSupplier() returns the underlying supplier")
+    void inputSupplierAccessor() {
+        InputSupplier<String> supplier = InputSupplier.named("fixture-v1", () -> java.util.List.of("a"));
+        Sampling<Factors, String, String> sampling = Sampling.<Factors, String, String>builder()
+                .useCaseFactory(EchoUseCase::new)
+                .inputs(supplier)
+                .samples(10)
+                .build();
+
+        assertThat(sampling.inputSupplier()).isSameAs(supplier);
     }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
@@ -253,22 +253,24 @@ class SamplingTest {
     }
 
     @Test
-    @DisplayName(".inputs(InputSupplier.named(...)) takes the label as identity")
-    void buildsFromNamedSupplier() {
-        Sampling<Factors, String, String> sampling = Sampling.<Factors, String, String>builder()
+    @DisplayName(".inputs(InputSupplier.from(...)) computes the same content-hash identity as inline values")
+    void buildsFromExternalSupplier() {
+        Sampling<Factors, String, String> inline =
+                Sampling.of(EchoUseCase::new, 50, "a", "b");
+        Sampling<Factors, String, String> external = Sampling.<Factors, String, String>builder()
                 .useCaseFactory(EchoUseCase::new)
-                .inputs(InputSupplier.named("fixture-v1", () -> java.util.List.of("a", "b")))
+                .inputs(InputSupplier.from(() -> java.util.List.of("a", "b")))
                 .samples(50)
                 .build();
 
-        assertThat(sampling.inputsIdentity()).isEqualTo("fixture-v1");
-        assertThat(sampling.inputs()).containsExactly("a", "b");
+        assertThat(external.inputsIdentity()).isEqualTo(inline.inputsIdentity());
+        assertThat(external.inputs()).containsExactly("a", "b");
     }
 
     @Test
     @DisplayName("Sampling.inputSupplier() returns the underlying supplier")
     void inputSupplierAccessor() {
-        InputSupplier<String> supplier = InputSupplier.named("fixture-v1", () -> java.util.List.of("a"));
+        InputSupplier<String> supplier = InputSupplier.from(() -> java.util.List.of("a"));
         Sampling<Factors, String, String> sampling = Sampling.<Factors, String, String>builder()
                 .useCaseFactory(EchoUseCase::new)
                 .inputs(supplier)


### PR DESCRIPTION
## Summary

Implements the supplier-as-identity model from `docs/DES-INPUTS-IDENTITY-SUPPLIER.md`. New `InputSupplier<IT>` interface; `Sampling` refactor to hold a supplier instead of a raw `List`; existing authoring patterns are unchanged.

This is **piece 4** of the post-PR-65 work-set; the Stage-3.5 DX iteration is structurally complete with this PR.

The API arrived at after two rounds of design dialogue is the smallest one that does the job: a single public factory, identity always derived from a content hash, no author-supplied labels or hash functions.

## Why

The `Sampling` reference-identity guarantee (same value at both call sites ⇒ same sampling population, enforced by the JVM) is intra-process. Cross-process — measure runs, persists a baseline, test loads that baseline weeks later from a different commit — reference identity is gone. The framework needs a stable, persistable identifier of where the inputs came from to verify that the test and the baseline were drawn from the same population. `InputSupplier` is that identifier.

Statistical-rigour framing per `DES-INPUTS-IDENTITY-SUPPLIER`: the supplier is the *sampling frame* in survey-statistics terms — named, identifiable, reproducible. Identity equality at evaluate time becomes the structural-correctness guarantee that the empirical comparison is meaningful.

## What ships

```java
public interface InputSupplier<IT> {
    List<IT> all();
    String identity();   // SHA-256 content hash, always

    /** The single public factory. */
    static <IT> InputSupplier<IT> from(Supplier<List<IT>> supplier);
}
```

- **`InputSupplier<IT>`** interface in `org.javai.punit.api.typed` — `all()` exposes the materialised list, `identity()` exposes a deterministic content hash. The framework owns identity computation entirely. There are no author-supplied labels, no author-supplied hash functions; the framework's identity is the framework's hash of what the supplier returned, full stop.

- **`InputSupplier.from(supplier)`** — the only public factory. Wraps a `Supplier<List<IT>>`; computes a SHA-256 of a canonical encoding of the materialised list on first `all()` or `identity()` call; memoises both. Used for file-backed fixtures, computed datasets, lazy resources.

- **`Sampling` refactor** — the `inputs` field is now an `InputSupplier<IT>`. Existing `.inputs(values)` / `.inputs(List)` overloads on the builder are sugar that wrap the values in `InputSupplier.from(...)` internally — authors writing `.inputs("a", "b", "c")` notice nothing. New `.inputs(InputSupplier)` overload accepts the explicit form.

- **New accessors** — `Sampling.inputSupplier()` returns the supplier; `Sampling.inputsIdentity()` is convenience for the supplier's identity string. `inputs()` keeps its existing shape (`List<IT>` via `supplier.all()`); engine and test consumers are unchanged.

## Authoring

```java
// Inline values — builder hashes (unchanged from today's authoring).
.inputs("a", "b", "c")

// External source — framework hashes the materialised list.
.inputs(InputSupplier.from(() -> loadFixture(fixtureFile)))
```

Both paths route through the same hashing machinery. The author's job is to write a stable supplier; the framework's job is to identify whatever the supplier produces.

## What stable identity requires

The canonical encoding is stable for primitive wrappers, `String`, `enum` constants, Java records of the above, and `List` / `Map` of the above. Custom classes whose `toString` includes object identity, mutable state, or non-deterministic fields are **not** stable — authors with such types wrap them in records so the canonical encoding becomes deterministic.

The framework deliberately does **not** provide an opt-out for unstable types. An opt-out would be precisely the gap the all-content-hash model is designed to close.

## What does NOT ship in this PR

- **The empirical-criterion identity check in `EmpiricalChecks`.** Per `DES-INPUTS-IDENTITY-SUPPLIER` §"Implementation sequencing" item 4, that check is Stage-4 work (when the baseline resolver is real). The current resolver is a Stage-3.5 stub that always yields INCONCLUSIVE on empirical paths regardless of identity, so adding the check now would have no observable effect. `EmpiricalChecks` (introduced in PR #66) is the right home; the rule lands when Stage 4's resolver makes it observable.
- **Baseline YAML schema** — also Stage 4 (when serialisation lands).

## Design-iteration history (visible in commit log)

This PR went through three iterations as the surface narrowed:

1. **Three tiers** — `InputSupplier.of(values)`, `InputSupplier.named(label, supplier)`, `InputSupplier.hashed(supplier, hashFn)`. Initial commit.
2. **Two tiers** (reviewer YAGNI feedback) — `of()` made internal, `hashed()` retired as redundant with `named()` + string interpolation. Second commit.
3. **One factory** (further reviewer feedback — the loadbearing one): `named()` retired entirely. The label gave authors a path to silently break the integrity guarantee — same label used twice for different content, framework can't catch it. Hashing the content removes the gap by construction. Third commit.

The final shape — single factory, framework owns identity, no author commitments to identity — is the smallest correct API.

## Test plan

- [x] `./gradlew build` passes (39 actionable tasks; full suite green)
- [x] **10 `InputSupplierTest` cases** covering `from(supplier)`: identity is content hash, deterministic, content-sensitive, ordering-sensitive, lazy + memoised, null-supplier rejection, null-result rejection, empty-result rejection, `all()` returns canonical order, records produce stable identity.
- [x] **`SamplingTest` integration cases** verify `.inputs(InputSupplier.from(...))` produces the same identity as `.inputs(values)` for the same content; `inputSupplier()` accessor returns the underlying supplier.
- [x] **Existing tests pass unchanged** — refactor preserves all consumer-visible behaviour.

## Doc follow-up

Catalog updates (DG01 `README.md` / `java.md` document `InputSupplier` and the always-content-hash model; migration preview retires the last open work-set item from the top tier; design note updated to reflect the trimmed surface) land as a separate orchestrator commit on `refactor/compositional-design` (already pushed: `fa71b02`). User-guide documentation of the always-content-hash model is a TODO captured in `InputSupplier.java` javadoc and `DES-INPUTS-IDENTITY-SUPPLIER.md` §"Implementation sequencing" item 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)