### PR TITLE
CV-3b: covariate-value filename hashes per EX09

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineRecord.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineRecord.java
@@ -98,10 +98,31 @@ public record BaselineRecord(
     }
 
     /**
-     * @return the canonical filename for this baseline, in the form
-     *         {@code {useCaseId}.{methodName}-{factorsFingerprint}.yaml}.
+     * @return the canonical filename for this baseline.
+     *
+     * <p>Empty covariate profile (the default — covariate-insensitive
+     * baselines):
+     * <pre>{@code
+     * {useCaseId}.{methodName}-{factorsFingerprint}.yaml
+     * }</pre>
+     *
+     * <p>Non-empty covariate profile — one 4-char EX09 hash per
+     * covariate, in declaration order, separated by hyphens after the
+     * factors fingerprint:
+     * <pre>{@code
+     * {useCaseId}.{methodName}-{factorsFingerprint}-{cov1}-{cov2}...-{covN}.yaml
+     * }</pre>
+     *
+     * <p>The empty-profile form is byte-identical to pre-CV-3
+     * filenames; legacy baselines on disk continue to match.
      */
     public String filename() {
-        return useCaseId + "." + methodName + "-" + factorsFingerprint + ".yaml";
+        StringBuilder name = new StringBuilder()
+                .append(useCaseId).append('.').append(methodName)
+                .append('-').append(factorsFingerprint);
+        for (String hash : CovariateHashing.hashesFor(covariateProfile)) {
+            name.append('-').append(hash);
+        }
+        return name.append(".yaml").toString();
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -95,19 +95,49 @@ public final class BaselineResolver {
             return Optional.empty();
         }
         String prefix = useCaseId + ".";
-        String suffix = "-" + factorsFingerprint + ".yaml";
+        String factorsSegment = "-" + factorsFingerprint;
+        String yamlExt = ".yaml";
         try (var stream = Files.list(baselineDir)) {
             return stream
-                    .filter(p -> {
-                        String name = p.getFileName().toString();
-                        return name.startsWith(prefix) && name.endsWith(suffix);
-                    })
+                    .filter(p -> matchesFactorsFingerprint(
+                            p.getFileName().toString(), prefix, factorsSegment, yamlExt))
                     .findFirst()
                     .map(this::readUnchecked);
         } catch (IOException e) {
             throw new UncheckedIOException(
                     "Failed to enumerate baselines in " + baselineDir, e);
         }
+    }
+
+    /**
+     * Match the legacy {@code -{ff}.yaml} suffix and the new
+     * {@code -{ff}-{cov1}...-{covN}.yaml} extension. Both forms
+     * share the {@code -{ff}} segment immediately followed by either
+     * the file extension or another hash component.
+     *
+     * <p>Stage 4 stays exact-match on {@code (useCaseId, fingerprint)};
+     * when multiple covariate-partitioned files share the same
+     * fingerprint, this method returns true for each and the caller
+     * picks the first one (file listing order). Covariate-aware
+     * selection lands in CV-3c.
+     */
+    private static boolean matchesFactorsFingerprint(
+            String name, String prefix, String factorsSegment, String yamlExt) {
+        if (!name.startsWith(prefix) || !name.endsWith(yamlExt)) {
+            return false;
+        }
+        int idx = name.indexOf(factorsSegment);
+        if (idx < 0) {
+            return false;
+        }
+        int afterSegment = idx + factorsSegment.length();
+        // The factors-fingerprint segment must be terminated by either
+        // ".yaml" (legacy / empty-profile case) or "-" (the start of
+        // a covariate hash). A bare longer-fingerprint match like
+        // -aabbccdd matching a file with fingerprint -aabbccddee would
+        // pass startsWith here but fail this terminator check.
+        return afterSegment == name.length() - yamlExt.length()
+                || name.charAt(afterSegment) == '-';
     }
 
     private BaselineRecord readUnchecked(Path file) {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/CovariateHashing.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/CovariateHashing.java
@@ -1,0 +1,70 @@
+package org.javai.punit.engine.baseline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.util.HashUtils;
+
+/**
+ * Per-covariate-value hashing per EX09.
+ *
+ * <p>Each covariate the use case declared contributes one 4-character
+ * hex hash to the baseline filename. The hash is computed as
+ *
+ * <pre>{@code
+ * first4(sha256("{key}={canonical_value}"))
+ * }</pre>
+ *
+ * with the following normative pieces:
+ *
+ * <ul>
+ *   <li>{@code {key}} is the covariate name exactly as
+ *       {@link org.javai.punit.api.typed.covariate.Covariate#name()}
+ *       returns it (snake_case for built-ins).</li>
+ *   <li>{@code {canonical_value}} is the resolved label produced by
+ *       the {@code CovariateResolver}'s contract (UC04). For
+ *       partitioned built-ins this is the partition label; for
+ *       {@code TimezoneCovariate} it is the IANA string; for
+ *       {@code CustomCovariate} it is whatever the developer-supplied
+ *       resolver returned.</li>
+ *   <li>The separator is exactly {@code "="} with no whitespace.</li>
+ *   <li>The hash input is UTF-8 bytes.</li>
+ *   <li>The truncation is the first 4 hex characters of the SHA-256
+ *       digest, matching the other 4-character hash components in the
+ *       baseline filename schema.</li>
+ * </ul>
+ *
+ * <p>Hashes appear in the filename in the order the covariates were
+ * declared by {@code UseCase.covariates()}; {@link CovariateProfile}
+ * preserves that order through resolution and round-trip, so the
+ * implementation here just iterates the profile's value map.
+ */
+final class CovariateHashing {
+
+    static final int HASH_LENGTH = 4;
+
+    private CovariateHashing() { }
+
+    /**
+     * @return one 4-character hex hash per entry in {@code profile},
+     *         in the profile's iteration (i.e. declaration) order;
+     *         empty list when the profile is empty
+     */
+    static List<String> hashesFor(CovariateProfile profile) {
+        if (profile.isEmpty()) {
+            return List.of();
+        }
+        List<String> hashes = new ArrayList<>(profile.size());
+        for (Map.Entry<String, String> entry : profile.values().entrySet()) {
+            hashes.add(hashOne(entry.getKey(), entry.getValue()));
+        }
+        return List.copyOf(hashes);
+    }
+
+    static String hashOne(String key, String canonicalValue) {
+        String input = key + "=" + canonicalValue;
+        return HashUtils.truncateHash(HashUtils.sha256(input), HASH_LENGTH);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineRecordTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineRecordTest.java
@@ -90,4 +90,39 @@ class BaselineRecordTest {
 
         assertThat(record.statisticsByCriterionName()).hasSize(1);
     }
+
+    @Test
+    @DisplayName("filename appends one 4-char EX09 hash per covariate, in declaration order")
+    void filenameWithCovariates() {
+        java.util.LinkedHashMap<String, String> profile =
+                new java.util.LinkedHashMap<>();
+        profile.put("day_of_week", "WEEKDAY");
+        profile.put("region", "DE_FR");
+
+        BaselineRecord record = new BaselineRecord(
+                "ShoppingBasketUseCase", "measureBaseline", "a1b2c3d4",
+                "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
+                ONE_ENTRY,
+                org.javai.punit.api.typed.covariate.CovariateProfile.of(profile));
+
+        String dowHash = CovariateHashing.hashOne("day_of_week", "WEEKDAY");
+        String regionHash = CovariateHashing.hashOne("region", "DE_FR");
+
+        assertThat(record.filename())
+                .isEqualTo("ShoppingBasketUseCase.measureBaseline-a1b2c3d4-"
+                        + dowHash + "-" + regionHash + ".yaml");
+    }
+
+    @Test
+    @DisplayName("filename for empty covariate profile is unchanged from pre-CV-3")
+    void filenameUnchangedWhenProfileEmpty() {
+        BaselineRecord record = new BaselineRecord(
+                "ShoppingBasketUseCase", "measureBaseline", "a1b2c3d4",
+                "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
+                ONE_ENTRY,
+                org.javai.punit.api.typed.covariate.CovariateProfile.empty());
+
+        assertThat(record.filename())
+                .isEqualTo("ShoppingBasketUseCase.measureBaseline-a1b2c3d4.yaml");
+    }
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineResolverTest.java
@@ -133,4 +133,39 @@ class BaselineResolverTest {
                 "ShoppingBasket", "a1b2c3d4", "percentile-latency",
                 LatencyStatistics.class)).isPresent();
     }
+
+    @Test
+    @DisplayName("matches a covariate-bearing filename on the (useCaseId, fingerprint) pair")
+    void matchesCovariateBearingFilename(@TempDir Path dir) throws IOException {
+        java.util.LinkedHashMap<String, String> profile = new java.util.LinkedHashMap<>();
+        profile.put("region", "DE_FR");
+        BaselineRecord record = new BaselineRecord(
+                "ShoppingBasket", "measureBaseline", "a1b2c3d4",
+                "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                org.javai.punit.api.typed.covariate.CovariateProfile.of(profile));
+        writer.write(record, dir);
+
+        var resolver = new BaselineResolver(dir);
+
+        assertThat(resolver.resolve(
+                "ShoppingBasket", "a1b2c3d4", "bernoulli-pass-rate",
+                PassRateStatistics.class)).isPresent();
+    }
+
+    @Test
+    @DisplayName("does not confuse a longer fingerprint that has the requested one as a prefix")
+    void doesNotConfusePrefixFingerprint(@TempDir Path dir) throws IOException {
+        // -aabbccdd would match a file whose fingerprint is aabbccddee
+        // if the resolver only checked startsWith — which it doesn't,
+        // because the segment must be terminated by '-' or '.yaml'.
+        writeBaseline(dir, "ShoppingBasket", "aabbccddee", Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.5, 100)));
+
+        var resolver = new BaselineResolver(dir);
+
+        assertThat(resolver.resolve(
+                "ShoppingBasket", "aabbccdd", "bernoulli-pass-rate",
+                PassRateStatistics.class)).isEmpty();
+    }
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/CovariateHashingTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/CovariateHashingTest.java
@@ -1,0 +1,92 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CovariateHashing — EX09 per-covariate-value 4-char hashes")
+class CovariateHashingTest {
+
+    @Test
+    @DisplayName("empty profile produces an empty list")
+    void empty() {
+        assertThat(CovariateHashing.hashesFor(CovariateProfile.empty())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("hashes are exactly 4 lowercase hex characters per covariate")
+    void shapeAndLength() {
+        Map<String, String> profile = new LinkedHashMap<>();
+        profile.put("day_of_week", "WEEKDAY");
+        profile.put("region", "DE_FR");
+        profile.put("model_version", "claude-opus-4-7");
+
+        List<String> hashes = CovariateHashing.hashesFor(CovariateProfile.of(profile));
+
+        assertThat(hashes).hasSize(3);
+        assertThat(hashes).allSatisfy(h -> {
+            assertThat(h).hasSize(4);
+            assertThat(h).matches("^[0-9a-f]{4}$");
+        });
+    }
+
+    @Test
+    @DisplayName("hashes appear in declaration (insertion) order")
+    void preservesOrder() {
+        Map<String, String> a = new LinkedHashMap<>();
+        a.put("first", "alpha");
+        a.put("second", "beta");
+
+        Map<String, String> b = new LinkedHashMap<>();
+        b.put("second", "beta");
+        b.put("first", "alpha");
+
+        List<String> hashesA = CovariateHashing.hashesFor(CovariateProfile.of(a));
+        List<String> hashesB = CovariateHashing.hashesFor(CovariateProfile.of(b));
+
+        // Same covariates, same values — but different declaration
+        // order produces different filename ordering. The hashes are
+        // the same set; the sequence differs.
+        assertThat(hashesA).containsExactlyInAnyOrderElementsOf(hashesB);
+        assertThat(hashesA).isNotEqualTo(hashesB);
+    }
+
+    @Test
+    @DisplayName("hash is deterministic — same (key, value) always produces the same hash")
+    void deterministic() {
+        String h1 = CovariateHashing.hashOne("region", "DE_FR");
+        String h2 = CovariateHashing.hashOne("region", "DE_FR");
+        assertThat(h1).isEqualTo(h2);
+    }
+
+    @Test
+    @DisplayName("changing key or value changes the hash")
+    void sensitiveToInputs() {
+        String base = CovariateHashing.hashOne("region", "DE_FR");
+        String differentKey = CovariateHashing.hashOne("Region", "DE_FR");
+        String differentValue = CovariateHashing.hashOne("region", "DE_GB");
+
+        assertThat(differentKey).isNotEqualTo(base);
+        assertThat(differentValue).isNotEqualTo(base);
+    }
+
+    @Test
+    @DisplayName("hash matches first-4 of SHA-256 over UTF-8 of 'key=value'")
+    void matchesNormativeAlgorithm() {
+        // Lock in EX09's algorithm against an externally-computable
+        // value. SHA-256("region=DE_FR") = the well-known digest;
+        // first 4 hex chars are stable across platforms.
+        String input = "region=DE_FR";
+        String full = org.javai.punit.util.HashUtils.sha256(input);
+        String expected = full.substring(0, 4);
+
+        assertThat(CovariateHashing.hashOne("region", "DE_FR"))
+                .isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## Summary

Second sub-slice of CV-3. Builds on CV-3a (#80). Each declared covariate now contributes one 4-character hex hash to the baseline filename, so a baseline measured under {region=DE_FR} no longer collides with one measured under {region=GB_IE} for the same use case + factors fingerprint.

### Filename format

| Profile | Filename |
|---|---|
| Empty (legacy / covariate-insensitive) | `{useCaseId}.{methodName}-{factorsFingerprint}.yaml` |
| Non-empty | `{useCaseId}.{methodName}-{factorsFingerprint}-{cov1}-{cov2}...-{covN}.yaml` |

Empty-profile filenames are **byte-identical** to pre-CV-3b. Existing on-disk baselines stay matchable after the upgrade.

### Hash algorithm (per EX09, normative)

```
first4(sha256("{key}={canonical_value}"))
```

- `{key}` is the covariate name as `Covariate.name()` returns it
- `{canonical_value}` is the resolved label from CV-2's resolver contract — partition labels for built-ins, IANA string for timezone, supplier output for custom
- Separator is exactly `=` with no whitespace
- Input is UTF-8 bytes; truncation is first 4 hex characters of SHA-256
- Hashes appear in **declaration order** (`CovariateProfile` preserves insertion order through the round-trip; we iterate it)

### Resolver behaviour

`BaselineResolver` matching relaxes the suffix check: the fingerprint segment may be terminated by either `.yaml` (legacy form) or `-` (start of a covariate hash). The new check also rejects a confounding case it previously couldn't have hit — searching for fingerprint `aabbccdd` no longer matches a file whose fingerprint is `aabbccddee`.

Stage 4 stays exact-match on `(useCaseId, fingerprint)`; when multiple covariate-partitioned files share the same fingerprint, the resolver returns the first by file-listing order. **Covariate-aware best-match selection lands in CV-3c.**

## Test plan

- [x] `CovariateHashingTest` — 6 cases: empty profile / shape & length / declaration order sensitivity / determinism / sensitivity to inputs / matches normative algorithm
- [x] `BaselineRecordTest` — appends-correctly-with-profile / unchanged-when-empty
- [x] `BaselineResolverTest` — matches-covariate-bearing-filename / does-not-confuse-prefix-fingerprint
- [x] All existing baseline tests pass (no callsite changes for empty profiles)
- [x] `./gradlew build` green across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)