### PR TITLE
CV-2: runtime covariate resolution producing a CovariateProfile

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/UseCase.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/UseCase.java
@@ -1,6 +1,8 @@
 package org.javai.punit.api.typed;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.typed.covariate.Covariate;
@@ -146,6 +148,33 @@ public interface UseCase<FT, IT, OT> {
      */
     default List<Covariate> covariates() {
         return List.of();
+    }
+
+    /**
+     * Resolvers for any {@code CustomCovariate} entries declared by
+     * {@link #covariates()}.
+     *
+     * <p>The framework owns the four built-in resolvers (day-of-week,
+     * time-of-day, region, timezone). For each {@code CustomCovariate}
+     * the use case declares, the framework consults this map (keyed
+     * by the covariate's {@link Covariate#name() name}) and invokes
+     * the supplier exactly once at the start of an experiment or
+     * test execution.
+     *
+     * <p>The supplier must be deterministic within a single
+     * execution: calling it twice in the same run must yield the
+     * same value, since all samples in that run share one resolved
+     * profile.
+     *
+     * <p>If the use case declares a {@code CustomCovariate} whose
+     * name has no entry in this map, the framework fails fast before
+     * any samples run — silent fallbacks would corrupt baseline
+     * identity.
+     *
+     * @return the resolver map; never null. The default is empty.
+     */
+    default Map<String, Supplier<String>> customCovariateResolvers() {
+        return Map.of();
     }
 
     /**

--- a/punit-api/src/main/java/org/javai/punit/api/typed/covariate/CovariateProfile.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/covariate/CovariateProfile.java
@@ -1,0 +1,110 @@
+package org.javai.punit.api.typed.covariate;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The resolved values of a use case's declared covariates at one
+ * point in time.
+ *
+ * <p>A profile is the snapshot of environmental conditions under which
+ * a measurement was taken, or under which a test is now running. Each
+ * entry maps a covariate's {@link Covariate#name() name} to its
+ * resolved label — the partition label for partitioned built-ins, the
+ * matching {@code HH:mm/Nh} period for time-of-day, the IANA string
+ * for timezone, or whatever a custom resolver returned.
+ *
+ * <p>The profile is part of a baseline's identity. Comparing today's
+ * test (resolved profile {@code dow=remainder, region=GB}) against a
+ * baseline measured under {@code dow=WEEKEND, region=FR} is comparing
+ * apples to oranges; baseline matching uses the profile to find the
+ * right baseline (or surface a misalignment when none matches).
+ *
+ * <p>An empty profile (the result of a use case declaring no
+ * covariates) is a valid value — the baseline's identity reduces to
+ * the use case alone.
+ *
+ * <p>Insertion order is preserved so callers iterating the profile
+ * see entries in the order their declarations were resolved.
+ */
+public final class CovariateProfile {
+
+    private static final CovariateProfile EMPTY = new CovariateProfile(Map.of());
+
+    private final Map<String, String> values;
+
+    private CovariateProfile(Map<String, String> values) {
+        this.values = values;
+    }
+
+    /**
+     * @return the singleton empty profile
+     */
+    public static CovariateProfile empty() {
+        return EMPTY;
+    }
+
+    /**
+     * @param values resolved name→label entries; insertion order is
+     *               preserved
+     * @return a new profile holding a defensive copy of the input
+     */
+    public static CovariateProfile of(Map<String, String> values) {
+        Objects.requireNonNull(values, "values");
+        if (values.isEmpty()) {
+            return EMPTY;
+        }
+        // LinkedHashMap defensive copy preserves insertion order; the
+        // wrapper makes the result unmodifiable.
+        Map<String, String> copy = new LinkedHashMap<>(values.size());
+        for (Map.Entry<String, String> e : values.entrySet()) {
+            Objects.requireNonNull(e.getKey(), "covariate name");
+            Objects.requireNonNull(e.getValue(), "covariate value for " + e.getKey());
+            copy.put(e.getKey(), e.getValue());
+        }
+        return new CovariateProfile(java.util.Collections.unmodifiableMap(copy));
+    }
+
+    /**
+     * @return the resolved label for {@code covariateName}, or empty
+     *         when the profile contains no such entry
+     */
+    public Optional<String> get(String covariateName) {
+        return Optional.ofNullable(values.get(covariateName));
+    }
+
+    /**
+     * @return the immutable underlying map; preserves resolution
+     *         order
+     */
+    public Map<String, String> values() {
+        return values;
+    }
+
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
+    public int size() {
+        return values.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CovariateProfile other)) return false;
+        return values.equals(other.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return values.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "CovariateProfile" + values;
+    }
+}

