### PR TITLE
Carry contractRef through the typed verdict for audit traceability

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
@@ -2,6 +2,7 @@ package org.javai.punit.api.typed.spec;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.typed.FactorBundle;
@@ -37,7 +38,10 @@ import org.javai.punit.api.typed.covariate.CovariateAlignment;
  * pointer to the external document the test's threshold derives from
  * — an SLA paragraph, an SLO contract, an internal policy reference.
  * The value is opaque to the framework and surfaces in the verdict
- * text and the verdict XML as audit-grade traceability.
+ * text and the verdict XML as audit-grade traceability. Truly
+ * optional fields like this one travel as {@link Optional} on the
+ * result so consumers don't have to discriminate {@code null} from
+ * value at every read site.
  *
  * @param verdict          the composed PASS / FAIL / INCONCLUSIVE
  * @param factors          the factor bundle observed
@@ -47,7 +51,8 @@ import org.javai.punit.api.typed.covariate.CovariateAlignment;
  * @param covariates       observed-vs-baseline covariate alignment
  * @param contractRef      author-supplied audit pointer to the
  *                         contract or policy document the threshold
- *                         derives from; {@code null} when not declared
+ *                         derives from; {@link Optional#empty()} when
+ *                         not declared
  */
 public record ProbabilisticTestResult(
         Verdict verdict,
@@ -56,7 +61,7 @@ public record ProbabilisticTestResult(
         TestIntent intent,
         List<String> warnings,
         CovariateAlignment covariates,
-        String contractRef) implements EngineResult {
+        Optional<String> contractRef) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -65,6 +70,7 @@ public record ProbabilisticTestResult(
         Objects.requireNonNull(intent, "intent");
         Objects.requireNonNull(warnings, "warnings");
         Objects.requireNonNull(covariates, "covariates");
+        Objects.requireNonNull(contractRef, "contractRef");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);
     }
@@ -72,7 +78,7 @@ public record ProbabilisticTestResult(
     /**
      * Convenience constructor for callers that don't carry covariate
      * alignment or a contract reference. Equivalent to the canonical
-     * constructor with {@link CovariateAlignment#none()} and a null
+     * constructor with {@link CovariateAlignment#none()} and an empty
      * contract reference.
      */
     public ProbabilisticTestResult(
@@ -82,13 +88,13 @@ public record ProbabilisticTestResult(
             TestIntent intent,
             List<String> warnings) {
         this(verdict, factors, criterionResults, intent, warnings,
-                CovariateAlignment.none(), null);
+                CovariateAlignment.none(), Optional.empty());
     }
 
     /**
      * Convenience constructor preserving the pre-contractRef shape:
      * canonical fields plus an explicit covariate alignment, with the
-     * contract reference defaulting to {@code null}.
+     * contract reference defaulting to {@link Optional#empty()}.
      */
     public ProbabilisticTestResult(
             Verdict verdict,
@@ -98,7 +104,7 @@ public record ProbabilisticTestResult(
             List<String> warnings,
             CovariateAlignment covariates) {
         this(verdict, factors, criterionResults, intent, warnings,
-                covariates, null);
+                covariates, Optional.empty());
     }
 
     /**
@@ -115,15 +121,22 @@ public record ProbabilisticTestResult(
     }
 
     /**
+     * @param contractRef the author-supplied audit pointer; {@code null}
+     *                    or blank values map to {@link Optional#empty()}
+     *                    so a test author calling {@code .contractRef(null)}
+     *                    or never calling it at all yield identical
+     *                    results.
      * @return a copy of this result with the given contract reference
      *         substituted. Used by the JUnit pipeline to post-stamp
-     *         the author-supplied reference (declared on the typed
-     *         test builder) onto the result coming back from
-     *         {@code Spec.conclude}.
+     *         the reference declared on the typed test builder onto
+     *         the result coming back from {@code Spec.conclude}.
      */
     public ProbabilisticTestResult withContractRef(String contractRef) {
+        Optional<String> wrapped = (contractRef == null || contractRef.isBlank())
+                ? Optional.empty()
+                : Optional.of(contractRef);
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
-                covariates, contractRef);
+                covariates, wrapped);
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
@@ -33,12 +33,21 @@ import org.javai.punit.api.typed.covariate.CovariateAlignment;
  * {@code CovariateStatus} so downstream tooling sees the same shape
  * from both pipelines.
  *
+ * <p>{@link #contractRef()} carries an author-supplied human-readable
+ * pointer to the external document the test's threshold derives from
+ * — an SLA paragraph, an SLO contract, an internal policy reference.
+ * The value is opaque to the framework and surfaces in the verdict
+ * text and the verdict XML as audit-grade traceability.
+ *
  * @param verdict          the composed PASS / FAIL / INCONCLUSIVE
  * @param factors          the factor bundle observed
  * @param criterionResults the full ordered list of evaluated criteria
  * @param intent           the test's declared intent (VERIFICATION / SMOKE)
  * @param warnings         free-form warnings (e.g. "statistics wiring pending")
  * @param covariates       observed-vs-baseline covariate alignment
+ * @param contractRef      author-supplied audit pointer to the
+ *                         contract or policy document the threshold
+ *                         derives from; {@code null} when not declared
  */
 public record ProbabilisticTestResult(
         Verdict verdict,
@@ -46,7 +55,8 @@ public record ProbabilisticTestResult(
         List<EvaluatedCriterion> criterionResults,
         TestIntent intent,
         List<String> warnings,
-        CovariateAlignment covariates) implements EngineResult {
+        CovariateAlignment covariates,
+        String contractRef) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -61,8 +71,9 @@ public record ProbabilisticTestResult(
 
     /**
      * Convenience constructor for callers that don't carry covariate
-     * alignment. Equivalent to the canonical constructor with
-     * {@link CovariateAlignment#none()}.
+     * alignment or a contract reference. Equivalent to the canonical
+     * constructor with {@link CovariateAlignment#none()} and a null
+     * contract reference.
      */
     public ProbabilisticTestResult(
             Verdict verdict,
@@ -71,7 +82,23 @@ public record ProbabilisticTestResult(
             TestIntent intent,
             List<String> warnings) {
         this(verdict, factors, criterionResults, intent, warnings,
-                CovariateAlignment.none());
+                CovariateAlignment.none(), null);
+    }
+
+    /**
+     * Convenience constructor preserving the pre-contractRef shape:
+     * canonical fields plus an explicit covariate alignment, with the
+     * contract reference defaulting to {@code null}.
+     */
+    public ProbabilisticTestResult(
+            Verdict verdict,
+            FactorBundle factors,
+            List<EvaluatedCriterion> criterionResults,
+            TestIntent intent,
+            List<String> warnings,
+            CovariateAlignment covariates) {
+        this(verdict, factors, criterionResults, intent, warnings,
+                covariates, null);
     }
 
     /**
@@ -83,6 +110,20 @@ public record ProbabilisticTestResult(
      */
     public ProbabilisticTestResult withCovariates(CovariateAlignment covariates) {
         return new ProbabilisticTestResult(
-                verdict, factors, criterionResults, intent, warnings, covariates);
+                verdict, factors, criterionResults, intent, warnings,
+                covariates, contractRef);
+    }
+
+    /**
+     * @return a copy of this result with the given contract reference
+     *         substituted. Used by the JUnit pipeline to post-stamp
+     *         the author-supplied reference (declared on the typed
+     *         test builder) onto the result coming back from
+     *         {@code Spec.conclude}.
+     */
+    public ProbabilisticTestResult withContractRef(String contractRef) {
+        return new ProbabilisticTestResult(
+                verdict, factors, criterionResults, intent, warnings,
+                covariates, contractRef);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
@@ -96,6 +96,9 @@ public final class TypedTransparentStatsRenderer {
         }
 
         sb.append("  Test intent: ").append(result.intent()).append('\n');
+        if (result.contractRef() != null && !result.contractRef().isEmpty()) {
+            sb.append("  Contract: ").append(result.contractRef()).append('\n');
+        }
         return sb.toString();
     }
 

--- a/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
@@ -96,9 +96,8 @@ public final class TypedTransparentStatsRenderer {
         }
 
         sb.append("  Test intent: ").append(result.intent()).append('\n');
-        if (result.contractRef() != null && !result.contractRef().isEmpty()) {
-            sb.append("  Contract: ").append(result.contractRef()).append('\n');
-        }
+        result.contractRef().ifPresent(ref ->
+                sb.append("  Contract: ").append(ref).append('\n'));
         return sb.toString();
     }
 

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -291,6 +291,14 @@ public final class Punit {
                 sb.append('\n');
             }
         }
+        // Author-supplied audit pointer to the document the threshold
+        // derives from — an SLA paragraph, an SLO contract, an
+        // internal policy reference. Emitted on every verdict so
+        // anyone reading the output can trace the threshold back to
+        // its source.
+        if (result.contractRef() != null && !result.contractRef().isEmpty()) {
+            sb.append('\n').append("  Contract: ").append(result.contractRef()).append('\n');
+        }
         return sb.toString().trim();
     }
 
