### PR TITLE
Stage 4 Slice D — EmpiricalChecks.inputsIdentityMatch + criterion wiring

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
@@ -47,6 +47,19 @@ public interface BaselineProvider {
             Class<S> statisticsType);
 
     /**
+     * @return the inputs identity recorded by the resolved baseline
+     *         for the given (use case, factors) pair, or
+     *         {@link Optional#empty()} when no matching baseline file
+     *         exists. The value is the
+     *         {@code Sampling.inputsIdentity()} the writer captured
+     *         at MEASURE time. Used for the cross-process
+     *         {@link EmpiricalChecks#inputsIdentityMatch}
+     *         integrity check.
+     */
+    Optional<String> baselineInputsIdentityFor(
+            String useCaseId, FactorBundle factors);
+
+    /**
      * The empty provider — always returns {@link Optional#empty()}.
      * Used by the engine's no-arg / unconfigured paths and by tests
      * that don't exercise empirical resolution.
@@ -58,6 +71,12 @@ public interface BaselineProvider {
                 FactorBundle factors,
                 String criterionName,
                 Class<S> statisticsType) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> baselineInputsIdentityFor(
+                String useCaseId, FactorBundle factors) {
             return Optional.empty();
         }
     };

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BernoulliPassRate.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BernoulliPassRate.java
@@ -150,11 +150,23 @@ public final class BernoulliPassRate<OT> implements Criterion<OT, PassRateStatis
                                 + "see DG02 §'Baseline relationship' for the resolution mechanism",
                         detail);
             }
-            // Sample-size rule. See EmpiricalChecks#sampleSizeConstraint.
-            Optional<CriterionResult> violation = EmpiricalChecks.sampleSizeConstraint(
-                    NAME, total, stats.sampleCount(), Map.of());
-            if (violation.isPresent()) {
-                return violation.get();
+            Map<String, Object> empiricalDetail = Map.of("confidence", confidence);
+            // Inputs-identity rule precedes the sample-size rule: an identity
+            // mismatch is a more fundamental violation, so its diagnostic
+            // wins when both would fire.
+            String baselineIdentity = ctx.baselineInputsIdentity().orElseThrow(() ->
+                    new IllegalStateException(
+                            "baseline statistics were resolved but baselineInputsIdentity is empty — "
+                                    + "the BaselineProvider is producing inconsistent state"));
+            Optional<CriterionResult> identityViolation = EmpiricalChecks.inputsIdentityMatch(
+                    NAME, ctx.testInputsIdentity(), baselineIdentity, empiricalDetail);
+            if (identityViolation.isPresent()) {
+                return identityViolation.get();
+            }
+            Optional<CriterionResult> sizeViolation = EmpiricalChecks.sampleSizeConstraint(
+                    NAME, total, stats.sampleCount(), empiricalDetail);
+            if (sizeViolation.isPresent()) {
+                return sizeViolation.get();
             }
             resolvedThreshold = stats.observedPassRate();
             resolvedOrigin = ThresholdOrigin.EMPIRICAL;

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/EmpiricalChecks.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/EmpiricalChecks.java
@@ -78,4 +78,76 @@ public final class EmpiricalChecks {
         return Optional.of(new CriterionResult(
                 criterionName, Verdict.INCONCLUSIVE, reason, detail));
     }
+
+    /**
+     * Inputs-identity rule: the test's inputs identity must equal the
+     * resolved baseline's recorded inputs identity. The two are the
+     * cross-process restatement of the same in-process integrity
+     * guarantee that the shared {@link org.javai.punit.api.typed.Sampling}
+     * value gives a measure / probabilistic-test pair.
+     *
+     * <p>An empirical comparison is statistically meaningful only when
+     * the test and the baseline draw from the same sampling population.
+     * Same use case + same factors is one half; same input list — by
+     * content, not by reference, since the two processes don't share
+     * memory — is the other. {@code Sampling.inputsIdentity()} is the
+     * SHA-256 content hash that captures the inputs half (per
+     * {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md}). The framework
+     * records it on every baseline at write time and compares here.
+     *
+     * <p>Returns {@link Verdict#INCONCLUSIVE} rather than
+     * {@link Verdict#FAIL}: a mismatch is configuration drift, not
+     * service degradation. The diagnostic names both identities
+     * (truncated for readability) and the corrective action.
+     *
+     * @param criterionName     the criterion's stable name
+     *                          ({@link Criterion#name()}) — used in the
+     *                          returned {@code CriterionResult}
+     * @param testIdentity      the test's
+     *                          {@code Sampling.inputsIdentity()}
+     * @param baselineIdentity  the inputs identity recorded by the
+     *                          resolved baseline
+     * @param additionalDetail  criterion-specific entries to include in
+     *                          the violation's detail map. May be empty.
+     * @return an INCONCLUSIVE {@code CriterionResult} when the two
+     *         identities differ; empty when they match
+     */
+    public static Optional<CriterionResult> inputsIdentityMatch(
+            String criterionName,
+            String testIdentity,
+            String baselineIdentity,
+            Map<String, Object> additionalDetail) {
+        Objects.requireNonNull(criterionName, "criterionName");
+        Objects.requireNonNull(testIdentity, "testIdentity");
+        Objects.requireNonNull(baselineIdentity, "baselineIdentity");
+        Objects.requireNonNull(additionalDetail, "additionalDetail");
+        if (testIdentity.equals(baselineIdentity)) {
+            return Optional.empty();
+        }
+        Map<String, Object> detail = new LinkedHashMap<>(additionalDetail);
+        detail.putIfAbsent("origin", ThresholdOrigin.EMPIRICAL.name());
+        detail.put("testInputsIdentity", testIdentity);
+        detail.put("baselineInputsIdentity", baselineIdentity);
+        String reason = "test inputs identity (" + truncate(testIdentity)
+                + ") differs from the resolved baseline's recorded inputs "
+                + "identity (" + truncate(baselineIdentity) + "). An empirical "
+                + "comparison requires both sides to draw from the same input "
+                + "population — re-run the baseline measure with the test's "
+                + "inputs, or pin the test to the baseline that was measured "
+                + "with these inputs.";
+        return Optional.of(new CriterionResult(
+                criterionName, Verdict.INCONCLUSIVE, reason, detail));
+    }
+
+    /**
+     * Truncates a {@code sha256:HEX...} identity string to a short
+     * prefix suitable for embedding in a diagnostic message. Other
+     * identity formats are returned as-is.
+     */
+    private static String truncate(String identity) {
+        if (identity.startsWith("sha256:") && identity.length() > 7 + 12) {
+            return identity.substring(0, 7 + 12) + "…";
+        }
+        return identity;
+    }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/EvaluationContext.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/EvaluationContext.java
@@ -29,4 +29,22 @@ public interface EvaluationContext<OT, S extends BaselineStatistics> {
 
     /** The bound factor bundle the spec was evaluated against. */
     FactorBundle factors();
+
+    /**
+     * The test's inputs identity — the
+     * {@code Sampling.inputsIdentity()} of the {@code Sampling} this
+     * spec was built from. Used by
+     * {@link EmpiricalChecks#inputsIdentityMatch(String, String, String, java.util.Map)}
+     * to verify cross-process that the test and its baseline drew
+     * from the same input population.
+     */
+    String testInputsIdentity();
+
+    /**
+     * The inputs identity recorded by the resolved baseline, when
+     * one was resolvable. Empty when the framework could not resolve
+     * a matching baseline (in which case {@link #baseline()} is also
+     * empty by construction).
+     */
+    Optional<String> baselineInputsIdentity();
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/PercentileLatency.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/PercentileLatency.java
@@ -136,12 +136,23 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
                                 + "see DG02 §'Baseline relationship' for the resolution mechanism",
                         Map.of("assertedPercentiles", assertedCsv(), "origin", ThresholdOrigin.EMPIRICAL.name()));
             }
