### PR TITLE
Wire transparent statistics into the typed pipeline

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/covariate/CovariateAlignment.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/covariate/CovariateAlignment.java
@@ -1,0 +1,109 @@
+package org.javai.punit.api.typed.covariate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * The alignment between a probabilistic test's observed (current
+ * run's) covariate profile and the matched baseline's covariate
+ * profile. Mirrors the legacy {@code CovariateStatus} so downstream
+ * consumers — verdict-text renderers, HTML report emitters, JSON
+ * sinks — see the same structured shape from both pipelines.
+ *
+ * <p>Empty profiles (the use case declared no covariates) produce
+ * the {@link #aligned() aligned} state with no misalignments. A
+ * baseline profile that matches the observed profile component-
+ * by-component also produces aligned. Any divergence — different
+ * value, key present in one and not the other — produces a
+ * {@link Mismatch} entry and {@code aligned == false}.
+ *
+ * @param observed       the run's resolved profile at sample time
+ * @param baseline       the matched baseline's profile
+ *                       ({@link CovariateProfile#empty()} when no
+ *                       baseline was matched, or when the matched
+ *                       baseline carried no covariate data)
+ * @param aligned        derived: {@code true} iff every key in
+ *                       {@code observed} ∪ {@code baseline} agrees
+ * @param mismatches     derived: per-key differences between the
+ *                       two profiles, in baseline-key insertion
+ *                       order followed by observed-only keys
+ */
+public record CovariateAlignment(
+        CovariateProfile observed,
+        CovariateProfile baseline,
+        boolean aligned,
+        List<Mismatch> mismatches) {
+
+    /**
+     * One key on which observed and baseline disagree.
+     *
+     * @param covariateKey the covariate name
+     * @param observed     the run-time value, or {@code null} when
+     *                     the key is present only on the baseline
+     * @param baseline     the baseline value, or {@code null} when
+     *                     the key is present only on the observed
+     *                     profile
+     */
+    public record Mismatch(String covariateKey, String observed, String baseline) {
+
+        public Mismatch {
+            Objects.requireNonNull(covariateKey, "covariateKey");
+        }
+    }
+
+    public CovariateAlignment {
+        Objects.requireNonNull(observed, "observed");
+        Objects.requireNonNull(baseline, "baseline");
+        Objects.requireNonNull(mismatches, "mismatches");
+        mismatches = List.copyOf(mismatches);
+    }
+
+    /**
+     * @return the canonical "no covariates declared, no baseline
+     *         matched" alignment — both profiles empty, aligned, no
+     *         mismatches
+     */
+    public static CovariateAlignment none() {
+        return new CovariateAlignment(
+                CovariateProfile.empty(), CovariateProfile.empty(), true, List.of());
+    }
+
+    /**
+     * Computes alignment from the two profiles. Aligned when the
+     * baseline is empty (nothing to compare against) or when every
+     * key on either side has equal values.
+     */
+    public static CovariateAlignment compute(
+            CovariateProfile observed, CovariateProfile baseline) {
+        Objects.requireNonNull(observed, "observed");
+        Objects.requireNonNull(baseline, "baseline");
+        if (baseline.isEmpty()) {
+            // No matched baseline, or the matched baseline had no
+            // covariate stamping. Nothing to misalign against.
+            return new CovariateAlignment(observed, baseline, true, List.of());
+        }
+        List<Mismatch> mismatches = new ArrayList<>();
+        // Compare baseline-side keys first, then any observed-only.
+        Set<String> seen = new TreeSet<>();
+        for (var entry : baseline.values().entrySet()) {
+            seen.add(entry.getKey());
+            String observedValue = observed.get(entry.getKey()).orElse(null);
+            if (!entry.getValue().equals(observedValue)) {
+                mismatches.add(new Mismatch(
+                        entry.getKey(), observedValue, entry.getValue()));
+            }
+        }
+        for (var entry : observed.values().entrySet()) {
+            if (seen.add(entry.getKey())) {
+                // Observed key absent from baseline — also a mismatch.
+                mismatches.add(new Mismatch(
+                        entry.getKey(), entry.getValue(), null));
+            }
+        }
+        return new CovariateAlignment(
+                observed, baseline, mismatches.isEmpty(), List.copyOf(mismatches));
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineLookup.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineLookup.java
@@ -4,48 +4,67 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+
 /**
  * The richer return shape of
  * {@link BaselineProvider#baselineLookup(String, org.javai.punit.api.typed.FactorBundle, String, Class, org.javai.punit.api.typed.covariate.CovariateProfile, java.util.List)}.
  *
  * <p>Carries the same {@code Optional<S>} that the convenience
- * {@code baselineFor} returns, plus a list of human-readable notes
- * about <em>why</em> a baseline was or wasn't selected — typically
- * one note per rejected candidate ("rejected: {file} —
- * CONFIGURATION mismatch on model_version (current=v1, baseline=v2)").
+ * {@code baselineFor} returns, plus:
  *
- * <p>Notes are surfaced through {@link ProbabilisticTestResult#warnings()}
- * so that an INCONCLUSIVE verdict explains the misalignment in the
- * report rather than leaving the author to infer it.
+ * <ul>
+ *   <li>{@code baselineProfile} — the resolved baseline's covariate
+ *       profile, when one was selected. Empty when no baseline
+ *       matched, or when the matched baseline carried no covariate
+ *       data (legacy / pre-CV-3a baselines).</li>
+ *   <li>{@code notes} — human-readable selection diagnostics: one
+ *       per rejected candidate, plus partial-match / fallback
+ *       announcements. Surfaced through
+ *       {@link ProbabilisticTestResult#warnings()} so an INCONCLUSIVE
+ *       verdict explains <em>why</em> the baseline didn't match.</li>
+ * </ul>
+ *
+ * <p>The baseline profile is what makes the verdict's "covariate
+ * alignment" diagnostic possible: comparing the matched baseline's
+ * profile against the current run's profile (resolved separately at
+ * the engine boundary) lets the renderer produce the
+ * {@code baseline=X, observed=Y} misalignment block the legacy
+ * pipeline emits.
  *
  * @param <S> the requested {@link BaselineStatistics} subtype
- * @param selected the selected statistics, when a candidate matched
- * @param notes    rejection / fallback reasons; possibly empty
+ * @param selected         the selected statistics, when a candidate matched
+ * @param baselineProfile  the matched baseline's covariate profile,
+ *                         when one was selected; otherwise empty
+ * @param notes            rejection / fallback reasons; possibly empty
  */
 public record BaselineLookup<S extends BaselineStatistics>(
         Optional<S> selected,
+        CovariateProfile baselineProfile,
         List<String> notes) {
 
     public BaselineLookup {
         Objects.requireNonNull(selected, "selected");
+        Objects.requireNonNull(baselineProfile, "baselineProfile");
         Objects.requireNonNull(notes, "notes");
         notes = List.copyOf(notes);
     }
 
     /**
-     * @return an empty lookup ({@link Optional#empty()} selected, no
-     *         notes) — the legacy "nothing to say" outcome
+     * @return an empty lookup ({@link Optional#empty()} selected,
+     *         empty profile, no notes)
      */
     public static <S extends BaselineStatistics> BaselineLookup<S> empty() {
-        return new BaselineLookup<>(Optional.empty(), List.of());
+        return new BaselineLookup<>(Optional.empty(), CovariateProfile.empty(), List.of());
     }
 
     /**
      * @return a lookup that wraps an existing {@code Optional<S>} with
-     *         no notes — convenience for default-method delegates
+     *         no profile + no notes — convenience for default-method
+     *         delegates
      */
     public static <S extends BaselineStatistics> BaselineLookup<S> of(
             Optional<S> selected) {
-        return new BaselineLookup<>(selected, List.of());
+        return new BaselineLookup<>(selected, CovariateProfile.empty(), List.of());
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -180,18 +180,49 @@ public final class ProbabilisticTest implements Spec {
             // produce N copies of every reason. The notes describe the
             // baseline file's misalignment, not any one criterion's.
             java.util.LinkedHashSet<String> warnings = new java.util.LinkedHashSet<>();
+            // The matched baseline's covariate profile. All empirical
+            // criteria that resolve a baseline for the same
+            // (useCaseId, factorsFingerprint) tuple resolve the same
+            // file, so the first non-empty profile we see is the one
+            // for the run. Stamped onto the result so verdict
+            // renderers / HTML emitters can compare against the
+            // observed profile (post-stamped at the JUnit boundary).
+            org.javai.punit.api.typed.covariate.CovariateProfile baselineProfile =
+                    org.javai.punit.api.typed.covariate.CovariateProfile.empty();
             for (Registered<OT> entry : registered) {
+                BaselineLookupCapture capture = new BaselineLookupCapture();
                 CriterionResult result = evaluate(
                         entry.criterion(), s, factorBundle, useCaseId,
                         testInputsIdentity, baselineInputsIdentity,
-                        provider, warnings);
+                        provider, warnings, capture);
                 evaluated.add(new EvaluatedCriterion(result, entry.role()));
+                if (baselineProfile.isEmpty() && !capture.profile.isEmpty()) {
+                    baselineProfile = capture.profile;
+                }
             }
 
             Verdict composed = Verdict.compose(evaluated);
             return new ProbabilisticTestResult(
                     composed, factorBundle, evaluated, intent,
-                    List.copyOf(warnings));
+                    List.copyOf(warnings),
+                    org.javai.punit.api.typed.covariate.CovariateAlignment.compute(
+                            org.javai.punit.api.typed.covariate.CovariateProfile.empty(),
+                            baselineProfile));
+        }
+
+        /**
+         * Side channel for {@link #evaluate} to surface the matched
+         * baseline's covariate profile back to {@link #conclude}.
+         * Kept off {@link CriterionResult} because the matched-baseline
+         * profile is a lookup-side concern, not a criterion-semantic
+         * concern — every empirical criterion that resolves a
+         * baseline for the same {@code (useCaseId, factorsFingerprint)}
+         * tuple sees the same profile, so the data belongs to the
+         * run, not to any one criterion.
+         */
+        private static final class BaselineLookupCapture {
+            org.javai.punit.api.typed.covariate.CovariateProfile profile =
+                    org.javai.punit.api.typed.covariate.CovariateProfile.empty();
         }
 
         private boolean anyEmpiricalCriterion() {
@@ -212,7 +243,8 @@ public final class ProbabilisticTest implements Spec {
                 String testInputsIdentity,
                 Optional<String> baselineInputsIdentity,
                 BaselineProvider provider,
-                java.util.Set<String> warnings) {
+                java.util.Set<String> warnings,
+                BaselineLookupCapture capture) {
             Criterion raw = criterion;
             Optional<? extends BaselineStatistics> resolved;
             if (criterion.isEmpirical()) {
@@ -220,6 +252,7 @@ public final class ProbabilisticTest implements Spec {
                         useCaseId, factorBundle, criterion.name(), criterion.statisticsType());
                 resolved = lookup.selected();
                 warnings.addAll(lookup.notes());
+                capture.profile = lookup.baselineProfile();
             } else {
                 resolved = Optional.empty();
             }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
 
 /**
  * The result of running a {@link ProbabilisticTest} — the composed
@@ -24,18 +25,28 @@ import org.javai.punit.api.typed.FactorBundle;
  * future feasibility-check machinery can decide whether a verification
  * claim is statistically supportable for the chosen sample size.
  *
+ * <p>{@link #covariates()} carries the alignment between the run's
+ * resolved covariate profile and the matched baseline's covariate
+ * profile (when an empirical criterion matched one). The structured
+ * value flows through to verdict-text renderers, HTML report
+ * emitters, and JSON sinks, mirroring the legacy pipeline's
+ * {@code CovariateStatus} so downstream tooling sees the same shape
+ * from both pipelines.
+ *
  * @param verdict          the composed PASS / FAIL / INCONCLUSIVE
  * @param factors          the factor bundle observed
  * @param criterionResults the full ordered list of evaluated criteria
  * @param intent           the test's declared intent (VERIFICATION / SMOKE)
  * @param warnings         free-form warnings (e.g. "statistics wiring pending")
+ * @param covariates       observed-vs-baseline covariate alignment
  */
 public record ProbabilisticTestResult(
         Verdict verdict,
         FactorBundle factors,
         List<EvaluatedCriterion> criterionResults,
         TestIntent intent,
-        List<String> warnings) implements EngineResult {
+        List<String> warnings,
+        CovariateAlignment covariates) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -43,7 +54,35 @@ public record ProbabilisticTestResult(
         Objects.requireNonNull(criterionResults, "criterionResults");
         Objects.requireNonNull(intent, "intent");
         Objects.requireNonNull(warnings, "warnings");
+        Objects.requireNonNull(covariates, "covariates");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);
+    }
+
+    /**
+     * Convenience constructor for callers that don't carry covariate
+     * alignment. Equivalent to the canonical constructor with
+     * {@link CovariateAlignment#none()}.
+     */
+    public ProbabilisticTestResult(
+            Verdict verdict,
+            FactorBundle factors,
+            List<EvaluatedCriterion> criterionResults,
+            TestIntent intent,
+            List<String> warnings) {
+        this(verdict, factors, criterionResults, intent, warnings,
+                CovariateAlignment.none());
+    }
+
+    /**
+     * @return a copy of this result with the given covariate
+     *         alignment substituted. Used by the JUnit pipeline to
+     *         post-stamp the observed profile (resolved at the
+     *         test-extension boundary) onto the result coming back
+     *         from {@code Spec.conclude}.
+     */
+    public ProbabilisticTestResult withCovariates(CovariateAlignment covariates) {
+        return new ProbabilisticTestResult(
+                verdict, factors, criterionResults, intent, warnings, covariates);
     }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/covariate/CovariateAlignmentTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/covariate/CovariateAlignmentTest.java
@@ -1,0 +1,130 @@
+package org.javai.punit.api.typed.covariate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CovariateAlignment — observed-vs-baseline structural alignment")
+class CovariateAlignmentTest {
+
+    @Test
+    @DisplayName("none() represents the no-covariates-declared state")
+    void noneCanonical() {
+        CovariateAlignment alignment = CovariateAlignment.none();
+
+        assertThat(alignment.observed().isEmpty()).isTrue();
+        assertThat(alignment.baseline().isEmpty()).isTrue();
+        assertThat(alignment.aligned()).isTrue();
+        assertThat(alignment.mismatches()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("identical profiles produce aligned = true and no mismatches")
+    void identicalProfiles() {
+        CovariateProfile profile = CovariateProfile.of(new LinkedHashMap<>(Map.of(
+                "region", "EU",
+                "model_version", "v1")));
+
+        CovariateAlignment alignment = CovariateAlignment.compute(profile, profile);
+
+        assertThat(alignment.aligned()).isTrue();
+        assertThat(alignment.mismatches()).isEmpty();
+        assertThat(alignment.observed()).isEqualTo(profile);
+        assertThat(alignment.baseline()).isEqualTo(profile);
+    }
+
+    @Test
+    @DisplayName("differing values on the same key produce a mismatch")
+    void differingValues() {
+        CovariateProfile observed = CovariateProfile.of(Map.of("region", "APAC"));
+        CovariateProfile baseline = CovariateProfile.of(Map.of("region", "EU"));
+
+        CovariateAlignment alignment = CovariateAlignment.compute(observed, baseline);
+
+        assertThat(alignment.aligned()).isFalse();
+        assertThat(alignment.mismatches())
+                .singleElement()
+                .satisfies(m -> {
+                    assertThat(m.covariateKey()).isEqualTo("region");
+                    assertThat(m.observed()).isEqualTo("APAC");
+                    assertThat(m.baseline()).isEqualTo("EU");
+                });
+    }
+
+    @Test
+    @DisplayName("baseline-only key produces a mismatch with observed=null")
+    void baselineOnlyKey() {
+        CovariateProfile observed = CovariateProfile.empty();
+        CovariateProfile baseline = CovariateProfile.of(Map.of("region", "EU"));
+
+        CovariateAlignment alignment = CovariateAlignment.compute(observed, baseline);
+
+        assertThat(alignment.aligned()).isFalse();
+        assertThat(alignment.mismatches())
+                .singleElement()
+                .satisfies(m -> {
+                    assertThat(m.covariateKey()).isEqualTo("region");
+                    assertThat(m.observed()).isNull();
+                    assertThat(m.baseline()).isEqualTo("EU");
+                });
+    }
+
+    @Test
+    @DisplayName("observed-only key (baseline lacks it) produces a mismatch with baseline=null")
+    void observedOnlyKey() {
+        CovariateProfile observed = CovariateProfile.of(new LinkedHashMap<>(Map.of(
+                "region", "EU",
+                "model_version", "v1")));
+        CovariateProfile baseline = CovariateProfile.of(Map.of("region", "EU"));
+
+        CovariateAlignment alignment = CovariateAlignment.compute(observed, baseline);
+
+        assertThat(alignment.aligned()).isFalse();
+        assertThat(alignment.mismatches())
+                .singleElement()
+                .satisfies(m -> {
+                    assertThat(m.covariateKey()).isEqualTo("model_version");
+                    assertThat(m.observed()).isEqualTo("v1");
+                    assertThat(m.baseline()).isNull();
+                });
+    }
+
+    @Test
+    @DisplayName("empty baseline (no matched baseline) produces aligned = true regardless of observed")
+    void emptyBaselineAligns() {
+        CovariateProfile observed = CovariateProfile.of(Map.of("region", "EU"));
+
+        CovariateAlignment alignment = CovariateAlignment.compute(
+                observed, CovariateProfile.empty());
+
+        assertThat(alignment.aligned()).isTrue();
+        assertThat(alignment.mismatches()).isEmpty();
+        assertThat(alignment.observed()).isEqualTo(observed);
+        assertThat(alignment.baseline().isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("multiple mismatches list every differing key")
+    void multipleMismatches() {
+        CovariateProfile observed = CovariateProfile.of(new LinkedHashMap<>(Map.of(
+                "region", "APAC",
+                "model_version", "v2",
+                "feature_flag", "on")));
+        CovariateProfile baseline = CovariateProfile.of(new LinkedHashMap<>(Map.of(
+                "region", "EU",
+                "model_version", "v1",
+                "feature_flag", "on")));
+
+        CovariateAlignment alignment = CovariateAlignment.compute(observed, baseline);
+
+        assertThat(alignment.aligned()).isFalse();
+        assertThat(alignment.mismatches()).hasSize(2);
+        assertThat(alignment.mismatches())
+                .extracting(CovariateAlignment.Mismatch::covariateKey)
+                .containsExactlyInAnyOrder("region", "model_version");
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -146,11 +146,14 @@ public final class BaselineResolver {
                 useCaseId, factorsFingerprint, currentProfile, declarations);
         Optional<BaselineRecord> selected = report.selected();
         if (selected.isEmpty()) {
-            return new BaselineLookup<>(Optional.empty(), report.notes());
+            return new BaselineLookup<>(
+                    Optional.empty(), CovariateProfile.empty(), report.notes());
         }
+        CovariateProfile baselineProfile = selected.get().covariateProfile();
         BaselineStatistics entry = selected.get().statisticsByCriterionName().get(criterionName);
         if (entry == null) {
-            return new BaselineLookup<>(Optional.empty(), report.notes());
+            return new BaselineLookup<>(
+                    Optional.empty(), baselineProfile, report.notes());
         }
         if (!statisticsType.isInstance(entry)) {
             throw new IllegalStateException(
@@ -160,7 +163,8 @@ public final class BaselineResolver {
                             + statisticsType.getSimpleName()
                             + " — write-side and read-side criterion kinds disagree");
         }
-        return new BaselineLookup<>(Optional.of(statisticsType.cast(entry)), report.notes());
+        return new BaselineLookup<>(
+                Optional.of(statisticsType.cast(entry)), baselineProfile, report.notes());
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
@@ -1,0 +1,212 @@
+package org.javai.punit.reporting;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.javai.punit.api.typed.spec.CriterionResult;
+import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+
+/**
+ * Verbose statistical breakdown of a typed
+ * {@link ProbabilisticTestResult} for the audit / compliance use
+ * case where the reasoning behind a verdict — including a passing
+ * one — has to be visible.
+ *
+ * <p>The legacy framework expressed this through
+ * {@code @ProbabilisticTest(transparentStats = true)}. The typed
+ * pipeline exposes the same feature through
+ * {@code Punit.testing(...).transparentStats()}; this class is the
+ * renderer that produces the actual output.
+ *
+ * <h2>What gets rendered</h2>
+ *
+ * <p>For every evaluated criterion, the renderer pulls the
+ * structured detail map and formats it into a labelled block:
+ *
+ * <pre>
+ * STATISTICAL ANALYSIS — verdict: PASS
+ *
+ *   testInstructionTranslation
+ *
+ *   [REQUIRED] bernoulli-pass-rate → PASS
+ *     Hypothesis test
+ *       H₀ (null):           True pass rate π ≥ 0.85
+ *       H₁ (alternative):    True pass rate π < 0.85
+ *       Test type:           One-sided Wilson-score lower bound
+ *     Observed data
+ *       Sample size (n):     100
+ *       Successes (k):       94
+ *       Observed rate (p̂):  0.9400
+ *     Inference
+ *       Wilson 95% lower:    0.8730
+ *       Threshold:           0.8500 (origin: SLA)
+ *       Reasoning:           0.8730 ≥ 0.8500  ✓
+ * </pre>
+ *
+ * <p>Empirical {@code BernoulliPassRate} runs get the full
+ * hypothesis + Wilson-bound rendering; contractual runs get the
+ * simpler {@code observed ≥ threshold} comparison; criteria the
+ * renderer doesn't yet know about (latency, future kinds) fall
+ * back to the criterion's explanation string plus its raw detail
+ * map.
+ *
+ * <p>Output is plain text — readable in IDE test consoles,
+ * surefire reports, and CI logs without further processing.
+ */
+public final class TypedTransparentStatsRenderer {
+
+    private static final String LABEL_INDENT = "      ";
+    private static final int LABEL_WIDTH = 22;
+
+    private TypedTransparentStatsRenderer() { }
+
+    /**
+     * @param testIdentity the className.methodName the verdict
+     *                     belongs to, for the report header
+     * @param result       the typed result to render
+     * @return a formatted plain-text report
+     */
+    public static String render(String testIdentity, ProbabilisticTestResult result) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("STATISTICAL ANALYSIS — verdict: ")
+                .append(result.verdict()).append("\n\n");
+        sb.append("  ").append(testIdentity).append("\n\n");
+
+        for (EvaluatedCriterion entry : result.criterionResults()) {
+            renderCriterion(sb, entry);
+        }
+
+        if (!result.warnings().isEmpty()) {
+            sb.append("  Notes\n");
+            for (String warning : result.warnings()) {
+                sb.append("    ! ").append(warning).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("  Test intent: ").append(result.intent()).append('\n');
+        return sb.toString();
+    }
+
+    private static void renderCriterion(StringBuilder sb, EvaluatedCriterion entry) {
+        CriterionResult cr = entry.result();
+        sb.append("  [").append(entry.role()).append("] ")
+                .append(cr.criterionName()).append(" → ")
+                .append(cr.verdict()).append('\n');
+
+        Map<String, Object> detail = cr.detail();
+        switch (cr.criterionName()) {
+            case "bernoulli-pass-rate" -> renderBernoulli(sb, cr, detail);
+            default -> renderGeneric(sb, cr, detail);
+        }
+        sb.append('\n');
+    }
+
+    private static void renderBernoulli(StringBuilder sb, CriterionResult cr, Map<String, Object> detail) {
+        Object origin = detail.get("origin");
+        Object threshold = detail.get("threshold");
+        Object observed = detail.get("observed");
+        Object successes = detail.get("successes");
+        Object failures = detail.get("failures");
+        Object total = detail.get("total");
+        Object confidence = detail.get("confidence");
+        Object wilsonLower = detail.get("wilsonLowerBound");
+        Object baselineSampleCount = detail.get("baselineSampleCount");
+
+        boolean isEmpirical = "EMPIRICAL".equals(String.valueOf(origin));
+
+        sb.append("    Hypothesis test\n");
+        sb.append(label("H₀ (null):",
+                "True pass rate π ≥ " + formatRate(threshold)));
+        sb.append(label("H₁ (alternative):",
+                "True pass rate π < " + formatRate(threshold)));
+        sb.append(label("Test type:",
+                isEmpirical
+                        ? "One-sided Wilson-score lower bound"
+                        : "Deterministic comparison (observed ≥ threshold)"));
+
+        sb.append("    Observed data\n");
+        sb.append(label("Sample size (n):", String.valueOf(total)));
+        sb.append(label("Successes (k):", String.valueOf(successes)));
+        sb.append(label("Failures:", String.valueOf(failures)));
+        sb.append(label("Observed rate (p̂):", formatRate(observed)));
+
+        sb.append("    Inference\n");
+        if (isEmpirical) {
+            String confidencePct = confidence == null
+                    ? "?"
+                    : String.format(Locale.ROOT, "%.0f%%",
+                            ((Number) confidence).doubleValue() * 100.0);
+            sb.append(label("Wilson " + confidencePct + " lower:", formatRate(wilsonLower)));
+            sb.append(label("Threshold:",
+                    formatRate(threshold) + " (origin: " + origin + ")"));
+            if (baselineSampleCount != null) {
+                sb.append(label("Baseline samples:", String.valueOf(baselineSampleCount)));
+            }
+            sb.append(label("Reasoning:", formatBernoulliReasoning(
+                    wilsonLower, threshold, cr.verdict())));
+        } else {
+            sb.append(label("Threshold:",
+                    formatRate(threshold) + " (origin: " + origin + ")"));
+            sb.append(label("Reasoning:", formatBernoulliReasoning(
+                    observed, threshold, cr.verdict())));
+        }
+    }
+
+    private static void renderGeneric(StringBuilder sb, CriterionResult cr, Map<String, Object> detail) {
+        sb.append("    Explanation: ").append(cr.explanation()).append('\n');
+        if (!detail.isEmpty()) {
+            sb.append("    Detail\n");
+            for (Map.Entry<String, Object> e : detail.entrySet()) {
+                sb.append(label(e.getKey() + ":", String.valueOf(e.getValue())));
+            }
+        }
+    }
+
+    private static String label(String text, String value) {
+        StringBuilder sb = new StringBuilder(LABEL_INDENT);
+        sb.append(text);
+        int padding = LABEL_WIDTH - text.length();
+        if (padding < 1) padding = 1;
+        sb.append(" ".repeat(padding));
+        sb.append(value).append('\n');
+        return sb.toString();
+    }
+
+    private static String formatRate(Object value) {
+        if (value == null) return "?";
+        if (value instanceof Number n) {
+            return String.format(Locale.ROOT, "%.4f", n.doubleValue());
+        }
+        return String.valueOf(value);
+    }
+
+    private static String formatBernoulliReasoning(Object lhs, Object threshold, Verdict verdict) {
+        String comparator = verdict == Verdict.PASS ? "≥" : "<";
+        String mark = verdict == Verdict.PASS ? " ✓"
+                : verdict == Verdict.FAIL ? " ✗"
+                : "";
+        return formatRate(lhs) + " " + comparator + " " + formatRate(threshold) + mark;
+    }
+
+    /**
+     * Snapshot the result's evaluated-criteria details as an
+     * ordered name → detail map. Useful for tests and tooling that
+     * want the structured numbers without re-parsing the rendered
+     * text.
+     */
+    public static Map<String, Map<String, Object>> snapshotCriteria(
+            ProbabilisticTestResult result) {
+        Map<String, Map<String, Object>> out = new LinkedHashMap<>();
+        List<EvaluatedCriterion> evaluated = result.criterionResults();
+        for (EvaluatedCriterion entry : evaluated) {
+            CriterionResult cr = entry.result();
+            out.put(cr.criterionName(), cr.detail());
+        }
+        return out;
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.api.typed.spec.CriterionResult;
 import org.javai.punit.api.typed.spec.EvaluatedCriterion;
 import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
@@ -67,7 +69,10 @@ public final class TypedTransparentStatsRenderer {
     /**
      * @param testIdentity the className.methodName the verdict
      *                     belongs to, for the report header
-     * @param result       the typed result to render
+     * @param result       the typed result to render — the renderer
+     *                     reads {@link ProbabilisticTestResult#covariates()
+     *                     covariates()} for observed-vs-baseline
+     *                     alignment, criterion details, and warnings
      * @return a formatted plain-text report
      */
     public static String render(String testIdentity, ProbabilisticTestResult result) {
@@ -75,6 +80,8 @@ public final class TypedTransparentStatsRenderer {
         sb.append("STATISTICAL ANALYSIS — verdict: ")
                 .append(result.verdict()).append("\n\n");
         sb.append("  ").append(testIdentity).append("\n\n");
+
+        renderCovariates(sb, result.covariates());
 
         for (EvaluatedCriterion entry : result.criterionResults()) {
             renderCriterion(sb, entry);
@@ -89,6 +96,47 @@ public final class TypedTransparentStatsRenderer {
         }
 
         sb.append("  Test intent: ").append(result.intent()).append('\n');
+        return sb.toString();
+    }
+
+    private static void renderCovariates(StringBuilder sb, CovariateAlignment alignment) {
+        CovariateProfile observed = alignment.observed();
+        CovariateProfile baseline = alignment.baseline();
+        if (observed.isEmpty() && baseline.isEmpty()) {
+            // Nothing to say — the use case declared no covariates
+            // and no baseline was matched. Skip the section.
+            return;
+        }
+        sb.append("  Covariates\n");
+        if (!observed.isEmpty()) {
+            sb.append(label("Observed:", formatProfile(observed)));
+        }
+        if (!baseline.isEmpty()) {
+            sb.append(label("Baseline:", formatProfile(baseline)));
+        }
+        sb.append(label("Aligned:", alignment.aligned() ? "yes" : "no"));
+        if (!alignment.mismatches().isEmpty()) {
+            for (CovariateAlignment.Mismatch m : alignment.mismatches()) {
+                String value = String.format(Locale.ROOT,
+                        "observed=%s, baseline=%s",
+                        m.observed() == null ? "<absent>" : m.observed(),
+                        m.baseline() == null ? "<absent>" : m.baseline());
+                sb.append(label("  " + m.covariateKey() + ":", value));
+            }
+        }
+        sb.append('\n');
+    }
+
+    private static String formatProfile(CovariateProfile profile) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> e : profile.values().entrySet()) {
+            if (!first) {
+                sb.append(", ");
+            }
+            sb.append(e.getKey()).append('=').append(e.getValue());
+            first = false;
+        }
         return sb.toString();
     }
 

--- a/punit-core/src/test/java/org/javai/punit/reporting/TypedTransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/reporting/TypedTransparentStatsRendererTest.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.api.typed.spec.CriterionResult;
 import org.javai.punit.api.typed.spec.CriterionRole;
 import org.javai.punit.api.typed.spec.EvaluatedCriterion;
@@ -188,6 +190,95 @@ class TypedTransparentStatsRendererTest {
                 .contains("Notes")
                 .contains("! rejected file-A — CONFIGURATION mismatch on region")
                 .contains("Test intent: VERIFICATION");
+    }
+
+    @Nested
+    @DisplayName("Covariate alignment rendering")
+    class Covariates {
+
+        private ProbabilisticTestResult resultWithAlignment(CovariateAlignment alignment) {
+            return new ProbabilisticTestResult(
+                    Verdict.PASS, FactorBundle.empty(),
+                    List.of(criterion("bernoulli-pass-rate", Verdict.PASS, "...",
+                            Map.of("observed", 0.95, "threshold", 0.85, "origin", "EMPIRICAL",
+                                    "successes", 95, "failures", 5, "total", 100,
+                                    "confidence", 0.95, "wilsonLowerBound", 0.90))),
+                    TestIntent.VERIFICATION,
+                    List.of(),
+                    alignment);
+        }
+
+        @Test
+        @DisplayName("aligned baseline + observed renders both profiles plus Aligned: yes")
+        void alignedRenders() {
+            CovariateProfile profile = CovariateProfile.of(new LinkedHashMap<>(Map.of(
+                    "region", "EU",
+                    "model_version", "v1")));
+            CovariateAlignment alignment = CovariateAlignment.compute(profile, profile);
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithAlignment(alignment));
+
+            assertThat(rendered)
+                    .contains("Covariates")
+                    .contains("Observed:")
+                    .contains("region=EU")
+                    .contains("Baseline:")
+                    .contains("Aligned:")
+                    .contains("yes")
+                    .doesNotContain("Aligned:              no");
+        }
+
+        @Test
+        @DisplayName("misaligned profiles list per-key differences")
+        void misalignmentRenders() {
+            CovariateProfile observed = CovariateProfile.of(new LinkedHashMap<>(Map.of(
+                    "region", "APAC",
+                    "model_version", "v1")));
+            CovariateProfile baseline = CovariateProfile.of(new LinkedHashMap<>(Map.of(
+                    "region", "EU",
+                    "model_version", "v1")));
+            CovariateAlignment alignment = CovariateAlignment.compute(observed, baseline);
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithAlignment(alignment));
+
+            assertThat(rendered)
+                    .contains("Observed:")
+                    .contains("region=APAC")
+                    .contains("Baseline:")
+                    .contains("region=EU")
+                    .contains("Aligned:")
+                    .contains("no")
+                    .contains("region:")
+                    .contains("observed=APAC, baseline=EU");
+        }
+
+        @Test
+        @DisplayName("empty alignment (no covariates declared, no baseline) renders no Covariates section")
+        void emptyAlignmentRendersNothing() {
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithAlignment(CovariateAlignment.none()));
+
+            assertThat(rendered).doesNotContain("Covariates");
+        }
+
+        @Test
+        @DisplayName("observed-only (baseline empty) renders observed but no alignment line")
+        void observedOnly() {
+            CovariateProfile observed = CovariateProfile.of(Map.of("region", "EU"));
+            CovariateAlignment alignment = CovariateAlignment.compute(
+                    observed, CovariateProfile.empty());
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithAlignment(alignment));
+
+            assertThat(rendered)
+                    .contains("Covariates")
+                    .contains("Observed:")
+                    .contains("region=EU")
+                    .doesNotContain("Baseline:");
+        }
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/reporting/TypedTransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/reporting/TypedTransparentStatsRendererTest.java
@@ -1,0 +1,213 @@
+package org.javai.punit.reporting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.spec.CriterionResult;
+import org.javai.punit.api.typed.spec.CriterionRole;
+import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TypedTransparentStatsRenderer — verbose statistical breakdown")
+class TypedTransparentStatsRendererTest {
+
+    private static ProbabilisticTestResult result(Verdict verdict, EvaluatedCriterion... evaluated) {
+        return new ProbabilisticTestResult(
+                verdict,
+                FactorBundle.empty(),
+                List.of(evaluated),
+                TestIntent.VERIFICATION,
+                List.of());
+    }
+
+    private static EvaluatedCriterion criterion(
+            String name, Verdict verdict, String explanation, Map<String, Object> detail) {
+        return new EvaluatedCriterion(
+                new CriterionResult(name, verdict, explanation, detail),
+                CriterionRole.REQUIRED);
+    }
+
+    @Nested
+    @DisplayName("BernoulliPassRate empirical path")
+    class BernoulliEmpirical {
+
+        @Test
+        @DisplayName("renders the hypothesis, observed, and inference sections with Wilson lower bound")
+        void rendersFullEmpiricalReport() {
+            Map<String, Object> detail = new LinkedHashMap<>();
+            detail.put("observed", 1.0);
+            detail.put("threshold", 0.94);
+            detail.put("origin", "EMPIRICAL");
+            detail.put("successes", 50);
+            detail.put("failures", 0);
+            detail.put("total", 50);
+            detail.put("confidence", 0.95);
+            detail.put("wilsonLowerBound", 0.929);
+            detail.put("baselineSampleCount", 1000);
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "shopping-basket.testInstructionTranslation",
+                    result(Verdict.FAIL, criterion(
+                            "bernoulli-pass-rate", Verdict.FAIL,
+                            "observed=1.0000 (Wilson-95% lower=0.9290) vs threshold=0.9400 (origin=EMPIRICAL) over 50 samples",
+                            detail)));
+
+            assertThat(rendered)
+                    .contains("STATISTICAL ANALYSIS — verdict: FAIL")
+                    .contains("shopping-basket.testInstructionTranslation")
+                    .contains("[REQUIRED] bernoulli-pass-rate → FAIL")
+                    .contains("Hypothesis test")
+                    .contains("H₀ (null):")
+                    .contains("True pass rate π ≥ 0.9400")
+                    .contains("H₁ (alternative):")
+                    .contains("True pass rate π < 0.9400")
+                    .contains("Test type:")
+                    .contains("One-sided Wilson-score lower bound")
+                    .contains("Observed data")
+                    .contains("Sample size (n):")
+                    .contains("50")
+                    .contains("Successes (k):")
+                    .contains("Observed rate (p̂):")
+                    .contains("1.0000")
+                    .contains("Inference")
+                    .contains("Wilson 95% lower:")
+                    .contains("0.9290")
+                    .contains("Threshold:")
+                    .contains("0.9400 (origin: EMPIRICAL)")
+                    .contains("Baseline samples:")
+                    .contains("1000")
+                    .contains("Reasoning:")
+                    .contains("0.9290 < 0.9400 ✗");
+        }
+
+        @Test
+        @DisplayName("PASS verdict shows ✓ in the reasoning line")
+        void passShowsCheckMark() {
+            Map<String, Object> detail = Map.of(
+                    "observed", 0.94,
+                    "threshold", 0.85,
+                    "origin", "EMPIRICAL",
+                    "successes", 94,
+                    "failures", 6,
+                    "total", 100,
+                    "confidence", 0.95,
+                    "wilsonLowerBound", 0.873);
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", result(Verdict.PASS, criterion(
+                            "bernoulli-pass-rate", Verdict.PASS, "...", detail)));
+
+            assertThat(rendered)
+                    .contains("STATISTICAL ANALYSIS — verdict: PASS")
+                    .contains("0.8730 ≥ 0.8500 ✓");
+        }
+    }
+
+    @Nested
+    @DisplayName("BernoulliPassRate contractual path")
+    class BernoulliContractual {
+
+        @Test
+        @DisplayName("renders deterministic-comparison test type, no Wilson section")
+        void rendersContractual() {
+            Map<String, Object> detail = Map.of(
+                    "observed", 0.94,
+                    "threshold", 0.90,
+                    "origin", ThresholdOrigin.SLA.name(),
+                    "successes", 94,
+                    "failures", 6,
+                    "total", 100);
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", result(Verdict.PASS, criterion(
+                            "bernoulli-pass-rate", Verdict.PASS, "...", detail)));
+
+            assertThat(rendered)
+                    .contains("Test type:")
+                    .contains("Deterministic comparison (observed ≥ threshold)")
+                    .contains("Threshold:")
+                    .contains("0.9000 (origin: SLA)")
+                    .contains("0.9400 ≥ 0.9000 ✓")
+                    .doesNotContain("Wilson")
+                    .doesNotContain("Baseline samples");
+        }
+    }
+
+    @Nested
+    @DisplayName("Unknown criterion fallback")
+    class UnknownCriterion {
+
+        @Test
+        @DisplayName("falls back to explanation + raw detail map")
+        void fallback() {
+            Map<String, Object> detail = Map.of(
+                    "p50", "PT0.001S",
+                    "p99", "PT0.020S");
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", result(Verdict.PASS, criterion(
+                            "percentile-latency", Verdict.PASS,
+                            "p50=1ms, p99=20ms within limits", detail)));
+
+            assertThat(rendered)
+                    .contains("[REQUIRED] percentile-latency → PASS")
+                    .contains("Explanation:")
+                    .contains("p50=1ms, p99=20ms within limits")
+                    .contains("Detail")
+                    .contains("p50:")
+                    .contains("PT0.001S")
+                    .contains("p99:")
+                    .contains("PT0.020S");
+        }
+    }
+
+    @Test
+    @DisplayName("warnings render under a Notes section")
+    void warningsRender() {
+        ProbabilisticTestResult resultWithWarnings = new ProbabilisticTestResult(
+                Verdict.INCONCLUSIVE,
+                FactorBundle.empty(),
+                List.of(criterion("bernoulli-pass-rate", Verdict.INCONCLUSIVE, "no baseline", Map.of())),
+                TestIntent.VERIFICATION,
+                List.of("rejected file-A — CONFIGURATION mismatch on region (current=APAC, baseline=EU)"));
+
+        String rendered = TypedTransparentStatsRenderer.render(
+                "test", resultWithWarnings);
+
+        assertThat(rendered)
+                .contains("Notes")
+                .contains("! rejected file-A — CONFIGURATION mismatch on region")
+                .contains("Test intent: VERIFICATION");
+    }
+
+    @Test
+    @DisplayName("snapshotCriteria returns a name → detail map preserving order")
+    void snapshotCriteria() {
+        Map<String, Object> bernoulliDetail = Map.of("observed", 0.95, "total", 100);
+        Map<String, Object> latencyDetail = Map.of("p99", "PT0.010S");
+
+        ProbabilisticTestResult r = result(Verdict.PASS,
+                criterion("bernoulli-pass-rate", Verdict.PASS, "ok", bernoulliDetail),
+                criterion("percentile-latency", Verdict.PASS, "ok", latencyDetail));
+
+        var snapshot = TypedTransparentStatsRenderer.snapshotCriteria(r);
+
+        assertThat(snapshot.keySet())
+                .containsExactly("bernoulli-pass-rate", "percentile-latency");
+        assertThat(snapshot.get("bernoulli-pass-rate"))
+                .containsEntry("observed", 0.95)
+                .containsEntry("total", 100);
+        assertThat(snapshot.get("percentile-latency"))
+                .containsEntry("p99", "PT0.010S");
+    }
+}

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -29,6 +29,8 @@ import org.javai.punit.engine.Engine;
 import org.javai.punit.engine.baseline.ProfileBoundBaselineProvider;
 import org.javai.punit.engine.covariate.CovariateResolver;
 import org.javai.punit.engine.criteria.Feasibility;
+import org.javai.punit.reporting.TypedTransparentStatsRenderer;
+import org.javai.punit.statistics.transparent.TransparentStatsConfig;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
@@ -340,6 +342,7 @@ public final class Punit {
         private final FT factors;
         private final List<Criterion<OT, ?>> requiredCriteria = new ArrayList<>();
         private TestIntent intent = TestIntent.VERIFICATION;
+        private Boolean transparentStatsOverride;
 
         TestBuilder(ProbabilisticTest.Builder<FT, IT, OT> delegate,
                     Sampling<FT, IT, OT> sampling, FT factors) {
@@ -367,6 +370,37 @@ public final class Punit {
             return this;
         }
 
+        /**
+         * Enables verbose statistical reporting on every verdict —
+         * including PASS — with the framework's hypothesis-test
+         * framing, observed-data section, threshold provenance, and
+         * inference reasoning. Output goes to stderr alongside the
+         * JUnit assertion message; visible in IDE test consoles,
+         * surefire reports, and CI logs.
+         *
+         * <p>Resolution precedence (highest first):
+         * <ol>
+         *   <li>This builder method.</li>
+         *   <li>System property {@code punit.stats.transparent}.</li>
+         *   <li>Environment variable {@code PUNIT_STATS_TRANSPARENT}.</li>
+         *   <li>Default: off.</li>
+         * </ol>
+         *
+         * <p>Use case: audit / compliance documentation where the
+         * statistical reasoning behind a passing verdict has to be
+         * shown, not just inferred from the absence of a failure.
+         */
+        public TestBuilder<FT, IT, OT> transparentStats() {
+            this.transparentStatsOverride = Boolean.TRUE;
+            return this;
+        }
+
+        /** Explicit-boolean variant of {@link #transparentStats()}. */
+        public TestBuilder<FT, IT, OT> transparentStats(boolean enabled) {
+            this.transparentStatsOverride = enabled;
+            return this;
+        }
+
         public ProbabilisticTest build() {
             return delegate.build();
         }
@@ -380,7 +414,16 @@ public final class Punit {
                         "Engine produced unexpected result type: " + result.getClass().getName());
             }
             warnings.forEach(System.err::println);
+            maybeRenderTransparentStats(typed);
             translate(typed);
+        }
+
+        private void maybeRenderTransparentStats(ProbabilisticTestResult result) {
+            if (!TransparentStatsConfig.resolve(transparentStatsOverride).enabled()) {
+                return;
+            }
+            String testIdentity = sampling.useCaseFactory().apply(factors).id();
+            System.err.println(TypedTransparentStatsRenderer.render(testIdentity, result));
         }
 
         private List<String> preflightFeasibility() {
@@ -418,6 +461,7 @@ public final class Punit {
         private Integer samples;
         private Criterion<?, ?> criterion;
         private TestIntent intent = TestIntent.VERIFICATION;
+        private Boolean transparentStatsOverride;
 
         EmpiricalTestBuilder(Supplier<Experiment> baselineSupplier) {
             this.baselineSupplier = baselineSupplier;
@@ -448,6 +492,18 @@ public final class Punit {
             return this;
         }
 
+        /** See {@link TestBuilder#transparentStats()}. */
+        public EmpiricalTestBuilder transparentStats() {
+            this.transparentStatsOverride = Boolean.TRUE;
+            return this;
+        }
+
+        /** See {@link TestBuilder#transparentStats(boolean)}. */
+        public EmpiricalTestBuilder transparentStats(boolean enabled) {
+            this.transparentStatsOverride = enabled;
+            return this;
+        }
+
         public ProbabilisticTest build() {
             if (samples == null) {
                 throw new IllegalStateException(
@@ -473,6 +529,7 @@ public final class Punit {
                         "Engine produced unexpected result type: " + result.getClass().getName());
             }
             warnings.forEach(System.err::println);
+            maybeRenderTransparentStats(spec, typed);
             translate(typed);
         }
 
@@ -504,6 +561,23 @@ public final class Punit {
                 }
             });
             return warnings;
+        }
+
+        private void maybeRenderTransparentStats(
+                ProbabilisticTest spec, ProbabilisticTestResult result) {
+            if (!TransparentStatsConfig.resolve(transparentStatsOverride).enabled()) {
+                return;
+            }
+            String testIdentity = spec.dispatch(
+                    new org.javai.punit.api.typed.spec.Spec.Dispatcher<String>() {
+                        @Override
+                        public <FT, IT, OT> String apply(
+                                org.javai.punit.api.typed.spec.TypedSpec<FT, IT, OT> typed) {
+                            FT factors = typed.configurations().next().factors();
+                            return typed.useCaseFactory().apply(factors).id();
+                        }
+                    });
+            System.err.println(TypedTransparentStatsRenderer.render(testIdentity, result));
         }
     }
 }

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -197,9 +197,41 @@ public final class Punit {
         }
         String message = formatMessage(result);
         if (verdict == Verdict.INCONCLUSIVE) {
+            // The covariate-alignment contract has three INCONCLUSIVE
+            // sub-cases that we resolve here — see the project's
+            // covariate-misalignment trichotomy:
+            //
+            //   1. No candidates considered (no baseline files yet)
+            //      — legitimate skip; the workflow is measure first,
+            //      then test. JUnit-aborted (TestAbortedException).
+            //   2. Candidates considered but all rejected (CONFIGURATION
+            //      mismatch on every one, or zero-overlap)
+            //      — misconfiguration: the user is asking for a
+            //      reference that doesn't exist for this configuration.
+            //      JUnit-failed (AssertionFailedError).
+            //   3. Candidate matched (possibly partial fallback)
+            //      — verdict is whatever the criterion produced; not
+            //      this branch.
+            //
+            // Detection: rejection notes on the result distinguish (2)
+            // from (1). BaselineSelector emits "rejected {filename} — …"
+            // for each candidate it couldn't select; their presence
+            // means candidates existed.
+            if (candidatesWereRejected(result)) {
+                throw new AssertionFailedError(message);
+            }
             throw new TestAbortedException(message);
         }
         throw new AssertionFailedError(message);
+    }
+
+    private static boolean candidatesWereRejected(ProbabilisticTestResult result) {
+        for (String warning : result.warnings()) {
+            if (warning.startsWith("rejected ")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String formatMessage(ProbabilisticTestResult result) {

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -129,12 +129,39 @@ public final class Punit {
 
     /**
      * Resolves the use case's covariate profile from {@code spec}'s
-     * first configuration and wraps {@link BaselineProviderResolver}'s
-     * provider so the engine and pre-flight feasibility see a
-     * profile-bound view.
+     * first configuration. Returns {@link CovariateProfile#empty()}
+     * when the use case declared no covariates.
      *
      * <p>Per UC04 the profile is resolved once per run, before any
-     * samples execute. {@link ProfileBoundBaselineProvider#bind}
+     * samples execute.
+     */
+    private static CovariateProfile resolveCovariateProfile(
+            org.javai.punit.api.typed.spec.Spec spec) {
+        return spec.dispatch(new org.javai.punit.api.typed.spec.Spec.Dispatcher<CovariateProfile>() {
+            @Override
+            public <FT, IT, OT> CovariateProfile apply(
+                    org.javai.punit.api.typed.spec.TypedSpec<FT, IT, OT> typed) {
+                var configs = typed.configurations();
+                if (!configs.hasNext()) {
+                    return CovariateProfile.empty();
+                }
+                FT factors = configs.next().factors();
+                UseCase<FT, IT, OT> useCase = typed.useCaseFactory().apply(factors);
+                List<Covariate> declarations = useCase.covariates();
+                if (declarations.isEmpty()) {
+                    return CovariateProfile.empty();
+                }
+                return CovariateResolver.defaults()
+                        .resolve(declarations, useCase.customCovariateResolvers());
+            }
+        });
+    }
+
+    /**
+     * Wraps {@link BaselineProviderResolver}'s provider in a
+     * profile-bound decorator carrying the run's covariate profile,
+     * so the engine and pre-flight feasibility see covariate-aware
+     * baseline lookups. {@link ProfileBoundBaselineProvider#bind}
      * returns the wrapped delegate unchanged when the use case
      * declared no covariates, so non-covariate tests pay no cost
      * here.
@@ -198,7 +225,54 @@ public final class Punit {
                 sb.append("  ! ").append(warning).append('\n');
             }
         }
+        // Covariate alignment — the conditions under which the test
+        // ran, paired with the matched baseline's covariates. Useful
+        // diagnostic context on FAIL / INCONCLUSIVE: the author
+        // should immediately see which environment was being tested
+        // and how it differed from the baseline (when at all). Same
+        // structured shape the legacy CovariateStatus emits, so HTML
+        // and XML report consumers see parity from both pipelines.
+        var alignment = result.covariates();
+        if (!alignment.observed().isEmpty() || !alignment.baseline().isEmpty()) {
+            sb.append('\n');
+            if (!alignment.observed().isEmpty()) {
+                sb.append("  Observed covariates: ")
+                        .append(formatProfile(alignment.observed())).append('\n');
+            }
+            if (!alignment.baseline().isEmpty()) {
+                sb.append("  Baseline covariates: ")
+                        .append(formatProfile(alignment.baseline())).append('\n');
+            }
+            if (!alignment.mismatches().isEmpty()) {
+                sb.append("  Misaligned: ");
+                boolean first = true;
+                for (var m : alignment.mismatches()) {
+                    if (!first) sb.append(", ");
+                    sb.append(m.covariateKey())
+                            .append(" (observed=")
+                            .append(m.observed() == null ? "<absent>" : m.observed())
+                            .append(", baseline=")
+                            .append(m.baseline() == null ? "<absent>" : m.baseline())
+                            .append(')');
+                    first = false;
+                }
+                sb.append('\n');
+            }
+        }
         return sb.toString().trim();
+    }
+
+    private static String formatProfile(CovariateProfile profile) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (var e : profile.values().entrySet()) {
+            if (!first) {
+                sb.append(", ");
+            }
+            sb.append(e.getKey()).append('=').append(e.getValue());
+            first = false;
+        }
+        return sb.toString();
     }
 
     // ── Wrapper builders ────────────────────────────────────────────
@@ -414,8 +488,19 @@ public final class Punit {
                         "Engine produced unexpected result type: " + result.getClass().getName());
             }
             warnings.forEach(System.err::println);
-            maybeRenderTransparentStats(typed);
-            translate(typed);
+            // Resolve the run's observed covariate profile and stamp
+            // it onto the result alongside the baseline profile that
+            // conclude collected. The structured CovariateAlignment
+            // flows downstream — to the verbose renderer here, and
+            // to HTML / XML / JSON sinks when the typed pipeline
+            // grows them — preserving parity with the legacy
+            // CovariateStatus shape.
+            CovariateProfile observed = resolveCovariateProfile(spec);
+            ProbabilisticTestResult stamped = typed.withCovariates(
+                    org.javai.punit.api.typed.covariate.CovariateAlignment.compute(
+                            observed, typed.covariates().baseline()));
+            maybeRenderTransparentStats(stamped);
+            translate(stamped);
         }
 
         private void maybeRenderTransparentStats(ProbabilisticTestResult result) {
@@ -529,8 +614,12 @@ public final class Punit {
                         "Engine produced unexpected result type: " + result.getClass().getName());
             }
             warnings.forEach(System.err::println);
-            maybeRenderTransparentStats(spec, typed);
-            translate(typed);
+            CovariateProfile observed = resolveCovariateProfile(spec);
+            ProbabilisticTestResult stamped = typed.withCovariates(
+                    org.javai.punit.api.typed.covariate.CovariateAlignment.compute(
+                            observed, typed.covariates().baseline()));
+            maybeRenderTransparentStats(spec, stamped);
+            translate(stamped);
         }
 
         @SuppressWarnings("unchecked")

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateMisalignmentTrichotomyTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateMisalignmentTrichotomyTest.java
@@ -1,0 +1,119 @@
+package org.javai.punit.junit5;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.javai.punit.junit5.testsubjects.CovariateSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * Pins the covariate-misalignment trichotomy that
+ * {@link Punit#translate} encodes:
+ *
+ * <ul>
+ *   <li><b>Case 1: legitimate INCONCLUSIVE.</b> No candidate
+ *       baseline files exist at all (the workflow is "measure first,
+ *       then test"). The author hasn't yet seeded a baseline. The
+ *       test produces {@code INCONCLUSIVE}, which the framework
+ *       maps to JUnit-aborted (skipped).</li>
+ *
+ *   <li><b>Case 2: misconfiguration FAIL.</b> Candidate baselines
+ *       exist but every one is rejected — typically because their
+ *       covariate profiles disagree with the current run on a
+ *       CONFIGURATION-category covariate (hard gate). The user is
+ *       asking for a reference that doesn't exist for this
+ *       configuration. The framework reads this as misconfiguration
+ *       and the test FAILS (JUnit-failed).</li>
+ *
+ *   <li><b>Case 3: matched and verdict-proceeds.</b> A candidate
+ *       matched (possibly partially); the verdict comes from the
+ *       criterion's own evaluation. Misalignment notes from soft
+ *       categories surface as warnings on the verdict.
+ *       {@link CovariateRoundTripTest} pins this end-to-end.</li>
+ * </ul>
+ */
+@DisplayName("Covariate misalignment trichotomy — INCONCLUSIVE vs FAIL")
+class CovariateMisalignmentTrichotomyTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+
+    @TempDir Path baselineDir;
+    private String savedBaselineProperty;
+    private String savedRegionProperty;
+
+    @BeforeEach
+    void setUp() {
+        savedBaselineProperty = System.getProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY);
+        System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+        savedRegionProperty = System.getProperty(CovariateSubjects.REGION_PROPERTY);
+        System.setProperty(CovariateSubjects.REGION_PROPERTY, "EU");
+    }
+
+    @AfterEach
+    void tearDown() {
+        restore(BaselineProviderResolver.BASELINE_DIR_PROPERTY, savedBaselineProperty);
+        restore(CovariateSubjects.REGION_PROPERTY, savedRegionProperty);
+    }
+
+    @Test
+    @DisplayName("Case 1: no candidates at all — JUnit aborted (legitimate INCONCLUSIVE)")
+    void case1_noCandidatesAborts() {
+        // Skip the measure phase deliberately. No baseline files
+        // exist anywhere; the BaselineSelector has nothing to
+        // consider. INCONCLUSIVE is legitimate — the author needs
+        // to run the measure experiment first.
+        Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
+        testEvents.assertStatistics(stats -> stats.started(1).aborted(1).failed(0));
+    }
+
+    @Test
+    @DisplayName("Case 2: candidates exist but all rejected — JUnit failed (misconfiguration)")
+    void case2_allRejectedFails() throws IOException {
+        // Phase 1: seed a baseline under region=EU.
+        run(CovariateSubjects.MeasureWithCovariate.class)
+                .assertStatistics(stats -> stats.started(1).succeeded(1));
+
+        // Phase 2: switch to region=APAC. The EU baseline exists
+        // but is CONFIG-rejected on the region mismatch. Every
+        // candidate is rejected; no empty-profile fallback exists.
+        // Misconfiguration → FAIL.
+        System.setProperty(CovariateSubjects.REGION_PROPERTY, "APAC");
+        Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
+        testEvents.assertStatistics(stats -> stats.started(1).aborted(0).failed(1));
+    }
+
+    @Test
+    @DisplayName("Case 3: candidate matched — verdict proceeds (PASS in this scenario)")
+    void case3_matchedProceedsToVerdict() throws IOException {
+        // Phase 1: seed a baseline under region=EU.
+        run(CovariateSubjects.MeasureWithCovariate.class)
+                .assertStatistics(stats -> stats.started(1).succeeded(1));
+
+        // Phase 2: stay under region=EU. Baseline matches; the
+        // criterion's own evaluation produces PASS.
+        Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
+        testEvents.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+    }
+
+    private static void restore(String key, String saved) {
+        if (saved == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, saved);
+        }
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
@@ -93,22 +93,26 @@ class CovariateRoundTripTest {
     }
 
     @Test
-    @DisplayName("test under non-matching covariate produces INCONCLUSIVE (no matching baseline)")
-    void testUnderDifferentCovariateInconclusive() throws IOException {
+    @DisplayName("test under non-matching covariate fails (misconfiguration: candidates exist but every one rejected)")
+    void testUnderDifferentCovariateFailsAsMisconfiguration() throws IOException {
         // Phase 1: write baseline under region=EU.
         run(CovariateSubjects.MeasureWithCovariate.class)
                 .assertStatistics(stats -> stats.started(1).succeeded(1));
 
-        // Phase 2: switch region to APAC; no baseline under that
-        // partition exists, the empty-profile fallback isn't there
-        // either → INCONCLUSIVE → JUnit aborted (skipped) test.
+        // Phase 2: switch region to APAC. The EU baseline exists but
+        // the framework rejects it on the CONFIGURATION-category
+        // hard gate (region mismatch). Every candidate is rejected
+        // and there is no empty-profile fallback baseline. The
+        // typed pipeline reads this as misconfiguration — the user
+        // is asking for a reference that doesn't exist for this
+        // configuration — and the test FAILS, not skips.
         System.setProperty(CovariateSubjects.REGION_PROPERTY, "APAC");
         Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
-        testEvents.assertStatistics(stats -> stats.started(1).aborted(1));
+        testEvents.assertStatistics(stats -> stats.started(1).failed(1));
     }
 
     @Test
-    @DisplayName("misalignment surfaces in the JUnit abort message — author sees why")
+    @DisplayName("misalignment surfaces in the JUnit failure message — author sees why")
     void misalignmentExplainedInVerdict() throws IOException {
         run(CovariateSubjects.MeasureWithCovariate.class)
                 .assertStatistics(stats -> stats.started(1).succeeded(1));
@@ -116,10 +120,10 @@ class CovariateRoundTripTest {
         System.setProperty(CovariateSubjects.REGION_PROPERTY, "APAC");
         Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
 
-        // The aborted-event payload carries the diagnostic that the
+        // The failed-event payload carries the diagnostic that the
         // empirical Punit.testing(...) translates from the test result.
         // It should mention the rejection reason for the EU baseline.
-        testEvents.aborted()
+        testEvents.failed()
                 .assertThatEvents()
                 .anySatisfy(event -> {
                     var throwable = event.getRequiredPayload(

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/TransparentStatsIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/TransparentStatsIntegrationTest.java
@@ -1,0 +1,76 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.javai.punit.junit5.testsubjects.PunitSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * Integration test for {@code Punit.TestBuilder.transparentStats()}:
+ * verifies that opting in produces the verbose statistical analysis
+ * on stderr and that off-by-default tests do not.
+ */
+@DisplayName("Transparent stats — verbose verdict reporting via the typed builder")
+class TransparentStatsIntegrationTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+
+    private PrintStream originalErr;
+    private ByteArrayOutputStream capturedErr;
+
+    @BeforeEach
+    void redirectStderr() {
+        originalErr = System.err;
+        capturedErr = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(capturedErr, true, StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void restoreStderr() {
+        System.setErr(originalErr);
+    }
+
+    @Test
+    @DisplayName("transparentStats() builder method renders the verbose breakdown to stderr")
+    void rendersVerboseBreakdown() {
+        Events events = run(PunitSubjects.TransparentStatsTest.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+
+        String stderr = capturedErr.toString(StandardCharsets.UTF_8);
+        assertThat(stderr)
+                .contains("STATISTICAL ANALYSIS — verdict: PASS")
+                .contains("[REQUIRED] bernoulli-pass-rate → PASS")
+                .contains("Hypothesis test")
+                .contains("H₀ (null):")
+                .contains("Observed data")
+                .contains("Inference")
+                .contains("Test intent: VERIFICATION");
+    }
+
+    @Test
+    @DisplayName("default (transparentStats off) emits no verbose breakdown")
+    void noOutputWhenDisabled() {
+        Events events = run(PunitSubjects.PassingContractualTest.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+
+        String stderr = capturedErr.toString(StandardCharsets.UTF_8);
+        assertThat(stderr).doesNotContain("STATISTICAL ANALYSIS");
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PunitSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PunitSubjects.java
@@ -81,6 +81,17 @@ public final class PunitSubjects {
         }
     }
 
+    /** Test that opts in to transparentStats — passes; renderer should emit. */
+    public static final class TransparentStatsTest {
+        @ProbabilisticTest
+        void passesWithTransparentStats() {
+            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
+                    .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
+                    .transparentStats()
+                    .assertPasses();
+        }
+    }
+
     /** Contractual test that should fail: 0% observed < 50% threshold. */
     public static final class FailingContractualTest {
         @ProbabilisticTest


### PR DESCRIPTION
## Summary

Adds a builder-side authoring surface for the framework's verbose statistical reporting feature. Authors writing typed `Punit.testing(...)` tests now opt in via:

```java
Punit.testing(sampling, factors)
        .criterion(BernoulliPassRate.empirical())
        .transparentStats()        // ← new
        .assertPasses();
```

When enabled, every verdict (including PASS) renders a verbose statistical breakdown to stderr — hypothesis-test framing, observed data, threshold provenance, and inference reasoning. **This is the audit / compliance use case where the reasoning behind a passing verdict has to be visible, not just inferred from the absence of a failure.**

### What's new

**`org.javai.punit.reporting.TypedTransparentStatsRenderer`** — plain-text renderer that takes a `ProbabilisticTestResult` + a test identity and formats labelled sections per criterion. Reads directly from `CriterionResult.detail()` — `BernoulliPassRate` already populates the structured numbers; the renderer just curates them.

- Empirical `BernoulliPassRate` gets the full hypothesis + Wilson-bound rendering
- Contractual `BernoulliPassRate` gets the simpler `observed ≥ threshold` comparison
- Other criterion kinds fall back to explanation + raw detail map (latency renderer can land later)

**Builder methods on both entry points:**

- `Punit.TestBuilder.transparentStats()` / `transparentStats(boolean)`
- `Punit.EmpiricalTestBuilder.transparentStats()` / `transparentStats(boolean)`

Resolution precedence: builder method > system property `punit.stats.transparent` > env var `PUNIT_STATS_TRANSPARENT` > default off. Re-uses the legacy `TransparentStatsConfig.resolve(Boolean)` so the same configuration hierarchy applies to both pipelines.

### Sample output

```
STATISTICAL ANALYSIS — verdict: PASS

  shopping-basket.testInstructionTranslation

  [REQUIRED] bernoulli-pass-rate → PASS
    Hypothesis test
      H₀ (null):           True pass rate π ≥ 0.8500
      H₁ (alternative):    True pass rate π < 0.8500
      Test type:           One-sided Wilson-score lower bound
    Observed data
      Sample size (n):     100
      Successes (k):       94
      Failures:            6
      Observed rate (p̂):  0.9400
    Inference
      Wilson 95% lower:    0.8730
      Threshold:           0.8500 (origin: EMPIRICAL)
      Baseline samples:    1000
      Reasoning:           0.8730 ≥ 0.8500 ✓

  Test intent: VERIFICATION
```

### Why a new typed renderer instead of reusing `VerdictTextRenderer`?

The legacy `VerdictTextRenderer` reads from `ProbabilisticTestVerdict` — the legacy verdict shape — which has fields the typed pipeline doesn't populate (`junitPassed`, full `ExecutionSummary` with `appliedMultiplier`, etc.). A focused typed-pipeline renderer reading directly from `CriterionResult.detail()` is leaner, has no legacy-only field dependencies, and lives next to the criterion implementations it mirrors.

## Test plan

- [x] **`TypedTransparentStatsRendererTest`** (6 cases): empirical full path, PASS-shows-checkmark, contractual deterministic-comparison shape, unknown-criterion fallback, warnings rendered as Notes, `snapshotCriteria` preserves order
- [x] **`TransparentStatsIntegrationTest`** (2 cases): builder method produces the verbose breakdown on stderr via real `Punit.testing(...).transparentStats()` flow under JUnit Platform TestKit; default (no opt-in) emits nothing
- [x] `./gradlew build` green across all modules

## Closes one of three pinned typed-surface gaps

This is the first of the three typed-pipeline enhancements surfaced during the punitexamples migration:

- [x] **Transparent stats wired into the typed pipeline** (this PR)
- [ ] Early-termination state on `ProbabilisticTestResult` for `Punit.translate` to render
- [ ] `FactorsStepper` sees per-iteration failure detail (not just score)

Once this lands, `ShoppingBasketDiagnosticsTest` (in punitexamples) regains its distinct pedagogical identity — a follow-up PR there opts the test methods in to `transparentStats()` and the file becomes the worked example for the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)