--- a/punit-api/src/test/java/org/javai/punit/api/typed/covariate/CovariateProfileTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/covariate/CovariateProfileTest.java
@@ -1,0 +1,96 @@
+package org.javai.punit.api.typed.covariate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CovariateProfile — value semantics and resolution-order preservation")
+class CovariateProfileTest {
+
+    @Test
+    @DisplayName("empty() returns the canonical empty singleton")
+    void emptySingleton() {
+        assertThat(CovariateProfile.empty()).isSameAs(CovariateProfile.empty());
+        assertThat(CovariateProfile.empty().isEmpty()).isTrue();
+        assertThat(CovariateProfile.empty().size()).isZero();
+    }
+
+    @Test
+    @DisplayName("of(emptyMap) returns the canonical empty singleton")
+    void ofEmptyMapReturnsEmpty() {
+        assertThat(CovariateProfile.of(Map.of())).isSameAs(CovariateProfile.empty());
+    }
+
+    @Test
+    @DisplayName("of(map) preserves insertion order")
+    void preservesInsertionOrder() {
+        LinkedHashMap<String, String> input = new LinkedHashMap<>();
+        input.put("zeta", "1");
+        input.put("alpha", "2");
+        input.put("middle", "3");
+
+        CovariateProfile profile = CovariateProfile.of(input);
+
+        assertThat(profile.values().keySet()).containsExactly("zeta", "alpha", "middle");
+    }
+
+    @Test
+    @DisplayName("get returns the resolved label")
+    void getResolvedLabel() {
+        CovariateProfile profile = CovariateProfile.of(Map.of("region", "DE_FR"));
+        assertThat(profile.get("region")).contains("DE_FR");
+        assertThat(profile.get("missing")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returned values map is unmodifiable")
+    void valuesUnmodifiable() {
+        CovariateProfile profile = CovariateProfile.of(Map.of("a", "1"));
+        assertThatThrownBy(() -> profile.values().put("b", "2"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("mutating the source map after of() does not mutate the profile")
+    void defensivelyCopied() {
+        Map<String, String> source = new HashMap<>();
+        source.put("a", "1");
+        CovariateProfile profile = CovariateProfile.of(source);
+
+        source.put("b", "2");
+
+        assertThat(profile.size()).isEqualTo(1);
+        assertThat(profile.get("b")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("rejects null keys and values")
+    void rejectsNulls() {
+        Map<String, String> withNullKey = new HashMap<>();
+        withNullKey.put(null, "v");
+        assertThatThrownBy(() -> CovariateProfile.of(withNullKey))
+                .isInstanceOf(NullPointerException.class);
+
+        Map<String, String> withNullValue = new HashMap<>();
+        withNullValue.put("k", null);
+        assertThatThrownBy(() -> CovariateProfile.of(withNullValue))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("equals is value-based on the values map")
+    void valueEquality() {
+        CovariateProfile a = CovariateProfile.of(Map.of("k", "v"));
+        CovariateProfile b = CovariateProfile.of(Map.of("k", "v"));
+        CovariateProfile c = CovariateProfile.of(Map.of("k", "x"));
+
+        assertThat(a).isEqualTo(b).isNotEqualTo(c);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/covariate/CovariateResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/covariate/CovariateResolver.java
@@ -1,0 +1,282 @@
+package org.javai.punit.engine.covariate;
+
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.covariate.CustomCovariate;
+import org.javai.punit.api.typed.covariate.DayOfWeekCovariate;
+import org.javai.punit.api.typed.covariate.RegionCovariate;
+import org.javai.punit.api.typed.covariate.TimeOfDayCovariate;
+import org.javai.punit.api.typed.covariate.TimezoneCovariate;
+
+/**
+ * Resolves a use case's declared covariates into a
+ * {@link CovariateProfile} at the start of an experiment or test run.
+ *
+ * <p>Built-in resolution dispatches on the {@link Covariate} sealed
+ * hierarchy:
+ *
+ * <ul>
+ *   <li>{@link DayOfWeekCovariate} — match the current day against
+ *       the declared partitions; days outside every partition resolve
+ *       to a complement-derived label (e.g. {@code WEEKEND} declared
+ *       → remainder labelled from {@code MONDAY..FRIDAY}).</li>
+ *   <li>{@link TimeOfDayCovariate} — parse the declared
+ *       {@code HH:mm/Nh} periods, find the one containing the current
+ *       local time; "no match" resolves to {@value #TIME_OUTSIDE_LABEL}.</li>
+ *   <li>{@link RegionCovariate} — read the configured region from
+ *       (in order) the {@value #REGION_PROPERTY} system property and
+ *       the {@value #REGION_ENV_VAR} environment variable; match
+ *       against the declared partitions; missing region resolves to
+ *       {@value #REGION_UNDEFINED_LABEL}, unmatched region to
+ *       {@value #REGION_OTHER_LABEL}.</li>
+ *   <li>{@link TimezoneCovariate} — return the configured zone's IANA
+ *       id (e.g. {@code Europe/Zurich}). No partitioning.</li>
+ *   <li>{@link CustomCovariate} — invoke the supplier the use case
+ *       provides; fail fast if no resolver is registered.</li>
+ * </ul>
+ *
+ * <p>Label conventions match the legacy resolvers (in
+ * {@code spec.baseline.covariate}) so a baseline emitted by the
+ * legacy pipeline and a baseline emitted by the typed pipeline use
+ * identical labels for identical covariate inputs.
+ *
+ * <p>Resolvers are deterministic for a given {@code Clock},
+ * {@code ZoneId}, and environment lookup. Inject custom values
+ * through {@link Builder} for tests; production code uses
+ * {@link #defaults()}.
+ *
+ * <p>Per UC04, this resolver is invoked once per experiment run or
+ * test execution — the resulting profile travels with every sample
+ * in that run. Re-resolving per sample would let the profile drift
+ * mid-run (the clock advances, the system property could mutate),
+ * defeating the purpose of recording a snapshot.
+ */
+public final class CovariateResolver {
+
+    static final String REGION_PROPERTY = "punit.region";
+    static final String REGION_ENV_VAR = "PUNIT_REGION";
+    static final String REGION_OTHER_LABEL = "OTHER";
+    static final String REGION_UNDEFINED_LABEL = "UNDEFINED";
+    static final String TIME_OUTSIDE_LABEL = "OUTSIDE";
+
+    private static final Set<DayOfWeek> WEEKEND_DAYS =
+            EnumSet.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+    private static final Set<DayOfWeek> WEEKDAY_DAYS =
+            EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
+                    DayOfWeek.THURSDAY, DayOfWeek.FRIDAY);
+
+    private final Clock clock;
+    private final ZoneId zoneId;
+    private final Function<String, Optional<String>> environment;
+
+    private CovariateResolver(
+            Clock clock,
+            ZoneId zoneId,
+            Function<String, Optional<String>> environment) {
+        this.clock = clock;
+        this.zoneId = zoneId;
+        this.environment = environment;
+    }
+
+    /**
+     * @return a resolver wired to the system clock, system default
+     *         zone, and a system-property-then-env-var environment
+     *         lookup
+     */
+    public static CovariateResolver defaults() {
+        return new CovariateResolver(
+                Clock.systemDefaultZone(),
+                ZoneId.systemDefault(),
+                CovariateResolver::lookupSystemPropertyThenEnv);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Resolve all declarations into a profile.
+     *
+     * @param declarations the covariates declared by the use case;
+     *                     never null
+     * @param customCovariateResolvers resolvers for custom-covariate
+     *                                 names; never null. Missing
+     *                                 resolvers for declared custom
+     *                                 covariates cause an
+     *                                 {@link IllegalStateException}.
+     */
+    public CovariateProfile resolve(
+            List<Covariate> declarations,
+            Map<String, Supplier<String>> customCovariateResolvers) {
+        Objects.requireNonNull(declarations, "declarations");
+        Objects.requireNonNull(customCovariateResolvers, "customCovariateResolvers");
+        if (declarations.isEmpty()) {
+            return CovariateProfile.empty();
+        }
+        Map<String, String> values = new LinkedHashMap<>(declarations.size());
+        for (Covariate c : declarations) {
+            String value = switch (c) {
+                case DayOfWeekCovariate d -> resolveDayOfWeek(d);
+                case TimeOfDayCovariate t -> resolveTimeOfDay(t);
+                case RegionCovariate r    -> resolveRegion(r);
+                case TimezoneCovariate t  -> resolveTimezone();
+                case CustomCovariate cu   -> resolveCustom(cu, customCovariateResolvers);
+            };
+            values.put(c.name(), value);
+        }
+        return CovariateProfile.of(values);
+    }
+
+    // ── Built-in resolution ─────────────────────────────────────────
+
+    private String resolveDayOfWeek(DayOfWeekCovariate covariate) {
+        DayOfWeek today = LocalDate.now(clock.withZone(zoneId)).getDayOfWeek();
+        for (Set<DayOfWeek> partition : covariate.partitions()) {
+            if (partition.contains(today)) {
+                return dayPartitionLabel(partition);
+            }
+        }
+        return dayRemainderLabel(covariate.partitions());
+    }
+
+    private String resolveTimeOfDay(TimeOfDayCovariate covariate) {
+        List<PeriodMatcher.Parsed> parsed = PeriodMatcher.parse(covariate.periods());
+        LocalTime now = LocalTime.now(clock.withZone(zoneId));
+        return PeriodMatcher.match(now, parsed).orElse(TIME_OUTSIDE_LABEL);
+    }
+
+    private String resolveRegion(RegionCovariate covariate) {
+        Optional<String> raw = environment.apply(REGION_PROPERTY)
+                .or(() -> environment.apply(REGION_ENV_VAR));
+        if (raw.isEmpty() || raw.get().isBlank()) {
+            return REGION_UNDEFINED_LABEL;
+        }
+        String code = raw.get().toUpperCase(Locale.ROOT);
+        for (Set<String> partition : covariate.partitions()) {
+            if (partition.contains(code)) {
+                return regionPartitionLabel(partition);
+            }
+        }
+        return REGION_OTHER_LABEL;
+    }
+
+    private String resolveTimezone() {
+        return zoneId.getId();
+    }
+
+    private String resolveCustom(
+            CustomCovariate covariate,
+            Map<String, Supplier<String>> customResolvers) {
+        Supplier<String> resolver = customResolvers.get(covariate.name());
+        if (resolver == null) {
+            throw new IllegalStateException(
+                    "no resolver registered for custom covariate '" + covariate.name()
+                            + "' — declare it in UseCase.customCovariateResolvers()");
+        }
+        String value = resolver.get();
+        if (value == null) {
+            throw new IllegalStateException(
+                    "resolver for custom covariate '" + covariate.name() + "' returned null");
+        }
+        return value;
+    }
+
+    // ── Label derivation ────────────────────────────────────────────
+
+    static String dayPartitionLabel(Set<DayOfWeek> days) {
+        if (days.equals(WEEKEND_DAYS)) {
+            return "WEEKEND";
+        }
+        if (days.equals(WEEKDAY_DAYS)) {
+            return "WEEKDAY";
+        }
+        return days.stream()
+                .sorted()
+                .map(DayOfWeek::name)
+                .collect(Collectors.joining("_"));
+    }
+
+    static String dayRemainderLabel(List<Set<DayOfWeek>> partitions) {
+        EnumSet<DayOfWeek> declared = EnumSet.noneOf(DayOfWeek.class);
+        for (Set<DayOfWeek> p : partitions) {
+            declared.addAll(p);
+        }
+        EnumSet<DayOfWeek> complement = EnumSet.complementOf(declared);
+        if (complement.isEmpty()) {
+            // All seven days were declared somewhere; remainder is
+            // unreachable. The label is empty by convention.
+            return "";
+        }
+        return dayPartitionLabel(complement);
+    }
+
+    static String regionPartitionLabel(Set<String> regions) {
+        // ISO codes uppercased on the way in; sort ascending for a
+        // deterministic label irrespective of declaration order.
+        TreeSet<String> sorted = new TreeSet<>(regions);
+        return String.join("_", sorted);
+    }
+
+    // ── Environment lookup ──────────────────────────────────────────
+
+    private static Optional<String> lookupSystemPropertyThenEnv(String key) {
+        String prop = System.getProperty(key);
+        if (prop != null && !prop.isBlank()) {
+            return Optional.of(prop);
+        }
+        String env = System.getenv(key);
+        if (env != null && !env.isBlank()) {
+            return Optional.of(env);
+        }
+        return Optional.empty();
+    }
+
+    // ── Builder ─────────────────────────────────────────────────────
+
+    public static final class Builder {
+        private Clock clock = Clock.systemDefaultZone();
+        private ZoneId zoneId = ZoneId.systemDefault();
+        private Function<String, Optional<String>> environment =
+                CovariateResolver::lookupSystemPropertyThenEnv;
+
+        public Builder clock(Clock clock) {
+            this.clock = Objects.requireNonNull(clock, "clock");
+            return this;
+        }
+
+        public Builder zoneId(ZoneId zoneId) {
+            this.zoneId = Objects.requireNonNull(zoneId, "zoneId");
+            return this;
+        }
+
+        /** Override the environment lookup. Receives a key, returns
+         *  the value or empty. Used by tests to inject region
+         *  without mutating real system state. */
+        public Builder environment(Function<String, Optional<String>> environment) {
+            this.environment = Objects.requireNonNull(environment, "environment");
+            return this;
+        }
+
+        public CovariateResolver build() {
+            return new CovariateResolver(clock, zoneId, environment);
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/covariate/PeriodMatcher.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/covariate/PeriodMatcher.java
@@ -1,0 +1,142 @@
+package org.javai.punit.engine.covariate;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses {@code HH:mm/Nh} time-of-day period strings into intervals
+ * and matches a given time against them.
+ *
+ * <p>Supported formats:
+ *
+ * <ul>
+ *   <li>{@code HH:mm/Nh} — N hours (e.g. {@code 08:00/2h})</li>
+ *   <li>{@code HH:mm/Nm} — N minutes (e.g. {@code 08:00/30m})</li>
+ *   <li>{@code HH:mm/NhMm} — combined (e.g. {@code 08:00/2h30m})</li>
+ * </ul>
+ *
+ * <p>Validation rejects: malformed strings, hour {@code > 23}, minute
+ * {@code > 59}, zero-duration periods, periods that cross midnight,
+ * and periods that overlap one another.
+ *
+ * <p>Logic ported from the legacy {@code TimePeriodExtractor} in
+ * {@code spec.baseline.covariate}; retains its semantics so the typed
+ * pipeline emits identical labels when the same periods are declared.
+ */
+final class PeriodMatcher {
+
+    private static final Pattern PERIOD_PATTERN =
+            Pattern.compile("^(\\d{2}):(\\d{2})/(?:(\\d+)h)?(?:(\\d+)m)?$");
+
+    private PeriodMatcher() { }
+
+    /** A parsed period: start instant, duration in minutes, and the
+     *  original declaration string used as the period's label. */
+    record Parsed(LocalTime start, int durationMinutes, String label) {
+
+        LocalTime end() {
+            // No wrap: validation rejects midnight-crossing periods.
+            int total = start.getHour() * 60 + start.getMinute() + durationMinutes;
+            int hours = total / 60;
+            int minutes = total % 60;
+            return hours == 24 ? LocalTime.of(0, 0).minusNanos(1) : LocalTime.of(hours, minutes);
+        }
+
+        boolean contains(LocalTime t) {
+            // [start, start+duration) — half-open
+            int target = t.getHour() * 60 + t.getMinute();
+            int begin = start.getHour() * 60 + start.getMinute();
+            return target >= begin && target < begin + durationMinutes;
+        }
+    }
+
+    /**
+     * Parse and validate a list of period strings. The returned list
+     * is in declaration order; overlap and midnight-crossing checks
+     * have already passed.
+     *
+     * @throws IllegalArgumentException if any period is malformed,
+     *         out of range, zero-duration, crosses midnight, or
+     *         overlaps another period
+     */
+    static List<Parsed> parse(List<String> periods) {
+        List<Parsed> parsed = new ArrayList<>(periods.size());
+        for (String period : periods) {
+            parsed.add(parseOne(period));
+        }
+
+        List<Parsed> sorted = new ArrayList<>(parsed);
+        sorted.sort(Comparator.comparing(Parsed::start));
+        for (int i = 0; i < sorted.size() - 1; i++) {
+            Parsed cur = sorted.get(i);
+            Parsed next = sorted.get(i + 1);
+            int curEndMin = cur.start().getHour() * 60 + cur.start().getMinute()
+                    + cur.durationMinutes();
+            int nextStartMin = next.start().getHour() * 60 + next.start().getMinute();
+            if (curEndMin > nextStartMin) {
+                throw new IllegalArgumentException(
+                        "time-of-day periods overlap: '" + cur.label()
+                                + "' and '" + next.label() + "'");
+            }
+        }
+        return List.copyOf(parsed);
+    }
+
+    /**
+     * @return the label of the first parsed period containing
+     *         {@code now}, or empty when no period covers it
+     */
+    static Optional<String> match(LocalTime now, List<Parsed> periods) {
+        for (Parsed p : periods) {
+            if (p.contains(now)) {
+                return Optional.of(p.label());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Parsed parseOne(String period) {
+        Matcher m = PERIOD_PATTERN.matcher(period);
+        if (!m.matches() || (m.group(3) == null && m.group(4) == null)) {
+            throw new IllegalArgumentException(
+                    "Invalid time period format: '" + period
+                            + "'. Expected 'HH:mm/Nh', 'HH:mm/Nm', or 'HH:mm/NhMm'");
+        }
+        int hours = Integer.parseInt(m.group(1));
+        int minutes = Integer.parseInt(m.group(2));
+        if (hours > 23) {
+            throw new IllegalArgumentException(
+                    "Invalid hour in time period '" + period
+                            + "': " + hours + " (must be 00-23)");
+        }
+        if (minutes > 59) {
+            throw new IllegalArgumentException(
+                    "Invalid minute in time period '" + period
+                            + "': " + minutes + " (must be 00-59)");
+        }
+        int durHours = m.group(3) != null ? Integer.parseInt(m.group(3)) : 0;
+        int durMins = m.group(4) != null ? Integer.parseInt(m.group(4)) : 0;
+        if (m.group(3) != null && m.group(4) != null && durMins > 59) {
+            throw new IllegalArgumentException(
+                    "Minutes component must be 0-59 when combined with hours: '"
+                            + period + "'");
+        }
+        int total = durHours * 60 + durMins;
+        if (total <= 0) {
+            throw new IllegalArgumentException(
+                    "Duration must be positive in time period '" + period + "'");
+        }
+        int startMin = hours * 60 + minutes;
+        if (startMin + total > 24 * 60) {
+            throw new IllegalArgumentException(
+                    "Time period '" + period
+                            + "' crosses midnight (start + duration exceeds 24:00)");
+        }
+        return new Parsed(LocalTime.of(hours, minutes), total, period);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/covariate/CovariateResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/covariate/CovariateResolverTest.java
@@ -1,0 +1,325 @@
+package org.javai.punit.engine.covariate;
+
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.javai.punit.api.CovariateCategory;
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CovariateResolver — runtime resolution of declared covariates")
+class CovariateResolverTest {
+
+    // 2026-04-29 is a Wednesday.
+    private static final Instant WEDNESDAY_NOON_UTC =
+            Instant.parse("2026-04-29T12:00:00Z");
+
+    private final Clock clock = Clock.fixed(WEDNESDAY_NOON_UTC, ZoneOffset.UTC);
+
+    @Test
+    @DisplayName("empty declarations resolve to the empty profile")
+    void emptyDeclarations() {
+        CovariateResolver resolver = CovariateResolver.builder()
+                .clock(clock)
+                .zoneId(ZoneOffset.UTC)
+                .build();
+
+        CovariateProfile profile = resolver.resolve(List.of(), Map.of());
+
+        assertThat(profile.isEmpty()).isTrue();
+        assertThat(profile).isSameAs(CovariateProfile.empty());
+    }
+
+    @Test
+    @DisplayName("resolution preserves declaration order in the profile")
+    void preservesOrder() {
+        CovariateResolver resolver = CovariateResolver.builder()
+                .clock(clock)
+                .zoneId(ZoneOffset.UTC)
+                .build();
+
+        CovariateProfile profile = resolver.resolve(
+                List.of(
+                        Covariate.timezone(),
+                        Covariate.dayOfWeek(List.of(Set.of(SATURDAY, SUNDAY)))),
+                Map.of());
+
+        assertThat(profile.values().keySet())
+                .containsExactly("timezone", "day_of_week");
+    }
+
+    @Nested
+    @DisplayName("DayOfWeek resolution")
+    class DayOfWeekTests {
+
+        @Test
+        @DisplayName("returns the matching partition's label for a declared partition")
+        void inDeclaredPartition() {
+            // Wednesday is in the {MON-FRI} weekday partition.
+            CovariateResolver resolver = resolverAtUtc();
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.dayOfWeek(List.of(
+                            Set.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+                            Set.of(SATURDAY, SUNDAY)))),
+                    Map.of());
+
+            assertThat(profile.get("day_of_week")).contains("WEEKDAY");
+        }
+
+        @Test
+        @DisplayName("returns the remainder label when no declared partition matches")
+        void inImplicitRemainder() {
+            // Wednesday is outside both declared partitions → remainder.
+            CovariateResolver resolver = resolverAtUtc();
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.dayOfWeek(List.of(
+                            Set.of(SATURDAY, SUNDAY),
+                            Set.of(MONDAY)))),
+                    Map.of());
+
+            // Complement of {SAT, SUN, MON} is {TUE, WED, THU, FRI}
+            // — labelled in enum order joined by underscores.
+            assertThat(profile.get("day_of_week"))
+                    .contains("TUESDAY_WEDNESDAY_THURSDAY_FRIDAY");
+        }
+
+        @Test
+        @DisplayName("recognises WEEKEND as a special label")
+        void weekendLabel() {
+            // Override the clock to a Saturday.
+            Clock saturday = Clock.fixed(
+                    Instant.parse("2026-04-25T12:00:00Z"), ZoneOffset.UTC);
+            CovariateResolver resolver = CovariateResolver.builder()
+                    .clock(saturday).zoneId(ZoneOffset.UTC).build();
+
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.dayOfWeek(List.of(Set.of(SATURDAY, SUNDAY)))),
+                    Map.of());
+
+            assertThat(profile.get("day_of_week")).contains("WEEKEND");
+        }
+    }
+
+    @Nested
+    @DisplayName("TimeOfDay resolution")
+    class TimeOfDayTests {
+
+        @Test
+        @DisplayName("returns the matching period's label")
+        void insidePeriod() {
+            // 12:00 is within 12:00/3h.
+            CovariateResolver resolver = resolverAtUtc();
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.timeOfDay(List.of("08:00/2h", "12:00/3h"))),
+                    Map.of());
+
+            assertThat(profile.get("time_of_day")).contains("12:00/3h");
+        }
+
+        @Test
+        @DisplayName("returns OUTSIDE when no period contains now")
+        void outside() {
+            // 12:00 falls between two periods that don't cover noon.
+            CovariateResolver resolver = resolverAtUtc();
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.timeOfDay(List.of("08:00/2h", "16:00/3h"))),
+                    Map.of());
+
+            assertThat(profile.get("time_of_day")).contains("OUTSIDE");
+        }
+    }
+
+    @Nested
+    @DisplayName("Region resolution")
+    class RegionTests {
+
+        @Test
+        @DisplayName("returns the partition label when region matches")
+        void inPartition() {
+            CovariateResolver resolver = CovariateResolver.builder()
+                    .clock(clock).zoneId(ZoneOffset.UTC)
+                    .environment(envWith(Map.of("punit.region", "FR")))
+                    .build();
+
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.region(List.of(
+                            Set.of("FR", "DE"), Set.of("GB", "IE")))),
+                    Map.of());
+
+            assertThat(profile.get("region")).contains("DE_FR");
+        }
+
+        @Test
+        @DisplayName("returns OTHER when configured region matches no partition")
+        void unmatchedRegion() {
+            CovariateResolver resolver = CovariateResolver.builder()
+                    .clock(clock).zoneId(ZoneOffset.UTC)
+                    .environment(envWith(Map.of("punit.region", "JP")))
+                    .build();
+
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.region(List.of(Set.of("FR", "DE")))),
+                    Map.of());
+
+            assertThat(profile.get("region")).contains("OTHER");
+        }
+
+        @Test
+        @DisplayName("returns UNDEFINED when no region is configured")
+        void undefinedRegion() {
+            CovariateResolver resolver = CovariateResolver.builder()
+                    .clock(clock).zoneId(ZoneOffset.UTC)
+                    .environment(envWith(Map.of()))  // empty environment
+                    .build();
+
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.region(List.of(Set.of("FR")))),
+                    Map.of());
+
+            assertThat(profile.get("region")).contains("UNDEFINED");
+        }
+
+        @Test
+        @DisplayName("falls back from system property to env var")
+        void envFallback() {
+            // No 'punit.region' but PUNIT_REGION is set.
+            CovariateResolver resolver = CovariateResolver.builder()
+                    .clock(clock).zoneId(ZoneOffset.UTC)
+                    .environment(envWith(Map.of("PUNIT_REGION", "fr")))
+                    .build();
+
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.region(List.of(Set.of("FR")))),
+                    Map.of());
+
+            // Lower-cased input is uppercased before partition match.
+            assertThat(profile.get("region")).contains("FR");
+        }
+    }
+
+    @Nested
+    @DisplayName("Timezone resolution")
+    class TimezoneTests {
+
+        @Test
+        @DisplayName("returns the configured zone's IANA id")
+        void zoneId() {
+            CovariateResolver resolver = CovariateResolver.builder()
+                    .clock(clock)
+                    .zoneId(ZoneId.of("Europe/Zurich"))
+                    .build();
+
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.timezone()), Map.of());
+
+            assertThat(profile.get("timezone")).contains("Europe/Zurich");
+        }
+    }
+
+    @Nested
+    @DisplayName("Custom resolution")
+    class CustomTests {
+
+        @Test
+        @DisplayName("invokes the registered resolver and stores its return")
+        void resolverInvoked() {
+            CovariateResolver resolver = resolverAtUtc();
+            Map<String, Supplier<String>> resolvers =
+                    Map.of("model_version", () -> "claude-opus-4-7");
+
+            CovariateProfile profile = resolver.resolve(
+                    List.of(Covariate.custom("model_version", CovariateCategory.CONFIGURATION)),
+                    resolvers);
+
+            assertThat(profile.get("model_version")).contains("claude-opus-4-7");
+        }
+
+        @Test
+        @DisplayName("fails fast when a declared custom covariate has no resolver")
+        void missingResolver() {
+            CovariateResolver resolver = resolverAtUtc();
+
+            assertThatThrownBy(() -> resolver.resolve(
+                    List.of(Covariate.custom("model_version", CovariateCategory.CONFIGURATION)),
+                    Map.of()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("no resolver registered")
+                    .hasMessageContaining("model_version");
+        }
+
+        @Test
+        @DisplayName("fails fast when a resolver returns null")
+        void resolverReturnsNull() {
+            CovariateResolver resolver = resolverAtUtc();
+            Map<String, Supplier<String>> resolvers = new HashMap<>();
+            resolvers.put("flag", () -> null);
+
+            assertThatThrownBy(() -> resolver.resolve(
+                    List.of(Covariate.custom("flag", CovariateCategory.CONFIGURATION)),
+                    resolvers))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("returned null");
+        }
+    }
+
+    @Test
+    @DisplayName("resolves a mixed declaration in declaration order")
+    void mixedDeclaration() {
+        CovariateResolver resolver = CovariateResolver.builder()
+                .clock(clock)
+                .zoneId(ZoneId.of("Europe/Zurich"))
+                .environment(envWith(Map.of("punit.region", "FR")))
+                .build();
+
+        CovariateProfile profile = resolver.resolve(
+                List.of(
+                        Covariate.dayOfWeek(List.of(Set.of(SATURDAY, SUNDAY))),
+                        Covariate.region(List.of(Set.of("FR", "DE"))),
+                        Covariate.timezone(),
+                        Covariate.custom("model_version", CovariateCategory.CONFIGURATION)),
+                Map.of("model_version", () -> "v1"));
+
+        // Wednesday with weekend declared → remainder = {MON-FRI},
+        // which collapses to the special WEEKDAY label.
+        assertThat(profile.values()).containsExactly(
+                Map.entry("day_of_week", "WEEKDAY"),
+                Map.entry("region", "DE_FR"),
+                Map.entry("timezone", "Europe/Zurich"),
+                Map.entry("model_version", "v1"));
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────
+
+    private CovariateResolver resolverAtUtc() {
+        return CovariateResolver.builder()
+                .clock(clock)
+                .zoneId(ZoneOffset.UTC)
+                .build();
+    }
+
+    private static java.util.function.Function<String, Optional<String>> envWith(
+            Map<String, String> entries) {
+        return key -> Optional.ofNullable(entries.get(key));
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/covariate/PeriodMatcherTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/covariate/PeriodMatcherTest.java
@@ -1,0 +1,120 @@
+package org.javai.punit.engine.covariate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PeriodMatcher — HH:mm/Nh parsing and matching")
+class PeriodMatcherTest {
+
+    @Nested
+    @DisplayName("parse")
+    class ParseTests {
+
+        @Test
+        @DisplayName("accepts HH:mm/Nh, HH:mm/Nm, and HH:mm/NhMm forms")
+        void acceptsAllForms() {
+            List<PeriodMatcher.Parsed> parsed = PeriodMatcher.parse(
+                    List.of("08:00/2h", "12:00/30m", "16:00/1h15m"));
+
+            assertThat(parsed).hasSize(3);
+            assertThat(parsed.get(0).durationMinutes()).isEqualTo(120);
+            assertThat(parsed.get(1).durationMinutes()).isEqualTo(30);
+            assertThat(parsed.get(2).durationMinutes()).isEqualTo(75);
+        }
+
+        @Test
+        @DisplayName("rejects malformed period strings")
+        void rejectsMalformed() {
+            assertThatThrownBy(() -> PeriodMatcher.parse(List.of("8:00/2h")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Invalid time period format");
+        }
+
+        @Test
+        @DisplayName("rejects out-of-range hour")
+        void rejectsBadHour() {
+            assertThatThrownBy(() -> PeriodMatcher.parse(List.of("24:00/1h")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Invalid hour");
+        }
+
+        @Test
+        @DisplayName("rejects zero-duration period")
+        void rejectsZeroDuration() {
+            assertThatThrownBy(() -> PeriodMatcher.parse(List.of("08:00/0h")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Duration must be positive");
+        }
+
+        @Test
+        @DisplayName("rejects period that crosses midnight")
+        void rejectsMidnightCross() {
+            assertThatThrownBy(() -> PeriodMatcher.parse(List.of("23:00/2h")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("crosses midnight");
+        }
+
+        @Test
+        @DisplayName("rejects overlapping periods")
+        void rejectsOverlap() {
+            assertThatThrownBy(() -> PeriodMatcher.parse(List.of("08:00/2h", "09:00/2h")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("overlap");
+        }
+
+        @Test
+        @DisplayName("accepts back-to-back periods (touching but not overlapping)")
+        void acceptsContiguous() {
+            // 08:00–10:00 ends exactly when 10:00–12:00 starts; OK.
+            List<PeriodMatcher.Parsed> parsed = PeriodMatcher.parse(
+                    List.of("08:00/2h", "10:00/2h"));
+            assertThat(parsed).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("match")
+    class MatchTests {
+
+        private final List<PeriodMatcher.Parsed> periods =
+                PeriodMatcher.parse(List.of("08:00/2h", "16:00/3h"));
+
+        @Test
+        @DisplayName("returns the label of a period containing now")
+        void inside() {
+            assertThat(PeriodMatcher.match(LocalTime.of(9, 30), periods))
+                    .contains("08:00/2h");
+        }
+
+        @Test
+        @DisplayName("returns empty when no period contains now")
+        void outside() {
+            assertThat(PeriodMatcher.match(LocalTime.of(12, 0), periods))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("treats period as half-open: end is exclusive")
+        void endExclusive() {
+            // 08:00/2h ends at 10:00 (exclusive).
+            assertThat(PeriodMatcher.match(LocalTime.of(10, 0), periods))
+                    .isEmpty();
+            assertThat(PeriodMatcher.match(LocalTime.of(9, 59), periods))
+                    .contains("08:00/2h");
+        }
+
+        @Test
+        @DisplayName("treats period as half-open: start is inclusive")
+        void startInclusive() {
+            assertThat(PeriodMatcher.match(LocalTime.of(8, 0), periods))
+                    .contains("08:00/2h");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second slice of covariate work toward closing the Slice-5E migration blocker on `ShoppingBasketCovariateTest`. Builds on CV-1 (#78). This PR adds the **resolution layer** — declarations from CV-1 become a concrete `CovariateProfile` (name→label snapshot) at the start of a run.

- **`CovariateProfile`** in `punit-api/.../typed/covariate/`: immutable, insertion-order-preserving `Map<String, String>` wrapper with a singleton `empty()`. This is the value type that will flow into `BaselineRecord` in CV-3.
- **`UseCase.customCovariateResolvers()`** default method: `Map<String, Supplier<String>>` keyed by custom-covariate name. The framework dispatches built-ins itself; for each `CustomCovariate` declared, this map must contain a resolver — missing resolvers fail fast (silent fallback would corrupt baseline identity, per the project memory pin).
- **`CovariateResolver`** in `punit-core/.../engine/covariate/`: dispatches over the sealed `Covariate` hierarchy via switch, returns the assembled profile. `Builder` takes injectable `Clock` / `ZoneId` / environment lookup so tests don't depend on real time/system state.
- **`PeriodMatcher`**: parses `HH:mm/Nh` / `HH:mm/Nm` / `HH:mm/NhMm` period strings, validates bounds + zero-duration + midnight-cross + overlap, matches a `LocalTime` against parsed periods (half-open intervals). Logic ported from legacy `TimePeriodExtractor` so the typed pipeline emits identical labels for identical inputs.

### Label conventions (matched to legacy for cross-pipeline identity)

| Variant | Resolved label |
|---|---|
| `DayOfWeek` matching partition | `WEEKEND`, `WEEKDAY`, or `MONDAY_TUESDAY_…` (sorted enum names) |
| `DayOfWeek` remainder | Complement-derived label (self-describing — readers know what days fell in) |
| `Region` matching partition | Sorted alpha-2 codes joined with `_` (e.g. `DE_FR`) |
| `Region` no match / unset | `OTHER` / `UNDEFINED` |
| `TimeOfDay` matching period | The declaration string itself (e.g. `08:00/2h`) |
| `TimeOfDay` no match | `OUTSIDE` |
| `Timezone` | `ZoneId.getId()` (e.g. `Europe/Zurich`) — no partitioning |
| `Custom` | Whatever the supplier returns; `null` rejected |

Resolver runs once per run per UC04 — the profile is the snapshot all samples share. Per-sample re-resolution would drift (clock, props) and defeat the snapshot purpose.

## What's *not* in this PR

- No engine wiring — `Punit.measuring/testing` don't yet invoke the resolver. **CV-3** wires it into `BaselineRecord` (the integrity-story slice).
- No constructor-time `HH:mm/Nh` format validation in CV-1's `TimeOfDayCovariate` — keeps the existing "non-blank" check; format errors surface at resolve time. Cleanup later.
- Migration of `ShoppingBasketCovariateTest` waits for CV-5.

## Test plan

- [x] `PeriodMatcherTest` — 11 cases covering parse/validation/match
- [x] `CovariateResolverTest` — 13 cases covering each variant, declaration order preservation, mixed declarations, custom-resolver missing/null failures
- [x] `CovariateProfileTest` — 8 cases covering value semantics
- [x] `./gradlew build` green across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)