### PR TITLE
Stage 4 Slice C — Baseline reader/resolver, wire empirical criteria

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
@@ -1,0 +1,64 @@
+package org.javai.punit.api.typed.spec;
+
+import java.util.Optional;
+
+import org.javai.punit.api.typed.FactorBundle;
+
+/**
+ * The framework's read-side adapter for resolving baseline statistics
+ * at criterion-evaluation time.
+ *
+ * <p>Conceptually a small functional interface (one query method); kept
+ * as a regular interface so the {@link #EMPTY} constant has a stable
+ * place to live. Implementations live in the engine layer
+ * (e.g. punit-core's {@code engine.baseline.YamlBaselineProvider}); the
+ * {@code punit-api} module declares only the contract.
+ *
+ * <p>The framework consults a {@code BaselineProvider} once per
+ * empirical {@link Criterion} during {@link Spec#dispatch dispatch} of
+ * a {@link ProbabilisticTest}'s {@code conclude} call, populating the
+ * matching slot on the {@link EvaluationContext}.
+ *
+ * <h2>Stage 4 lookup contract</h2>
+ *
+ * <p>Stage-4 implementations resolve by exact match on
+ * <em>(use case id, factors fingerprint, criterion name)</em>. The
+ * {@link FactorBundle} is the runtime carrier of the factors record;
+ * implementations derive a fingerprint from
+ * {@code String.valueOf(factors.value())} or equivalent, matching the
+ * write-side fingerprint algorithm.
+ *
+ * <p>A future stage may add covariate-aware closest-match resolution;
+ * this interface stays unchanged because the additional matching
+ * happens entirely inside the implementation.
+ */
+public interface BaselineProvider {
+
+    /**
+     * @return the baseline statistics of the requested kind for the
+     *         given (use case, factors, criterion) tuple, or
+     *         {@link Optional#empty()} when no matching baseline is
+     *         resolvable.
+     */
+    <S extends BaselineStatistics> Optional<S> baselineFor(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType);
+
+    /**
+     * The empty provider — always returns {@link Optional#empty()}.
+     * Used by the engine's no-arg / unconfigured paths and by tests
+     * that don't exercise empirical resolution.
+     */
+    BaselineProvider EMPTY = new BaselineProvider() {
+        @Override
+        public <S extends BaselineStatistics> Optional<S> baselineFor(
+                String useCaseId,
+                FactorBundle factors,
+                String criterionName,
+                Class<S> statisticsType) {
+            return Optional.empty();
+        }
+    };
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
@@ -237,7 +237,7 @@ public final class Experiment implements Spec {
             this.lastSummary = Optional.of(summary);
         }
 
-        @Override public EngineResult conclude() {
+        @Override public EngineResult conclude(BaselineProvider provider) {
             FactorBundle bundle = FactorBundle.of(factors);
             Path path = defaultBaselinePath(experimentId, bundle);
             String message = "measure baseline (stage 2 placeholder — serialisation lands in stage 4); "
@@ -339,7 +339,7 @@ public final class Experiment implements Spec {
             perConfig.put(config.factors(), summary);
         }
 
-        @Override public EngineResult conclude() {
+        @Override public EngineResult conclude(BaselineProvider provider) {
             Path dir = Paths.get("explorations", experimentId);
             String message = "explore artefact (stage 2 placeholder); configurations="
                     + perConfig.size();
@@ -421,7 +421,7 @@ public final class Experiment implements Spec {
             history.add(new IterationResult<>(config.factors(), score));
         }
 
-        @Override public EngineResult conclude() {
+        @Override public EngineResult conclude(BaselineProvider provider) {
             IterationResult<FT> best = bestSoFar();
             Path dir = Paths.get("optimizations", experimentId);
             String message = "optimize artefact (stage 2 placeholder); iterations="

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -159,33 +159,43 @@ public final class ProbabilisticTest implements Spec {
             this.summary = summary;
         }
 
-        @Override public EngineResult conclude() {
+        @Override public EngineResult conclude(BaselineProvider provider) {
+            Objects.requireNonNull(provider, "provider");
             SampleSummary<OT> s = summary != null
                     ? summary
                     : SampleSummary.from(List.of(), Duration.ZERO);
             FactorBundle factorBundle = FactorBundle.of(factors);
+            String useCaseId = sampling.useCaseFactory().apply(factors).id();
 
             List<EvaluatedCriterion> evaluated = new ArrayList<>(registered.size());
             for (Registered<OT> entry : registered) {
-                CriterionResult result = evaluate(entry.criterion(), s, factorBundle);
+                CriterionResult result = evaluate(
+                        entry.criterion(), s, factorBundle, useCaseId, provider);
                 evaluated.add(new EvaluatedCriterion(result, entry.role()));
             }
 
             Verdict composed = Verdict.compose(evaluated);
-            List<String> warnings = new ArrayList<>();
-            warnings.add("baseline resolver is a Stage-3.5 stub — empirical criteria "
-                    + "yield INCONCLUSIVE until Stage 4 lands real resolution");
-
-            return new ProbabilisticTestResult(composed, factorBundle, evaluated, intent, warnings);
+            return new ProbabilisticTestResult(
+                    composed, factorBundle, evaluated, intent, List.of());
         }
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         private CriterionResult evaluate(
-                Criterion<OT, ?> criterion, SampleSummary<OT> s, FactorBundle factorBundle) {
+                Criterion<OT, ?> criterion,
+                SampleSummary<OT> s,
+                FactorBundle factorBundle,
+                String useCaseId,
+                BaselineProvider provider) {
             Criterion raw = criterion;
+            Optional<? extends BaselineStatistics> resolved = criterion.isEmpirical()
+                    ? provider.baselineFor(
+                            useCaseId, factorBundle, criterion.name(), criterion.statisticsType())
+                    : Optional.empty();
             EvaluationContext ctx = new EvaluationContext<OT, BaselineStatistics>() {
                 @Override public SampleSummary<OT> summary() { return s; }
-                @Override public Optional<BaselineStatistics> baseline() { return Optional.empty(); }
+                @Override public Optional<BaselineStatistics> baseline() {
+                    return (Optional<BaselineStatistics>) resolved;
+                }
                 @Override public FactorBundle factors() { return factorBundle; }
             };
             return (CriterionResult) raw.evaluate(ctx);

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/TypedSpec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/TypedSpec.java
@@ -38,7 +38,18 @@ public interface TypedSpec<FT, IT, OT> {
 
     void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary);
 
-    EngineResult conclude();
+    /**
+     * Engine-driven termination of the run. The {@code provider}
+     * supplies baseline statistics for empirical criteria; specs that
+     * make no empirical claims (every {@link Experiment} kind) ignore
+     * the parameter.
+     */
+    EngineResult conclude(BaselineProvider provider);
+
+    /** Convenience shortcut for tests and other callers without a real provider. */
+    default EngineResult conclude() {
+        return conclude(BaselineProvider.EMPTY);
+    }
 
     default Optional<Duration> timeBudget() { return Optional.empty(); }
     default OptionalLong tokenBudget() { return OptionalLong.empty(); }

--- a/punit-core/src/main/java/org/javai/punit/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/Engine.java
@@ -12,6 +12,7 @@ import org.javai.punit.api.typed.MatchResult;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.ValueMatcher;
+import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.api.typed.spec.Configuration;
 import org.javai.punit.api.typed.spec.EngineResult;
 import org.javai.punit.api.typed.spec.ExceptionPolicy;
@@ -46,13 +47,23 @@ import org.javai.punit.api.typed.spec.TypedSpec;
 public final class Engine {
 
     private final SampleExecutor executor;
+    private final BaselineProvider baselineProvider;
 
     public Engine() {
-        this(new SerialSampleExecutor());
+        this(new SerialSampleExecutor(), BaselineProvider.EMPTY);
     }
 
     public Engine(SampleExecutor executor) {
+        this(executor, BaselineProvider.EMPTY);
+    }
+
+    public Engine(BaselineProvider baselineProvider) {
+        this(new SerialSampleExecutor(), baselineProvider);
+    }
+
+    public Engine(SampleExecutor executor, BaselineProvider baselineProvider) {
         this.executor = Objects.requireNonNull(executor, "executor");
+        this.baselineProvider = Objects.requireNonNull(baselineProvider, "baselineProvider");
     }
 
     public EngineResult run(Spec spec) {
@@ -75,7 +86,7 @@ public final class Engine {
             spec.consume(cfg, summary);
             cycleStart = (cycleStart + summary.total()) % cfg.inputs().size();
         }
-        return spec.conclude();
+        return spec.conclude(baselineProvider);
     }
 
     private <FT, IT, OT> SampleSummary<OT> runConfig(

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
@@ -1,0 +1,214 @@
+package org.javai.punit.engine.baseline;
+
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_FACTORS_FINGERPRINT;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_GENERATED_AT;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_INPUTS_IDENTITY;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_METHOD_NAME;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_OBSERVED_PASS_RATE;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_PERCENTILES;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_SAMPLE_COUNT;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_SCHEMA_VERSION;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_STATISTICS;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_USE_CASE_ID;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P50;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P90;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P95;
+import static org.javai.punit.engine.baseline.BaselineSchema.PERCENTILE_KEY_P99;
+import static org.javai.punit.engine.baseline.BaselineSchema.SCHEMA_VERSION_VALUE;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.LatencyStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/**
+ * Parses a {@code punit-baseline-2} YAML file into a
+ * {@link BaselineRecord}. Strict on schema discriminator and on field
+ * presence — a malformed file fails loudly rather than silently
+ * producing a partial record that the resolver might match against.
+ */
+public final class BaselineReader {
+
+    /** Reads and parses the file at {@code baselineFile}. */
+    public BaselineRecord read(Path baselineFile) throws IOException {
+        Objects.requireNonNull(baselineFile, "baselineFile");
+        String content = Files.readString(baselineFile, StandardCharsets.UTF_8);
+        try {
+            return parse(content);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Failed to parse baseline file " + baselineFile + ": " + e.getMessage(), e);
+        }
+    }
+
+    /** Parses {@code yaml} into a {@link BaselineRecord}. */
+    public BaselineRecord parse(String yaml) {
+        Objects.requireNonNull(yaml, "yaml");
+        Map<String, Object> root = loadYaml(yaml);
+
+        String version = requireString(root, FIELD_SCHEMA_VERSION);
+        if (!SCHEMA_VERSION_VALUE.equals(version)) {
+            throw new IllegalArgumentException(
+                    "Unsupported schema version '" + version + "' (expected '"
+                            + SCHEMA_VERSION_VALUE + "')");
+        }
+
+        String useCaseId = requireString(root, FIELD_USE_CASE_ID);
+        String methodName = requireString(root, FIELD_METHOD_NAME);
+        String factorsFingerprint = requireString(root, FIELD_FACTORS_FINGERPRINT);
+        String inputsIdentity = requireString(root, FIELD_INPUTS_IDENTITY);
+        int sampleCount = requireInt(root, FIELD_SAMPLE_COUNT);
+        Instant generatedAt = requireInstant(root, FIELD_GENERATED_AT);
+
+        Map<String, Object> statsMap = requireMap(root, FIELD_STATISTICS);
+        Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : statsMap.entrySet()) {
+            entries.put(e.getKey(), parseStatisticsEntry(e.getKey(), e.getValue()));
+        }
+
+        return new BaselineRecord(
+                useCaseId, methodName, factorsFingerprint,
+                inputsIdentity, sampleCount, generatedAt, entries);
+    }
+
+    private BaselineStatistics parseStatisticsEntry(String criterionName, Object raw) {
+        if (!(raw instanceof Map<?, ?> mapRaw)) {
+            throw new IllegalArgumentException(
+                    "statistics entry '" + criterionName + "' must be a mapping, got "
+                            + (raw == null ? "null" : raw.getClass().getSimpleName()));
+        }
+        Map<String, Object> entry = asStringKeyedMap(mapRaw, "statistics." + criterionName);
+
+        if (entry.containsKey(FIELD_OBSERVED_PASS_RATE)) {
+            double observed = requireDouble(entry, FIELD_OBSERVED_PASS_RATE);
+            int sampleCount = requireInt(entry, FIELD_SAMPLE_COUNT);
+            return new PassRateStatistics(observed, sampleCount);
+        }
+        if (entry.containsKey(FIELD_PERCENTILES)) {
+            Map<String, Object> percentiles = requireMap(entry, FIELD_PERCENTILES);
+            int sampleCount = requireInt(entry, FIELD_SAMPLE_COUNT);
+            LatencyResult result = new LatencyResult(
+                    parseDuration(percentiles, PERCENTILE_KEY_P50),
+                    parseDuration(percentiles, PERCENTILE_KEY_P90),
+                    parseDuration(percentiles, PERCENTILE_KEY_P95),
+                    parseDuration(percentiles, PERCENTILE_KEY_P99),
+                    sampleCount);
+            return new LatencyStatistics(result, sampleCount);
+        }
+        throw new IllegalArgumentException(
+                "Unrecognised statistics entry shape for criterion '" + criterionName
+                        + "' — expected a known discriminator field ('"
+                        + FIELD_OBSERVED_PASS_RATE + "' or '" + FIELD_PERCENTILES + "')");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> loadYaml(String yaml) {
+        Yaml parser = new Yaml(new SafeConstructor(new LoaderOptions()));
+        Object parsed = parser.load(yaml);
+        if (parsed == null) {
+            throw new IllegalArgumentException("baseline file is empty");
+        }
+        if (!(parsed instanceof Map<?, ?> map)) {
+            throw new IllegalArgumentException(
+                    "baseline file root must be a mapping, got "
+                            + parsed.getClass().getSimpleName());
+        }
+        return asStringKeyedMap(map, "<root>");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asStringKeyedMap(Map<?, ?> map, String location) {
+        Map<String, Object> out = new LinkedHashMap<>(map.size());
+        for (Map.Entry<?, ?> e : map.entrySet()) {
+            if (!(e.getKey() instanceof String key)) {
+                throw new IllegalArgumentException(
+                        "Non-string key at " + location + ": " + e.getKey());
+            }
+            out.put(key, e.getValue());
+        }
+        return out;
+    }
+
+    private static String requireString(Map<String, Object> map, String key) {
+        Object v = require(map, key);
+        if (!(v instanceof String s)) {
+            throw new IllegalArgumentException(
+                    "Field '" + key + "' must be a string, got " + v.getClass().getSimpleName());
+        }
+        return s;
+    }
+
+    private static int requireInt(Map<String, Object> map, String key) {
+        Object v = require(map, key);
+        if (v instanceof Integer i) {
+            return i;
+        }
+        if (v instanceof Number n) {
+            return n.intValue();
+        }
+        throw new IllegalArgumentException(
+                "Field '" + key + "' must be an integer, got " + v.getClass().getSimpleName());
+    }
+
+    private static double requireDouble(Map<String, Object> map, String key) {
+        Object v = require(map, key);
+        if (v instanceof Number n) {
+            return n.doubleValue();
+        }
+        throw new IllegalArgumentException(
+                "Field '" + key + "' must be numeric, got " + v.getClass().getSimpleName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> requireMap(Map<String, Object> map, String key) {
+        Object v = require(map, key);
+        if (!(v instanceof Map<?, ?> nested)) {
+            throw new IllegalArgumentException(
+                    "Field '" + key + "' must be a mapping, got " + v.getClass().getSimpleName());
+        }
+        return asStringKeyedMap(nested, key);
+    }
+
+    private static Object require(Map<String, Object> map, String key) {
+        if (!map.containsKey(key)) {
+            throw new IllegalArgumentException("Missing required field '" + key + "'");
+        }
+        Object v = map.get(key);
+        if (v == null) {
+            throw new IllegalArgumentException("Field '" + key + "' must not be null");
+        }
+        return v;
+    }
+
+    private static Duration parseDuration(Map<String, Object> map, String key) {
+        return Duration.parse(requireString(map, key));
+    }
+
+    private static Instant requireInstant(Map<String, Object> map, String key) {
+        Object v = require(map, key);
+        // SnakeYAML's SafeConstructor recognises ISO-8601 timestamps and decodes
+        // them as java.util.Date; accept either that or a String.
+        if (v instanceof java.util.Date d) {
+            return d.toInstant();
+        }
+        if (v instanceof String s) {
+            return Instant.parse(s);
+        }
+        throw new IllegalArgumentException(
+                "Field '" + key + "' must be an ISO-8601 timestamp (string or date), got "
+                        + v.getClass().getSimpleName());
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -1,0 +1,121 @@
+package org.javai.punit.engine.baseline;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+
+/**
+ * Exact-match baseline resolver. Looks up a baseline by
+ * {@code (useCaseId, factorsFingerprint)}, then projects out the
+ * matching {@link BaselineStatistics} entry by criterion name.
+ *
+ * <p>Stage 4 ships exact-match resolution only. Methodless lookup
+ * (no {@code methodName} key in the lookup tuple) is by design —
+ * Stage 4 lands ahead of the JUnit extension wiring (Stage 5) and
+ * therefore has no spec-method context to drive a method-aware key.
+ * The resolver matches the first file whose
+ * {@code {useCaseId}.{methodName}-{factorsFingerprint}.yaml} pattern
+ * agrees on the two known segments, regardless of the {@code methodName}
+ * segment in between.
+ *
+ * <p>Future stages may layer covariate-aware closest-match resolution
+ * on top of this base. The exact-match contract is forward-compatible:
+ * closest-match is strictly more permissive.
+ */
+public final class BaselineResolver {
+
+    private final Path baselineDir;
+    private final BaselineReader reader;
+
+    public BaselineResolver(Path baselineDir) {
+        this(baselineDir, new BaselineReader());
+    }
+
+    BaselineResolver(Path baselineDir, BaselineReader reader) {
+        this.baselineDir = Objects.requireNonNull(baselineDir, "baselineDir");
+        this.reader = Objects.requireNonNull(reader, "reader");
+    }
+
+    /**
+     * @return the {@link BaselineStatistics} of the requested kind for
+     *         the given criterion, or {@link Optional#empty()} when no
+     *         matching baseline file exists or the named criterion has
+     *         no entry in it
+     * @throws IllegalStateException when a baseline file matches but its
+     *         entry for {@code criterionName} is of a different
+     *         {@link BaselineStatistics} flavour than {@code statisticsType}
+     */
+    public <S extends BaselineStatistics> Optional<S> resolve(
+            String useCaseId,
+            String factorsFingerprint,
+            String criterionName,
+            Class<S> statisticsType) {
+        Objects.requireNonNull(useCaseId, "useCaseId");
+        Objects.requireNonNull(factorsFingerprint, "factorsFingerprint");
+        Objects.requireNonNull(criterionName, "criterionName");
+        Objects.requireNonNull(statisticsType, "statisticsType");
+
+        Optional<BaselineRecord> record = findRecord(useCaseId, factorsFingerprint);
+        if (record.isEmpty()) {
+            return Optional.empty();
+        }
+        BaselineStatistics entry = record.get().statisticsByCriterionName().get(criterionName);
+        if (entry == null) {
+            return Optional.empty();
+        }
+        if (!statisticsType.isInstance(entry)) {
+            throw new IllegalStateException(
+                    "Baseline for use case '" + useCaseId + "' carries criterion '"
+                            + criterionName + "' as " + entry.getClass().getSimpleName()
+                            + " but the criterion declares "
+                            + statisticsType.getSimpleName()
+                            + " — write-side and read-side criterion kinds disagree");
+        }
+        return Optional.of(statisticsType.cast(entry));
+    }
+
+    /**
+     * @return the recorded inputs identity from the matching baseline,
+     *         or {@link Optional#empty()} when no match exists
+     */
+    public Optional<String> resolveInputsIdentity(
+            String useCaseId, String factorsFingerprint) {
+        Objects.requireNonNull(useCaseId, "useCaseId");
+        Objects.requireNonNull(factorsFingerprint, "factorsFingerprint");
+        return findRecord(useCaseId, factorsFingerprint).map(BaselineRecord::inputsIdentity);
+    }
+
+    private Optional<BaselineRecord> findRecord(String useCaseId, String factorsFingerprint) {
+        if (!Files.isDirectory(baselineDir)) {
+            return Optional.empty();
+        }
+        String prefix = useCaseId + ".";
+        String suffix = "-" + factorsFingerprint + ".yaml";
+        try (var stream = Files.list(baselineDir)) {
+            return stream
+                    .filter(p -> {
+                        String name = p.getFileName().toString();
+                        return name.startsWith(prefix) && name.endsWith(suffix);
+                    })
+                    .findFirst()
+                    .map(this::readUnchecked);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Failed to enumerate baselines in " + baselineDir, e);
+        }
+    }
+
+    private BaselineRecord readUnchecked(Path file) {
+        try {
+            return reader.read(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Failed to read baseline file " + file, e);
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/FactorsFingerprint.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/FactorsFingerprint.java
@@ -4,21 +4,26 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.Objects;
+
+import org.javai.punit.api.typed.FactorBundle;
 
 /**
  * Computes the {@code factorsFingerprint} field carried by every
- * {@link BaselineRecord} and used by the resolver as one of the
- * three exact-match lookup keys.
+ * {@link BaselineRecord} and used by the resolver as a lookup key.
  *
  * <p>The fingerprint is the first eight hex characters of
- * {@code SHA-256(String.valueOf(factors))}. Records'
- * {@code toString()} is deterministic per the JLS, so the
- * fingerprint is stable across runs and processes given a
- * record-typed factors value.
+ * {@code SHA-256(bundle.canonicalJson())}. {@link FactorBundle}'s
+ * canonical-JSON form is the framework's stable per-factors-instance
+ * representation — keys sorted, types lifted via {@code FactorValue},
+ * stable across runs and processes by construction. Both writer-side
+ * (during MEASURE) and reader-side (during PROBABILISTIC_TEST) hash
+ * the same canonical form, so the lookup key matches without the two
+ * sides having to coordinate beyond agreeing on this utility.
  *
- * <p>{@code null} factors produces the literal string {@code "null"}
- * — distinct from any hex fingerprint, so a measure with no factors
- * cannot collide with a measure under any actual factor value.
+ * <p>{@code FactorBundle.empty()} (no factors) hashes to a stable
+ * fingerprint of its own, distinct from any non-empty factors
+ * fingerprint.
  *
  * <p>See {@code docs/DES-BASELINE-YAML-SCHEMA.md} §"factorsFingerprint"
  * for the design rationale.
@@ -26,20 +31,16 @@ import java.util.HexFormat;
 public final class FactorsFingerprint {
 
     private static final int HEX_PREFIX_LENGTH = 8;
-    private static final String NULL_FINGERPRINT = "null";
 
     private FactorsFingerprint() { }
 
     /**
-     * @return the fingerprint of {@code factors} — the first eight
-     *         hex characters of {@code SHA-256(String.valueOf(factors))},
-     *         or the literal {@code "null"} when {@code factors} is null.
+     * @return the 8-hex-character fingerprint of {@code bundle}'s
+     *         canonical JSON form
      */
-    public static String of(Object factors) {
-        if (factors == null) {
-            return NULL_FINGERPRINT;
-        }
-        byte[] hash = sha256(String.valueOf(factors));
+    public static String of(FactorBundle bundle) {
+        Objects.requireNonNull(bundle, "bundle");
+        byte[] hash = sha256(bundle.canonicalJson());
         return HexFormat.of().formatHex(hash).substring(0, HEX_PREFIX_LENGTH);
     }
 

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
@@ -1,0 +1,39 @@
+package org.javai.punit.engine.baseline;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.spec.BaselineProvider;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+
+/**
+ * Adapts a {@link BaselineResolver} (file-system / YAML-aware) to the
+ * {@link BaselineProvider} interface the typed-spec layer programs
+ * against. The fingerprint computation lives in
+ * {@link FactorsFingerprint} so the read-side and the write-side use
+ * the same algorithm by construction.
+ */
+public final class YamlBaselineProvider implements BaselineProvider {
+
+    private final BaselineResolver resolver;
+
+    public YamlBaselineProvider(Path baselineDir) {
+        this(new BaselineResolver(Objects.requireNonNull(baselineDir, "baselineDir")));
+    }
+
+    public YamlBaselineProvider(BaselineResolver resolver) {
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
+    }
+
+    @Override
+    public <S extends BaselineStatistics> Optional<S> baselineFor(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType) {
+        String fingerprint = FactorsFingerprint.of(factors);
+        return resolver.resolve(useCaseId, fingerprint, criterionName, statisticsType);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
@@ -1,0 +1,132 @@
+package org.javai.punit.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.javai.punit.api.typed.spec.BaselineProvider;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.BernoulliPassRate;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.javai.punit.api.typed.spec.ProbabilisticTest;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+import org.javai.punit.engine.baseline.BaselineRecord;
+import org.javai.punit.engine.baseline.BaselineWriter;
+import org.javai.punit.engine.baseline.FactorsFingerprint;
+import org.javai.punit.engine.baseline.YamlBaselineProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("Empirical criterion end-to-end — Engine + YamlBaselineProvider + BernoulliPassRate.empirical()")
+class EmpiricalEndToEndIntegrationTest {
+
+    record Factors(String model, double temperature) { }
+
+    private static final Factors FACTORS = new Factors("gpt-4o", 0.0);
+    private static final String USE_CASE_ID = "always-passes-use-case";
+
+    static class AlwaysPassesUseCase implements UseCase<Factors, Integer, Boolean> {
+        @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+            return UseCaseOutcome.ok(true);
+        }
+        @Override public String id() { return USE_CASE_ID; }
+    }
+
+    private static Sampling<Factors, Integer, Boolean> sampling(int samples) {
+        return Sampling.<Factors, Integer, Boolean>builder()
+                .useCaseFactory(f -> new AlwaysPassesUseCase())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    private static ProbabilisticTest empiricalTest(Sampling<Factors, Integer, Boolean> sampling) {
+        return ProbabilisticTest
+                .testing(sampling, FACTORS)
+                .criterion(BernoulliPassRate.<Boolean>empirical())
+                .build();
+    }
+
+    private static void writeBaselineWithPassRate(
+            Path baselineDir, double passRate, int sampleCount) throws IOException {
+        String fingerprint = FactorsFingerprint.of(FactorBundle.of(FACTORS));
+        BaselineRecord record = new BaselineRecord(
+                USE_CASE_ID, "measureBaseline", fingerprint,
+                "sha256:any", sampleCount,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                Map.<String, BaselineStatistics>of(
+                        "bernoulli-pass-rate",
+                        new PassRateStatistics(passRate, sampleCount)));
+        new BaselineWriter().write(record, baselineDir);
+    }
+
+    @Test
+    @DisplayName("with an on-disk baseline at p = 0.80, an always-passing test produces PASS")
+    void empiricalProducesPassWhenObservedExceedsBaseline(@TempDir Path baselineDir)
+            throws IOException {
+        writeBaselineWithPassRate(baselineDir, 0.80, 1000);
+
+        var engine = new Engine(new YamlBaselineProvider(baselineDir));
+        var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(20)));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsEntry("origin", "EMPIRICAL");
+        assertThat(detail).containsEntry("threshold", 0.80);
+        assertThat(detail).containsEntry("baselineSampleCount", 1000);
+    }
+
+    @Test
+    @DisplayName("with no on-disk baseline, the empirical criterion still yields INCONCLUSIVE — same as the EMPTY provider")
+    void empiricalYieldsInconclusiveWhenNoBaselineFile(@TempDir Path emptyDir) {
+        var engine = new Engine(new YamlBaselineProvider(emptyDir));
+        var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(20)));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+        assertThat(result.criterionResults().get(0).result().explanation())
+                .contains("baseline");
+    }
+
+    @Test
+    @DisplayName("without an explicit provider, Engine uses BaselineProvider.EMPTY — empirical criteria yield INCONCLUSIVE")
+    void emptyProviderIsTheDefault() {
+        // No baselineDir at all — default Engine() falls back to BaselineProvider.EMPTY.
+        var result = (ProbabilisticTestResult) new Engine().run(empiricalTest(sampling(20)));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+    }
+
+    @Test
+    @DisplayName("with a baseline whose sample count is below the test's, EmpiricalChecks rejects → INCONCLUSIVE")
+    void empiricalRejectsWhenTestOutRiguresBaseline(@TempDir Path baselineDir) throws IOException {
+        // Test asks for 1000 samples; baseline only has 100.
+        writeBaselineWithPassRate(baselineDir, 0.50, 100);
+
+        var engine = new Engine(new YamlBaselineProvider(baselineDir));
+        var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(1000)));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsEntry("testSampleCount", 1000);
+        assertThat(detail).containsEntry("baselineSampleCount", 100);
+    }
+
+    @Test
+    @DisplayName("the empty provider returns Optional.empty for any query")
+    void baselineProviderEmptyContract() {
+        var resolved = BaselineProvider.EMPTY.baselineFor(
+                "any-id", FactorBundle.of(FACTORS),
+                "any-criterion", PassRateStatistics.class);
+
+        assertThat(resolved).isEmpty();
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
@@ -1,0 +1,165 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.LatencyStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("BaselineReader")
+class BaselineReaderTest {
+
+    private final BaselineReader reader = new BaselineReader();
+    private final BaselineWriter writer = new BaselineWriter();
+
+    private BaselineRecord roundTrip(Map<String, BaselineStatistics> entries) {
+        BaselineRecord original = new BaselineRecord(
+                "ShoppingBasket", "measureBaseline", "a1b2c3d4",
+                "sha256:abc123", 1000,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                entries);
+        return reader.parse(writer.toYaml(original));
+    }
+
+    @Test
+    @DisplayName("round-trips a PassRateStatistics record without loss")
+    void roundTripPassRate() {
+        BaselineRecord parsed = roundTrip(Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+
+        assertThat(parsed.useCaseId()).isEqualTo("ShoppingBasket");
+        assertThat(parsed.methodName()).isEqualTo("measureBaseline");
+        assertThat(parsed.factorsFingerprint()).isEqualTo("a1b2c3d4");
+        assertThat(parsed.inputsIdentity()).isEqualTo("sha256:abc123");
+        assertThat(parsed.sampleCount()).isEqualTo(1000);
+        assertThat(parsed.generatedAt()).isEqualTo(Instant.parse("2026-04-26T15:30:00Z"));
+
+        BaselineStatistics entry = parsed.statisticsByCriterionName().get("bernoulli-pass-rate");
+        assertThat(entry).isInstanceOf(PassRateStatistics.class);
+        PassRateStatistics passRate = (PassRateStatistics) entry;
+        assertThat(passRate.observedPassRate()).isEqualTo(0.94);
+        assertThat(passRate.sampleCount()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("round-trips a LatencyStatistics record (all four percentiles)")
+    void roundTripLatency() {
+        LatencyResult percentiles = new LatencyResult(
+                Duration.ofMillis(250),
+                Duration.ofMillis(500),
+                Duration.ofMillis(800),
+                Duration.ofMillis(1200),
+                1000);
+
+        BaselineRecord parsed = roundTrip(Map.of(
+                "percentile-latency", new LatencyStatistics(percentiles, 1000)));
+
+        BaselineStatistics entry = parsed.statisticsByCriterionName().get("percentile-latency");
+        assertThat(entry).isInstanceOf(LatencyStatistics.class);
+        LatencyStatistics latency = (LatencyStatistics) entry;
+        assertThat(latency.percentiles().p50()).isEqualTo(Duration.ofMillis(250));
+        assertThat(latency.percentiles().p90()).isEqualTo(Duration.ofMillis(500));
+        assertThat(latency.percentiles().p95()).isEqualTo(Duration.ofMillis(800));
+        assertThat(latency.percentiles().p99()).isEqualTo(Duration.ofMillis(1200));
+        assertThat(latency.sampleCount()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("round-trips multiple criterion entries side-by-side")
+    void roundTripBothCriteria() {
+        Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
+        entries.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+        entries.put("percentile-latency", new LatencyStatistics(LatencyResult.empty(), 1000));
+
+        BaselineRecord parsed = roundTrip(entries);
+
+        assertThat(parsed.statisticsByCriterionName()).containsOnlyKeys(
+                "bernoulli-pass-rate", "percentile-latency");
+    }
+
+    @Test
+    @DisplayName("read(Path) wraps parse failure with the file path in the diagnostic")
+    void readWrapsErrorWithPath(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("malformed.yaml");
+        Files.writeString(file, "schemaVersion: punit-baseline-2\n");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> reader.read(file))
+                .withMessageContaining("malformed.yaml")
+                .withMessageContaining("Missing required field");
+    }
+
+    @Test
+    @DisplayName("rejects unknown schemaVersion")
+    void rejectsUnknownSchemaVersion() {
+        String yaml = "schemaVersion: punit-baseline-99\n"
+                + "useCaseId: x\n"
+                + "methodName: m\n"
+                + "factorsFingerprint: f\n"
+                + "inputsIdentity: sha256:x\n"
+                + "sampleCount: 1\n"
+                + "generatedAt: 2026-04-26T15:30:00Z\n"
+                + "statistics:\n"
+                + "  bernoulli-pass-rate:\n"
+                + "    observedPassRate: 0.5\n"
+                + "    sampleCount: 1\n";
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> reader.parse(yaml))
+                .withMessageContaining("punit-baseline-99")
+                .withMessageContaining("punit-baseline-2");
+    }
+
+    @Test
+    @DisplayName("rejects an empty file")
+    void rejectsEmptyFile() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> reader.parse(""))
+                .withMessageContaining("empty");
+    }
+
+    @Test
+    @DisplayName("rejects a missing required field with the field name in the diagnostic")
+    void rejectsMissingField() {
+        String yaml = "schemaVersion: punit-baseline-2\n"
+                + "useCaseId: x\n";
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> reader.parse(yaml))
+                .withMessageContaining("methodName");
+    }
+
+    @Test
+    @DisplayName("rejects a statistics entry whose shape matches no known statistics kind")
+    void rejectsUnknownStatisticsShape() {
+        String yaml = "schemaVersion: punit-baseline-2\n"
+                + "useCaseId: x\n"
+                + "methodName: m\n"
+                + "factorsFingerprint: f\n"
+                + "inputsIdentity: sha256:x\n"
+                + "sampleCount: 1\n"
+                + "generatedAt: 2026-04-26T15:30:00Z\n"
+                + "statistics:\n"
+                + "  weird-criterion:\n"
+                + "    foo: 1\n"
+                + "    bar: 2\n";
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> reader.parse(yaml))
+                .withMessageContaining("weird-criterion")
+                .withMessageContaining("Unrecognised statistics entry shape");
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineResolverTest.java
@@ -1,0 +1,136 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.LatencyStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("BaselineResolver — exact-match by useCaseId + factorsFingerprint")
+class BaselineResolverTest {
+
+    private final BaselineWriter writer = new BaselineWriter();
+
+    private void writeBaseline(Path dir, String useCaseId, String fingerprint,
+                                Map<String, BaselineStatistics> entries) throws IOException {
+        BaselineRecord record = new BaselineRecord(
+                useCaseId, "measureBaseline", fingerprint,
+                "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
+                entries);
+        writer.write(record, dir);
+    }
+
+    @Test
+    @DisplayName("resolves a present PassRateStatistics entry")
+    void resolvesPresentEntry(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+
+        var resolver = new BaselineResolver(dir);
+
+        var resolved = resolver.resolve(
+                "ShoppingBasket", "a1b2c3d4", "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().observedPassRate()).isEqualTo(0.94);
+    }
+
+    @Test
+    @DisplayName("returns empty when the baseline directory does not exist")
+    void emptyForMissingDirectory(@TempDir Path tempDir) {
+        var resolver = new BaselineResolver(tempDir.resolve("does-not-exist"));
+
+        var resolved = resolver.resolve(
+                "X", "f", "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(resolved).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns empty when no file matches the (useCaseId, fingerprint) pair")
+    void emptyForNonMatchingFile(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, "Other", "a1b2c3d4", Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.5, 100)));
+
+        var resolver = new BaselineResolver(dir);
+
+        var resolved = resolver.resolve(
+                "ShoppingBasket", "a1b2c3d4", "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(resolved).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns empty when the file matches but the criterion name does not")
+    void emptyForUnknownCriterion(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+
+        var resolver = new BaselineResolver(dir);
+
+        var resolved = resolver.resolve(
+                "ShoppingBasket", "a1b2c3d4", "percentile-latency", LatencyStatistics.class);
+
+        assertThat(resolved).isEmpty();
+    }
+
+    @Test
+    @DisplayName("rejects mismatch between recorded statistics flavour and requested type")
+    void rejectsStatisticsTypeMismatch(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+
+        var resolver = new BaselineResolver(dir);
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> resolver.resolve(
+                        "ShoppingBasket", "a1b2c3d4", "bernoulli-pass-rate",
+                        LatencyStatistics.class))
+                .withMessageContaining("PassRateStatistics")
+                .withMessageContaining("LatencyStatistics");
+    }
+
+    @Test
+    @DisplayName("resolveInputsIdentity returns the recorded identity when the baseline matches")
+    void resolveInputsIdentity(@TempDir Path dir) throws IOException {
+        BaselineRecord record = new BaselineRecord(
+                "ShoppingBasket", "measureBaseline", "a1b2c3d4",
+                "sha256:specific-identity", 1000,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+        writer.write(record, dir);
+
+        var resolver = new BaselineResolver(dir);
+
+        assertThat(resolver.resolveInputsIdentity("ShoppingBasket", "a1b2c3d4"))
+                .contains("sha256:specific-identity");
+        assertThat(resolver.resolveInputsIdentity("Other", "a1b2c3d4")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("resolves multiple criterion entries from one baseline file")
+    void resolvesMultipleEntries(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", new java.util.LinkedHashMap<>(Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000),
+                "percentile-latency", new LatencyStatistics(LatencyResult.empty(), 1000))));
+
+        var resolver = new BaselineResolver(dir);
+
+        assertThat(resolver.resolve(
+                "ShoppingBasket", "a1b2c3d4", "bernoulli-pass-rate",
+                PassRateStatistics.class)).isPresent();
+        assertThat(resolver.resolve(
+                "ShoppingBasket", "a1b2c3d4", "percentile-latency",
+                LatencyStatistics.class)).isPresent();
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/FactorsFingerprintTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/FactorsFingerprintTest.java
@@ -1,7 +1,9 @@
 package org.javai.punit.engine.baseline;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import org.javai.punit.api.typed.FactorBundle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,18 +13,19 @@ class FactorsFingerprintTest {
     record Factors(String model, double temperature) { }
 
     @Test
-    @DisplayName("8-char hex for any non-null value")
-    void hexLengthForNonNull() {
-        String fingerprint = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
+    @DisplayName("8-char hex for any FactorBundle")
+    void hexLength() {
+        String fingerprint = FactorsFingerprint.of(
+                FactorBundle.of(new Factors("gpt-4o", 0.0)));
 
         assertThat(fingerprint).hasSize(8).matches("[0-9a-f]{8}");
     }
 
     @Test
-    @DisplayName("deterministic — equal inputs produce equal fingerprints")
+    @DisplayName("deterministic — equal bundles produce equal fingerprints")
     void deterministic() {
-        String a = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
-        String b = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
+        String a = FactorsFingerprint.of(FactorBundle.of(new Factors("gpt-4o", 0.0)));
+        String b = FactorsFingerprint.of(FactorBundle.of(new Factors("gpt-4o", 0.0)));
 
         assertThat(a).isEqualTo(b);
     }
@@ -30,38 +33,27 @@ class FactorsFingerprintTest {
     @Test
     @DisplayName("differs when any factor field differs")
     void contentSensitivity() {
-        String a = FactorsFingerprint.of(new Factors("gpt-4o", 0.0));
-        String b = FactorsFingerprint.of(new Factors("gpt-4o", 0.1));
-        String c = FactorsFingerprint.of(new Factors("gpt-3.5", 0.0));
+        String a = FactorsFingerprint.of(FactorBundle.of(new Factors("gpt-4o", 0.0)));
+        String b = FactorsFingerprint.of(FactorBundle.of(new Factors("gpt-4o", 0.1)));
+        String c = FactorsFingerprint.of(FactorBundle.of(new Factors("gpt-3.5", 0.0)));
 
         assertThat(a).isNotEqualTo(b).isNotEqualTo(c);
         assertThat(b).isNotEqualTo(c);
     }
 
     @Test
-    @DisplayName("null factors produce the literal 'null' fingerprint")
-    void nullFactors() {
-        assertThat(FactorsFingerprint.of(null)).isEqualTo("null");
+    @DisplayName("empty FactorBundle has a stable fingerprint distinct from any non-empty one")
+    void emptyBundle() {
+        String empty = FactorsFingerprint.of(FactorBundle.empty());
+        String nonEmpty = FactorsFingerprint.of(FactorBundle.of(new Factors("anything", 1.0)));
+
+        assertThat(empty).hasSize(8).matches("[0-9a-f]{8}");
+        assertThat(empty).isNotEqualTo(nonEmpty);
     }
 
     @Test
-    @DisplayName("'null' literal cannot collide with any hex fingerprint")
-    void nullSentinelIsDistinct() {
-        String literal = FactorsFingerprint.of(null);
-        String hex = FactorsFingerprint.of(new Factors("anything", 1.0));
-
-        assertThat(literal).isNotEqualTo(hex);
-        assertThat(hex).matches("[0-9a-f]{8}");
-    }
-
-    @Test
-    @DisplayName("works for non-record types — relies on String.valueOf, so toString stability is the caller's contract")
-    void stringValueOfUsage() {
-        String forString = FactorsFingerprint.of("plain string");
-        String forInteger = FactorsFingerprint.of(42);
-
-        assertThat(forString).hasSize(8);
-        assertThat(forInteger).hasSize(8);
-        assertThat(forString).isNotEqualTo(forInteger);
+    @DisplayName("rejects null bundle")
+    void rejectsNullBundle() {
+        assertThatNullPointerException().isThrownBy(() -> FactorsFingerprint.of(null));
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/YamlBaselineProviderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/YamlBaselineProviderTest.java
@@ -1,0 +1,79 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("YamlBaselineProvider — bridges BaselineProvider contract to file-system resolver")
+class YamlBaselineProviderTest {
+
+    record Factors(String model, double temperature) { }
+
+    private final BaselineWriter writer = new BaselineWriter();
+
+    @Test
+    @DisplayName("returns the recorded statistics when use case + factors fingerprint match")
+    void resolvesPresent(@TempDir Path dir) throws IOException {
+        FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
+        BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+        writer.write(record, dir);
+
+        var provider = new YamlBaselineProvider(dir);
+
+        var resolved = provider.baselineFor(
+                "ShoppingBasket", bundle, "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().observedPassRate()).isEqualTo(0.92);
+    }
+
+    @Test
+    @DisplayName("returns empty for an unmatched factor bundle (different fingerprint)")
+    void emptyForDifferentFactors(@TempDir Path dir) throws IOException {
+        FactorBundle measured = FactorBundle.of(new Factors("gpt-4o", 0.0));
+        FactorBundle queried = FactorBundle.of(new Factors("gpt-4o", 0.7));
+        BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(measured),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+        writer.write(record, dir);
+
+        var provider = new YamlBaselineProvider(dir);
+
+        var resolved = provider.baselineFor(
+                "ShoppingBasket", queried, "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(resolved).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns empty for an empty baseline directory")
+    void emptyForNoBaselines(@TempDir Path dir) {
+        var provider = new YamlBaselineProvider(dir);
+
+        var resolved = provider.baselineFor(
+                "ShoppingBasket",
+                FactorBundle.of(new Factors("gpt-4o", 0.0)),
+                "bernoulli-pass-rate",
+                PassRateStatistics.class);
+
+        assertThat(resolved).isEmpty();
+    }
+
+    private BaselineRecord baseline(String useCaseId, String fingerprint,
+                                     Map<String, BaselineStatistics> entries) {
+        return new BaselineRecord(
+                useCaseId, "measureBaseline", fingerprint,
+                "sha256:irrelevant", 1000, Instant.parse("2026-04-26T15:30:00Z"),
+                entries);
+    }
+}


### PR DESCRIPTION
## Summary

Builds on PR #68's writer with the read side. Empirical CR02 / CR03 criteria
flip from `INCONCLUSIVE`-by-stub to producing real verdicts whenever a
matching on-disk baseline exists.

Three commits:

1. **FactorsFingerprint refactor** — takes `FactorBundle` and hashes
   `canonicalJson()`. PR #68's `Object` form (hashing record `toString()`)
   was the wrong basis: `FactorBundle.canonicalJson()` is the framework's
   stable per-factors-instance representation. Both write-side and
   read-side now hash the same canonical form, so the lookup key matches
   without coordination beyond agreeing on this utility.

2. **BaselineProvider in `punit-api`** — one-method functional contract
   the framework consults to resolve baseline statistics. `EMPTY`
   constant for the unwired path. `TypedSpec.conclude()` splits into
   `conclude(BaselineProvider)` (canonical) and a no-arg default that
   calls it with `EMPTY`. `ProbabilisticTest.Internal.conclude(provider)`
   threads the resolved Optional into the per-criterion EvaluationContext,
   replacing the always-empty stub.

3. **BaselineReader + BaselineResolver + YamlBaselineProvider** in
   `punit-core/.../engine/baseline/`. Engine accepts a BaselineProvider
   (default EMPTY) and threads it into `spec.conclude(provider)`.

## Stage 4 scope decisions

- **Methodless lookup.** Stage 4's exact-match key is `(useCaseId,
  factorsFingerprint, criterionName)` — no `methodName`. The methodName
  segment in filenames is preserved for forward compatibility, but the
  resolver matches on prefix + suffix, ignoring the middle. methodName
  has no source in the typed pipeline until Stage 5's JUnit wiring lands.
- **Build fresh, not on top of legacy `org.javai.punit.spec.baseline`.**
  The legacy package's covariate / closest-match machinery is out of
  Stage 4's scope; reusing it would entangle the typed pipeline with
  concerns the Stage-3.5 compositional surface doesn't yet model. New
  package `org.javai.punit.engine.baseline` builds against the typed
  Criterion / BaselineStatistics types directly.

## Test plan

- [x] 26 new unit + integration tests pass:
      - 8 `BaselineReaderTest` (round-trip, schema-version rejection,
        malformed-file diagnostics)
      - 7 `BaselineResolverTest` (exact-match success/miss, type-mismatch
        diagnostic, multi-criterion files)
      - 3 `YamlBaselineProviderTest` (FactorBundle → fingerprint
        end-to-end through the resolver)
      - 5 `EmpiricalEndToEndIntegrationTest` (Engine + provider + real
        baseline → real verdict; empty-provider fallback; sample-size
        rule rejection)
      - 3 updated `FactorsFingerprintTest` (now exercising the
        FactorBundle-based shape)
- [x] Full `./gradlew build` green; ArchUnit rules pass with the new
  `engine.baseline` package; existing engine integration tests still
  pass with the EMPTY-provider default

## Still to come (later Stage-4 slices)

- **Slice D** — `EmpiricalChecks.inputsIdentityMatch(...)` (the
  cross-process integrity check PR #67's TODO flagged)
- **Slice E** — Wilson-score-aware comparison in `BernoulliPassRate`
  (replacing the placeholder `observed >= threshold`)
- **Slice F** — `PowerAnalysis` reading the real baseline rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)