### PR TITLE
CV-3d: wire CovariateResolver into measure emission and test resolution

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
@@ -1,63 +1,102 @@
 package org.javai.punit.api.typed.spec;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 
 /**
  * The framework's read-side adapter for resolving baseline statistics
  * at criterion-evaluation time.
  *
- * <p>Conceptually a small functional interface (one query method); kept
- * as a regular interface so the {@link #EMPTY} constant has a stable
- * place to live. Implementations live in the engine layer
- * (e.g. punit-core's {@code engine.baseline.YamlBaselineProvider}); the
- * {@code punit-api} module declares only the contract.
+ * <p>Conceptually a small functional interface (one query method per
+ * concern); kept as a regular interface so the {@link #EMPTY} constant
+ * has a stable place to live. Implementations live in the engine
+ * layer (e.g. punit-core's {@code engine.baseline.YamlBaselineProvider});
+ * the {@code punit-api} module declares only the contract.
  *
  * <p>The framework consults a {@code BaselineProvider} once per
  * empirical {@link Criterion} during {@link Spec#dispatch dispatch} of
  * a {@link ProbabilisticTest}'s {@code conclude} call, populating the
  * matching slot on the {@link EvaluationContext}.
  *
- * <h2>Stage 4 lookup contract</h2>
+ * <h2>Lookup contract</h2>
  *
- * <p>Stage-4 implementations resolve by exact match on
- * <em>(use case id, factors fingerprint, criterion name)</em>. The
- * {@link FactorBundle} is the runtime carrier of the factors record;
- * implementations derive a fingerprint from
- * {@code String.valueOf(factors.value())} or equivalent, matching the
- * write-side fingerprint algorithm.
+ * <p>The covariate-aware overloads ({@link #baselineFor(String, FactorBundle,
+ * String, Class, CovariateProfile, List)} and the matching identity
+ * lookup) are the primary contract. Implementations supply them.
+ * The convenience overloads without {@code currentProfile} and
+ * {@code declarations} default-delegate with {@link CovariateProfile#empty()}
+ * and {@link List#of()}; covariate-aware implementations interpret
+ * those defaults as the legacy ("use case declares no covariates")
+ * path.
  *
- * <p>A future stage may add covariate-aware closest-match resolution;
- * this interface stays unchanged because the additional matching
- * happens entirely inside the implementation.
+ * <p>The framework wraps the underlying provider in a profile-bound
+ * decorator before handing it to {@link Spec#dispatch} so that
+ * spec implementations can call the convenience overloads and still
+ * exercise covariate-aware lookup with the run's resolved profile.
+ *
+ * @see CovariateProfile
+ * @see Covariate
  */
 public interface BaselineProvider {
 
     /**
+     * @param currentProfile the resolved covariate profile for the
+     *                       current run; {@link CovariateProfile#empty()}
+     *                       when the use case declared no covariates
+     * @param declarations   the use case's covariate declarations,
+     *                       in declaration order; {@link List#of()}
+     *                       when the use case declared no covariates
      * @return the baseline statistics of the requested kind for the
-     *         given (use case, factors, criterion) tuple, or
-     *         {@link Optional#empty()} when no matching baseline is
-     *         resolvable.
+     *         best-matching baseline per UC05, or {@link Optional#empty()}
+     *         when none is selectable
      */
     <S extends BaselineStatistics> Optional<S> baselineFor(
             String useCaseId,
             FactorBundle factors,
             String criterionName,
-            Class<S> statisticsType);
+            Class<S> statisticsType,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations);
 
     /**
-     * @return the inputs identity recorded by the resolved baseline
-     *         for the given (use case, factors) pair, or
-     *         {@link Optional#empty()} when no matching baseline file
-     *         exists. The value is the
-     *         {@code Sampling.inputsIdentity()} the writer captured
-     *         at MEASURE time. Used for the cross-process
-     *         {@link EmpiricalChecks#inputsIdentityMatch}
-     *         integrity check.
+     * Covariate-aware identity lookup. Used for the cross-process
+     * {@link EmpiricalChecks#inputsIdentityMatch} integrity check.
      */
     Optional<String> baselineInputsIdentityFor(
-            String useCaseId, FactorBundle factors);
+            String useCaseId,
+            FactorBundle factors,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations);
+
+    /**
+     * Convenience overload for callers that don't carry covariate
+     * state. Equivalent to the covariate-aware overload with empty
+     * profile + empty declarations — restricts selection to
+     * baselines whose own profile is empty.
+     */
+    default <S extends BaselineStatistics> Optional<S> baselineFor(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType) {
+        return baselineFor(useCaseId, factors, criterionName, statisticsType,
+                CovariateProfile.empty(), List.of());
+    }
+
+    /**
+     * Convenience overload for callers that don't carry covariate
+     * state. Same legacy semantics as the four-arg
+     * {@link #baselineFor(String, FactorBundle, String, Class) baselineFor}.
+     */
+    default Optional<String> baselineInputsIdentityFor(
+            String useCaseId, FactorBundle factors) {
+        return baselineInputsIdentityFor(useCaseId, factors,
+                CovariateProfile.empty(), List.of());
+    }
 
     /**
      * The empty provider — always returns {@link Optional#empty()}.
@@ -70,13 +109,16 @@ public interface BaselineProvider {
                 String useCaseId,
                 FactorBundle factors,
                 String criterionName,
-                Class<S> statisticsType) {
+                Class<S> statisticsType,
+                CovariateProfile currentProfile,
+                List<Covariate> declarations) {
             return Optional.empty();
         }
 
         @Override
         public Optional<String> baselineInputsIdentityFor(
-                String useCaseId, FactorBundle factors) {
+                String useCaseId, FactorBundle factors,
+                CovariateProfile currentProfile, List<Covariate> declarations) {
             return Optional.empty();
         }
     };

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/ProfileBoundBaselineProvider.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/ProfileBoundBaselineProvider.java
@@ -1,0 +1,104 @@
+package org.javai.punit.engine.baseline;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.spec.BaselineProvider;
+import org.javai.punit.api.typed.spec.BaselineStatistics;
+
+/**
+ * Wraps a {@link BaselineProvider} with a captured covariate profile
+ * and declarations so that legacy-shape lookups (no profile/declarations
+ * arguments) become covariate-aware lookups against the captured
+ * values.
+ *
+ * <p>The framework constructs one of these per probabilistic-test run
+ * after resolving the run's covariate profile from the use case, so
+ * that {@link org.javai.punit.api.typed.spec.ProbabilisticTest#dispatch}
+ * implementations can call the convenience overloads on
+ * {@code BaselineProvider} and still exercise covariate-aware
+ * selection.
+ *
+ * <p>The covariate-aware overloads pass through with whatever profile
+ * / declarations the caller supplies; only the legacy overloads get
+ * the captured-profile substitution. This means a caller that
+ * <em>already</em> has covariate state can still bypass the binding
+ * and pass its own.
+ */
+public final class ProfileBoundBaselineProvider implements BaselineProvider {
+
+    private final BaselineProvider delegate;
+    private final CovariateProfile profile;
+    private final List<Covariate> declarations;
+
+    private ProfileBoundBaselineProvider(
+            BaselineProvider delegate,
+            CovariateProfile profile,
+            List<Covariate> declarations) {
+        this.delegate = delegate;
+        this.profile = profile;
+        this.declarations = declarations;
+    }
+
+    /**
+     * @return a binding wrapper, or {@code delegate} unchanged when
+     *         there is nothing to bind ({@code declarations} empty)
+     */
+    public static BaselineProvider bind(
+            BaselineProvider delegate,
+            CovariateProfile profile,
+            List<Covariate> declarations) {
+        Objects.requireNonNull(delegate, "delegate");
+        Objects.requireNonNull(profile, "profile");
+        Objects.requireNonNull(declarations, "declarations");
+        if (declarations.isEmpty()) {
+            // No covariates declared → legacy semantics suffice.
+            // Avoiding the wrapper keeps stack traces and toString
+            // honest for non-covariate use cases.
+            return delegate;
+        }
+        return new ProfileBoundBaselineProvider(delegate,
+                profile, List.copyOf(declarations));
+    }
+
+    @Override
+    public <S extends BaselineStatistics> Optional<S> baselineFor(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
+        return delegate.baselineFor(useCaseId, factors, criterionName,
+                statisticsType, currentProfile, declarations);
+    }
+
+    @Override
+    public Optional<String> baselineInputsIdentityFor(
+            String useCaseId, FactorBundle factors,
+            CovariateProfile currentProfile, List<Covariate> declarations) {
+        return delegate.baselineInputsIdentityFor(
+                useCaseId, factors, currentProfile, declarations);
+    }
+
+    @Override
+    public <S extends BaselineStatistics> Optional<S> baselineFor(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType) {
+        return delegate.baselineFor(useCaseId, factors, criterionName,
+                statisticsType, profile, declarations);
+    }
+
+    @Override
+    public Optional<String> baselineInputsIdentityFor(
+            String useCaseId, FactorBundle factors) {
+        return delegate.baselineInputsIdentityFor(useCaseId, factors,
+                profile, declarations);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
@@ -1,10 +1,13 @@
 package org.javai.punit.engine.baseline;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 
@@ -32,15 +35,20 @@ public final class YamlBaselineProvider implements BaselineProvider {
             String useCaseId,
             FactorBundle factors,
             String criterionName,
-            Class<S> statisticsType) {
+            Class<S> statisticsType,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
         String fingerprint = FactorsFingerprint.of(factors);
-        return resolver.resolve(useCaseId, fingerprint, criterionName, statisticsType);
+        return resolver.resolve(useCaseId, fingerprint, criterionName, statisticsType,
+                currentProfile, declarations);
     }
 
     @Override
     public Optional<String> baselineInputsIdentityFor(
-            String useCaseId, FactorBundle factors) {
+            String useCaseId, FactorBundle factors,
+            CovariateProfile currentProfile, List<Covariate> declarations) {
         String fingerprint = FactorsFingerprint.of(factors);
-        return resolver.resolveInputsIdentity(useCaseId, fingerprint);
+        return resolver.resolveInputsIdentity(useCaseId, fingerprint,
+                currentProfile, declarations);
     }
 }

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
@@ -6,12 +6,15 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.InputSupplier;
 import org.javai.punit.api.typed.LatencyResult;
 import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 import org.javai.punit.api.typed.spec.Configuration;
 import org.javai.punit.api.typed.spec.Experiment;
@@ -23,6 +26,7 @@ import org.javai.punit.api.typed.spec.TypedSpec;
 import org.javai.punit.engine.baseline.BaselineRecord;
 import org.javai.punit.engine.baseline.BaselineWriter;
 import org.javai.punit.engine.baseline.FactorsFingerprint;
+import org.javai.punit.engine.covariate.CovariateResolver;
 
 /**
  * Translates a completed MEASURE {@link Experiment} into a
@@ -115,6 +119,18 @@ final class BaselineEmitter {
             stats.put("percentile-latency", new LatencyStatistics(latency, total));
         }
 
+        // Per UC04, the resolved covariate profile is part of the
+        // baseline's identity. The use case's declarations + custom
+        // resolvers feed the resolver; the resulting profile is
+        // stamped into the BaselineRecord and surfaces as an EX09
+        // covariate-hash tail in the filename, plus a covariates:
+        // block in the YAML body.
+        List<Covariate> declarations = useCase.covariates();
+        CovariateProfile profile = declarations.isEmpty()
+                ? CovariateProfile.empty()
+                : CovariateResolver.defaults()
+                        .resolve(declarations, useCase.customCovariateResolvers());
+
         return new BaselineRecord(
                 useCaseId,
                 experimentId,
@@ -122,7 +138,8 @@ final class BaselineEmitter {
                 inputsIdentity,
                 total,
                 Instant.now(),
-                stats);
+                stats,
+                profile);
     }
 
     private static void writeRecord(BaselineRecord record, Path baselineDir) {

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -22,7 +22,12 @@ import org.javai.punit.api.typed.spec.ProbabilisticTest;
 import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
 import org.javai.punit.api.typed.spec.Scorer;
 import org.javai.punit.api.typed.spec.Verdict;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.engine.Engine;
+import org.javai.punit.engine.baseline.ProfileBoundBaselineProvider;
+import org.javai.punit.engine.covariate.CovariateResolver;
 import org.javai.punit.engine.criteria.Feasibility;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
@@ -111,12 +116,49 @@ public final class Punit {
     // ── Internal: drive an experiment / test ────────────────────────
 
     private static EngineResult drive(org.javai.punit.api.typed.spec.Spec spec) {
-        return new Engine(BaselineProviderResolver.resolve()).run(spec);
+        BaselineProvider provider = profileBoundProvider(spec);
+        return new Engine(provider).run(spec);
     }
 
     private static void driveAndEmit(Experiment experiment) {
         drive(experiment);
         BaselineEmitter.emit(experiment, BaselineProviderResolver.resolveDir());
+    }
+
+    /**
+     * Resolves the use case's covariate profile from {@code spec}'s
+     * first configuration and wraps {@link BaselineProviderResolver}'s
+     * provider so the engine and pre-flight feasibility see a
+     * profile-bound view.
+     *
+     * <p>Per UC04 the profile is resolved once per run, before any
+     * samples execute. {@link ProfileBoundBaselineProvider#bind}
+     * returns the wrapped delegate unchanged when the use case
+     * declared no covariates, so non-covariate tests pay no cost
+     * here.
+     */
+    private static BaselineProvider profileBoundProvider(
+            org.javai.punit.api.typed.spec.Spec spec) {
+        BaselineProvider provider = BaselineProviderResolver.resolve();
+        return spec.dispatch(new org.javai.punit.api.typed.spec.Spec.Dispatcher<>() {
+            @Override
+            public <FT, IT, OT> BaselineProvider apply(
+                    org.javai.punit.api.typed.spec.TypedSpec<FT, IT, OT> typed) {
+                var configs = typed.configurations();
+                if (!configs.hasNext()) {
+                    return provider;
+                }
+                FT factors = configs.next().factors();
+                UseCase<FT, IT, OT> useCase = typed.useCaseFactory().apply(factors);
+                List<Covariate> declarations = useCase.covariates();
+                if (declarations.isEmpty()) {
+                    return provider;
+                }
+                CovariateProfile profile = CovariateResolver.defaults()
+                        .resolve(declarations, useCase.customCovariateResolvers());
+                return ProfileBoundBaselineProvider.bind(provider, profile, declarations);
+            }
+        });
     }
 
     private static void translate(ProbabilisticTestResult result) {
@@ -333,9 +375,20 @@ public final class Punit {
         }
 
         private List<String> preflightFeasibility() {
-            String useCaseId = sampling.useCaseFactory().apply(factors).id();
+            UseCase<FT, IT, OT> useCase = sampling.useCaseFactory().apply(factors);
+            String useCaseId = useCase.id();
             FactorBundle bundle = FactorBundle.of(factors);
-            BaselineProvider provider = BaselineProviderResolver.resolve();
+            BaselineProvider raw = BaselineProviderResolver.resolve();
+            // Bind the run's covariate profile so Feasibility sees the
+            // baseline that will actually drive evaluation, not a sibling
+            // covariate-tagged file that happens to share useCaseId+ff.
+            List<Covariate> declarations = useCase.covariates();
+            CovariateProfile profile = declarations.isEmpty()
+                    ? CovariateProfile.empty()
+                    : CovariateResolver.defaults()
+                            .resolve(declarations, useCase.customCovariateResolvers());
+            BaselineProvider provider = ProfileBoundBaselineProvider.bind(
+                    raw, profile, declarations);
             List<String> warnings = new ArrayList<>();
             for (Criterion<OT, ?> c : requiredCriteria) {
                 warnings.addAll(Feasibility.check(
@@ -416,7 +469,7 @@ public final class Punit {
 
         @SuppressWarnings("unchecked")
         private List<String> preflightFeasibility(ProbabilisticTest spec) {
-            BaselineProvider provider = BaselineProviderResolver.resolve();
+            BaselineProvider raw = BaselineProviderResolver.resolve();
             List<String> warnings = new ArrayList<>();
             spec.dispatch(new org.javai.punit.api.typed.spec.Spec.Dispatcher<Void>() {
                 @Override
@@ -424,8 +477,16 @@ public final class Punit {
                         org.javai.punit.api.typed.spec.TypedSpec<FT, IT, OT> typed) {
                     var cfg = typed.configurations().next();
                     FT factors = cfg.factors();
-                    String useCaseId = typed.useCaseFactory().apply(factors).id();
+                    UseCase<FT, IT, OT> useCase = typed.useCaseFactory().apply(factors);
+                    String useCaseId = useCase.id();
                     FactorBundle bundle = FactorBundle.of(factors);
+                    List<Covariate> declarations = useCase.covariates();
+                    CovariateProfile profile = declarations.isEmpty()
+                            ? CovariateProfile.empty()
+                            : CovariateResolver.defaults()
+                                    .resolve(declarations, useCase.customCovariateResolvers());
+                    BaselineProvider provider = ProfileBoundBaselineProvider.bind(
+                            raw, profile, declarations);
                     warnings.addAll(Feasibility.check(
                             cfg.samples(),
                             (Criterion<Object, ?>) criterion,

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
@@ -1,0 +1,116 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.javai.punit.junit5.testsubjects.CovariateSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * End-to-end covariate wiring: a use case declares a custom
+ * {@code region} covariate; a measure experiment writes a baseline
+ * stamped with the resolved value; an empirical test resolves the
+ * matching baseline at evaluate time. Demonstrates that the
+ * declaration→resolution→identity→matching loop is closed.
+ */
+@DisplayName("Covariate end-to-end: MEASURE writes profile, TEST resolves matching baseline")
+class CovariateRoundTripTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+
+    @TempDir Path baselineDir;
+    private String savedProperty;
+    private String savedCustomCovariate;
+
+    @BeforeEach
+    void setUp() {
+        savedProperty = System.getProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY,
+                baselineDir.toString());
+        savedCustomCovariate = System.getProperty(CovariateSubjects.REGION_PROPERTY);
+        System.setProperty(CovariateSubjects.REGION_PROPERTY, "EU");
+    }
+
+    @AfterEach
+    void tearDown() {
+        restoreProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, savedProperty);
+        restoreProperty(CovariateSubjects.REGION_PROPERTY, savedCustomCovariate);
+    }
+
+    private static void restoreProperty(String key, String saved) {
+        if (saved == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, saved);
+        }
+    }
+
+    @Test
+    @DisplayName("measure stamps the resolved covariate profile into the baseline filename")
+    void measureWritesProfileStampedFilename() throws IOException {
+        Events events = run(CovariateSubjects.MeasureWithCovariate.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+
+        try (Stream<Path> files = Files.list(baselineDir)) {
+            List<Path> emitted = files.toList();
+            assertThat(emitted)
+                    .as("baseline emitted under %s", baselineDir)
+                    .hasSize(1);
+            String filename = emitted.get(0).getFileName().toString();
+            // EX09: filename ends with -{covHash}.yaml when a covariate
+            // is declared. The exact hash is environment-derived; we
+            // pin shape, not value.
+            assertThat(filename)
+                    .startsWith(CovariateSubjects.USE_CASE_ID + ".measureBaseline-")
+                    // Factors fingerprint is 8 hex chars; one declared
+                    // covariate adds a -{4-hex} tail per EX09.
+                    .matches(".*-[0-9a-f]{8}-[0-9a-f]{4}\\.yaml$");
+        }
+    }
+
+    @Test
+    @DisplayName("test under matching covariate resolves the just-written baseline")
+    void testResolvesMatchingBaseline() throws IOException {
+        // Phase 1: write a baseline under region=EU.
+        run(CovariateSubjects.MeasureWithCovariate.class)
+                .assertStatistics(stats -> stats.started(1).succeeded(1));
+
+        // Phase 2: empirical test under same region=EU resolves it.
+        Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
+        testEvents.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+    }
+
+    @Test
+    @DisplayName("test under non-matching covariate produces INCONCLUSIVE (no matching baseline)")
+    void testUnderDifferentCovariateInconclusive() throws IOException {
+        // Phase 1: write baseline under region=EU.
+        run(CovariateSubjects.MeasureWithCovariate.class)
+                .assertStatistics(stats -> stats.started(1).succeeded(1));
+
+        // Phase 2: switch region to APAC; no baseline under that
+        // partition exists, the empty-profile fallback isn't there
+        // either → INCONCLUSIVE → JUnit aborted (skipped) test.
+        System.setProperty(CovariateSubjects.REGION_PROPERTY, "APAC");
+        Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
+        testEvents.assertStatistics(stats -> stats.started(1).aborted(1));
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -1,0 +1,101 @@
+package org.javai.punit.junit5.testsubjects;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.javai.punit.api.CovariateCategory;
+import org.javai.punit.api.Experiment;
+import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.javai.punit.api.typed.covariate.Covariate;
+import org.javai.punit.engine.criteria.BernoulliPassRate;
+import org.javai.punit.junit5.Punit;
+
+/**
+ * Test subjects for {@link org.javai.punit.junit5.CovariateRoundTripTest}.
+ *
+ * <p>The use case declares one custom covariate ({@code region}) whose
+ * resolver reads a system property. The test sets the property in
+ * {@code @BeforeEach}, runs a measure to stamp a baseline with the
+ * resolved value, then runs an empirical test that should resolve
+ * the matching baseline.
+ */
+public final class CovariateSubjects {
+
+    public static final String USE_CASE_ID = "covariate-subject";
+    public static final String REGION_PROPERTY = "punit.test.region";
+
+    private CovariateSubjects() { }
+
+    public record NoFactors() { }
+
+    /**
+     * A use case that always passes and declares a single CONFIGURATION
+     * covariate read from {@link #REGION_PROPERTY}. Hard-gating
+     * CONFIGURATION means a test under {@code region=APAC} cannot
+     * silently fall back to a baseline measured under {@code region=EU}.
+     */
+    private static UseCase<NoFactors, Integer, Boolean> covariateUseCase() {
+        return new UseCase<>() {
+            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+                return UseCaseOutcome.ok(true);
+            }
+            @Override public String id() { return USE_CASE_ID; }
+
+            @Override
+            public List<Covariate> covariates() {
+                return List.of(Covariate.custom("region",
+                        CovariateCategory.CONFIGURATION));
+            }
+
+            @Override
+            public Map<String, Supplier<String>> customCovariateResolvers() {
+                return Map.of("region",
+                        () -> System.getProperty(REGION_PROPERTY, "UNSET"));
+            }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> covariateUseCase())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    /** Phase 1: stamp a baseline under whatever value REGION_PROPERTY holds. */
+    public static final class MeasureWithCovariate {
+        @Experiment
+        void measureBaseline() {
+            Punit.measuring(sampling(100), new NoFactors())
+                    .experimentId("measureBaseline")
+                    .run();
+        }
+    }
+
+    /**
+     * Phase 2: run the empirical test. Resolution finds the baseline
+     * stamped with the matching covariate; criterion produces PASS
+     * when match found, INCONCLUSIVE when no match (the
+     * "different region" scenario in the round-trip test).
+     */
+    public static final class TestWithMatchingCovariate {
+        @ProbabilisticTest
+        void shouldMatchBaseline() {
+            // Wilson lower bound at observed=1.0, n=20, c=0.95 ≈ 0.83;
+            // baseline observed rate is 1.0 → bound 0.83 < threshold
+            // 1.0 → would FAIL on a strict-rate baseline. We instead
+            // assert resolution-time correctness: when the baseline
+            // matches we get a real verdict (not INCONCLUSIVE), and
+            // when it doesn't we get INCONCLUSIVE.
+            Punit.testing(sampling(20), new NoFactors())
+                    .criterion(BernoulliPassRate.<Boolean>empirical()
+                            .atConfidence(0.50))
+                    .assertPasses();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Final sub-slice of CV-3 (baseline identity). Closes the **declaration → resolution → identity → matching** loop. Builds on CV-1 (#78), CV-2 (#79), CV-3a (#80), CV-3b (#81), CV-3c (#82).

Authors who declare covariates on a `UseCase` now see the full integrity story end-to-end: measure runs stamp the resolved profile into the baseline; tests resolve the matching baseline at evaluate time, producing INCONCLUSIVE when no profile matches rather than silently using a "wrong" baseline.

### What's wired

**API contract change** (additive, with default delegation):
- `BaselineProvider` grows two abstract methods that take a `CovariateProfile` + `List<Covariate>`. The pre-CV-3d signatures become *default* methods that delegate with empty profile + empty declarations — semantically equivalent to the old behaviour for callers with no covariate state.
- `YamlBaselineProvider` implements the new abstract methods, delegating to `BaselineResolver`'s CV-3c covariate-aware overloads.
- `BaselineProvider.EMPTY` overrides the new abstracts.

**Profile binding** (`engine.baseline.ProfileBoundBaselineProvider`):
- Wraps a provider with a captured `(profile, declarations)` pair. Overrides the legacy convenience methods to forward to the underlying provider's covariate-aware methods using the captured values.
- `Punit.drive(spec)` resolves the profile from the spec's first configuration and binds it before constructing the `Engine`. The engine + `ProbabilisticTest` dispatch path doesn't change.
- `Punit.TestBuilder.preflightFeasibility` and `EmpiricalTestBuilder.preflightFeasibility` do the same wrapping so the pre-flight gate sees the same baseline as the engine.
- `bind(...)` returns the unwrapped delegate when `declarations` is empty — non-covariate use cases pay no per-call overhead.

**Measure-side wiring** (`BaselineEmitter`):
- `composeRecord()` now resolves the use case's covariate profile via `CovariateResolver.defaults()` and passes it to the canonical `BaselineRecord` constructor. The profile surfaces via the YAML `covariates:` block (CV-3a) and the EX09 filename hash (CV-3b).
- Use cases with no declared covariates produce empty-profile baselines — byte-identical to pre-CV-3 emissions.

Per UC04 the resolver is invoked **once per run** (at the run-level boundaries — `Punit.drive` / `preflightFeasibility`), not once per sample.

## Test plan

- [x] `CovariateRoundTripTest` exercises the full loop with a use case declaring a custom CONFIGURATION covariate read from a system property:
  1. Measure stamps the resolved value into the baseline filename (regex pins the EX09 4-hex-tail shape)
  2. Test under matching covariate resolves the just-written baseline → **PASS**
  3. Test under non-matching covariate produces **INCONCLUSIVE** → JUnit aborted (skipped). Demonstrates the integrity rule: baselines are not silently reused across covariate identity.
- [x] All existing punit + punit-junit5 tests pass; non-covariate use cases continue to write byte-identical filenames and YAML
- [x] `./gradlew build` green across all modules

## CV-3 series complete

- ✅ CV-3a (#80) — `CovariateProfile` field on `BaselineRecord` + YAML schema
- ✅ CV-3b (#81) — filename hashes per EX09
- ✅ CV-3c (#82) — covariate-aware best-match selection per UC05
- 🟡 CV-3d (this PR) — engine wiring; closes the loop

After this lands: **CV-4** (verdict surfacing of misalignment) and **CV-5** (migrate `ShoppingBasketCovariateTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)