### PR TITLE
BaselineProviderResolver: always return a directory; defaults to convention

### DIFF
--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
@@ -1,11 +1,11 @@
 package org.javai.punit.junit5;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.javai.punit.api.typed.spec.BaselineProvider;
+import org.javai.punit.engine.baseline.BaselineResolver;
 import org.javai.punit.engine.baseline.YamlBaselineProvider;
 
 /**
@@ -44,27 +44,30 @@ final class BaselineProviderResolver {
     private BaselineProviderResolver() { }
 
     /**
-     * @return the configured baseline directory, when one is
-     *         specified and exists; empty otherwise
+     * @return the configured baseline directory. Returns the
+     *         system-property path when set, otherwise the
+     *         convention-default {@value #CONVENTION_PATH} path.
+     *         The directory is not required to exist —
+     *         {@link BaselineEmitter} creates it on first write,
+     *         and the {@link BaselineResolver} downstream handles
+     *         missing directories (returns empty for any lookup).
+     *         Symmetric with the legacy convention.
      */
-    static Optional<Path> resolveDir() {
-        Optional<Path> fromProperty = systemProperty();
-        if (fromProperty.isPresent()) {
-            return fromProperty.filter(Files::isDirectory);
-        }
-        Path convention = Paths.get(CONVENTION_PATH);
-        return Files.isDirectory(convention) ? Optional.of(convention) : Optional.empty();
+    static Path resolveDir() {
+        return systemProperty().orElseGet(() -> Paths.get(CONVENTION_PATH));
     }
 
     /**
-     * @return a {@link YamlBaselineProvider} when a baseline
-     *         directory resolves; {@link BaselineProvider#EMPTY}
-     *         otherwise
+     * @return a {@link YamlBaselineProvider} backed by the resolved
+     *         baseline directory. When the directory is missing the
+     *         provider's lookups return empty for every query (the
+     *         underlying {@link BaselineResolver} treats a missing
+     *         directory as "no baselines available"), so the
+     *         empirical-criterion path produces {@code INCONCLUSIVE}
+     *         — the same outcome as a hard {@link BaselineProvider#EMPTY}.
      */
     static BaselineProvider resolve() {
-        return resolveDir()
-                .<BaselineProvider>map(YamlBaselineProvider::new)
-                .orElse(BaselineProvider.EMPTY);
+        return new YamlBaselineProvider(resolveDir());
     }
 
     private static Optional<Path> systemProperty() {

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -111,7 +111,7 @@ public final class Punit {
 
     private static void driveAndEmit(Experiment experiment) {
         drive(experiment);
-        BaselineProviderResolver.resolveDir().ifPresent(dir -> BaselineEmitter.emit(experiment, dir));
+        BaselineEmitter.emit(experiment, BaselineProviderResolver.resolveDir());
     }
 
     private static void translate(ProbabilisticTestResult result) {

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineProviderResolverTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineProviderResolverTest.java
@@ -2,11 +2,10 @@ package org.javai.punit.junit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
-import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.engine.baseline.YamlBaselineProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,36 +34,32 @@ class BaselineProviderResolverTest {
     }
 
     @Test
-    @DisplayName("system property pointing at an existing directory wins")
-    void systemPropertyWinsWhenDirectoryExists(@TempDir Path tempDir) throws IOException {
-        Files.createDirectories(tempDir);
+    @DisplayName("system property takes precedence over the convention default")
+    void systemPropertyTakesPrecedence(@TempDir Path tempDir) {
+        Files.exists(tempDir);
         System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, tempDir.toString());
 
-        assertThat(BaselineProviderResolver.resolveDir()).contains(tempDir);
+        assertThat(BaselineProviderResolver.resolveDir()).isEqualTo(tempDir);
         assertThat(BaselineProviderResolver.resolve()).isInstanceOf(YamlBaselineProvider.class);
     }
 
     @Test
-    @DisplayName("system property pointing at a missing directory falls back to EMPTY")
-    void missingPropertyTargetFallsBackToEmpty(@TempDir Path tempDir) {
-        System.setProperty(
-                BaselineProviderResolver.BASELINE_DIR_PROPERTY,
-                tempDir.resolve("does-not-exist").toString());
-
-        assertThat(BaselineProviderResolver.resolveDir()).isEmpty();
-        assertThat(BaselineProviderResolver.resolve()).isSameAs(BaselineProvider.EMPTY);
+    @DisplayName("with no property set, falls back to the convention path")
+    void noPropertyConvention() {
+        assertThat(BaselineProviderResolver.resolveDir())
+                .isEqualTo(Paths.get(BaselineProviderResolver.CONVENTION_PATH));
+        assertThat(BaselineProviderResolver.resolve()).isInstanceOf(YamlBaselineProvider.class);
     }
 
     @Test
-    @DisplayName("with no property set, falls back to convention or EMPTY")
-    void noPropertyConventionOrEmpty() {
-        // Convention dir resolution depends on the current working directory.
-        // We assert only the consistency between resolveDir and resolve.
-        var dir = BaselineProviderResolver.resolveDir();
-        if (dir.isPresent()) {
-            assertThat(BaselineProviderResolver.resolve()).isInstanceOf(YamlBaselineProvider.class);
-        } else {
-            assertThat(BaselineProviderResolver.resolve()).isSameAs(BaselineProvider.EMPTY);
-        }
+    @DisplayName("returns the configured directory regardless of whether it currently exists")
+    void returnsDirWhenMissing(@TempDir Path tempDir) {
+        Path missing = tempDir.resolve("does-not-exist-yet");
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, missing.toString());
+
+        assertThat(BaselineProviderResolver.resolveDir()).isEqualTo(missing);
+        // Provider is constructed unconditionally; underlying lookups
+        // return empty for any query against a non-existent directory.
+        assertThat(BaselineProviderResolver.resolve()).isInstanceOf(YamlBaselineProvider.class);
     }
 }

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
@@ -10,19 +10,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.javai.punit.api.Experiment;
-import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.InputSupplier;
-import org.javai.punit.api.typed.Sampling;
-import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 import org.javai.punit.api.typed.spec.PassRateStatistics;
 import org.javai.punit.engine.baseline.BaselineRecord;
 import org.javai.punit.engine.baseline.BaselineWriter;
 import org.javai.punit.engine.baseline.FactorsFingerprint;
-import org.javai.punit.engine.criteria.BernoulliPassRate;
+import org.javai.punit.junit5.testsubjects.RoundTripSubjects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -61,7 +56,7 @@ class MeasureToTestRoundTripTest {
     void measureWritesBaseline(@TempDir Path baselineDir) throws IOException {
         System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
 
-        Events events = run(MeasureSubjects.PassingMeasure.class);
+        Events events = run(RoundTripSubjects.PassingMeasure.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
 
         try (Stream<Path> files = Files.list(baselineDir)) {
@@ -72,10 +67,14 @@ class MeasureToTestRoundTripTest {
     }
 
     @Test
-    @DisplayName("with no baseline directory configured, .run() succeeds silently — no file emitted")
-    void measureSkipsEmissionWithoutDirectory() {
+    @DisplayName("with no baseline directory configured, .run() succeeds — falls back to the convention path")
+    void measureFallsBackToConvention() {
         System.clearProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
-        Events events = run(MeasureSubjects.PassingMeasure.class);
+        // The convention path may or may not exist in the test runner's
+        // working directory; either way the run completes cleanly. The
+        // BaselineWriter creates the directory on first write, so emission
+        // succeeds whenever the test process can create directories there.
+        Events events = run(RoundTripSubjects.PassingMeasure.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 
@@ -92,7 +91,7 @@ class MeasureToTestRoundTripTest {
         writeBaselineAt(baselineDir, 0.5, 50);
         System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
 
-        Events events = run(MeasureSubjects.EmpiricalAgainstBaseline.class);
+        Events events = run(RoundTripSubjects.EmpiricalAgainstBaseline.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 
@@ -104,7 +103,7 @@ class MeasureToTestRoundTripTest {
         // which is too tight a threshold for a Wilson-bound test to clear.
         // We overwrite with a hand-written 0.5 baseline so Phase 2 can pass.
         System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
-        Events emitEvents = run(MeasureSubjects.PassingMeasure.class);
+        Events emitEvents = run(RoundTripSubjects.PassingMeasure.class);
         emitEvents.assertStatistics(stats -> stats.started(1).succeeded(1));
         try (Stream<Path> files = Files.list(baselineDir)) {
             assertThat(files.anyMatch(p -> p.toString().endsWith(".yaml")))
@@ -119,7 +118,7 @@ class MeasureToTestRoundTripTest {
         writeBaselineAt(baselineDir, 0.5, 50);
 
         // Phase 2 — empirical test resolves the baseline and produces PASS.
-        Events testEvents = run(MeasureSubjects.EmpiricalAgainstBaseline.class);
+        Events testEvents = run(RoundTripSubjects.EmpiricalAgainstBaseline.class);
         testEvents.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 
@@ -130,7 +129,7 @@ class MeasureToTestRoundTripTest {
         BaselineRecord record = new BaselineRecord(
                 USE_CASE_ID,
                 "hand-written",
-                FactorsFingerprint.of(FactorBundle.of(new MeasureSubjects.NoFactors())),
+                FactorsFingerprint.of(FactorBundle.of(new RoundTripSubjects.NoFactors())),
                 InputSupplier.from(() -> List.of(1, 2, 3)).identity(),
                 sampleCount,
                 Instant.parse("2026-04-28T12:00:00Z"),
@@ -145,52 +144,5 @@ class MeasureToTestRoundTripTest {
                 .selectors(DiscoverySelectors.selectClass(testClass))
                 .execute()
                 .testEvents();
-    }
-
-    /**
-     * Subjects co-located with the test (rather than under
-     * {@code testsubjects/}) because they share state via the
-     * baseline directory configured per-test through a system
-     * property — keeping them next to their consumers makes the
-     * coupling visible.
-     */
-    static final class MeasureSubjects {
-
-        record NoFactors() { }
-
-        private static UseCase<NoFactors, Integer, Boolean> useCase() {
-            return new UseCase<>() {
-                @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-                    return UseCaseOutcome.ok(true);
-                }
-                @Override public String id() { return USE_CASE_ID; }
-            };
-        }
-
-        private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
-            return Sampling.<NoFactors, Integer, Boolean>builder()
-                    .useCaseFactory(f -> useCase())
-                    .inputs(1, 2, 3)
-                    .samples(samples)
-                    .build();
-        }
-
-        public static final class PassingMeasure {
-            @Experiment
-            void measure() {
-                Punit.measuring(sampling(50), new NoFactors())
-                        .experimentId("baseline-v1")
-                        .run();
-            }
-        }
-
-        public static final class EmpiricalAgainstBaseline {
-            @ProbabilisticTest
-            void shouldPass() {
-                Punit.testing(sampling(20), new NoFactors())
-                        .criterion(BernoulliPassRate.<Boolean>empirical())
-                        .assertPasses();
-            }
-        }
     }
 }

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PunitJunitIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PunitJunitIntegrationTest.java
@@ -1,8 +1,13 @@
 package org.javai.punit.junit5;
 
+import java.nio.file.Path;
+
 import org.javai.punit.junit5.testsubjects.PunitSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.Events;
@@ -13,6 +18,32 @@ import org.opentest4j.TestAbortedException;
 class PunitJunitIntegrationTest {
 
     private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+
+    /**
+     * Scope each test to a fresh, empty tempDir as the baseline
+     * directory. Without this, empirical-criterion subjects would
+     * accidentally find baselines emitted by earlier subjects (e.g.
+     * the {@code @Experiment} path now writes via {@link BaselineEmitter}
+     * to whatever directory the resolver returns).
+     */
+    @TempDir
+    Path baselineDir;
+    private String savedProperty;
+
+    @BeforeEach
+    void isolateBaselineDir() {
+        savedProperty = System.getProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+    }
+
+    @AfterEach
+    void restoreBaselineDir() {
+        if (savedProperty == null) {
+            System.clearProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        } else {
+            System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, savedProperty);
+        }
+    }
 
     // ── @ProbabilisticTest path ────────────────────────────────────
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PunitSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PunitSubjects.java
@@ -45,6 +45,9 @@ public final class PunitSubjects {
             @Override public UseCaseOutcome<Boolean> apply(Integer input) {
                 return UseCaseOutcome.ok(true);
             }
+            // Anonymous-class getSimpleName() is "", which BaselineRecord
+            // rejects as a blank useCaseId. Override with a stable id.
+            @Override public String id() { return "always-passes-subject"; }
         };
     }
 
@@ -53,6 +56,7 @@ public final class PunitSubjects {
             @Override public UseCaseOutcome<Boolean> apply(Integer input) {
                 return UseCaseOutcome.fail("nope", "always fails");
             }
+            @Override public String id() { return "always-fails-subject"; }
         };
     }
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -1,0 +1,62 @@
+package org.javai.punit.junit5.testsubjects;
+
+import org.javai.punit.api.Experiment;
+import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.javai.punit.engine.criteria.BernoulliPassRate;
+import org.javai.punit.junit5.Punit;
+
+/**
+ * Subjects for {@code MeasureToTestRoundTripTest}.
+ *
+ * <p>Lives under {@code testsubjects/} so the punit-gradle-plugin's
+ * {@code exclude("**}{@code /testsubjects/**")} keeps these out of the
+ * normal test-discovery sweep. The hosting test sets the baseline-
+ * directory system property in {@code @BeforeEach} and runs each
+ * subject through {@link org.junit.platform.testkit.engine.EngineTestKit}.
+ */
+public final class RoundTripSubjects {
+
+    private RoundTripSubjects() { }
+
+    public static final String USE_CASE_ID = "round-trip-use-case";
+
+    public record NoFactors() { }
+
+    private static UseCase<NoFactors, Integer, Boolean> useCase() {
+        return new UseCase<>() {
+            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+                return UseCaseOutcome.ok(true);
+            }
+            @Override public String id() { return USE_CASE_ID; }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> useCase())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    public static final class PassingMeasure {
+        @Experiment
+        void measure() {
+            Punit.measuring(sampling(50), new NoFactors())
+                    .experimentId("baseline-v1")
+                    .run();
+        }
+    }
+
+    public static final class EmpiricalAgainstBaseline {
+        @ProbabilisticTest
+        void shouldPass() {
+            Punit.testing(sampling(20), new NoFactors())
+                    .criterion(BernoulliPassRate.<Boolean>empirical())
+                    .assertPasses();
+        }
+    }
+}


### PR DESCRIPTION
Three follow-on issues surfaced when wiring punitexamples to the new API. All three are user-discovered DX gaps after PR #75 merged.

## 1. Resolver filtered to existing directories

\`resolveDir()\` previously gated the configured path through \`Files.isDirectory(...)\`. Authors who set \`-Dpunit.baseline.dir=build/punit/baselines\` — pointing at a directory that doesn't exist yet, intended to be created on first emission — found the system property silently dropped because the path resolved to "missing → fall back to convention or empty."

Fixed: \`resolveDir()\` always returns the configured path. \`BaselineWriter\` creates parent directories on write; \`BaselineResolver\` already handles missing-directory lookups (returns empty for any query). The "directory must exist" gate added nothing useful.

## 2. Anonymous-inner-class UseCase produces empty id

Test subjects using \`new UseCase<>() { ... }\` produced \`useCase.id() = ""\` because anonymous-class \`getSimpleName()\` returns "". \`BaselineRecord\` correctly rejects blank ids — surfacing as opaque test failures once \`@Experiment .run()\` began emitting baselines unconditionally.

Fixed: subjects override \`id()\` explicitly. Real-world authors writing concrete \`UseCase\` classes get a sensible default; only test fixtures using anonymous classes hit this.

## 3. Co-located subjects polluted the convention path

\`MeasureSubjects\` was nested inside \`MeasureToTestRoundTripTest\` for cohesion. JUnit's auto-discovery picked them up as test classes, ran them standalone (outside the hosting test's \`@BeforeEach\` system-property setup), and they wrote baselines into the convention path \`src/test/resources/punit/baselines\`. Subsequent empirical-criterion tests then found those baselines unintentionally.

Fixed: subjects moved to \`testsubjects/RoundTripSubjects.java\` where the punit-gradle-plugin's \`exclude("**/testsubjects/**")\` keeps them out of the discovery sweep.

Plus: \`PunitJunitIntegrationTest\` now scopes each case to a per-test \`@TempDir\` via system-property setup, so the new always-emit behaviour doesn't cross-pollute test cases.

## Test plan

- [x] All previously passing \`PunitJunitIntegrationTest\` cases still pass
- [x] \`MeasureToTestRoundTripTest\` (full pipeline through JUnit) still passes
- [x] \`BaselineProviderResolverTest\` updated for the new "always returns a path" semantics; 3 cases pass
- [x] Full \`./gradlew build\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)