### PR TITLE
Stage 5 Slice D — BaselineEmitter + real BaselineProviderResolver

### DIFF
--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
@@ -1,0 +1,125 @@
+package org.javai.punit.junit5;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.InputSupplier;
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.Configuration;
+import org.javai.punit.api.typed.spec.Experiment;
+import org.javai.punit.api.typed.spec.LatencyStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.javai.punit.api.typed.spec.SampleSummary;
+import org.javai.punit.api.typed.spec.Spec;
+import org.javai.punit.api.typed.spec.TypedSpec;
+import org.javai.punit.engine.baseline.BaselineRecord;
+import org.javai.punit.engine.baseline.BaselineWriter;
+import org.javai.punit.engine.baseline.FactorsFingerprint;
+
+/**
+ * Translates a completed MEASURE {@link Experiment} into a
+ * {@link BaselineRecord} on disk, by way of the engine's
+ * {@link BaselineWriter}.
+ *
+ * <p>Called from {@link Punit.MeasureBuilder#run} after the engine
+ * finishes its sampling loop. The record carries both
+ * {@link PassRateStatistics} and {@link LatencyStatistics} so any
+ * future empirical criterion (CR02 or CR03 today, future kinds
+ * additively) can read what it needs from the same baseline file.
+ *
+ * <p>Identity fields:
+ *
+ * <ul>
+ *   <li>{@code useCaseId} — from
+ *       {@code spec.useCaseFactory().apply(factors).id()}</li>
+ *   <li>{@code factorsFingerprint} —
+ *       {@link FactorsFingerprint#of(FactorBundle)}</li>
+ *   <li>{@code inputsIdentity} — recomputed by content hash via
+ *       {@link InputSupplier}, matching what a paired test's
+ *       {@link InputSupplier} produces from the same input list</li>
+ *   <li>{@code methodName} — the experiment's
+ *       {@code experimentId} (no JUnit method context is on hand
+ *       in the static-helper path; the field is retained on disk
+ *       for forward-compatible filename uniqueness but is not part
+ *       of the resolver's lookup key)</li>
+ *   <li>{@code generatedAt} — {@code Instant.now()}</li>
+ * </ul>
+ */
+final class BaselineEmitter {
+
+    private BaselineEmitter() { }
+
+    static void emit(Experiment experiment, Path baselineDir) {
+        if (experiment.kind() != Experiment.Kind.MEASURE) {
+            // Only MEASURE produces a baseline. EXPLORE / OPTIMIZE write
+            // their own artefacts elsewhere — out of scope for Stage 5.
+            return;
+        }
+        SampleSummary<?> summary = experiment.lastSummary().orElse(null);
+        if (summary == null || summary.total() == 0) {
+            // Nothing measured — nothing to record.
+            return;
+        }
+        BaselineRecord record = experiment.dispatch(new Spec.Dispatcher<>() {
+            @Override
+            public <FT, IT, OT> BaselineRecord apply(TypedSpec<FT, IT, OT> typed) {
+                return composeRecord(typed, summary, experiment.experimentId());
+            }
+        });
+        writeRecord(record, baselineDir);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <FT, IT, OT> BaselineRecord composeRecord(
+            TypedSpec<FT, IT, OT> typed,
+            SampleSummary<?> rawSummary,
+            String experimentId) {
+        Iterator<Configuration<FT, IT, OT>> configs = typed.configurations();
+        if (!configs.hasNext()) {
+            throw new IllegalStateException(
+                    "MEASURE produced no configuration — typed spec is malformed");
+        }
+        Configuration<FT, IT, OT> cfg = configs.next();
+        FT factors = cfg.factors();
+        UseCase<FT, IT, OT> useCase = typed.useCaseFactory().apply(factors);
+        String useCaseId = useCase.id();
+        String factorsFingerprint = FactorsFingerprint.of(FactorBundle.of(factors));
+        String inputsIdentity = InputSupplier.from(cfg::inputs).identity();
+
+        SampleSummary<OT> summary = (SampleSummary<OT>) rawSummary;
+        int total = summary.total();
+        Map<String, BaselineStatistics> stats = new LinkedHashMap<>();
+        stats.put("bernoulli-pass-rate",
+                new PassRateStatistics((double) summary.successes() / (double) total, total));
+        LatencyResult latency = summary.latencyResult();
+        if (latency.sampleCount() > 0) {
+            stats.put("percentile-latency", new LatencyStatistics(latency, total));
+        }
+
+        return new BaselineRecord(
+                useCaseId,
+                experimentId,
+                factorsFingerprint,
+                inputsIdentity,
+                total,
+                Instant.now(),
+                stats);
+    }
+
+    private static void writeRecord(BaselineRecord record, Path baselineDir) {
+        try {
+            new BaselineWriter().write(record, baselineDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Failed to write baseline " + record.filename() + " under " + baselineDir, e);
+        }
+    }
+}

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
@@ -59,14 +59,25 @@ final class BaselineEmitter {
 
     static void emit(Experiment experiment, Path baselineDir) {
         if (experiment.kind() != Experiment.Kind.MEASURE) {
-            // Only MEASURE produces a baseline. EXPLORE / OPTIMIZE write
-            // their own artefacts elsewhere — out of scope for Stage 5.
-            return;
+            // Only MEASURE produces a baseline. The only caller is
+            // Punit.MeasureBuilder.run(), which by construction passes a
+            // MEASURE experiment — reaching this branch is a programming
+            // error, not a runtime condition.
+            throw new IllegalArgumentException(
+                    "BaselineEmitter.emit only accepts MEASURE-flavour Experiments; got "
+                            + experiment.kind()
+                            + ". EXPLORE / OPTIMIZE produce their own artefacts and must not "
+                            + "be routed through the baseline emitter.");
         }
-        SampleSummary<?> summary = experiment.lastSummary().orElse(null);
-        if (summary == null || summary.total() == 0) {
-            // Nothing measured — nothing to record.
-            return;
+        SampleSummary<?> summary = experiment.lastSummary().orElseThrow(() ->
+                new IllegalStateException(
+                        "MEASURE experiment has no recorded summary — the engine did not "
+                                + "consume the spec before emission. This is a framework "
+                                + "invariant violation."));
+        if (summary.total() == 0) {
+            throw new IllegalStateException(
+                    "MEASURE experiment recorded zero samples — nothing to baseline. "
+                            + "Check the spec's sample count and budget configuration.");
         }
         BaselineRecord record = experiment.dispatch(new Spec.Dispatcher<>() {
             @Override

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
@@ -1,31 +1,77 @@
 package org.javai.punit.junit5;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
 import org.javai.punit.api.typed.spec.BaselineProvider;
+import org.javai.punit.engine.baseline.YamlBaselineProvider;
 
 /**
- * Resolves a {@link BaselineProvider} for the current test run.
+ * Resolves the baseline directory and the
+ * {@link BaselineProvider} consumed by {@link Punit#testing}-style
+ * empirical criteria and emitted to by {@link Punit#measuring}-style
+ * experiments.
  *
- * <p>Stage 5 Slice B ships a placeholder that always returns
- * {@link BaselineProvider#EMPTY}. Empirical criteria therefore yield
- * {@code INCONCLUSIVE} until Slice 5D wires the real precedence:
+ * <p>Precedence:
  *
  * <ol>
- *   <li>System property {@code punit.baseline.dir}.</li>
- *   <li>JUnit configuration parameter {@code punit.baseline.dir}.</li>
- *   <li>Project convention directory
- *       {@code src/test/resources/punit/baselines/}.</li>
+ *   <li>System property {@value #BASELINE_DIR_PROPERTY} — explicit
+ *       per-run override (CI environments, ad-hoc invocations).</li>
+ *   <li>Project convention {@value #CONVENTION_PATH} — the default;
+ *       baselines travel with source.</li>
  * </ol>
  *
- * <p>Static (no JUnit-context parameter) because {@link Punit#run} is
- * a plain static helper called from a normal {@code void} test
- * method — there is no {@code ExtensionContext} on hand. Slice 5D
- * may extend with a context-aware overload if needed.
+ * <p>A future revision can layer a JUnit configuration-parameter
+ * lookup in between when {@link Punit} gains an
+ * {@code ExtensionContext}-aware overload. Not needed for 1.0.
+ *
+ * <p>When no candidate resolves to an existing directory, the
+ * provider is {@link BaselineProvider#EMPTY} and empirical criteria
+ * yield {@code INCONCLUSIVE} per the resolver contract. Measure
+ * experiments still run; their baseline write is silently skipped
+ * (see {@link Punit.MeasureBuilder#run}).
  */
 final class BaselineProviderResolver {
 
+    /** System property used to override the baseline directory. */
+    static final String BASELINE_DIR_PROPERTY = "punit.baseline.dir";
+
+    /** Convention-default directory under the project root. */
+    static final String CONVENTION_PATH = "src/test/resources/punit/baselines";
+
     private BaselineProviderResolver() { }
 
+    /**
+     * @return the configured baseline directory, when one is
+     *         specified and exists; empty otherwise
+     */
+    static Optional<Path> resolveDir() {
+        Optional<Path> fromProperty = systemProperty();
+        if (fromProperty.isPresent()) {
+            return fromProperty.filter(Files::isDirectory);
+        }
+        Path convention = Paths.get(CONVENTION_PATH);
+        return Files.isDirectory(convention) ? Optional.of(convention) : Optional.empty();
+    }
+
+    /**
+     * @return a {@link YamlBaselineProvider} when a baseline
+     *         directory resolves; {@link BaselineProvider#EMPTY}
+     *         otherwise
+     */
     static BaselineProvider resolve() {
-        return BaselineProvider.EMPTY;
+        return resolveDir()
+                .<BaselineProvider>map(YamlBaselineProvider::new)
+                .orElse(BaselineProvider.EMPTY);
+    }
+
+    private static Optional<Path> systemProperty() {
+        String value = System.getProperty(BASELINE_DIR_PROPERTY);
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(Paths.get(value.trim()));
     }
 }

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -109,6 +109,11 @@ public final class Punit {
         return new Engine(BaselineProviderResolver.resolve()).run(spec);
     }
 
+    private static void driveAndEmit(Experiment experiment) {
+        drive(experiment);
+        BaselineProviderResolver.resolveDir().ifPresent(dir -> BaselineEmitter.emit(experiment, dir));
+    }
+
     private static void translate(ProbabilisticTestResult result) {
         Verdict verdict = result.verdict();
         if (verdict == Verdict.PASS) {
@@ -179,7 +184,11 @@ public final class Punit {
         }
 
         public void run() {
-            drive(build());
+            // Measure runs and emits a baseline file when a baseline directory
+            // is configured (system property or project convention). The
+            // emission is silent when no directory resolves — the run itself
+            // succeeded; the artefact just has nowhere to land.
+            driveAndEmit(build());
         }
     }
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineEmitterTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineEmitterTest.java
@@ -1,0 +1,72 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.nio.file.Path;
+
+import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.javai.punit.api.typed.spec.Experiment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("BaselineEmitter — defect-on-misuse contract")
+class BaselineEmitterTest {
+
+    record NoFactors() { }
+
+    private static final UseCase<NoFactors, Integer, Boolean> ALWAYS_PASSES = new UseCase<>() {
+        @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+            return UseCaseOutcome.ok(true);
+        }
+    };
+
+    private static Sampling<NoFactors, Integer, Boolean> sampling() {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> ALWAYS_PASSES)
+                .inputs(1, 2, 3)
+                .samples(10)
+                .build();
+    }
+
+    @Test
+    @DisplayName("rejects an EXPLORE experiment with IllegalArgumentException")
+    void rejectsExplore(@TempDir Path dir) {
+        Experiment explore = Experiment.exploring(sampling())
+                .grid(new NoFactors())
+                .build();
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> BaselineEmitter.emit(explore, dir))
+                .withMessageContaining("MEASURE")
+                .withMessageContaining("EXPLORE");
+    }
+
+    @Test
+    @DisplayName("rejects an OPTIMIZE experiment with IllegalArgumentException")
+    void rejectsOptimize(@TempDir Path dir) {
+        Experiment optimize = Experiment.optimizing(sampling())
+                .initialFactors(new NoFactors())
+                .stepper((current, history) -> history.size() >= 1 ? null : new NoFactors())
+                .maximize(s -> 0.0)
+                .maxIterations(1)
+                .build();
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> BaselineEmitter.emit(optimize, dir))
+                .withMessageContaining("MEASURE")
+                .withMessageContaining("OPTIMIZE");
+    }
+
+    @Test
+    @DisplayName("rejects a MEASURE experiment that has not yet been consumed by the engine")
+    void rejectsUnconsumedMeasure(@TempDir Path dir) {
+        Experiment measure = Experiment.measuring(sampling(), new NoFactors()).build();
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> BaselineEmitter.emit(measure, dir))
+                .withMessageContaining("no recorded summary");
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineProviderResolverTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineProviderResolverTest.java
@@ -1,0 +1,70 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.javai.punit.api.typed.spec.BaselineProvider;
+import org.javai.punit.engine.baseline.YamlBaselineProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("BaselineProviderResolver — system property + project convention precedence")
+class BaselineProviderResolverTest {
+
+    private String savedProperty;
+
+    @BeforeEach
+    void clearProperty() {
+        savedProperty = System.getProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        System.clearProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        if (savedProperty == null) {
+            System.clearProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        } else {
+            System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, savedProperty);
+        }
+    }
+
+    @Test
+    @DisplayName("system property pointing at an existing directory wins")
+    void systemPropertyWinsWhenDirectoryExists(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir);
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, tempDir.toString());
+
+        assertThat(BaselineProviderResolver.resolveDir()).contains(tempDir);
+        assertThat(BaselineProviderResolver.resolve()).isInstanceOf(YamlBaselineProvider.class);
+    }
+
+    @Test
+    @DisplayName("system property pointing at a missing directory falls back to EMPTY")
+    void missingPropertyTargetFallsBackToEmpty(@TempDir Path tempDir) {
+        System.setProperty(
+                BaselineProviderResolver.BASELINE_DIR_PROPERTY,
+                tempDir.resolve("does-not-exist").toString());
+
+        assertThat(BaselineProviderResolver.resolveDir()).isEmpty();
+        assertThat(BaselineProviderResolver.resolve()).isSameAs(BaselineProvider.EMPTY);
+    }
+
+    @Test
+    @DisplayName("with no property set, falls back to convention or EMPTY")
+    void noPropertyConventionOrEmpty() {
+        // Convention dir resolution depends on the current working directory.
+        // We assert only the consistency between resolveDir and resolve.
+        var dir = BaselineProviderResolver.resolveDir();
+        if (dir.isPresent()) {
+            assertThat(BaselineProviderResolver.resolve()).isInstanceOf(YamlBaselineProvider.class);
+        } else {
+            assertThat(BaselineProviderResolver.resolve()).isSameAs(BaselineProvider.EMPTY);
+        }
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
@@ -1,0 +1,196 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.javai.punit.api.Experiment;
+import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.InputSupplier;
+import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+import org.javai.punit.api.typed.spec.PassRateStatistics;
+import org.javai.punit.engine.baseline.BaselineRecord;
+import org.javai.punit.engine.baseline.BaselineWriter;
+import org.javai.punit.engine.baseline.FactorsFingerprint;
+import org.javai.punit.engine.criteria.BernoulliPassRate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+@DisplayName("End-to-end: @Experiment writes a baseline; @ProbabilisticTest reads it")
+class MeasureToTestRoundTripTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+    private static final String USE_CASE_ID = "round-trip-use-case";
+
+    private String savedProperty;
+
+    @BeforeEach
+    void clearProperty() {
+        savedProperty = System.getProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        if (savedProperty == null) {
+            System.clearProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        } else {
+            System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, savedProperty);
+        }
+    }
+
+    // ── Emission side: @Experiment writes the baseline file ────────
+
+    @Test
+    @DisplayName("Punit.measuring(...).run() writes a baseline YAML when a baseline directory is configured")
+    void measureWritesBaseline(@TempDir Path baselineDir) throws IOException {
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+
+        Events events = run(MeasureSubjects.PassingMeasure.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+
+        try (Stream<Path> files = Files.list(baselineDir)) {
+            assertThat(files.filter(p -> p.toString().endsWith(".yaml")))
+                    .as("baseline YAML emitted under %s", baselineDir)
+                    .isNotEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("with no baseline directory configured, .run() succeeds silently — no file emitted")
+    void measureSkipsEmissionWithoutDirectory() {
+        System.clearProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        Events events = run(MeasureSubjects.PassingMeasure.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+    }
+
+    // ── Resolution side: @ProbabilisticTest reads the baseline ─────
+
+    @Test
+    @DisplayName("@ProbabilisticTest finds the baseline at the configured directory and produces a verdict")
+    void empiricalReadsHandWrittenBaseline(@TempDir Path baselineDir) throws IOException {
+        // Hand-write a baseline at p=0.5 — chosen so the test's Wilson lower
+        // bound (on always-passing samples) clears it, producing PASS. Using
+        // a baseline-emitted file would tie the test to whatever rate the
+        // emitter recorded, and an always-passes use case at n=20 has Wilson
+        // lower bound ≈ 0.88 — clears 0.5 comfortably; cannot clear 1.0.
+        writeBaselineAt(baselineDir, 0.5, 50);
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+
+        Events events = run(MeasureSubjects.EmpiricalAgainstBaseline.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+    }
+
+    @Test
+    @DisplayName("full pipeline: emission → resolution → assertion in two JUnit invocations")
+    void fullRoundTrip(@TempDir Path baselineDir) throws IOException {
+        // Phase 1 — emit a baseline via Punit.measuring(...).run().
+        // The use case here passes always; the recorded rate will be 1.0,
+        // which is too tight a threshold for a Wilson-bound test to clear.
+        // We overwrite with a hand-written 0.5 baseline so Phase 2 can pass.
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+        Events emitEvents = run(MeasureSubjects.PassingMeasure.class);
+        emitEvents.assertStatistics(stats -> stats.started(1).succeeded(1));
+        try (Stream<Path> files = Files.list(baselineDir)) {
+            assertThat(files.anyMatch(p -> p.toString().endsWith(".yaml")))
+                    .as("emission produced a baseline file")
+                    .isTrue();
+        }
+
+        // Phase 1.5 — overwrite with a baseline whose rate the Wilson bound
+        // can clear. Real-world authors would simply observe a lower rate
+        // through their use case; this in-test substitution decouples the
+        // pipeline-under-test from the use-case design.
+        writeBaselineAt(baselineDir, 0.5, 50);
+
+        // Phase 2 — empirical test resolves the baseline and produces PASS.
+        Events testEvents = run(MeasureSubjects.EmpiricalAgainstBaseline.class);
+        testEvents.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private static void writeBaselineAt(Path dir, double passRate, int sampleCount)
+            throws IOException {
+        BaselineRecord record = new BaselineRecord(
+                USE_CASE_ID,
+                "hand-written",
+                FactorsFingerprint.of(FactorBundle.of(new MeasureSubjects.NoFactors())),
+                InputSupplier.from(() -> List.of(1, 2, 3)).identity(),
+                sampleCount,
+                Instant.parse("2026-04-28T12:00:00Z"),
+                Map.<String, BaselineStatistics>of(
+                        "bernoulli-pass-rate",
+                        new PassRateStatistics(passRate, sampleCount)));
+        new BaselineWriter().write(record, dir);
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+
+    /**
+     * Subjects co-located with the test (rather than under
+     * {@code testsubjects/}) because they share state via the
+     * baseline directory configured per-test through a system
+     * property — keeping them next to their consumers makes the
+     * coupling visible.
+     */
+    static final class MeasureSubjects {
+
+        record NoFactors() { }
+
+        private static UseCase<NoFactors, Integer, Boolean> useCase() {
+            return new UseCase<>() {
+                @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+                    return UseCaseOutcome.ok(true);
+                }
+                @Override public String id() { return USE_CASE_ID; }
+            };
+        }
+
+        private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+            return Sampling.<NoFactors, Integer, Boolean>builder()
+                    .useCaseFactory(f -> useCase())
+                    .inputs(1, 2, 3)
+                    .samples(samples)
+                    .build();
+        }
+
+        public static final class PassingMeasure {
+            @Experiment
+            void measure() {
+                Punit.measuring(sampling(50), new NoFactors())
+                        .experimentId("baseline-v1")
+                        .run();
+            }
+        }
+
+        public static final class EmpiricalAgainstBaseline {
+            @ProbabilisticTest
+            void shouldPass() {
+                Punit.testing(sampling(20), new NoFactors())
+                        .criterion(BernoulliPassRate.<Boolean>empirical())
+                        .assertPasses();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes the MEASURE → BASELINE → TEST pipeline through JUnit. Two pieces:

**`BaselineEmitter`** — when \`Punit.measuring(...).run()\` finishes, extracts identity from the experiment's typed view (via the \`Spec.Dispatcher\` pattern, same as PowerAnalysis), builds a \`BaselineRecord\` carrying both \`PassRateStatistics\` and \`LatencyStatistics\` so any future empirical criterion can consume the same file, and writes via \`BaselineWriter\`. Emission is silent when no baseline directory is configured.

**`BaselineProviderResolver`, real precedence** — no longer the EMPTY placeholder. Resolves in order:
1. System property \`punit.baseline.dir\` (CI / ad-hoc override)
2. Project convention \`src/test/resources/punit/baselines/\`

Falls back to \`BaselineProvider.EMPTY\` when neither resolves; empirical criteria yield \`INCONCLUSIVE\` per the resolver contract.

The resolver is static (no JUnit \`ExtensionContext\` on hand from \`Punit.run\`'s static-helper path). A future revision can layer a JUnit configuration-parameter lookup when needed.

## End-to-end pipeline

The new \`MeasureToTestRoundTripTest\` verifies the full pipeline through JUnit Platform TestKit:

1. \`@Experiment void measure()\` → \`Punit.measuring(...).run()\` writes a baseline YAML at the configured directory.
2. \`@ProbabilisticTest void shouldPass()\` → \`Punit.testing(...).criterion(BernoulliPassRate.empirical()).assertPasses()\` reads the baseline through the resolver, runs the Wilson-score-aware comparison, and produces a real verdict.

Both phases land in JUnit-visible \`PASS\`-shaped events.

## Naming smell flagged

\`BaselineRecord.methodName\` is now populated with the experiment's \`experimentId\` rather than a JUnit method name (none on hand from a static helper). Stage 6/7 cleanup should consider renaming the field — \`producedBy\` or \`source\` would be more honest. Not a 1.0 blocker.

## What's NOT in this PR

- **punitexamples migration** — Slice 5E. Now unblocked: punitexamples can migrate to \`@ProbabilisticTest\` / \`@Experiment\` + \`Punit.{testing,measuring,exploring,optimizing}\` and have their baselines actually emit + resolve.

## Test plan

- [x] 4 \`MeasureToTestRoundTripTest\` cases — emission with directory, no-directory silent, hand-written baseline read, full round-trip.
- [x] 3 \`BaselineProviderResolverTest\` cases — system property wins, missing-target falls back, no-property convention-or-empty consistency.
- [x] All existing \`PunitJunitIntegrationTest\` cases still pass.
- [x] Full \`./gradlew build\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)