-            // Sample-size rule. See EmpiricalChecks#sampleSizeConstraint.
-            Optional<CriterionResult> violation = EmpiricalChecks.sampleSizeConstraint(
-                    NAME, summary.total(), stats.sampleCount(),
-                    Map.of("assertedPercentiles", assertedCsv()));
-            if (violation.isPresent()) {
-                return violation.get();
+            Map<String, Object> empiricalDetail = Map.of("assertedPercentiles", assertedCsv());
+            // Inputs-identity rule precedes the sample-size rule: an identity
+            // mismatch is a more fundamental violation, so its diagnostic
+            // wins when both would fire.
+            String baselineIdentity = ctx.baselineInputsIdentity().orElseThrow(() ->
+                    new IllegalStateException(
+                            "baseline statistics were resolved but baselineInputsIdentity is empty — "
+                                    + "the BaselineProvider is producing inconsistent state"));
+            Optional<CriterionResult> identityViolation = EmpiricalChecks.inputsIdentityMatch(
+                    NAME, ctx.testInputsIdentity(), baselineIdentity, empiricalDetail);
+            if (identityViolation.isPresent()) {
+                return identityViolation.get();
+            }
+            Optional<CriterionResult> sizeViolation = EmpiricalChecks.sampleSizeConstraint(
+                    NAME, summary.total(), stats.sampleCount(), empiricalDetail);
+            if (sizeViolation.isPresent()) {
+                return sizeViolation.get();
             }
             thresholds = thresholdsFromBaseline(stats.percentiles());
             resolvedOrigin = ThresholdOrigin.EMPIRICAL;

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -166,11 +166,18 @@ public final class ProbabilisticTest implements Spec {
                     : SampleSummary.from(List.of(), Duration.ZERO);
             FactorBundle factorBundle = FactorBundle.of(factors);
             String useCaseId = sampling.useCaseFactory().apply(factors).id();
+            String testInputsIdentity = sampling.inputsIdentity();
+            // Looked up once and reused across criteria — the identity is a
+            // property of the baseline file, not of any individual criterion.
+            Optional<String> baselineInputsIdentity = anyEmpiricalCriterion()
+                    ? provider.baselineInputsIdentityFor(useCaseId, factorBundle)
+                    : Optional.empty();
 
             List<EvaluatedCriterion> evaluated = new ArrayList<>(registered.size());
             for (Registered<OT> entry : registered) {
                 CriterionResult result = evaluate(
-                        entry.criterion(), s, factorBundle, useCaseId, provider);
+                        entry.criterion(), s, factorBundle, useCaseId,
+                        testInputsIdentity, baselineInputsIdentity, provider);
                 evaluated.add(new EvaluatedCriterion(result, entry.role()));
             }
 
@@ -179,12 +186,23 @@ public final class ProbabilisticTest implements Spec {
                     composed, factorBundle, evaluated, intent, List.of());
         }
 
