### PR TITLE
Stage 4 Slice B — BaselineRecord + BaselineWriter

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineRecord.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineRecord.java
@@ -1,0 +1,79 @@
+package org.javai.punit.engine.baseline;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+
+/**
+ * In-memory shape of a baseline file. Carries the identity keys the
+ * {@link BaselineResolver} matches against, the
+ * sampling-population integrity fields the empirical criteria
+ * cross-check, and a per-criterion-name map of
+ * {@link BaselineStatistics} flavours.
+ *
+ * <p>Mirrors the schema documented in
+ * {@code docs/DES-BASELINE-YAML-SCHEMA.md}.
+ *
+ * @param useCaseId           the use case's stable identity, as
+ *                            returned by {@code UseCase.id()}
+ * @param methodName          the spec-method name that produced
+ *                            this baseline
+ * @param factorsFingerprint  short hash of the factor values the
+ *                            measure ran under
+ * @param inputsIdentity      full SHA-256 inputs identity, as
+ *                            returned by {@code Sampling.inputsIdentity()}
+ * @param sampleCount         the total number of samples the
+ *                            measure executed
+ * @param generatedAt         when the measure produced this baseline
+ * @param statisticsByCriterionName  one
+ *        {@link BaselineStatistics} entry per criterion, keyed by
+ *        {@code Criterion.name()}
+ */
+public record BaselineRecord(
+        String useCaseId,
+        String methodName,
+        String factorsFingerprint,
+        String inputsIdentity,
+        int sampleCount,
+        Instant generatedAt,
+        Map<String, BaselineStatistics> statisticsByCriterionName) {
+
+    public BaselineRecord {
+        Objects.requireNonNull(useCaseId, "useCaseId");
+        Objects.requireNonNull(methodName, "methodName");
+        Objects.requireNonNull(factorsFingerprint, "factorsFingerprint");
+        Objects.requireNonNull(inputsIdentity, "inputsIdentity");
+        Objects.requireNonNull(generatedAt, "generatedAt");
+        Objects.requireNonNull(statisticsByCriterionName, "statisticsByCriterionName");
+        if (useCaseId.isBlank()) {
+            throw new IllegalArgumentException("useCaseId must not be blank");
+        }
+        if (methodName.isBlank()) {
+            throw new IllegalArgumentException("methodName must not be blank");
+        }
+        if (factorsFingerprint.isBlank()) {
+            throw new IllegalArgumentException("factorsFingerprint must not be blank");
+        }
+        if (sampleCount < 0) {
+            throw new IllegalArgumentException(
+                    "sampleCount must be non-negative, got " + sampleCount);
+        }
+        if (statisticsByCriterionName.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "statisticsByCriterionName must not be empty — a baseline with no "
+                            + "criterion entries is not consumable by any empirical criterion");
+        }
+        statisticsByCriterionName = Map.copyOf(new LinkedHashMap<>(statisticsByCriterionName));
+    }
+
+    /**
+     * @return the canonical filename for this baseline, in the form
+     *         {@code {useCaseId}.{methodName}-{factorsFingerprint}.yaml}.
+     */
+    public String filename() {
+        return useCaseId + "." + methodName + "-" + factorsFingerprint + ".yaml";
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineSchema.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineSchema.java
@@ -1,0 +1,40 @@
+package org.javai.punit.engine.baseline;
+
+/**
+ * Schema constants shared by the baseline writer and reader.
+ *
+ * <p>See {@code docs/DES-BASELINE-YAML-SCHEMA.md} for the full
+ * specification. Keeping the field names and the discriminator value
+ * in one place avoids a drift class — the writer and reader either
+ * agree, or the build breaks.
+ */
+final class BaselineSchema {
+
+    private BaselineSchema() { }
+
+    /** The structural-version discriminator for the typed-compositional schema. */
+    static final String SCHEMA_VERSION_VALUE = "punit-baseline-2";
+
+    static final String FIELD_SCHEMA_VERSION = "schemaVersion";
+    static final String FIELD_USE_CASE_ID = "useCaseId";
+    static final String FIELD_METHOD_NAME = "methodName";
+    static final String FIELD_FACTORS_FINGERPRINT = "factorsFingerprint";
+    static final String FIELD_INPUTS_IDENTITY = "inputsIdentity";
+    static final String FIELD_SAMPLE_COUNT = "sampleCount";
+    static final String FIELD_GENERATED_AT = "generatedAt";
+    static final String FIELD_STATISTICS = "statistics";
+
+    // BernoulliPassRate / PassRateStatistics
+    static final String FIELD_OBSERVED_PASS_RATE = "observedPassRate";
+
+    // PercentileLatency / LatencyStatistics
+    static final String FIELD_PERCENTILES = "percentiles";
+    static final String PERCENTILE_KEY_P50 = "p50";
+    static final String PERCENTILE_KEY_P90 = "p90";
+    static final String PERCENTILE_KEY_P95 = "p95";
+    static final String PERCENTILE_KEY_P99 = "p99";
+
+    // Criterion-name keys (mirror Criterion.name() values).
+    static final String CRITERION_BERNOULLI_PASS_RATE = "bernoulli-pass-rate";
+    static final String CRITERION_PERCENTILE_LATENCY = "percentile-latency";
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
@@ -1,0 +1,147 @@
+package org.javai.punit.engine.baseline;
+
+import static org.javai.punit.engine.baseline.BaselineSchema.CRITERION_BERNOULLI_PASS_RATE;
+import static org.javai.punit.engine.baseline.BaselineSchema.CRITERION_PERCENTILE_LATENCY;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_FACTORS_FINGERPRINT;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_GENERATED_AT;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_INPUTS_IDENTITY;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_METHOD_NAME;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_OBSERVED_PASS_RATE;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_PERCENTILES;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_SAMPLE_COUNT;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_SCHEMA_VERSION;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_STATISTICS;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_USE_CASE_ID;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P50;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P90;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P95;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P99;
+import static org.javai.punit.engine.baseline.BaselineSchema.SCHEMA_VERSION_VALUE;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.LatencyStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Serialises a {@link BaselineRecord} to the
+ * {@code punit-baseline-2} YAML schema and writes it to disk.
+ *
+ * <p>Filename is derived from the record itself
+ * ({@link BaselineRecord#filename()}). The writer creates the parent
+ * directory if it does not exist.
+ *
+ * <p>Two unsupported {@link BaselineStatistics} flavours are rejected
+ * at write time with an {@link IllegalStateException}: the writer's
+ * job is to produce a file the reader can fully parse, so silently
+ * dropping unknown statistics kinds would create asymmetry. New
+ * statistics kinds extend {@link #serialiseStatisticsEntry} alongside
+ * a matching read path in {@link BaselineReader}.
+ */
+public final class BaselineWriter {
+
+    /**
+     * Writes {@code record} to {@code baselineDir} under its canonical
+     * filename. Returns the path the file was written to.
+     */
+    public Path write(BaselineRecord record, Path baselineDir) throws IOException {
+        Objects.requireNonNull(record, "record");
+        Objects.requireNonNull(baselineDir, "baselineDir");
+        Files.createDirectories(baselineDir);
+        Path file = baselineDir.resolve(record.filename());
+        Files.writeString(file, toYaml(record), StandardCharsets.UTF_8);
+        return file;
+    }
+
+    /** Serialises {@code record} to the YAML schema as a string. */
+    public String toYaml(BaselineRecord record) {
+        Objects.requireNonNull(record, "record");
+        return yaml().dump(toYamlMap(record));
+    }
+
+    private Map<String, Object> toYamlMap(BaselineRecord record) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put(FIELD_SCHEMA_VERSION, SCHEMA_VERSION_VALUE);
+        root.put(FIELD_USE_CASE_ID, record.useCaseId());
+        root.put(FIELD_METHOD_NAME, record.methodName());
+        root.put(FIELD_FACTORS_FINGERPRINT, record.factorsFingerprint());
+        root.put(FIELD_INPUTS_IDENTITY, record.inputsIdentity());
+        root.put(FIELD_SAMPLE_COUNT, record.sampleCount());
+        root.put(FIELD_GENERATED_AT, DateTimeFormatter.ISO_INSTANT.format(record.generatedAt()));
+
+        Map<String, Object> stats = new LinkedHashMap<>();
+        record.statisticsByCriterionName().forEach((name, value) ->
+                stats.put(name, serialiseStatisticsEntry(name, value)));
+        root.put(FIELD_STATISTICS, stats);
+        return root;
+    }
+
+    private Map<String, Object> serialiseStatisticsEntry(
+            String criterionName, BaselineStatistics statistics) {
+        if (statistics instanceof PassRateStatistics passRate) {
+            return serialisePassRate(passRate);
+        }
+        if (statistics instanceof LatencyStatistics latency) {
+            return serialiseLatency(latency);
+        }
+        throw new IllegalStateException(
+                "Unsupported baseline statistics kind for criterion '" + criterionName
+                        + "': " + statistics.getClass().getName()
+                        + " — extend BaselineWriter and BaselineReader together to add support.");
+    }
+
+    private Map<String, Object> serialisePassRate(PassRateStatistics stats) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put(FIELD_OBSERVED_PASS_RATE, stats.observedPassRate());
+        entry.put(FIELD_SAMPLE_COUNT, stats.sampleCount());
+        return entry;
+    }
+
+    private Map<String, Object> serialiseLatency(LatencyStatistics stats) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put(FIELD_SAMPLE_COUNT, stats.sampleCount());
+
+        LatencyResult percentiles = stats.percentiles();
+        Map<String, Object> percentileMap = new LinkedHashMap<>();
+        percentileMap.put(PERCENTILE_KEY_P50, isoDuration(percentiles.p50()));
+        percentileMap.put(PERCENTILE_KEY_P90, isoDuration(percentiles.p90()));
+        percentileMap.put(PERCENTILE_KEY_P95, isoDuration(percentiles.p95()));
+        percentileMap.put(PERCENTILE_KEY_P99, isoDuration(percentiles.p99()));
+        entry.put(FIELD_PERCENTILES, percentileMap);
+        return entry;
+    }
+
+    private static String isoDuration(Duration duration) {
+        return duration.toString();
+    }
+
+    private static Yaml yaml() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        return new Yaml(options);
+    }
+
+    /**
+     * The criterion-name keys this writer recognises. Useful for
+     * tests and for callers that build {@link BaselineRecord}
+     * instances programmatically.
+     */
+    public static final class CriterionNames {
+        private CriterionNames() { }
+        public static final String BERNOULLI_PASS_RATE = CRITERION_BERNOULLI_PASS_RATE;
+        public static final String PERCENTILE_LATENCY = CRITERION_PERCENTILE_LATENCY;
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/FactorsFingerprint.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/FactorsFingerprint.java
@@ -1,0 +1,55 @@
+package org.javai.punit.engine.baseline;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Computes the {@code factorsFingerprint} field carried by every
+ * {@link BaselineRecord} and used by the resolver as one of the
+ * three exact-match lookup keys.
+ *
+ * <p>The fingerprint is the first eight hex characters of
+ * {@code SHA-256(String.valueOf(factors))}. Records'
+ * {@code toString()} is deterministic per the JLS, so the
+ * fingerprint is stable across runs and processes given a
+ * record-typed factors value.
+ *
+ * <p>{@code null} factors produces the literal string {@code "null"}
+ * — distinct from any hex fingerprint, so a measure with no factors
+ * cannot collide with a measure under any actual factor value.
+ *
+ * <p>See {@code docs/DES-BASELINE-YAML-SCHEMA.md} §"factorsFingerprint"
+ * for the design rationale.
+ */
+public final class FactorsFingerprint {
+
+    private static final int HEX_PREFIX_LENGTH = 8;
+    private static final String NULL_FINGERPRINT = "null";
+
+    private FactorsFingerprint() { }
+
+    /**
+     * @return the fingerprint of {@code factors} — the first eight
+     *         hex characters of {@code SHA-256(String.valueOf(factors))},
+     *         or the literal {@code "null"} when {@code factors} is null.
+     */
+    public static String of(Object factors) {
+        if (factors == null) {
+            return NULL_FINGERPRINT;
+        }
+        byte[] hash = sha256(String.valueOf(factors));
+        return HexFormat.of().formatHex(hash).substring(0, HEX_PREFIX_LENGTH);
+    }
+
+    private static byte[] sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return md.digest(input.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandatory in every JDK 8+; this branch is unreachable.
+            throw new AssertionError("SHA-256 unavailable on this JVM", e);
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/package-info.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Baseline-file machinery for the typed-compositional pipeline.
+ *
+ * <p>This package is the on-disk persistence layer for
+ * {@link org.javai.punit.api.typed.spec.BaselineStatistics} values
+ * produced by {@code Experiment.measuring(...)} and consumed by the
+ * empirical variants of {@link org.javai.punit.api.typed.spec.BernoulliPassRate}
+ * and {@link org.javai.punit.api.typed.spec.PercentileLatency}.
+ *
+ * <p>The schema is documented in
+ * {@code docs/DES-BASELINE-YAML-SCHEMA.md}; the directive driving
+ * Stage-4 implementation is {@code DIR-PUNIT-S4-BASELINE-RESOLVER.md}.
+ *
+ * <p>Distinct from the legacy {@code org.javai.punit.spec.baseline}
+ * package, which carries pre-Stage-3.5 baseline machinery (covariate
+ * matching, multi-baseline selection, expiration policy) tied to the
+ * legacy annotation-driven surface.
+ */
+package org.javai.punit.engine.baseline;

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineRecordTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineRecordTest.java
@@ -1,0 +1,93 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("BaselineRecord")
+class BaselineRecordTest {
+
+    private static final Map<String, BaselineStatistics> ONE_ENTRY =
+            Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+
+    @Test
+    @DisplayName("filename is {useCaseId}.{methodName}-{factorsFingerprint}.yaml")
+    void filename() {
+        BaselineRecord record = new BaselineRecord(
+                "ShoppingBasketUseCase", "measureBaseline", "a1b2c3d4",
+                "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
+                ONE_ENTRY);
+
+        assertThat(record.filename())
+                .isEqualTo("ShoppingBasketUseCase.measureBaseline-a1b2c3d4.yaml");
+    }
+
+    @Test
+    @DisplayName("rejects null required fields")
+    void rejectsNulls() {
+        Instant now = Instant.now();
+
+        assertThatNullPointerException().isThrownBy(() -> new BaselineRecord(
+                null, "m", "f", "sha256:x", 1, now, ONE_ENTRY));
+        assertThatNullPointerException().isThrownBy(() -> new BaselineRecord(
+                "u", null, "f", "sha256:x", 1, now, ONE_ENTRY));
+        assertThatNullPointerException().isThrownBy(() -> new BaselineRecord(
+                "u", "m", null, "sha256:x", 1, now, ONE_ENTRY));
+        assertThatNullPointerException().isThrownBy(() -> new BaselineRecord(
+                "u", "m", "f", null, 1, now, ONE_ENTRY));
+        assertThatNullPointerException().isThrownBy(() -> new BaselineRecord(
+                "u", "m", "f", "sha256:x", 1, null, ONE_ENTRY));
+        assertThatNullPointerException().isThrownBy(() -> new BaselineRecord(
+                "u", "m", "f", "sha256:x", 1, now, null));
+    }
+
+    @Test
+    @DisplayName("rejects blank identity fields")
+    void rejectsBlanks() {
+        Instant now = Instant.now();
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                new BaselineRecord("", "m", "f", "sha256:x", 1, now, ONE_ENTRY));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                new BaselineRecord("u", " ", "f", "sha256:x", 1, now, ONE_ENTRY));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                new BaselineRecord("u", "m", "", "sha256:x", 1, now, ONE_ENTRY));
+    }
+
+    @Test
+    @DisplayName("rejects negative sampleCount")
+    void rejectsNegativeSampleCount() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                new BaselineRecord("u", "m", "f", "sha256:x", -1, Instant.now(), ONE_ENTRY));
+    }
+
+    @Test
+    @DisplayName("rejects empty statistics map — a baseline without entries cannot be consumed")
+    void rejectsEmptyStatistics() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                new BaselineRecord("u", "m", "f", "sha256:x", 1, Instant.now(), Map.of()))
+                .withMessageContaining("must not be empty");
+    }
+
+    @Test
+    @DisplayName("statistics map is defensively copied — caller mutations don't leak in")
+    void defensiveCopy() {
+        java.util.HashMap<String, BaselineStatistics> mutable = new java.util.HashMap<>();
+        mutable.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+
+        BaselineRecord record = new BaselineRecord(
+                "u", "m", "f", "sha256:x", 1, Instant.now(), mutable);
+
+        mutable.clear();
+
+        assertThat(record.statisticsByCriterionName()).hasSize(1);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
@@ -1,0 +1,143 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.LatencyStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
+
+@DisplayName("BaselineWriter — punit-baseline-2 schema serialisation")
+class BaselineWriterTest {
+
+    private final BaselineWriter writer = new BaselineWriter();
+
+    private BaselineRecord recordWith(Map<String, BaselineStatistics> stats) {
+        return new BaselineRecord(
+                "ShoppingBasketUseCase",
+                "measureBaseline",
+                "a1b2c3d4",
+                "sha256:7d3a8c1e9b2f",
+                1000,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                stats);
+    }
+
+    @Test
+    @DisplayName("emits the schema discriminator and identity keys")
+    void emitsHeader() {
+        String yaml = writer.toYaml(recordWith(Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+
+        Map<String, Object> root = new Yaml().load(yaml);
+
+        assertThat(root)
+                .containsEntry("schemaVersion", "punit-baseline-2")
+                .containsEntry("useCaseId", "ShoppingBasketUseCase")
+                .containsEntry("methodName", "measureBaseline")
+                .containsEntry("factorsFingerprint", "a1b2c3d4")
+                .containsEntry("inputsIdentity", "sha256:7d3a8c1e9b2f")
+                .containsEntry("sampleCount", 1000)
+                .containsEntry("generatedAt", "2026-04-26T15:30:00Z");
+    }
+
+    @Test
+    @DisplayName("serialises a PassRateStatistics entry with observedPassRate + sampleCount")
+    void serialisesPassRate() {
+        String yaml = writer.toYaml(recordWith(Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+
+        Map<String, Object> root = new Yaml().load(yaml);
+        Map<String, Object> stats = (Map<String, Object>) root.get("statistics");
+        Map<String, Object> entry = (Map<String, Object>) stats.get("bernoulli-pass-rate");
+
+        assertThat(entry)
+                .containsEntry("observedPassRate", 0.94)
+                .containsEntry("sampleCount", 1000);
+    }
+
+    @Test
+    @DisplayName("serialises a LatencyStatistics entry with all four percentiles in ISO-8601")
+    void serialisesLatency() {
+        LatencyResult percentiles = new LatencyResult(
+                Duration.ofMillis(250),
+                Duration.ofMillis(500),
+                Duration.ofMillis(800),
+                Duration.ofMillis(1200),
+                1000);
+
+        String yaml = writer.toYaml(recordWith(Map.of(
+                "percentile-latency", new LatencyStatistics(percentiles, 1000))));
+
+        Map<String, Object> root = new Yaml().load(yaml);
+        Map<String, Object> stats = (Map<String, Object>) root.get("statistics");
+        Map<String, Object> entry = (Map<String, Object>) stats.get("percentile-latency");
+
+        assertThat(entry).containsEntry("sampleCount", 1000);
+
+        Map<String, Object> percentileMap = (Map<String, Object>) entry.get("percentiles");
+        assertThat(percentileMap)
+                .containsEntry("p50", "PT0.25S")
+                .containsEntry("p90", "PT0.5S")
+                .containsEntry("p95", "PT0.8S")
+                .containsEntry("p99", "PT1.2S");
+    }
+
+    @Test
+    @DisplayName("serialises multiple criterion entries side-by-side")
+    void serialisesBothCriteria() {
+        Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
+        entries.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+        entries.put("percentile-latency", new LatencyStatistics(LatencyResult.empty(), 1000));
+
+        String yaml = writer.toYaml(recordWith(entries));
+        Map<String, Object> root = new Yaml().load(yaml);
+        Map<String, Object> stats = (Map<String, Object>) root.get("statistics");
+
+        assertThat(stats).containsKeys("bernoulli-pass-rate", "percentile-latency");
+    }
+
+    @Test
+    @DisplayName("write(...) creates baselineDir if missing and returns the file path")
+    void writeCreatesDirectory(@TempDir Path tempDir) throws IOException {
+        Path baselineDir = tempDir.resolve("baselines");
+
+        Path file = writer.write(
+                recordWith(Map.of("bernoulli-pass-rate", new PassRateStatistics(0.5, 100))),
+                baselineDir);
+
+        assertThat(Files.exists(baselineDir)).isTrue();
+        assertThat(file)
+                .exists()
+                .isEqualTo(baselineDir.resolve(
+                        "ShoppingBasketUseCase.measureBaseline-a1b2c3d4.yaml"));
+
+        String content = Files.readString(file);
+        assertThat(content).contains("schemaVersion: punit-baseline-2");
+    }
+
+    @Test
+    @DisplayName("rejects an unsupported BaselineStatistics flavour with a diagnostic")
+    void rejectsUnknownStatisticsKind() {
+        BaselineStatistics unknown = () -> 1;
+        BaselineRecord record = recordWith(Map.of("custom-criterion", unknown));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> writer.toYaml(record))
+                .withMessageContaining("custom-criterion")
+                .withMessageContaining("Unsupported baseline statistics kind");
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/FactorsFingerprintTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/FactorsFingerprintTest.java
@@ -1,0 +1,67 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FactorsFingerprint")
+class FactorsFingerprintTest {
+
+    record Factors(String model, double temperature) { }
+
+    @Test
+    @DisplayName("8-char hex for any non-null value")
+    void hexLengthForNonNull() {
+        String fingerprint = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
+
+        assertThat(fingerprint).hasSize(8).matches("[0-9a-f]{8}");
+    }
+
+    @Test
+    @DisplayName("deterministic — equal inputs produce equal fingerprints")
+    void deterministic() {
+        String a = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
+        String b = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
+
+        assertThat(a).isEqualTo(b);
+    }
+
+    @Test
+    @DisplayName("differs when any factor field differs")
+    void contentSensitivity() {
+        String a = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
+        String b = FactorsFingerprint.of(new Factors("gpt-4o", 0.1));
+        String c = FactorsFingerprint.of(new Factors("gpt-3.5", 0.0));
+
+        assertThat(a).isNotEqualTo(b).isNotEqualTo(c);
+        assertThat(b).isNotEqualTo(c);
+    }
+
+    @Test
+    @DisplayName("null factors produce the literal 'null' fingerprint")
+    void nullFactors() {
+        assertThat(FactorsFingerprint.of(null)).isEqualTo("null");
+    }
+
+    @Test
+    @DisplayName("'null' literal cannot collide with any hex fingerprint")
+    void nullSentinelIsDistinct() {
+        String literal = FactorsFingerprint.of(null);
+        String hex = FactorsFingerprint.of(new Factors("anything", 1.0));
+
+        assertThat(literal).isNotEqualTo(hex);
+        assertThat(hex).matches("[0-9a-f]{8}");
+    }
+
+    @Test
+    @DisplayName("works for non-record types — relies on String.valueOf, so toString stability is the caller's contract")
+    void stringValueOfUsage() {
+        String forString = FactorsFingerprint.of("plain string");
+        String forInteger = FactorsFingerprint.of(42);
+
+        assertThat(forString).hasSize(8);
+        assertThat(forInteger).hasSize(8);
+        assertThat(forString).isNotEqualTo(forInteger);
+    }
+}


### PR DESCRIPTION
## Summary

First slice of Stage 4. Introduces the typed-compositional baseline
persistence layer in `punit-core/.../engine/baseline/`:

- `BaselineRecord` — in-memory shape of a baseline file (use case
  identity, method name, factors fingerprint, inputs identity, sample
  count, timestamp, per-criterion-name map of `BaselineStatistics`).
- `BaselineWriter` — serialises to the `punit-baseline-2` YAML schema
  via SnakeYAML, writes to disk under `{useCaseId}.{methodName}-{factorsFingerprint}.yaml`.
- `BaselineSchema` — package-private constants shared with the
  upcoming reader so writer and reader can't drift.

The schema is documented in `docs/DES-BASELINE-YAML-SCHEMA.md`
(orchestrator). The directive driving Stage 4 is
`DIR-PUNIT-S4-BASELINE-RESOLVER.md` (orchestrator).

No engine wiring yet — Slice C adds the reader/resolver and plumbs
both into the empirical criteria so `BernoulliPassRate.empirical()`
and `PercentileLatency.empirical()` produce real verdicts when a
matching baseline exists.

## Test plan

- [x] 12 new unit tests pass (`BaselineRecordTest`, `BaselineWriterTest`)
- [x] Full `./gradlew build` is green (no regressions in existing tests)
- [x] ArchUnit rules pass with the new `engine.baseline` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)