### PR TITLE
CV-4: surface covariate misalignment in verdict warnings

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineLookup.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineLookup.java
@@ -1,0 +1,51 @@
+package org.javai.punit.api.typed.spec;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The richer return shape of
+ * {@link BaselineProvider#baselineLookup(String, org.javai.punit.api.typed.FactorBundle, String, Class, org.javai.punit.api.typed.covariate.CovariateProfile, java.util.List)}.
+ *
+ * <p>Carries the same {@code Optional<S>} that the convenience
+ * {@code baselineFor} returns, plus a list of human-readable notes
+ * about <em>why</em> a baseline was or wasn't selected — typically
+ * one note per rejected candidate ("rejected: {file} —
+ * CONFIGURATION mismatch on model_version (current=v1, baseline=v2)").
+ *
+ * <p>Notes are surfaced through {@link ProbabilisticTestResult#warnings()}
+ * so that an INCONCLUSIVE verdict explains the misalignment in the
+ * report rather than leaving the author to infer it.
+ *
+ * @param <S> the requested {@link BaselineStatistics} subtype
+ * @param selected the selected statistics, when a candidate matched
+ * @param notes    rejection / fallback reasons; possibly empty
+ */
+public record BaselineLookup<S extends BaselineStatistics>(
+        Optional<S> selected,
+        List<String> notes) {
+
+    public BaselineLookup {
+        Objects.requireNonNull(selected, "selected");
+        Objects.requireNonNull(notes, "notes");
+        notes = List.copyOf(notes);
+    }
+
+    /**
+     * @return an empty lookup ({@link Optional#empty()} selected, no
+     *         notes) — the legacy "nothing to say" outcome
+     */
+    public static <S extends BaselineStatistics> BaselineLookup<S> empty() {
+        return new BaselineLookup<>(Optional.empty(), List.of());
+    }
+
+    /**
+     * @return a lookup that wraps an existing {@code Optional<S>} with
+     *         no notes — convenience for default-method delegates
+     */
+    public static <S extends BaselineStatistics> BaselineLookup<S> of(
+            Optional<S> selected) {
+        return new BaselineLookup<>(selected, List.of());
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineProvider.java
@@ -99,6 +99,47 @@ public interface BaselineProvider {
     }
 
     /**
+     * Lookup that returns both the selected statistics and a list of
+     * human-readable notes describing rejected candidates and
+     * fallback decisions — for surfacing through
+     * {@link ProbabilisticTestResult#warnings()} so an INCONCLUSIVE
+     * verdict can explain <em>why</em> the baseline didn't match.
+     *
+     * <p>Default implementation delegates to {@link #baselineFor}
+     * and produces no notes. Concrete providers override to populate
+     * the notes from the selection algorithm.
+     */
+    default <S extends BaselineStatistics> BaselineLookup<S> baselineLookup(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
+        return BaselineLookup.of(baselineFor(
+                useCaseId, factors, criterionName, statisticsType,
+                currentProfile, declarations));
+    }
+
+    /**
+     * Convenience overload of {@link #baselineLookup} for callers
+     * (typically the typed-spec dispatch path) that don't carry
+     * covariate state directly. Delegates with empty profile + empty
+     * declarations; the framework's profile-bound decorator
+     * overrides this to substitute the run's captured covariate
+     * state, so a bare call from {@code conclude()} still exercises
+     * covariate-aware lookup.
+     */
+    default <S extends BaselineStatistics> BaselineLookup<S> baselineLookup(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType) {
+        return baselineLookup(useCaseId, factors, criterionName, statisticsType,
+                CovariateProfile.empty(), List.of());
+    }
+
+    /**
      * The empty provider — always returns {@link Optional#empty()}.
      * Used by the engine's no-arg / unconfigured paths and by tests
      * that don't exercise empirical resolution.

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -174,16 +174,24 @@ public final class ProbabilisticTest implements Spec {
                     : Optional.empty();
 
             List<EvaluatedCriterion> evaluated = new ArrayList<>(registered.size());
+            // De-duplicated misalignment notes — selection runs once per
+            // empirical criterion against the same file, so each criterion
+            // accumulates the same notes; recording per-criterion would
+            // produce N copies of every reason. The notes describe the
+            // baseline file's misalignment, not any one criterion's.
+            java.util.LinkedHashSet<String> warnings = new java.util.LinkedHashSet<>();
             for (Registered<OT> entry : registered) {
                 CriterionResult result = evaluate(
                         entry.criterion(), s, factorBundle, useCaseId,
-                        testInputsIdentity, baselineInputsIdentity, provider);
+                        testInputsIdentity, baselineInputsIdentity,
+                        provider, warnings);
                 evaluated.add(new EvaluatedCriterion(result, entry.role()));
             }
 
             Verdict composed = Verdict.compose(evaluated);
             return new ProbabilisticTestResult(
-                    composed, factorBundle, evaluated, intent, List.of());
+                    composed, factorBundle, evaluated, intent,
+                    List.copyOf(warnings));
         }
 
         private boolean anyEmpiricalCriterion() {
@@ -203,12 +211,18 @@ public final class ProbabilisticTest implements Spec {
                 String useCaseId,
                 String testInputsIdentity,
                 Optional<String> baselineInputsIdentity,
-                BaselineProvider provider) {
+                BaselineProvider provider,
+                java.util.Set<String> warnings) {
             Criterion raw = criterion;
-            Optional<? extends BaselineStatistics> resolved = criterion.isEmpirical()
-                    ? provider.baselineFor(
-                            useCaseId, factorBundle, criterion.name(), criterion.statisticsType())
-                    : Optional.empty();
+            Optional<? extends BaselineStatistics> resolved;
+            if (criterion.isEmpirical()) {
+                BaselineLookup<? extends BaselineStatistics> lookup = provider.baselineLookup(
+                        useCaseId, factorBundle, criterion.name(), criterion.statisticsType());
+                resolved = lookup.selected();
+                warnings.addAll(lookup.notes());
+            } else {
+                resolved = Optional.empty();
+            }
             EvaluationContext ctx = new EvaluationContext<OT, BaselineStatistics>() {
                 @Override public SampleSummary<OT> summary() { return s; }
                 @Override public Optional<BaselineStatistics> baseline() {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import org.javai.punit.api.typed.covariate.Covariate;
 import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.spec.BaselineLookup;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 
 /**
@@ -88,6 +89,23 @@ public final class BaselineResolver {
             Class<S> statisticsType,
             CovariateProfile currentProfile,
             List<Covariate> declarations) {
+        return lookup(useCaseId, factorsFingerprint, criterionName,
+                statisticsType, currentProfile, declarations).selected();
+    }
+
+    /**
+     * Like {@link #resolve} but additionally returns selection notes
+     * (one per rejected candidate, plus partial-match / fallback
+     * announcements) for surfacing through
+     * {@link org.javai.punit.api.typed.spec.ProbabilisticTestResult#warnings()}.
+     */
+    public <S extends BaselineStatistics> BaselineLookup<S> lookup(
+            String useCaseId,
+            String factorsFingerprint,
+            String criterionName,
+            Class<S> statisticsType,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
         Objects.requireNonNull(useCaseId, "useCaseId");
         Objects.requireNonNull(factorsFingerprint, "factorsFingerprint");
         Objects.requireNonNull(criterionName, "criterionName");
@@ -95,14 +113,15 @@ public final class BaselineResolver {
         Objects.requireNonNull(currentProfile, "currentProfile");
         Objects.requireNonNull(declarations, "declarations");
 
-        Optional<BaselineRecord> selected = findAndSelect(
+        BaselineSelector.SelectionReport report = findAndSelectWithReport(
                 useCaseId, factorsFingerprint, currentProfile, declarations);
+        Optional<BaselineRecord> selected = report.selected();
         if (selected.isEmpty()) {
-            return Optional.empty();
+            return new BaselineLookup<>(Optional.empty(), report.notes());
         }
         BaselineStatistics entry = selected.get().statisticsByCriterionName().get(criterionName);
         if (entry == null) {
-            return Optional.empty();
+            return new BaselineLookup<>(Optional.empty(), report.notes());
         }
         if (!statisticsType.isInstance(entry)) {
             throw new IllegalStateException(
@@ -112,7 +131,7 @@ public final class BaselineResolver {
                             + statisticsType.getSimpleName()
                             + " — write-side and read-side criterion kinds disagree");
         }
-        return Optional.of(statisticsType.cast(entry));
+        return new BaselineLookup<>(Optional.of(statisticsType.cast(entry)), report.notes());
     }
 
     /**
@@ -148,11 +167,21 @@ public final class BaselineResolver {
             String factorsFingerprint,
             CovariateProfile currentProfile,
             List<Covariate> declarations) {
+        return findAndSelectWithReport(useCaseId, factorsFingerprint,
+                currentProfile, declarations).selected();
+    }
+
+    private BaselineSelector.SelectionReport findAndSelectWithReport(
+            String useCaseId,
+            String factorsFingerprint,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
         List<BaselineRecord> candidates = findRecords(useCaseId, factorsFingerprint);
         if (candidates.isEmpty()) {
-            return Optional.empty();
+            return BaselineSelector.SelectionReport.NONE;
         }
-        return BaselineSelector.select(candidates, currentProfile, declarations);
+        return BaselineSelector.selectWithReport(
+                candidates, currentProfile, declarations);
     }
 
     private List<BaselineRecord> findRecords(String useCaseId, String factorsFingerprint) {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineSelector.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineSelector.java
@@ -86,46 +86,96 @@ final class BaselineSelector {
             List<BaselineRecord> candidates,
             CovariateProfile currentProfile,
             List<Covariate> declarations) {
+        return selectWithReport(candidates, currentProfile, declarations).selected;
+    }
+
+    /**
+     * Selects the best-matching baseline (UC05) and returns the
+     * decision <em>plus</em> a list of human-readable notes capturing
+     * each candidate that was rejected and why. The notes are surfaced
+     * upstream through {@link BaselineLookup#notes()} so that an
+     * INCONCLUSIVE verdict explains the misalignment.
+     *
+     * <p>Notes are only emitted on the covariate-aware path
+     * ({@code declarations} non-empty); the legacy "no declarations"
+     * path returns an empty notes list.
+     */
+    static SelectionReport selectWithReport(
+            List<BaselineRecord> candidates,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
         Objects.requireNonNull(candidates, "candidates");
         Objects.requireNonNull(currentProfile, "currentProfile");
         Objects.requireNonNull(declarations, "declarations");
 
         if (candidates.isEmpty()) {
-            return Optional.empty();
+            return SelectionReport.NONE;
         }
         // No covariate declarations → only match unstamped baselines.
         // Preserves pre-CV-3 behaviour for use cases that don't opt in.
         if (declarations.isEmpty()) {
-            return candidates.stream()
-                    .filter(c -> c.covariateProfile().isEmpty())
-                    .findFirst();
+            return new SelectionReport(
+                    candidates.stream()
+                            .filter(c -> c.covariateProfile().isEmpty())
+                            .findFirst(),
+                    List.of());
         }
 
         Map<String, CovariateCategory> categoriesByName = categoryIndex(declarations);
 
         List<Scored> scored = new ArrayList<>(candidates.size());
+        List<String> notes = new ArrayList<>();
         for (BaselineRecord c : candidates) {
-            Scored s = score(c, currentProfile, categoriesByName);
-            if (s == null) {
-                continue;
+            ScoreResult result = scoreWithReason(c, currentProfile, categoriesByName);
+            if (result.scored != null) {
+                Scored s = result.scored;
+                // A covariate-tagged candidate that matches zero
+                // declared covariates is the "wrong" baseline by
+                // identity — it was measured under environmental
+                // conditions disjoint from the current run. Reject it;
+                // the empty-profile baseline (UC05's default fallback)
+                // is the only candidate allowed at score 0.
+                if (s.matches == 0 && !c.covariateProfile().isEmpty()) {
+                    notes.add(rejectedNote(c.filename(),
+                            "no overlap with the current covariate profile"));
+                    continue;
+                }
+                scored.add(s);
+            } else {
+                notes.add(rejectedNote(c.filename(), result.rejectionReason));
             }
-            // A covariate-tagged candidate that matches zero declared
-            // covariates is the "wrong" baseline by identity — it was
-            // measured under environmental conditions disjoint from
-            // the current run. Reject it; the empty-profile baseline
-            // (UC05's default fallback) is the only candidate allowed
-            // at score 0.
-            if (s.matches == 0 && !c.covariateProfile().isEmpty()) {
-                continue;
-            }
-            scored.add(s);
         }
 
         if (scored.isEmpty()) {
-            return Optional.empty();
+            return new SelectionReport(Optional.empty(), List.copyOf(notes));
         }
         scored.sort(BEST_FIRST);
-        return Optional.of(scored.get(0).record);
+        Scored chosen = scored.get(0);
+        // Note partial matches and default-fallback selections so the
+        // verdict report can flag them — full-match selections are
+        // expected and not noisy enough to warrant a note.
+        if (chosen.matches < declarations.size()) {
+            if (chosen.record.covariateProfile().isEmpty()) {
+                notes.add("falling back to default (covariate-insensitive) baseline "
+                        + chosen.record.filename()
+                        + " — no covariate-tagged candidate matched");
+            } else {
+                notes.add("partial match: " + chosen.record.filename()
+                        + " — matched " + chosen.matches + " of "
+                        + declarations.size() + " declared covariates");
+            }
+        }
+        return new SelectionReport(Optional.of(chosen.record), List.copyOf(notes));
+    }
+
+    private static String rejectedNote(String filename, String reason) {
+        return "rejected " + filename + " — " + reason;
+    }
+
+    /** Selection result with notes for verdict-level surfacing. */
+    record SelectionReport(Optional<BaselineRecord> selected, List<String> notes) {
+        static final SelectionReport NONE =
+                new SelectionReport(Optional.empty(), List.of());
     }
 
     private static Map<String, CovariateCategory> categoryIndex(
@@ -139,14 +189,16 @@ final class BaselineSelector {
     }
 
     /**
-     * @return the candidate's score, or {@code null} when it must be
-     *         rejected (a CONFIGURATION-category covariate disagrees).
+     * @return either a populated {@link ScoreResult#scored} (the
+     *         candidate is a viable match) or a populated
+     *         {@link ScoreResult#rejectionReason} explaining the
+     *         CONFIGURATION-category mismatch that rejected it.
      *         The empty-profile candidate scores 0 with no matched
      *         categories — it loses any tie-breaker to a candidate
      *         that matched something, but wins as a fallback when no
      *         scoring candidate beats it.
      */
-    private static Scored score(
+    private static ScoreResult scoreWithReason(
             BaselineRecord candidate,
             CovariateProfile current,
             Map<String, CovariateCategory> categoriesByName) {
@@ -170,20 +222,37 @@ final class BaselineSelector {
             // was measured before that covariate was declared, and
             // we cannot prove it was equivalent.
             if (category.isHardGate() && !valuesAgree && baselineDeclares) {
-                return null;
+                return ScoreResult.rejected(String.format(
+                        "%s mismatch on %s (current=%s, baseline=%s)",
+                        category.name(), name,
+                        currentValue == null ? "<unset>" : currentValue,
+                        baselineValue));
             }
             if (valuesAgree) {
                 matches++;
                 matchedCategories.add(category);
             }
         }
-        return new Scored(candidate, matches, matchedCategories);
+        return ScoreResult.matched(new Scored(candidate, matches, matchedCategories));
     }
 
     private record Scored(
             BaselineRecord record,
             int matches,
             List<CovariateCategory> matchedCategories) { }
+
+    /**
+     * Outcome of evaluating one candidate: either a viable match
+     * (with score) or an outright rejection (with reason text).
+     */
+    private record ScoreResult(Scored scored, String rejectionReason) {
+        static ScoreResult matched(Scored scored) {
+            return new ScoreResult(scored, null);
+        }
+        static ScoreResult rejected(String reason) {
+            return new ScoreResult(null, reason);
+        }
+    }
 
     /**
      * Higher score first; on tie, candidate whose best matched

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/ProfileBoundBaselineProvider.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/ProfileBoundBaselineProvider.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.covariate.Covariate;
 import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.spec.BaselineLookup;
 import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 
@@ -100,5 +101,27 @@ public final class ProfileBoundBaselineProvider implements BaselineProvider {
             String useCaseId, FactorBundle factors) {
         return delegate.baselineInputsIdentityFor(useCaseId, factors,
                 profile, declarations);
+    }
+
+    @Override
+    public <S extends BaselineStatistics> BaselineLookup<S> baselineLookup(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
+        return delegate.baselineLookup(useCaseId, factors, criterionName,
+                statisticsType, currentProfile, declarations);
+    }
+
+    @Override
+    public <S extends BaselineStatistics> BaselineLookup<S> baselineLookup(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType) {
+        return delegate.baselineLookup(useCaseId, factors, criterionName,
+                statisticsType, profile, declarations);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/YamlBaselineProvider.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.covariate.Covariate;
 import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.spec.BaselineLookup;
 import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 
@@ -50,5 +51,18 @@ public final class YamlBaselineProvider implements BaselineProvider {
         String fingerprint = FactorsFingerprint.of(factors);
         return resolver.resolveInputsIdentity(useCaseId, fingerprint,
                 currentProfile, declarations);
+    }
+
+    @Override
+    public <S extends BaselineStatistics> BaselineLookup<S> baselineLookup(
+            String useCaseId,
+            FactorBundle factors,
+            String criterionName,
+            Class<S> statisticsType,
+            CovariateProfile currentProfile,
+            List<Covariate> declarations) {
+        String fingerprint = FactorsFingerprint.of(factors);
+        return resolver.lookup(useCaseId, fingerprint, criterionName,
+                statisticsType, currentProfile, declarations);
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineSelectorTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineSelectorTest.java
@@ -245,6 +245,95 @@ class BaselineSelectorTest {
         }
 
         @Test
+        @DisplayName("selectWithReport: CONFIGURATION rejection surfaces a structured note")
+        void reportConfigurationRejection() {
+            BaselineRecord wrongModel = baseline("ff", profile(Map.of(
+                    "day_of_week", "WEEKDAY",
+                    "region", "DE_FR",
+                    "model_version", "v2")));
+
+            BaselineSelector.SelectionReport report = BaselineSelector.selectWithReport(
+                    List.of(wrongModel), current, declarations);
+
+            assertThat(report.selected()).isEmpty();
+            assertThat(report.notes()).hasSize(1);
+            assertThat(report.notes().get(0))
+                    .contains("rejected " + wrongModel.filename())
+                    .contains("CONFIGURATION mismatch on model_version")
+                    .contains("current=v1")
+                    .contains("baseline=v2");
+        }
+
+        @Test
+        @DisplayName("selectWithReport: zero-overlap rejection surfaces its own note")
+        void reportZeroOverlapRejection() {
+            List<Covariate> softOnly = List.of(
+                    Covariate.dayOfWeek(List.of(java.util.Set.of(java.time.DayOfWeek.MONDAY))),
+                    Covariate.region(List.of(java.util.Set.of("FR"))));
+            CovariateProfile softCurrent = profile(Map.of(
+                    "day_of_week", "WEEKDAY",
+                    "region", "FR"));
+            BaselineRecord allDisagree = baseline("ff", profile(Map.of(
+                    "day_of_week", "WEEKEND",
+                    "region", "OTHER")));
+
+            BaselineSelector.SelectionReport report = BaselineSelector.selectWithReport(
+                    List.of(allDisagree), softCurrent, softOnly);
+
+            assertThat(report.selected()).isEmpty();
+            assertThat(report.notes()).hasSize(1);
+            assertThat(report.notes().get(0))
+                    .contains("rejected " + allDisagree.filename())
+                    .contains("no overlap");
+        }
+
+        @Test
+        @DisplayName("selectWithReport: partial match emits a note alongside the selection")
+        void reportPartialMatch() {
+            BaselineRecord partial = baseline("ff", profile(Map.of(
+                    "day_of_week", "WEEKDAY",
+                    "region", "GB_IE",
+                    "model_version", "v1")));
+
+            BaselineSelector.SelectionReport report = BaselineSelector.selectWithReport(
+                    List.of(partial), current, declarations);
+
+            assertThat(report.selected()).contains(partial);
+            assertThat(report.notes()).hasSize(1);
+            assertThat(report.notes().get(0))
+                    .contains("partial match")
+                    .contains(partial.filename())
+                    .contains("matched 2 of 3 declared covariates");
+        }
+
+        @Test
+        @DisplayName("selectWithReport: default-fallback selection emits a note")
+        void reportDefaultFallback() {
+            BaselineRecord empty = baseline("ff", CovariateProfile.empty());
+
+            BaselineSelector.SelectionReport report = BaselineSelector.selectWithReport(
+                    List.of(empty), current, declarations);
+
+            assertThat(report.selected()).contains(empty);
+            assertThat(report.notes()).hasSize(1);
+            assertThat(report.notes().get(0))
+                    .contains("falling back to default")
+                    .contains(empty.filename());
+        }
+
+        @Test
+        @DisplayName("selectWithReport: exact match emits no notes (silence on success)")
+        void reportExactMatchSilent() {
+            BaselineRecord exact = baseline("ff", current);
+
+            BaselineSelector.SelectionReport report = BaselineSelector.selectWithReport(
+                    List.of(exact), current, declarations);
+
+            assertThat(report.selected()).contains(exact);
+            assertThat(report.notes()).isEmpty();
+        }
+
+        @Test
         @DisplayName("a CONFIGURATION covariate omitted from the baseline is treated as a mismatch")
         void omittedConfigIsMismatch() {
             // The empty-profile candidate fields no model_version.

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -187,6 +187,15 @@ public final class Punit {
                         .append(cr.explanation()).append('\n');
             }
         }
+        // Misalignment / fallback notes from baseline selection — appear
+        // here so an INCONCLUSIVE verdict explains *why* the baseline
+        // didn't match (CONFIGURATION mismatch, partial match, fallback).
+        if (!result.warnings().isEmpty()) {
+            sb.append('\n');
+            for (String warning : result.warnings()) {
+                sb.append("  ! ").append(warning).append('\n');
+            }
+        }
         return sb.toString().trim();
     }
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
@@ -107,6 +107,31 @@ class CovariateRoundTripTest {
         testEvents.assertStatistics(stats -> stats.started(1).aborted(1));
     }
 
+    @Test
+    @DisplayName("misalignment surfaces in the JUnit abort message — author sees why")
+    void misalignmentExplainedInVerdict() throws IOException {
+        run(CovariateSubjects.MeasureWithCovariate.class)
+                .assertStatistics(stats -> stats.started(1).succeeded(1));
+
+        System.setProperty(CovariateSubjects.REGION_PROPERTY, "APAC");
+        Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
+
+        // The aborted-event payload carries the diagnostic that the
+        // empirical Punit.testing(...) translates from the test result.
+        // It should mention the rejection reason for the EU baseline.
+        testEvents.aborted()
+                .assertThatEvents()
+                .anySatisfy(event -> {
+                    var throwable = event.getRequiredPayload(
+                            org.junit.platform.engine.TestExecutionResult.class)
+                            .getThrowable().orElseThrow();
+                    org.assertj.core.api.Assertions.assertThat(throwable.getMessage())
+                            .contains("CONFIGURATION mismatch on region")
+                            .contains("current=APAC")
+                            .contains("baseline=EU");
+                });
+    }
+
     private static Events run(Class<?> testClass) {
         return EngineTestKit.engine(JUNIT_ENGINE_ID)
                 .selectors(DiscoverySelectors.selectClass(testClass))


### PR DESCRIPTION
## Summary

Final layer of CV-3's integrity story. Builds on CV-1 (#78), CV-2 (#79), CV-3a (#80), CV-3b (#81), CV-3c (#82), CV-3d (#83). Authors who run a test under covariates that don't match any baseline now see **why** in the verdict diagnostic, not just the generic "no matching baseline was resolvable":

```
INCONCLUSIVE
  [REQUIRED] bernoulli-pass-rate → INCONCLUSIVE: no matching baseline was resolvable …

  ! rejected basket.measure-aabbcc-eeff.yaml — CONFIGURATION mismatch on model_version (current=v1, baseline=v2)
  ! falling back to default (covariate-insensitive) baseline basket.measure-aabbcc.yaml — no covariate-tagged candidate matched
```

### Selection-time changes (`engine.baseline`)

- `BaselineSelector` grows `selectWithReport(...)` returning a `SelectionReport(selected, notes)`. Existing `select(...)` keeps its `Optional<BaselineRecord>` shape and delegates. Notes capture:
  - each **rejected** candidate (CONFIGURATION mismatch with the current/baseline values, or zero-overlap)
  - **partial matches** (selected, but matched fewer than all declared covariates — flagged so authors can audit)
  - **default-fallback selections** (empty-profile baseline used when no covariate-tagged candidate scored positively)
- Exact matches emit **no note** — silence on success.
- `BaselineResolver` gains `lookup(...)` returning the new `BaselineLookup<S>`; `resolve(...)` keeps `Optional<S>` and delegates.

### API surface (`punit-api`)

- New `BaselineLookup<S>` record carrying `Optional<S> selected` + `List<String> notes`.
- `BaselineProvider` grows two `baselineLookup` overloads (6-arg covariate-aware and 4-arg convenience), both default to delegating through `baselineFor` with empty notes. Existing `baselineFor` methods unchanged.
- `YamlBaselineProvider` overrides `baselineLookup` to consult the resolver's rich lookup. `ProfileBoundBaselineProvider` overrides both overloads — the 4-arg substitutes the captured profile, the 6-arg passes through.

### Wiring

- `ProbabilisticTest.conclude` calls `baselineLookup` per empirical criterion, accumulates notes into a `LinkedHashSet` (multiple criteria look up the same file → same notes; dedup keeps the warnings list clean), passes them into `ProbabilisticTestResult.warnings`.
- `Punit.formatMessage` appends warnings under the per-criterion breakdown so the JUnit abort message includes them. The pre-existing warnings slot (previously used only for SMOKE feasibility `[SMOKE] …` notes) becomes the natural carrier.

## Test plan

- [x] 5 new `BaselineSelectorTest` cases for `selectWithReport`: CONFIGURATION rejection / zero-overlap rejection / partial match / default fallback / exact-match silence
- [x] `CovariateRoundTripTest` grows `misalignmentExplainedInVerdict`: a test that fails baseline matching surfaces the rejection text in the JUnit abort message
- [x] All existing tests pass; non-covariate use cases still emit no warnings (notes list empty when declarations is empty)
- [x] `./gradlew build` green across all modules

## CV series status after this lands

- ✅ CV-1 → CV-3d (#78–#83 merged)
- 🟡 CV-4 (this PR) — verdict surfacing
- ⏭ **CV-5** — migrate `ShoppingBasketCovariateTest` to the typed API and close the migration blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)