+        private boolean anyEmpiricalCriterion() {
+            for (Registered<OT> entry : registered) {
+                if (entry.criterion().isEmpirical()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         @SuppressWarnings({"unchecked", "rawtypes"})
         private CriterionResult evaluate(
                 Criterion<OT, ?> criterion,
                 SampleSummary<OT> s,
                 FactorBundle factorBundle,
                 String useCaseId,
+                String testInputsIdentity,
+                Optional<String> baselineInputsIdentity,
                 BaselineProvider provider) {
             Criterion raw = criterion;
             Optional<? extends BaselineStatistics> resolved = criterion.isEmpirical()
@@ -197,6 +215,10 @@ public final class ProbabilisticTest implements Spec {
                     return (Optional<BaselineStatistics>) resolved;
                 }
                 @Override public FactorBundle factors() { return factorBundle; }
+                @Override public String testInputsIdentity() { return testInputsIdentity; }
+                @Override public Optional<String> baselineInputsIdentity() {
+                    return baselineInputsIdentity;
+                }
             };
             return (CriterionResult) raw.evaluate(ctx);
         }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/BernoulliPassRateTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/BernoulliPassRateTest.java
@@ -33,12 +33,25 @@ class BernoulliPassRateTest {
                 List.of());
     }
 
+    private static final String DEFAULT_IDENTITY = "sha256:test-default-identity";
+
     private static <OT> EvaluationContext<OT, PassRateStatistics> ctx(
             SampleSummary<OT> summary, Optional<PassRateStatistics> baseline) {
+        return ctx(summary, baseline, DEFAULT_IDENTITY,
+                baseline.isPresent() ? Optional.of(DEFAULT_IDENTITY) : Optional.empty());
+    }
+
+    private static <OT> EvaluationContext<OT, PassRateStatistics> ctx(
+            SampleSummary<OT> summary,
+            Optional<PassRateStatistics> baseline,
+            String testIdentity,
+            Optional<String> baselineIdentity) {
         return new EvaluationContext<OT, PassRateStatistics>() {
             @Override public SampleSummary<OT> summary() { return summary; }
             @Override public Optional<PassRateStatistics> baseline() { return baseline; }
             @Override public FactorBundle factors() { return FactorBundle.of(new Factors("x")); }
+            @Override public String testInputsIdentity() { return testIdentity; }
+            @Override public Optional<String> baselineInputsIdentity() { return baselineIdentity; }
         };
     }
 
@@ -158,6 +171,57 @@ class BernoulliPassRateTest {
         CriterionResult result = criterion.evaluate(ctx(summary(45, 5), Optional.of(baseline)));
 
         assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+    }
+
+    // ── inputs-identity check ───────────────────────────────────────
+
+    @Test
+    @DisplayName("empirical() with mismatched test/baseline inputs identity returns INCONCLUSIVE")
+    void empiricalRejectsIdentityMismatch() {
+        BernoulliPassRate<String> criterion = BernoulliPassRate.empirical();
+        PassRateStatistics baseline = new PassRateStatistics(0.88, 1000);
+
+        CriterionResult result = criterion.evaluate(ctx(
+                summary(90, 10), Optional.of(baseline),
+                "sha256:test-inputs-A",
+                Optional.of("sha256:baseline-inputs-B")));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+        assertThat(result.explanation())
+                .contains("inputs identity")
+                .contains("re-run the baseline measure");
+        assertThat(result.detail())
+                .containsEntry("testInputsIdentity", "sha256:test-inputs-A")
+                .containsEntry("baselineInputsIdentity", "sha256:baseline-inputs-B");
+    }
+
+    @Test
+    @DisplayName("empirical() with matching test/baseline identity proceeds to verdict")
+    void empiricalAcceptsMatchingIdentity() {
+        BernoulliPassRate<String> criterion = BernoulliPassRate.empirical();
+        PassRateStatistics baseline = new PassRateStatistics(0.88, 1000);
+
+        CriterionResult result = criterion.evaluate(ctx(
+                summary(90, 10), Optional.of(baseline),
+                "sha256:matching-id",
+                Optional.of("sha256:matching-id")));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+    }
+
+    @Test
+    @DisplayName("empirical() identity-mismatch fires before sample-size — identity is the more fundamental violation")
+    void identityMismatchPrecedesSampleSize() {
+        BernoulliPassRate<String> criterion = BernoulliPassRate.empirical();
+        PassRateStatistics baseline = new PassRateStatistics(0.88, 100);
+
+        // Both rules would fire: 200 test samples > 100 baseline AND identities differ.
+        CriterionResult result = criterion.evaluate(ctx(
+                summary(180, 20), Optional.of(baseline),
+                "sha256:test-id", Optional.of("sha256:baseline-id")));
+
+        assertThat(result.explanation()).contains("inputs identity");
+        assertThat(result.explanation()).doesNotContain("sample size");
     }
 
     @Test

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/CriterionResultDetailTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/CriterionResultDetailTest.java
@@ -35,12 +35,18 @@ class CriterionResultDetailTest {
                 List.of());
     }
 