@@ -449,6 +457,7 @@ public final class Punit {
         private final List<Criterion<OT, ?>> requiredCriteria = new ArrayList<>();
         private TestIntent intent = TestIntent.VERIFICATION;
         private Boolean transparentStatsOverride;
+        private String contractRef;
 
         TestBuilder(ProbabilisticTest.Builder<FT, IT, OT> delegate,
                     Sampling<FT, IT, OT> sampling, FT factors) {
@@ -507,6 +516,20 @@ public final class Punit {
             return this;
         }
 
+        /**
+         * Records a human-readable pointer to the external document
+         * the test's threshold derives from — an SLA paragraph, an
+         * SLO contract, an internal policy reference. The value is
+         * opaque to the framework; it surfaces in the verdict text
+         * and the verdict XML as audit-grade traceability.
+         *
+         * <p>Example: {@code .contractRef("Acme API SLA v3.2 §2.1")}.
+         */
+        public TestBuilder<FT, IT, OT> contractRef(String contractRef) {
+            this.contractRef = contractRef;
+            return this;
+        }
+
         public ProbabilisticTest build() {
             return delegate.build();
         }
@@ -529,8 +552,9 @@ public final class Punit {
             // CovariateStatus shape.
             CovariateProfile observed = resolveCovariateProfile(spec);
             ProbabilisticTestResult stamped = typed.withCovariates(
-                    org.javai.punit.api.typed.covariate.CovariateAlignment.compute(
-                            observed, typed.covariates().baseline()));
+                            org.javai.punit.api.typed.covariate.CovariateAlignment.compute(
+                                    observed, typed.covariates().baseline()))
+                    .withContractRef(contractRef);
             maybeRenderTransparentStats(stamped);
             translate(stamped);
         }
@@ -579,6 +603,7 @@ public final class Punit {
         private Criterion<?, ?> criterion;
         private TestIntent intent = TestIntent.VERIFICATION;
         private Boolean transparentStatsOverride;
+        private String contractRef;
 
         EmpiricalTestBuilder(Supplier<Experiment> baselineSupplier) {
             this.baselineSupplier = baselineSupplier;
@@ -621,6 +646,12 @@ public final class Punit {
             return this;
         }
 
+        /** See {@link TestBuilder#contractRef(String)}. */
+        public EmpiricalTestBuilder contractRef(String contractRef) {
+            this.contractRef = contractRef;
+            return this;
+        }
+
         public ProbabilisticTest build() {
             if (samples == null) {
                 throw new IllegalStateException(
@@ -648,8 +679,9 @@ public final class Punit {
             warnings.forEach(System.err::println);
             CovariateProfile observed = resolveCovariateProfile(spec);
             ProbabilisticTestResult stamped = typed.withCovariates(
-                    org.javai.punit.api.typed.covariate.CovariateAlignment.compute(
-                            observed, typed.covariates().baseline()));
+                            org.javai.punit.api.typed.covariate.CovariateAlignment.compute(
+                                    observed, typed.covariates().baseline()))
+                    .withContractRef(contractRef);
             maybeRenderTransparentStats(spec, stamped);
             translate(stamped);
         }

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/Punit.java
@@ -296,9 +296,8 @@ public final class Punit {
         // internal policy reference. Emitted on every verdict so
         // anyone reading the output can trace the threshold back to
         // its source.
-        if (result.contractRef() != null && !result.contractRef().isEmpty()) {
-            sb.append('\n').append("  Contract: ").append(result.contractRef()).append('\n');
-        }
+        result.contractRef().ifPresent(ref ->
+                sb.append('\n').append("  Contract: ").append(ref).append('\n'));
         return sb.toString().trim();
     }
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/ContractRefIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/ContractRefIntegrationTest.java
@@ -1,0 +1,82 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.javai.punit.junit5.testsubjects.PunitSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * Pins the audit-traceability contract for the typed builder's
+ * {@code contractRef(...)}: the author-supplied reference must
+ * surface on every verdict — pass or fail — so anyone reading the
+ * output can trace the threshold back to its source document.
+ *
+ * <p>Renders are pinned in two places: the JUnit assertion message
+ * (failure path) and the verbose statistical analysis emitted on
+ * stderr (transparentStats path).
+ */
+@DisplayName("Contract reference — audit traceability on the verdict")
+class ContractRefIntegrationTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+    private static final String EXPECTED_REF = "Acme API SLA v3.2 §2.1";
+
+    private PrintStream originalErr;
+    private ByteArrayOutputStream capturedErr;
+
+    @BeforeEach
+    void redirectStderr() {
+        originalErr = System.err;
+        capturedErr = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(capturedErr, true, StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void restoreStderr() {
+        System.setErr(originalErr);
+    }
+
+    @Test
+    @DisplayName("transparentStats output includes the contract reference")
+    void renderedInTransparentStats() {
+        Events events = run(PunitSubjects.ContractRefPassingTest.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+
+        String stderr = capturedErr.toString(StandardCharsets.UTF_8);
+        assertThat(stderr).contains("Contract: " + EXPECTED_REF);
+    }
+
+    @Test
+    @DisplayName("failure message includes the contract reference")
+    void renderedInFailureMessage() {
+        Events events = run(PunitSubjects.ContractRefFailingTest.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+
+        String failureMessage = events.failed().stream()
+                .findFirst()
+                .orElseThrow()
+                .getPayload(org.junit.platform.engine.TestExecutionResult.class)
+                .orElseThrow()
+                .getThrowable()
+                .orElseThrow()
+                .getMessage();
+        assertThat(failureMessage).contains("Contract: " + EXPECTED_REF);
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PunitSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PunitSubjects.java
@@ -92,6 +92,39 @@ public final class PunitSubjects {
         }
     }
 
+    /**
+     * Passing test that declares a contract reference and opts in to
+     * transparentStats — both the rendered verdict and the verbose
+     * statistical analysis must surface the reference for audit
+     * traceability.
+     */
+    public static final class ContractRefPassingTest {
+        @ProbabilisticTest
+        void passesWithContractRef() {
+            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
+                    .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
+                    .contractRef("Acme API SLA v3.2 §2.1")
+                    .transparentStats()
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * Failing test that declares a contract reference. The contract
+     * reference must appear in the JUnit assertion message so failure
+     * triage can trace the threshold back to the document it derives
+     * from.
+     */
+    public static final class ContractRefFailingTest {
+        @ProbabilisticTest
+        void failsWithContractRef() {
+            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysFails(), 20), new NoFactors())
+                    .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
+                    .contractRef("Acme API SLA v3.2 §2.1")
+                    .assertPasses();
+        }
+    }
+
     /** Contractual test that should fail: 0% observed < 50% threshold. */
     public static final class FailingContractualTest {
         @ProbabilisticTest


### PR DESCRIPTION
## Summary

Authors of contractual / SLA / SLO tests have always been able to declare an external document the threshold derives from via `@ProbabilisticTest(contractRef = …)`, and that reference surfaces on every verdict — text output, XML, `SpecProvenance` — so anyone reading the result can trace the threshold back to its source. The typed builder lacked an equivalent: a test author had `ThresholdOrigin` (SLA / SLO / POLICY) but no place to record the human-readable pointer.

This PR closes that gap.

```java
Punit.testing(sampling, factors)
     .criterion(BernoulliPassRate.meeting(0.99, ThresholdOrigin.SLO))
     .contractRef("Internal message SLO - Q4 2024")
     .assertPasses();
```

The reference post-stamps onto `ProbabilisticTestResult` (mirroring how observed covariates are threaded), and surfaces on:
- the JUnit assertion message produced on FAIL / INCONCLUSIVE
- the verbose statistical-analysis output emitted by `.transparentStats()`

The verdict-XML side of the audit story is a separate gap (the typed pipeline doesn't yet emit RP07 verdict XML at all) and stays tracked in the legacy-retirement directive in the orchestrator.

## Test plan

- [x] `./gradlew :punit-junit5:test --tests "*ContractRef*"` — both new tests pass
- [x] `./gradlew build` — full suite green
- [x] `ContractRefIntegrationTest.renderedInTransparentStats` — verbose output contains `Contract: <ref>` line
- [x] `ContractRefIntegrationTest.renderedInFailureMessage` — JUnit failure message contains `Contract: <ref>` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)