### PR TITLE
Share baseline-directory resolution; PowerAnalysis no longer leaks Path

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +34,34 @@ import org.javai.punit.api.typed.spec.BaselineStatistics;
  * closest-match is strictly more permissive.
  */
 public final class BaselineResolver {
+
+    /** System property used to override the baseline directory. */
+    public static final String BASELINE_DIR_PROPERTY = "punit.baseline.dir";
+
+    /** Convention-default directory under the project root. */
+    public static final String CONVENTION_PATH = "src/test/resources/punit/baselines";
+
+    /**
+     * Resolves the baseline directory from {@value #BASELINE_DIR_PROPERTY}
+     * if set, otherwise from the convention path
+     * {@value #CONVENTION_PATH}. The returned path is not required to
+     * exist — callers that read or list it must handle a missing
+     * directory.
+     *
+     * <p>Exposed for utilities that consume the same baseline directory
+     * the test pipeline does (e.g.
+     * {@link org.javai.punit.power.PowerAnalysis}). The JUnit
+     * extension's {@code BaselineProviderResolver} delegates here too
+     * so framework and user code resolve the same path through one
+     * implementation.
+     */
+    public static Path defaultDir() {
+        String prop = System.getProperty(BASELINE_DIR_PROPERTY);
+        if (prop != null && !prop.isBlank()) {
+            return Paths.get(prop.trim());
+        }
+        return Paths.get(CONVENTION_PATH);
+    }
 
     private final Path baselineDir;
     private final BaselineReader reader;

--- a/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
+++ b/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
@@ -59,6 +59,26 @@ public final class PowerAnalysis {
     private PowerAnalysis() { }
 
     /**
+     * Convenience overload that resolves the baseline directory the
+     * same way the test pipeline does — via
+     * {@link BaselineResolver#defaultDir()}, which honours the
+     * {@code punit.baseline.dir} system property and falls back to
+     * the project convention path.
+     *
+     * <p>This is the right call for tests using {@code PowerAnalysis}
+     * inside an {@code @ProbabilisticTest} method body — the test
+     * doesn't need to know where baselines live; the framework does.
+     *
+     * @see #sampleSize(Path, Supplier, double, double)
+     */
+    public static int sampleSize(
+            Supplier<Experiment> baseline,
+            double mde,
+            double power) {
+        return sampleSize(BaselineResolver.defaultDir(), baseline, mde, power);
+    }
+
+    /**
      * Computes the sample size required to detect a difference of at
      * least {@code mde} from the baseline's recorded pass rate at the
      * given statistical power, using the default confidence

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
@@ -1,26 +1,28 @@
 package org.javai.punit.junit5;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Optional;
 
 import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.engine.baseline.BaselineResolver;
 import org.javai.punit.engine.baseline.YamlBaselineProvider;
 
 /**
- * Resolves the baseline directory and the
- * {@link BaselineProvider} consumed by {@link Punit#testing}-style
- * empirical criteria and emitted to by {@link Punit#measuring}-style
- * experiments.
+ * Resolves the {@link BaselineProvider} consumed by
+ * {@link Punit#testing}-style empirical criteria and emitted to by
+ * {@link Punit#measuring}-style experiments. Directory resolution
+ * delegates to {@link BaselineResolver#defaultDir()} — the same
+ * implementation any other consumer (e.g.
+ * {@link org.javai.punit.power.PowerAnalysis}) calls — so framework
+ * and user code resolve the same path through one source of truth.
  *
- * <p>Precedence:
+ * <p>Precedence (defined in {@code BaselineResolver}):
  *
  * <ol>
- *   <li>System property {@value #BASELINE_DIR_PROPERTY} — explicit
- *       per-run override (CI environments, ad-hoc invocations).</li>
- *   <li>Project convention {@value #CONVENTION_PATH} — the default;
- *       baselines travel with source.</li>
+ *   <li>System property {@value BaselineResolver#BASELINE_DIR_PROPERTY}
+ *       — explicit per-run override (CI environments, ad-hoc
+ *       invocations).</li>
+ *   <li>Project convention {@value BaselineResolver#CONVENTION_PATH}
+ *       — the default; baselines travel with source.</li>
  * </ol>
  *
  * <p>A future revision can layer a JUnit configuration-parameter
@@ -28,53 +30,43 @@ import org.javai.punit.engine.baseline.YamlBaselineProvider;
  * {@code ExtensionContext}-aware overload. Not needed for 1.0.
  *
  * <p>When no candidate resolves to an existing directory, the
- * provider is {@link BaselineProvider#EMPTY} and empirical criteria
- * yield {@code INCONCLUSIVE} per the resolver contract. Measure
+ * provider's lookups return empty and empirical criteria yield
+ * {@code INCONCLUSIVE} per the resolver contract. Measure
  * experiments still run; their baseline write is silently skipped
  * (see {@link Punit.MeasureBuilder#run}).
  */
 final class BaselineProviderResolver {
 
-    /** System property used to override the baseline directory. */
-    static final String BASELINE_DIR_PROPERTY = "punit.baseline.dir";
-
-    /** Convention-default directory under the project root. */
-    static final String CONVENTION_PATH = "src/test/resources/punit/baselines";
+    /**
+     * Re-exposed for tests that want to set the system property
+     * deterministically; the canonical declaration is on
+     * {@link BaselineResolver}.
+     */
+    static final String BASELINE_DIR_PROPERTY =
+            BaselineResolver.BASELINE_DIR_PROPERTY;
 
     private BaselineProviderResolver() { }
 
     /**
-     * @return the configured baseline directory. Returns the
-     *         system-property path when set, otherwise the
-     *         convention-default {@value #CONVENTION_PATH} path.
-     *         The directory is not required to exist —
-     *         {@link BaselineEmitter} creates it on first write,
-     *         and the {@link BaselineResolver} downstream handles
-     *         missing directories (returns empty for any lookup).
-     *         Symmetric with the legacy convention.
+     * @return the configured baseline directory. The directory is
+     *         not required to exist — {@link BaselineEmitter}
+     *         creates it on first write, and the
+     *         {@link BaselineResolver} downstream handles missing
+     *         directories (returns empty for any lookup).
      */
     static Path resolveDir() {
-        return systemProperty().orElseGet(() -> Paths.get(CONVENTION_PATH));
+        return BaselineResolver.defaultDir();
     }
 
     /**
      * @return a {@link YamlBaselineProvider} backed by the resolved
      *         baseline directory. When the directory is missing the
-     *         provider's lookups return empty for every query (the
-     *         underlying {@link BaselineResolver} treats a missing
-     *         directory as "no baselines available"), so the
-     *         empirical-criterion path produces {@code INCONCLUSIVE}
-     *         — the same outcome as a hard {@link BaselineProvider#EMPTY}.
+     *         provider's lookups return empty for every query, so
+     *         the empirical-criterion path produces
+     *         {@code INCONCLUSIVE} — the same outcome as a hard
+     *         {@link BaselineProvider#EMPTY}.
      */
     static BaselineProvider resolve() {
         return new YamlBaselineProvider(resolveDir());
-    }
-
-    private static Optional<Path> systemProperty() {
-        String value = System.getProperty(BASELINE_DIR_PROPERTY);
-        if (value == null || value.isBlank()) {
-            return Optional.empty();
-        }
-        return Optional.of(Paths.get(value.trim()));
     }
 }

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineProviderResolverTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineProviderResolverTest.java
@@ -47,7 +47,7 @@ class BaselineProviderResolverTest {
     @DisplayName("with no property set, falls back to the convention path")
     void noPropertyConvention() {
         assertThat(BaselineProviderResolver.resolveDir())
-                .isEqualTo(Paths.get(BaselineProviderResolver.CONVENTION_PATH));
+                .isEqualTo(Paths.get(org.javai.punit.engine.baseline.BaselineResolver.CONVENTION_PATH));
         assertThat(BaselineProviderResolver.resolve()).isInstanceOf(YamlBaselineProvider.class);
     }
 


### PR DESCRIPTION
## Summary

Surfaced from a punitexamples migration review (punitexamples#22 — `ShoppingBasketThresholdApproachesTest`): tests that called `PowerAnalysis.sampleSize(...)` had to pass a `Path` argument and hardcode the convention path themselves, because the directory-resolution logic lived privately in punit-junit5's `BaselineProviderResolver` and `PowerAnalysis` (in punit-core) couldn't reach it. The `Path` parameter was leaking an internal concern ("where do baselines live?") into user-facing API.

### Changes

- `BASELINE_DIR_PROPERTY` and `CONVENTION_PATH` constants move from `BaselineProviderResolver` to **`BaselineResolver`** (punit-core), where any consumer can reach them. Single source of truth.
- `BaselineResolver.defaultDir()` — the static resolution method — now lives in punit-core. Honours `punit.baseline.dir` if set, falls back to the convention path.
- `BaselineProviderResolver` delegates to `BaselineResolver.defaultDir()`. Re-exposes `BASELINE_DIR_PROPERTY` for tests that set the system property deterministically (canonical declaration is now on `BaselineResolver`).
- `PowerAnalysis` grows a no-`Path` overload: `sampleSize(baseline, mde, power)` that uses `BaselineResolver.defaultDir()` internally. The existing `Path`-taking overload stays for callers who really do want to point at a custom directory (e.g. integration tests with a dedicated baseline corpus).

### Effect

Test authors using `PowerAnalysis` no longer need a static `BASELINE_DIR` constant. The `confidenceFirst` test in punitexamples#22 will collapse from:

```java
private static final Path BASELINE_DIR =
        Path.of("src/test/resources/punit/baselines");
...
int n = PowerAnalysis.sampleSize(BASELINE_DIR, this::baseline, 0.05, 0.80);
```

to:

```java
int n = PowerAnalysis.sampleSize(this::baseline, 0.05, 0.80);
```

That follow-up commit goes on the punitexamples PR after this lands.

## Test plan

- [x] `./gradlew build` green across all modules
- [x] Existing `BaselineProviderResolver` tests pass via the delegated path (one test updated to read the constant from its new home)
- [x] `PowerAnalysis` existing `Path`-taking overload signature unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)