+    private static final String DEFAULT_IDENTITY = "sha256:test-default-identity";
+
     private static <S extends BaselineStatistics> EvaluationContext<Integer, S> ctx(
             SampleSummary<Integer> s, Optional<S> baseline) {
         return new EvaluationContext<Integer, S>() {
             @Override public SampleSummary<Integer> summary() { return s; }
             @Override public Optional<S> baseline() { return baseline; }
             @Override public FactorBundle factors() { return FactorBundle.of(new Factors("m")); }
+            @Override public String testInputsIdentity() { return DEFAULT_IDENTITY; }
+            @Override public Optional<String> baselineInputsIdentity() {
+                return baseline.isPresent() ? Optional.of(DEFAULT_IDENTITY) : Optional.empty();
+            }
         };
     }
 

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/EmpiricalChecksTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/EmpiricalChecksTest.java
@@ -71,4 +71,77 @@ class EmpiricalChecksTest {
         assertThatNullPointerException()
                 .isThrownBy(() -> EmpiricalChecks.sampleSizeConstraint("c", 1, 1, null));
     }
+
+    // ── inputsIdentityMatch ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("inputsIdentityMatch returns empty when identities are equal")
+    void inputsIdentityMatching() {
+        assertThat(EmpiricalChecks.inputsIdentityMatch(
+                "c", "sha256:abc", "sha256:abc", Map.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("inputsIdentityMatch returns INCONCLUSIVE when identities differ")
+    void inputsIdentityMismatch() {
+        Optional<CriterionResult> result = EmpiricalChecks.inputsIdentityMatch(
+                "bernoulli-pass-rate", "sha256:test", "sha256:baseline", Map.of());
+
+        assertThat(result).isPresent();
+        CriterionResult r = result.get();
+        assertThat(r.criterionName()).isEqualTo("bernoulli-pass-rate");
+        assertThat(r.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+        assertThat(r.explanation())
+                .contains("inputs identity")
+                .contains("sha256:test")
+                .contains("sha256:baseline")
+                .contains("re-run the baseline measure");
+        assertThat(r.detail()).containsEntry("testInputsIdentity", "sha256:test");
+        assertThat(r.detail()).containsEntry("baselineInputsIdentity", "sha256:baseline");
+        assertThat(r.detail()).containsEntry("origin", "EMPIRICAL");
+    }
+
+    @Test
+    @DisplayName("inputsIdentityMatch truncates long sha256 identities in the explanation")
+    void inputsIdentityTruncatesLongHashes() {
+        String longTestIdentity = "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        String longBaselineIdentity = "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+        CriterionResult result = EmpiricalChecks.inputsIdentityMatch(
+                "c", longTestIdentity, longBaselineIdentity, Map.of()).orElseThrow();
+
+        // Explanation contains the truncated forms (12 hex chars), not the full hashes.
+        assertThat(result.explanation())
+                .contains("sha256:abcdef012345…")
+                .contains("sha256:fedcba987654…")
+                .doesNotContain(longTestIdentity)
+                .doesNotContain(longBaselineIdentity);
+        // Full identities still surface in the detail map for downstream reporting.
+        assertThat(result.detail()).containsEntry("testInputsIdentity", longTestIdentity);
+        assertThat(result.detail()).containsEntry("baselineInputsIdentity", longBaselineIdentity);
+    }
+
+    @Test
+    @DisplayName("inputsIdentityMatch additionalDetail entries are merged into the violation's detail map")
+    void inputsIdentityAdditionalDetailMerged() {
+        Optional<CriterionResult> result = EmpiricalChecks.inputsIdentityMatch(
+                "percentile-latency", "sha256:a", "sha256:b",
+                Map.of("assertedPercentiles", "p95,p99"));
+
+        Map<String, Object> detail = result.orElseThrow().detail();
+        assertThat(detail).containsEntry("assertedPercentiles", "p95,p99");
+    }
+
+    @Test
+    @DisplayName("inputsIdentityMatch rejects null arguments")
+    void inputsIdentityRejectsNulls() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> EmpiricalChecks.inputsIdentityMatch(null, "a", "b", Map.of()));
+        assertThatNullPointerException()
+                .isThrownBy(() -> EmpiricalChecks.inputsIdentityMatch("c", null, "b", Map.of()));
+        assertThatNullPointerException()
+                .isThrownBy(() -> EmpiricalChecks.inputsIdentityMatch("c", "a", null, Map.of()));
+        assertThatNullPointerException()
+                .isThrownBy(() -> EmpiricalChecks.inputsIdentityMatch("c", "a", "b", null));
+    }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/PercentileLatencyTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/PercentileLatencyTest.java
@@ -43,12 +43,25 @@ class PercentileLatencyTest {
                 n);
     }
 
+    private static final String DEFAULT_IDENTITY = "sha256:test-default-identity";
+
     private static <OT> EvaluationContext<OT, LatencyStatistics> ctx(
             SampleSummary<OT> summary, Optional<LatencyStatistics> baseline) {
+        return ctx(summary, baseline, DEFAULT_IDENTITY,
+                baseline.isPresent() ? Optional.of(DEFAULT_IDENTITY) : Optional.empty());
+    }
+
+    private static <OT> EvaluationContext<OT, LatencyStatistics> ctx(
+            SampleSummary<OT> summary,
+            Optional<LatencyStatistics> baseline,
+            String testIdentity,
+            Optional<String> baselineIdentity) {
         return new EvaluationContext<OT, LatencyStatistics>() {
             @Override public SampleSummary<OT> summary() { return summary; }
             @Override public Optional<LatencyStatistics> baseline() { return baseline; }
             @Override public FactorBundle factors() { return FactorBundle.of(new Factors("x")); }
+            @Override public String testInputsIdentity() { return testIdentity; }
+            @Override public Optional<String> baselineInputsIdentity() { return baselineIdentity; }
         };
     }
 
@@ -172,6 +185,39 @@ class PercentileLatencyTest {
 
         assertThat(equal.verdict()).isEqualTo(Verdict.PASS);
         assertThat(smaller.verdict()).isEqualTo(Verdict.PASS);
+    }
+
+    // ── inputs-identity check ───────────────────────────────────────
+
+    @Test
+    @DisplayName("empirical() with mismatched test/baseline inputs identity returns INCONCLUSIVE")
+    void empiricalRejectsIdentityMismatch() {
+        PercentileLatency<String> criterion = PercentileLatency.empirical(PercentileKey.P95);
+        LatencyStatistics baseline = new LatencyStatistics(observed(100, 200, 500, 1000, 1000), 1000);
+
+        CriterionResult result = criterion.evaluate(ctx(
+                summary(observed(80, 180, 480, 950, 200), 200, 0), Optional.of(baseline),
+                "sha256:test-id", Optional.of("sha256:baseline-id")));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+        assertThat(result.explanation()).contains("inputs identity");
+        assertThat(result.detail())
+                .containsEntry("testInputsIdentity", "sha256:test-id")
+                .containsEntry("baselineInputsIdentity", "sha256:baseline-id")
+                .containsEntry("assertedPercentiles", "p95");
+    }
+
+    @Test
+    @DisplayName("empirical() with matching test/baseline identity proceeds to verdict")
+    void empiricalAcceptsMatchingIdentity() {
+        PercentileLatency<String> criterion = PercentileLatency.empirical(PercentileKey.P95);
+        LatencyStatistics baseline = new LatencyStatistics(observed(100, 200, 500, 1000, 1000), 1000);
+
+        CriterionResult result = criterion.evaluate(ctx(
+                summary(observed(80, 180, 480, 950, 200), 200, 0), Optional.of(baseline),
+                "sha256:matching", Optional.of("sha256:matching")));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
     }
 
     @Test

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
@@ -36,4 +36,11 @@ public final class YamlBaselineProvider implements BaselineProvider {
         String fingerprint = FactorsFingerprint.of(factors);
         return resolver.resolve(useCaseId, fingerprint, criterionName, statisticsType);
     }
+
+    @Override
+    public Optional<String> baselineInputsIdentityFor(
+            String useCaseId, FactorBundle factors) {
+        String fingerprint = FactorsFingerprint.of(factors);
+        return resolver.resolveInputsIdentity(useCaseId, fingerprint);
+    }
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
@@ -56,12 +56,29 @@ class EmpiricalEndToEndIntegrationTest {
                 .build();
     }
 
+    /**
+     * Writes a baseline whose recorded inputs identity matches what
+     * {@link #sampling(int)} produces — the in-process integrity
+     * guarantee, restated cross-process. Tests that want to exercise
+     * an identity mismatch use {@link #writeBaselineWithMismatchedIdentity}.
+     */
     private static void writeBaselineWithPassRate(
             Path baselineDir, double passRate, int sampleCount) throws IOException {
+        writeBaseline(baselineDir, passRate, sampleCount, sampling(1).inputsIdentity());
+    }
+
+    private static void writeBaselineWithMismatchedIdentity(
+            Path baselineDir, double passRate, int sampleCount) throws IOException {
+        writeBaseline(baselineDir, passRate, sampleCount, "sha256:other-input-population");
+    }
+
+    private static void writeBaseline(
+            Path baselineDir, double passRate, int sampleCount,
+            String inputsIdentity) throws IOException {
         String fingerprint = FactorsFingerprint.of(FactorBundle.of(FACTORS));
         BaselineRecord record = new BaselineRecord(
                 USE_CASE_ID, "measureBaseline", fingerprint,
-                "sha256:any", sampleCount,
+                inputsIdentity, sampleCount,
                 Instant.parse("2026-04-26T15:30:00Z"),
                 Map.<String, BaselineStatistics>of(
                         "bernoulli-pass-rate",
@@ -118,6 +135,23 @@ class EmpiricalEndToEndIntegrationTest {
         var detail = result.criterionResults().get(0).result().detail();
         assertThat(detail).containsEntry("testSampleCount", 1000);
         assertThat(detail).containsEntry("baselineSampleCount", 100);
+    }
+
+    @Test
+    @DisplayName("with a baseline whose recorded inputs identity differs, EmpiricalChecks rejects → INCONCLUSIVE")
+    void empiricalRejectsIdentityMismatch(@TempDir Path baselineDir) throws IOException {
+        writeBaselineWithMismatchedIdentity(baselineDir, 0.80, 1000);
+
+        var engine = new Engine(new YamlBaselineProvider(baselineDir));
+        var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(20)));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsKey("testInputsIdentity");
+        assertThat(detail).containsEntry("baselineInputsIdentity", "sha256:other-input-population");
+        assertThat(result.criterionResults().get(0).result().explanation())
+                .contains("inputs identity")
+                .contains("re-run the baseline measure");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes the TODO PR #67 left when it shipped `InputSupplier`. The framework
now consummates the inputs-identity guarantee: every baseline records
`Sampling.inputsIdentity()` at MEASURE time, and both empirical criteria
re-check it at TEST time. Mismatch yields `INCONCLUSIVE` with a diagnostic
naming both identities (truncated for readability) and the corrective
action.

## Surface changes

- **`EvaluationContext`** gains `testInputsIdentity()` and
  `baselineInputsIdentity()` accessors. `ProbabilisticTest.Internal`
  populates both — the test side from the spec's `Sampling`, the
  baseline side from one provider lookup per spec run (memoised across
  the criterion loop).
- **`BaselineProvider`** gains `baselineInputsIdentityFor(useCaseId,
  factors)` — wired from `BaselineResolver.resolveInputsIdentity()` in
  `YamlBaselineProvider`.
- **`EmpiricalChecks.inputsIdentityMatch`** — new helper alongside the
  existing `sampleSizeConstraint`. Same `Optional<CriterionResult>`
  shape; both empirical criteria consult it.
- **Order matters.** `BernoulliPassRate.evaluate()` and
  `PercentileLatency.evaluate()` now consult `inputsIdentityMatch`
  *before* `sampleSizeConstraint` — identity mismatch is the more
  fundamental violation, so its diagnostic wins when both would fire.

## Test plan

- [x] 9 new unit tests covering the helper and the two criteria's
  identity-mismatch / identity-match paths
- [x] 1 new end-to-end integration test covering the full pipeline:
  write a baseline with one identity, run the test against a different
  one, assert `INCONCLUSIVE` with the mismatch diagnostic
- [x] Existing tests updated to populate the two new EvaluationContext
  fields (default identities chosen so existing assertions still hold)
- [x] Full `./gradlew build` green; ArchUnit rules pass

## Still to come

- **Slice E** — Wilson-score-aware comparison in `BernoulliPassRate`
  (replacing the placeholder `observed >= threshold`)
- **Slice F** — `PowerAnalysis` reading the real baseline rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)