### PR TITLE
CV-3a: plumb CovariateProfile through BaselineRecord and YAML schema

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
@@ -1,5 +1,6 @@
 package org.javai.punit.engine.baseline;
 
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_COVARIATES;
 import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_FACTORS_FINGERPRINT;
 import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_GENERATED_AT;
 import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_INPUTS_IDENTITY;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 import org.javai.punit.api.typed.spec.LatencyStatistics;
 import org.javai.punit.api.typed.spec.PassRateStatistics;
@@ -79,9 +81,41 @@ public final class BaselineReader {
             entries.put(e.getKey(), parseStatisticsEntry(e.getKey(), e.getValue()));
         }
 
+        CovariateProfile profile = parseCovariates(root);
+
         return new BaselineRecord(
                 useCaseId, methodName, factorsFingerprint,
-                inputsIdentity, sampleCount, generatedAt, entries);
+                inputsIdentity, sampleCount, generatedAt, entries, profile);
+    }
+
+    private CovariateProfile parseCovariates(Map<String, Object> root) {
+        if (!root.containsKey(FIELD_COVARIATES)) {
+            return CovariateProfile.empty();
+        }
+        Object raw = root.get(FIELD_COVARIATES);
+        if (raw == null) {
+            return CovariateProfile.empty();
+        }
+        if (!(raw instanceof Map<?, ?> nested)) {
+            throw new IllegalArgumentException(
+                    "Field '" + FIELD_COVARIATES + "' must be a mapping, got "
+                            + raw.getClass().getSimpleName());
+        }
+        Map<String, Object> typed = asStringKeyedMap(nested, FIELD_COVARIATES);
+        if (typed.isEmpty()) {
+            return CovariateProfile.empty();
+        }
+        Map<String, String> values = new LinkedHashMap<>(typed.size());
+        for (Map.Entry<String, Object> e : typed.entrySet()) {
+            Object v = e.getValue();
+            if (!(v instanceof String s)) {
+                throw new IllegalArgumentException(
+                        "Covariate '" + e.getKey() + "' must be a string, got "
+                                + (v == null ? "null" : v.getClass().getSimpleName()));
+            }
+            values.put(e.getKey(), s);
+        }
+        return CovariateProfile.of(values);
     }
 
     private BaselineStatistics parseStatisticsEntry(String criterionName, Object raw) {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineRecord.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineRecord.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 
 /**
@@ -31,6 +32,12 @@ import org.javai.punit.api.typed.spec.BaselineStatistics;
  * @param statisticsByCriterionName  one
  *        {@link BaselineStatistics} entry per criterion, keyed by
  *        {@code Criterion.name()}
+ * @param covariateProfile    the resolved covariate profile under
+ *        which this baseline was measured. Empty when the use case
+ *        declared no covariates (legacy / covariate-insensitive
+ *        baselines). Part of the baseline's identity per UC04 — a
+ *        baseline measured under one profile must not silently match
+ *        a test running under a different profile.
  */
 public record BaselineRecord(
         String useCaseId,
@@ -39,7 +46,8 @@ public record BaselineRecord(
         String inputsIdentity,
         int sampleCount,
         Instant generatedAt,
-        Map<String, BaselineStatistics> statisticsByCriterionName) {
+        Map<String, BaselineStatistics> statisticsByCriterionName,
+        CovariateProfile covariateProfile) {
 
     public BaselineRecord {
         Objects.requireNonNull(useCaseId, "useCaseId");
@@ -48,6 +56,7 @@ public record BaselineRecord(
         Objects.requireNonNull(inputsIdentity, "inputsIdentity");
         Objects.requireNonNull(generatedAt, "generatedAt");
         Objects.requireNonNull(statisticsByCriterionName, "statisticsByCriterionName");
+        Objects.requireNonNull(covariateProfile, "covariateProfile");
         if (useCaseId.isBlank()) {
             throw new IllegalArgumentException("useCaseId must not be blank");
         }
@@ -67,6 +76,25 @@ public record BaselineRecord(
                             + "criterion entries is not consumable by any empirical criterion");
         }
         statisticsByCriterionName = Map.copyOf(new LinkedHashMap<>(statisticsByCriterionName));
+    }
+
+    /**
+     * Convenience constructor for callers that don't carry a covariate
+     * profile (legacy baselines, tests that don't exercise covariate
+     * resolution). Equivalent to the canonical constructor with
+     * {@link CovariateProfile#empty()}.
+     */
+    public BaselineRecord(
+            String useCaseId,
+            String methodName,
+            String factorsFingerprint,
+            String inputsIdentity,
+            int sampleCount,
+            Instant generatedAt,
+            Map<String, BaselineStatistics> statisticsByCriterionName) {
+        this(useCaseId, methodName, factorsFingerprint, inputsIdentity,
+                sampleCount, generatedAt, statisticsByCriterionName,
+                CovariateProfile.empty());
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineSchema.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineSchema.java
@@ -23,6 +23,7 @@ final class BaselineSchema {
     static final String FIELD_SAMPLE_COUNT = "sampleCount";
     static final String FIELD_GENERATED_AT = "generatedAt";
     static final String FIELD_STATISTICS = "statistics";
+    static final String FIELD_COVARIATES = "covariates";
 
     // BernoulliPassRate / PassRateStatistics
     static final String FIELD_OBSERVED_PASS_RATE = "observedPassRate";

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
@@ -2,6 +2,7 @@ package org.javai.punit.engine.baseline;
 
 import static org.javai.punit.engine.baseline.BaselineSchema.CRITERION_BERNOULLI_PASS_RATE;
 import static org.javai.punit.engine.baseline.BaselineSchema.CRITERION_PERCENTILE_LATENCY;
+import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_COVARIATES;
 import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_FACTORS_FINGERPRINT;
 import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_GENERATED_AT;
 import static org.javai.punit.engine.baseline.BaselineSchema.FIELD_INPUTS_IDENTITY;
@@ -85,6 +86,14 @@ public final class BaselineWriter {
         record.statisticsByCriterionName().forEach((name, value) ->
                 stats.put(name, serialiseStatisticsEntry(name, value)));
         root.put(FIELD_STATISTICS, stats);
+
+        if (!record.covariateProfile().isEmpty()) {
+            // Insertion order of the profile is the use case's
+            // covariate-declaration order — preserved on the way out
+            // so EX09's filename hashes appear in the same order.
+            root.put(FIELD_COVARIATES,
+                    new LinkedHashMap<>(record.covariateProfile().values()));
+        }
         return root;
     }
 

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
@@ -162,4 +162,73 @@ class BaselineReaderTest {
                 .withMessageContaining("weird-criterion")
                 .withMessageContaining("Unrecognised statistics entry shape");
     }
+
+    @Test
+    @DisplayName("round-trips a baseline with a covariate profile, preserving order")
+    void roundTripCovariates() {
+        Map<String, String> profile = new LinkedHashMap<>();
+        profile.put("day_of_week", "WEEKDAY");
+        profile.put("region", "DE_FR");
+        profile.put("model_version", "v1");
+
+        BaselineRecord original = new BaselineRecord(
+                "ShoppingBasket", "measureBaseline", "a1b2c3d4",
+                "sha256:abc123", 1000,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                org.javai.punit.api.typed.covariate.CovariateProfile.of(profile));
+
+        BaselineRecord parsed = reader.parse(writer.toYaml(original));
+
+        assertThat(parsed.covariateProfile().values())
+                .containsExactly(
+                        Map.entry("day_of_week", "WEEKDAY"),
+                        Map.entry("region", "DE_FR"),
+                        Map.entry("model_version", "v1"));
+    }
+
+    @Test
+    @DisplayName("legacy baselines without a covariates block parse to an empty profile")
+    void legacyMissingCovariates() {
+        // A YAML emitted before CV-3a has no covariates: block. The
+        // reader must accept it and assign the empty profile, so old
+        // baselines on disk continue to work after the upgrade.
+        String yaml = "schemaVersion: punit-baseline-2\n"
+                + "useCaseId: x\n"
+                + "methodName: m\n"
+                + "factorsFingerprint: f\n"
+                + "inputsIdentity: sha256:x\n"
+                + "sampleCount: 1\n"
+                + "generatedAt: 2026-04-26T15:30:00Z\n"
+                + "statistics:\n"
+                + "  bernoulli-pass-rate:\n"
+                + "    observedPassRate: 0.5\n"
+                + "    sampleCount: 1\n";
+
+        BaselineRecord parsed = reader.parse(yaml);
+        assertThat(parsed.covariateProfile().isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("rejects a non-string covariate value")
+    void rejectsNonStringCovariate() {
+        String yaml = "schemaVersion: punit-baseline-2\n"
+                + "useCaseId: x\n"
+                + "methodName: m\n"
+                + "factorsFingerprint: f\n"
+                + "inputsIdentity: sha256:x\n"
+                + "sampleCount: 1\n"
+                + "generatedAt: 2026-04-26T15:30:00Z\n"
+                + "statistics:\n"
+                + "  bernoulli-pass-rate:\n"
+                + "    observedPassRate: 0.5\n"
+                + "    sampleCount: 1\n"
+                + "covariates:\n"
+                + "  region: 42\n";
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> reader.parse(yaml))
+                .withMessageContaining("region")
+                .withMessageContaining("must be a string");
+    }
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
@@ -140,4 +140,46 @@ class BaselineWriterTest {
                 .withMessageContaining("custom-criterion")
                 .withMessageContaining("Unsupported baseline statistics kind");
     }
+
+    @Test
+    @DisplayName("omits the covariates section when the profile is empty (default constructor)")
+    void omitsCovariatesWhenEmpty() {
+        String yaml = writer.toYaml(recordWith(Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+
+        assertThat(yaml).doesNotContain("covariates:");
+    }
+
+    @Test
+    @DisplayName("emits a covariates block when the profile is non-empty, preserving order")
+    void emitsCovariatesBlock() {
+        Map<String, String> profile = new LinkedHashMap<>();
+        profile.put("day_of_week", "WEEKDAY");
+        profile.put("region", "DE_FR");
+        profile.put("model_version", "v1");
+
+        BaselineRecord record = new BaselineRecord(
+                "ShoppingBasketUseCase",
+                "measureBaseline",
+                "a1b2c3d4",
+                "sha256:7d3a8c1e9b2f",
+                1000,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                org.javai.punit.api.typed.covariate.CovariateProfile.of(profile));
+
+        String yaml = writer.toYaml(record);
+        Map<String, Object> root = new Yaml().load(yaml);
+
+        assertThat(root).containsKey("covariates");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> covariates = (Map<String, Object>) root.get("covariates");
+        // SnakeYAML preserves declaration order on the way in.
+        assertThat(covariates.keySet())
+                .containsExactly("day_of_week", "region", "model_version");
+        assertThat(covariates)
+                .containsEntry("day_of_week", "WEEKDAY")
+                .containsEntry("region", "DE_FR")
+                .containsEntry("model_version", "v1");
+    }
 }


### PR DESCRIPTION
## Summary

First sub-slice of CV-3 (baseline identity). Builds on CV-1 (#78) and CV-2 (#79). Plumbs `CovariateProfile` through the data layer — a baseline now carries the resolved covariate profile under which it was measured. **No matching logic, no filename hashing, no engine wire-up in this PR** — those land in CV-3b/3c/3d.

- `BaselineRecord` gains a `CovariateProfile` as the last canonical-constructor field. A secondary constructor delegates to the canonical one with `CovariateProfile.empty()`, so every existing callsite (12 of them) compiles unchanged.
- `BaselineWriter` emits a `covariates:` block when the profile is non-empty. When empty, the block is omitted — legacy baselines round-trip byte-identical.
- `BaselineReader` accepts both: present block → populated profile; absent block → `CovariateProfile.empty()`. **Forward-compatible** with files written before this change.
- Insertion order of the profile is the use case's covariate-declaration order — preserved through the round-trip. CV-3b will rely on this to emit filename hashes in declaration order per EX09.

Schema version stays at `punit-baseline-2`. The addition is a new *optional* field — a backwards-compatible extension. A bump would be misleading since old readers handle the file fine.

## Test plan

- [x] Writer: omits-when-empty / emits-when-populated / preserves-order
- [x] Reader: round-trips a populated profile / accepts a legacy file without a covariates block / rejects a non-string covariate value
- [x] All existing baseline tests pass via the convenience constructor (no callsite changes)
- [x] `./gradlew build` green across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)