### PR TITLE
Rename Punit → PUnit to match JUnit camelcase convention

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -12,5 +12,5 @@
 > **Source**: https://github.com/javai-org/javai-R/blob/main/docs/GLOSSARY.md
 >
 > The glossary has been generalised to use framework-agnostic terminology.
-> Punit-specific annotations and class names are documented in punit's own
+> PUnit-specific annotations and class names are documented in punit's own
 > user guide and API documentation.

--- a/plan/DES-EXPERIMENT-DX.md
+++ b/plan/DES-EXPERIMENT-DX.md
@@ -60,7 +60,7 @@ preceded it.
 Feotest's post-refactor shape is a useful source of principles
 (explicit identity, framework-owned instance lifecycle, first-class
 factor types, cross-experiment consistency), but it is not the target.
-Punit is Java inside JUnit 5 and should land on its own idiomatic shape.
+PUnit is Java inside JUnit 5 and should land on its own idiomatic shape.
 
 The immutable use case principle is stated informally across the
 codebase (deprecation notices on `@FactorSetter` / `@FactorGetter`,

--- a/plan/DES-VERDICT-RESTRUCTURE.md
+++ b/plan/DES-VERDICT-RESTRUCTURE.md
@@ -64,7 +64,7 @@ public record ProbabilisticTestVerdict(
         Termination termination,
         Map<String, String> environmentMetadata,
         boolean junitPassed,
-        PunitVerdict punitVerdict,
+        PUnitVerdict punitVerdict,
         String verdictReason               // NEW
 ) { ... }
 ```
@@ -142,7 +142,7 @@ String title = "VERDICT: " + verdictLabel + " (" + verdict.verdictReason() + ")"
 ### 3.2 Covariate comparison block (R2)
 
 Add a new private method `appendCovariateComparison` called when
-`verdict.punitVerdict() == PunitVerdict.INCONCLUSIVE` and
+`verdict.punitVerdict() == PUnitVerdict.INCONCLUSIVE` and
 `!verdict.covariates().aligned()`:
 
 ```java
@@ -180,7 +180,7 @@ Insert the call in `printConsoleSummary` immediately after the existing
 
 ```java
 // REMOVE
-if (verdict.punitVerdict() == PunitVerdict.INCONCLUSIVE) {
+if (verdict.punitVerdict() == PUnitVerdict.INCONCLUSIVE) {
     sb.append(PUnitReporter.labelValueLn("Verdict:", "Inconclusive — covariate misalignment"));
 }
 
@@ -238,7 +238,7 @@ For (1), add a private method:
 
 ```java
 private String deriveVerdictReason() {
-    if (punitVerdict == PunitVerdict.INCONCLUSIVE) {
+    if (punitVerdict == PUnitVerdict.INCONCLUSIVE) {
         if (!covariateStatus.aligned()) {
             return "covariate misalignment";
         }
@@ -342,7 +342,7 @@ private ProbabilisticTestVerdict buildVerdictFromInputs(JsonNode inputs) {
     return ProbabilisticTestVerdict.builder()
             .className(inputs.at("/identity/className").asText())
             .methodName(inputs.at("/identity/methodName").asText())
-            .verdict(PunitVerdict.valueOf(inputs.get("verdict").asText()))
+            .verdict(PUnitVerdict.valueOf(inputs.get("verdict").asText()))
             .successes(inputs.at("/execution/successes").asInt())
             .failures(inputs.at("/execution/failures").asInt())
             // ... remaining fields mapped from JSON paths

--- a/plan/REQ-VERDICT-RESTRUCTURE.md
+++ b/plan/REQ-VERDICT-RESTRUCTURE.md
@@ -205,7 +205,7 @@ layer.
   detection
 - `ProbabilisticTestVerdict.CovariateStatus` — misalignment data model
 - `TestIntent` — VERIFICATION / SMOKE enum
-- `PunitVerdict` — PASS / FAIL / INCONCLUSIVE enum
+- `PUnitVerdict` — PASS / FAIL / INCONCLUSIVE enum
 - Observed in: `punitexamples` →
   `ShoppingBasketCovariateTest$HighTemperatureConfiguration.testWithHighTemperature`
   (baseline at `temperature=0.3`, test at `temperature=0.7`)

--- a/plan/REVIEW-EXPERIMENT-DX.md
+++ b/plan/REVIEW-EXPERIMENT-DX.md
@@ -2,7 +2,7 @@
 
 ## Goal of this review
 
-Punit's experiment-side developer experience has evolved across several
+PUnit's experiment-side developer experience has evolved across several
 iterations, and the addition of the **immutable use case principle**
 forced a rethink of how factors are expressed. The result is a surface
 that works but carries legacy from earlier thinking — two partially
@@ -98,7 +98,7 @@ documentation under `punit/docs/`.
 
 ## The history to respect
 
-Punit's current DX is **not** the result of naive design. It
+PUnit's current DX is **not** the result of naive design. It
 accumulated through several earlier iterations, and the **immutable
 use case** principle arrived after the factor-arguments machinery was
 already in place. That arrival triggered `@ConfigSource` as a second
@@ -203,7 +203,7 @@ proposed direction:
     lifecycle, reporters that CI systems already understand. Which
     of these make a Rust-style builder pattern **inappropriate** for
     punit, and which are orthogonal?
-16. Punit's proc-macro / annotation style makes it easy to express
+16. PUnit's proc-macro / annotation style makes it easy to express
     *metadata* about an experiment (time budget, expiration days,
     skip warmup). Feotest has to spell those as setter calls.
     When is metadata-as-annotation the right choice, and when does
@@ -221,7 +221,7 @@ proposed direction:
   alignment on *principles* — identity is explicit, instance
   lifecycle is framework-owned, factors are first-class — not on
   mechanical API shapes.
-- **Leave a migration path.** Punit has real users (`punitexamples`
+- **Leave a migration path.** PUnit has real users (`punitexamples`
   at minimum). A proposal should note what each change breaks and
   what a deprecation / migration sequence would look like. "Big
   bang rewrite" is a legitimate answer but it has to be argued for.

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
@@ -51,10 +51,10 @@ import org.javai.punit.api.typed.spec.ExceptionPolicy;
  *     return Sampling.of(f -> new MyUseCase(f), samples, input1, input2);
  * }
  *
- * @PunitExperiment Experiment baseline() {
+ * @PUnitExperiment Experiment baseline() {
  *     return Experiment.measuring(sampling(1000), factors).build();
  * }
- * @PunitTest ProbabilisticTest meets() {
+ * @PUnitTest ProbabilisticTest meets() {
  *     return ProbabilisticTest.testing(sampling(100), factors)
  *             .criterion(BernoulliPassRate.empirical())
  *             .build();
@@ -69,10 +69,10 @@ import org.javai.punit.api.typed.spec.ExceptionPolicy;
  * <h2>Other consumers</h2>
  *
  * <pre>{@code
- * @PunitExperiment Experiment compare() {
+ * @PUnitExperiment Experiment compare() {
  *     return Experiment.exploring(sampling(50)).grid(a, b, c).build();
  * }
- * @PunitExperiment Experiment tune() {
+ * @PUnitExperiment Experiment tune() {
  *     return Experiment.optimizing(sampling(20))
  *             .initialFactors(f0).stepper(...).maximize(...).build();
  * }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/UseCaseOutcome.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/UseCaseOutcome.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import org.javai.outcome.Outcome;
 
 /**
- * Punit's per-sample outcome record. Wraps the raw result of a use
+ * PUnit's per-sample outcome record. Wraps the raw result of a use
  * case invocation together with the {@link PostconditionEvaluator}
  * that classifies it against the service contract, the optional
  * {@link MatchResult} from an instance-conformance check, and a

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -61,10 +61,10 @@ public final class ProbabilisticTest implements Spec {
      * <pre>{@code
      * private Sampling<F, I, O> sampling(int samples) { ... }
      *
-     * @PunitExperiment Experiment baseline() {
+     * @PUnitExperiment Experiment baseline() {
      *     return Experiment.measuring(sampling(1000), factors).build();
      * }
-     * @PunitTest ProbabilisticTest meets() {
+     * @PUnitTest ProbabilisticTest meets() {
      *     return ProbabilisticTest.testing(sampling(100), factors)
      *             .criterion(BernoulliPassRate.empirical())
      *             .build();
@@ -439,10 +439,10 @@ public final class ProbabilisticTest implements Spec {
                                     + "    private Sampling<F, I, O> sampling(int samples) {\n"
                                     + "        return Sampling.of(useCaseFactory, samples, inputs);\n"
                                     + "    }\n"
-                                    + "    @PunitExperiment Experiment baseline() {\n"
+                                    + "    @PUnitExperiment Experiment baseline() {\n"
                                     + "        return Experiment.measuring(sampling(1000), factors).build();\n"
                                     + "    }\n"
-                                    + "    @PunitTest ProbabilisticTest meets() {\n"
+                                    + "    @PUnitTest ProbabilisticTest meets() {\n"
                                     + "        return ProbabilisticTest.testing(sampling(100), factors)\n"
                                     + "                .criterion(BernoulliPassRate.empirical())\n"
                                     + "                .build();\n"

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Spec.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Spec.java
@@ -18,7 +18,7 @@ package org.javai.punit.api.typed.spec;
  * dispatcher.
  *
  * <p>The user touches this interface only as a return type from
- * {@code @PunitExperiment} / {@code @PunitTest} methods; the
+ * {@code @PUnitExperiment} / {@code @PUnitTest} methods; the
  * dispatch mechanism is engine-internal.
  *
  * @see TypedSpec

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Verdict.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Verdict.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * call.
  *
  * <p>Kept distinct from the legacy
- * {@code org.javai.punit.verdict.PunitVerdict} used by the existing
+ * {@code org.javai.punit.verdict.PUnitVerdict} used by the existing
  * reporting pipeline; Stage 8 reconciles the two.
  */
 public enum Verdict {

--- a/punit-api/src/test/java/org/javai/punit/api/typed/architecture/PUnitApiArchitectureTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/architecture/PUnitApiArchitectureTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
  * without JUnit on the classpath.
  */
 @DisplayName("punit-api Architecture Rules")
-class PunitApiArchitectureTest {
+class PUnitApiArchitectureTest {
 
     private static JavaClasses classes;
 
@@ -46,7 +46,7 @@ class PunitApiArchitectureTest {
 
     @Test
     @DisplayName("punit-api classes must not depend on any other punit package")
-    void mustNotDependOnInternalPunit() {
+    void mustNotDependOnInternalPUnit() {
         ArchRule rule = noClasses()
                 .that().resideInAPackage("org.javai.punit.api.typed..")
                 .should().dependOnClassesThat()

--- a/punit-core/src/main/java/org/javai/punit/api/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Experiment.java
@@ -21,12 +21,12 @@ import org.junit.jupiter.api.Test;
  * <pre>{@code
  * @Experiment
  * void shoppingBaseline() {
- *     Punit.measuring(shoppingSampling(1000), shoppingFactors()).run();
+ *     PUnit.measuring(shoppingSampling(1000), shoppingFactors()).run();
  * }
  *
  * @Experiment
  * void shoppingAcrossModels() {
- *     Punit.exploring(shoppingSampling(100))
+ *     PUnit.exploring(shoppingSampling(100))
  *             .grid(new Factors("gpt-4o", 0.0),
  *                   new Factors("gpt-4o", 0.5),
  *                   new Factors("claude-3-sonnet", 0.0))
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
  *
  * @Experiment
  * void shoppingOptimize() {
- *     Punit.optimizing(shoppingSampling(50))
+ *     PUnit.optimizing(shoppingSampling(50))
  *             .initialFactors(new Factors("gpt-4o", 0.0))
  *             .stepper(stepper)
  *             .maximize(scorer)

--- a/punit-core/src/main/java/org/javai/punit/api/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ProbabilisticTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
  * <pre>{@code
  * @ProbabilisticTest
  * void shoppingMeetsBaseline() {
- *     Punit.testing(this::shoppingBaseline)
+ *     PUnit.testing(this::shoppingBaseline)
  *             .samples(100)
  *             .criterion(BernoulliPassRate.empirical())
  *             .assertPasses();

--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/BernoulliPassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/BernoulliPassRate.java
@@ -136,7 +136,7 @@ public final class BernoulliPassRate<OT> implements Criterion<OT, PassRateStatis
      * The confidence level (1 − α) used by the empirical Wilson-score
      * comparison. Defaults to {@code 0.95}; override via
      * {@link #atConfidence(double)}. Surfaced for the framework's
-     * pre-flight feasibility check (see {@code Punit}'s wire-up of
+     * pre-flight feasibility check (see {@code PUnit}'s wire-up of
      * {@link org.javai.punit.statistics.VerificationFeasibilityEvaluator})
      * — given a configured {@code samples} and a resolved baseline
      * rate, the check needs the criterion's confidence to decide

--- a/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
+++ b/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
@@ -96,7 +96,7 @@ public final class PowerAnalysis {
      * @param baseline    a supplier yielding the {@code MEASURE}
      *                    {@link Experiment} the sample size is being
      *                    planned against — typically a method
-     *                    reference to an {@code @PunitExperiment} method
+     *                    reference to an {@code @PUnitExperiment} method
      * @param mde         the minimum detectable effect, in (0, 1)
      * @param power       the required statistical power, in (0, 1)
      * @return the required sample count, ceiling-rounded
@@ -127,7 +127,7 @@ public final class PowerAnalysis {
             throw new IllegalArgumentException(
                     "PowerAnalysis.sampleSize requires a MEASURE-flavour Experiment "
                             + "(one that produces a baseline); got " + experiment.kind()
-                            + ". Pass a method reference to an @PunitExperiment method "
+                            + ". Pass a method reference to an @PUnitExperiment method "
                             + "whose body returns Experiment.measuring(...).build().");
         }
 

--- a/punit-core/src/main/java/org/javai/punit/ptest/engine/ResultPublisher.java
+++ b/punit-core/src/main/java/org/javai/punit/ptest/engine/ResultPublisher.java
@@ -28,7 +28,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdict.LatencyDimension;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.Misalignment;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.SpecProvenance;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.Termination;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.javai.punit.verdict.VerdictTextRenderer;
 
 /**

--- a/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
@@ -21,7 +21,7 @@ import org.javai.punit.api.typed.spec.Verdict;
  * <p>The legacy framework expressed this through
  * {@code @ProbabilisticTest(transparentStats = true)}. The typed
  * pipeline exposes the same feature through
- * {@code Punit.testing(...).transparentStats()}; this class is the
+ * {@code PUnit.testing(...).transparentStats()}; this class is the
  * renderer that produces the actual output.
  *
  * <h2>What gets rendered</h2>

--- a/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/CovariateResolutionContext.java
+++ b/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/CovariateResolutionContext.java
@@ -72,7 +72,7 @@ public interface CovariateResolutionContext {
      * @param key the environment key
      * @return the value, or empty if not set
      */
-    Optional<String> getPunitEnvironment(String key);
+    Optional<String> getPUnitEnvironment(String key);
 
     /**
      * Returns the use case instance for @CovariateSource method invocation.

--- a/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/CustomCovariateResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/CustomCovariateResolver.java
@@ -43,7 +43,7 @@ public final class CustomCovariateResolver implements CovariateResolver {
         // Try sources in order: system property, env var, punit env
         var value = context.getSystemProperty(key)
             .or(() -> context.getEnvironmentVariable(toEnvVarName(key)))
-            .or(() -> context.getPunitEnvironment(key))
+            .or(() -> context.getPUnitEnvironment(key))
             .orElse(CovariateProfile.UNDEFINED);
 
         return new CovariateValue.StringValue(value);

--- a/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/DefaultCovariateResolutionContext.java
+++ b/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/DefaultCovariateResolutionContext.java
@@ -80,7 +80,7 @@ public final class DefaultCovariateResolutionContext implements CovariateResolut
     }
 
     @Override
-    public Optional<String> getPunitEnvironment(String key) {
+    public Optional<String> getPUnitEnvironment(String key) {
         Objects.requireNonNull(key, "key must not be null");
         return Optional.ofNullable(punitEnvironment.get(key));
     }

--- a/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/RegionResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/spec/baseline/covariate/RegionResolver.java
@@ -43,7 +43,7 @@ public final class RegionResolver implements CovariateResolver {
     public CovariateValue resolve(CovariateResolutionContext context) {
         var rawRegion = context.getSystemProperty(SYSTEM_PROPERTY_KEY)
                 .or(() -> context.getEnvironmentVariable(ENV_VAR_KEY))
-                .or(() -> context.getPunitEnvironment(PUNIT_ENV_KEY))
+                .or(() -> context.getPUnitEnvironment(PUNIT_ENV_KEY))
                 .orElse(null);
 
         if (rawRegion == null) {

--- a/punit-core/src/main/java/org/javai/punit/verdict/PUnitVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/PUnitVerdict.java
@@ -15,7 +15,7 @@ package org.javai.punit.verdict;
  * <p>This is independent of the JUnit pass/fail state. JUnit red + PUnit PASS is a legitimate
  * combination meaning "samples failed, but within the expected statistical range — no breach."
  */
-public enum PunitVerdict {
+public enum PUnitVerdict {
     PASS,
     FAIL,
     INCONCLUSIVE

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
@@ -37,7 +37,7 @@ public record ProbabilisticTestVerdict(
         Termination termination,
         Map<String, String> environmentMetadata,
         boolean junitPassed,
-        PunitVerdict punitVerdict,
+        PUnitVerdict punitVerdict,
         String verdictReason
 ) {
 

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -262,7 +262,7 @@ public class ProbabilisticTestVerdictBuilder {
         Optional<PacingSummary> pacing = buildPacingSummary();
         Optional<SpecProvenance> provenance = buildSpecProvenance();
         Termination termination = buildTermination();
-        PunitVerdict punitVerdict = derivePunitVerdict(covariates);
+        PUnitVerdict punitVerdict = derivePUnitVerdict(covariates);
         String verdictReason = deriveVerdictReason(punitVerdict, covariates);
 
         return new ProbabilisticTestVerdict(
@@ -498,15 +498,15 @@ public class ProbabilisticTestVerdictBuilder {
         return new Termination(terminationReason, Optional.ofNullable(terminationDetails));
     }
 
-    private PunitVerdict derivePunitVerdict(CovariateStatus covariates) {
+    private PUnitVerdict derivePUnitVerdict(CovariateStatus covariates) {
         if (!covariates.aligned()) {
-            return PunitVerdict.INCONCLUSIVE;
+            return PUnitVerdict.INCONCLUSIVE;
         }
-        return passedStatistically ? PunitVerdict.PASS : PunitVerdict.FAIL;
+        return passedStatistically ? PUnitVerdict.PASS : PUnitVerdict.FAIL;
     }
 
-    private String deriveVerdictReason(PunitVerdict punitVerdict, CovariateStatus covariates) {
-        if (punitVerdict == PunitVerdict.INCONCLUSIVE) {
+    private String deriveVerdictReason(PUnitVerdict punitVerdict, CovariateStatus covariates) {
+        if (punitVerdict == PUnitVerdict.INCONCLUSIVE) {
             if (!covariates.aligned()) {
                 return "covariate misalignment";
             }

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictTextRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictTextRenderer.java
@@ -106,7 +106,7 @@ public final class VerdictTextRenderer {
 
         appendDimensionBreakdown(sb, verdict);
 
-        if (verdict.punitVerdict() == PunitVerdict.INCONCLUSIVE) {
+        if (verdict.punitVerdict() == PUnitVerdict.INCONCLUSIVE) {
             sb.append(PUnitReporter.labelValueLn("Verdict:",
                     "Inconclusive \u2014 " + verdict.verdictReason()));
         }

--- a/punit-core/src/test/java/org/javai/punit/architecture/PUnitApiVisibilityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/architecture/PUnitApiVisibilityTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
  * would otherwise only be noticed when a downstream consumer compiles.
  */
 @DisplayName("punit-api visibility from punit-core")
-class PunitApiVisibilityTest {
+class PUnitApiVisibilityTest {
 
     record SampleFactors(int n) {}
 

--- a/punit-core/src/test/java/org/javai/punit/spec/baseline/covariate/CustomCovariateResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/spec/baseline/covariate/CustomCovariateResolverTest.java
@@ -40,7 +40,7 @@ class CustomCovariateResolverTest {
 
         @Test
         @DisplayName("should use punit environment as fallback")
-        void shouldUsePunitEnvironmentAsFallback() {
+        void shouldUsePUnitEnvironmentAsFallback() {
             var key = "punit.test.custom.covariate";
             
             var context = DefaultCovariateResolutionContext.builder()

--- a/punit-core/src/test/java/org/javai/punit/spec/baseline/covariate/DefaultCovariateResolutionContextTest.java
+++ b/punit-core/src/test/java/org/javai/punit/spec/baseline/covariate/DefaultCovariateResolutionContextTest.java
@@ -115,8 +115,8 @@ class DefaultCovariateResolutionContextTest {
     }
 
     @Nested
-    @DisplayName("getPunitEnvironment()")
-    class GetPunitEnvironmentTests {
+    @DisplayName("getPUnitEnvironment()")
+    class GetPUnitEnvironmentTests {
 
         @Test
         @DisplayName("should return value for existing key")
@@ -125,8 +125,8 @@ class DefaultCovariateResolutionContextTest {
                 .punitEnvironment(Map.of("region", "EU", "env", "prod"))
                 .build();
             
-            assertThat(context.getPunitEnvironment("region")).contains("EU");
-            assertThat(context.getPunitEnvironment("env")).contains("prod");
+            assertThat(context.getPUnitEnvironment("region")).contains("EU");
+            assertThat(context.getPUnitEnvironment("env")).contains("prod");
         }
 
         @Test
@@ -136,7 +136,7 @@ class DefaultCovariateResolutionContextTest {
                 .punitEnvironment(Map.of("region", "EU"))
                 .build();
             
-            assertThat(context.getPunitEnvironment("nonexistent")).isEmpty();
+            assertThat(context.getPUnitEnvironment("nonexistent")).isEmpty();
         }
 
         @Test
@@ -144,7 +144,7 @@ class DefaultCovariateResolutionContextTest {
         void shouldReturnEmptyWhenNoEnvironmentSet() {
             var context = DefaultCovariateResolutionContext.forNow();
             
-            assertThat(context.getPunitEnvironment("anything")).isEmpty();
+            assertThat(context.getPUnitEnvironment("anything")).isEmpty();
         }
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
@@ -277,7 +277,7 @@ class ProbabilisticTestVerdictBuilderTest {
 
             assertThat(verdict.covariates().aligned()).isTrue();
             assertThat(verdict.covariates().misalignments()).isEmpty();
-            assertThat(verdict.punitVerdict()).isEqualTo(PunitVerdict.PASS);
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.PASS);
         }
 
         @Test
@@ -286,7 +286,7 @@ class ProbabilisticTestVerdictBuilderTest {
                     .passedStatistically(false)
                     .build();
 
-            assertThat(verdict.punitVerdict()).isEqualTo(PunitVerdict.FAIL);
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.FAIL);
         }
 
         @Test
@@ -300,7 +300,7 @@ class ProbabilisticTestVerdictBuilderTest {
             assertThat(verdict.covariates().aligned()).isFalse();
             assertThat(verdict.covariates().misalignments()).hasSize(1);
             assertThat(verdict.covariates().misalignments().getFirst().covariateKey()).isEqualTo("model");
-            assertThat(verdict.punitVerdict()).isEqualTo(PunitVerdict.INCONCLUSIVE);
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
         }
 
         @Test
@@ -311,7 +311,7 @@ class ProbabilisticTestVerdictBuilderTest {
                     .passedStatistically(false)
                     .build();
 
-            assertThat(verdict.punitVerdict()).isEqualTo(PunitVerdict.INCONCLUSIVE);
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
         }
     }
 
@@ -329,14 +329,14 @@ class ProbabilisticTestVerdictBuilderTest {
         }
 
         @Test
-        void junitFailWithPunitPassIsLegitimate() {
+        void junitFailWithPUnitPassIsLegitimate() {
             ProbabilisticTestVerdict verdict = minimalBuilder()
                     .junitPassed(false)
                     .passedStatistically(true)
                     .build();
 
             assertThat(verdict.junitPassed()).isFalse();
-            assertThat(verdict.punitVerdict()).isEqualTo(PunitVerdict.PASS);
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.PASS);
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/verdict/ScenarioFixtures.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/ScenarioFixtures.java
@@ -70,7 +70,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(),
                 true,
-                PunitVerdict.PASS,
+                PUnitVerdict.PASS,
                 "0.9600 >= 0.9374"
         );
     }
@@ -108,7 +108,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(),
                 false,
-                PunitVerdict.FAIL,
+                PUnitVerdict.FAIL,
                 "0.8500 < 0.9374"
         );
     }
@@ -142,7 +142,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED, Optional.empty()),
                 Map.of(),
                 false,
-                PunitVerdict.FAIL,
+                PUnitVerdict.FAIL,
                 "budget exhausted"
         );
     }
@@ -176,7 +176,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(),
                 true,
-                PunitVerdict.PASS,
+                PUnitVerdict.PASS,
                 "0.9000 >= 0.8500"
         );
     }
@@ -221,7 +221,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(),
                 true,
-                PunitVerdict.PASS,
+                PUnitVerdict.PASS,
                 "0.9500 >= 0.9000"
         );
     }
@@ -257,7 +257,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(),
                 false,
-                PunitVerdict.INCONCLUSIVE,
+                PUnitVerdict.INCONCLUSIVE,
                 "covariate misalignment"
         );
     }
@@ -296,7 +296,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.IMPOSSIBILITY, Optional.empty()),
                 Map.of(),
                 false,
-                PunitVerdict.FAIL,
+                PUnitVerdict.FAIL,
                 "0.6667 < 0.9000"
         );
     }
@@ -335,7 +335,7 @@ final class ScenarioFixtures {
                 new Termination(TerminationReason.METHOD_TOKEN_BUDGET_EXHAUSTED, Optional.empty()),
                 Map.of(),
                 false,
-                PunitVerdict.FAIL,
+                PUnitVerdict.FAIL,
                 "budget exhausted"
         );
     }

--- a/punit-core/src/test/java/org/javai/punit/verdict/VerdictTextRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/VerdictTextRendererTest.java
@@ -466,19 +466,19 @@ class VerdictTextRendererTest {
     // ── Helpers ──────────────────────────────────────────────────────────
 
     private ProbabilisticTestVerdict passingVerdict() {
-        return minimalVerdict("shouldPass", true, PunitVerdict.PASS, 100, 95);
+        return minimalVerdict("shouldPass", true, PUnitVerdict.PASS, 100, 95);
     }
 
     private ProbabilisticTestVerdict failingVerdict() {
-        return minimalVerdict("shouldFail", false, PunitVerdict.FAIL, 100, 80);
+        return minimalVerdict("shouldFail", false, PUnitVerdict.FAIL, 100, 80);
     }
 
     private ProbabilisticTestVerdict verdictWithSamples(int samples, int successes) {
-        return minimalVerdict("smallTest", true, PunitVerdict.PASS, samples, successes);
+        return minimalVerdict("smallTest", true, PUnitVerdict.PASS, samples, successes);
     }
 
     private ProbabilisticTestVerdict minimalVerdict(String methodName, boolean passed,
-            PunitVerdict punitVerdict, int samples, int successes) {
+            PUnitVerdict punitVerdict, int samples, int successes) {
         double observedRate = samples > 0 ? (double) successes / samples : 0.0;
         return new ProbabilisticTestVerdict(
                 "v:test01",
@@ -496,7 +496,7 @@ class VerdictTextRendererTest {
                 Optional.empty(), Optional.empty(),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(), passed, punitVerdict,
-                punitVerdict == PunitVerdict.PASS
+                punitVerdict == PUnitVerdict.PASS
                         ? String.format("%.4f >= 0.9000", (double) successes / samples)
                         : String.format("%.4f < 0.9000", (double) successes / samples)
         );

--- a/punit-gradle-plugin/build.gradle.kts
+++ b/punit-gradle-plugin/build.gradle.kts
@@ -14,7 +14,7 @@ gradlePlugin {
     plugins {
         create("punit") {
             id = "org.javai.punit"
-            implementationClass = "org.javai.punit.gradle.PunitPlugin"
+            implementationClass = "org.javai.punit.gradle.PUnitPlugin"
             displayName = "PUnit Gradle Plugin"
             description = "Configures test and experiment tasks for PUnit probabilistic testing"
         }
@@ -49,11 +49,11 @@ val generateVersionFile = tasks.register("generateVersionFile") {
     doLast {
         val dir = outputDir.get().asFile.resolve("org/javai/punit/gradle")
         dir.mkdirs()
-        dir.resolve("PunitVersion.kt").writeText(
+        dir.resolve("PUnitVersion.kt").writeText(
             """
             package org.javai.punit.gradle
 
-            internal object PunitVersion {
+            internal object PUnitVersion {
                 const val VERSION = "$punitVersion"
             }
             """.trimIndent() + "\n"

--- a/punit-gradle-plugin/src/functionalTest/kotlin/org/javai/punit/gradle/PUnitPluginFunctionalTest.kt
+++ b/punit-gradle-plugin/src/functionalTest/kotlin/org/javai/punit/gradle/PUnitPluginFunctionalTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 
 @DisplayName("PUnit Gradle Plugin")
-class PunitPluginFunctionalTest {
+class PUnitPluginFunctionalTest {
 
     @TempDir
     lateinit var projectDir: File
@@ -236,7 +236,7 @@ class PunitPluginFunctionalTest {
 
     @Nested
     @DisplayName("PUnit Report Task")
-    inner class PunitReportTaskTests {
+    inner class PUnitReportTaskTests {
 
         @Test
         @DisplayName("punitReport task is registered with correct description")

--- a/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitExperimentExtension.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitExperimentExtension.kt
@@ -20,7 +20,7 @@ import org.gradle.api.provider.Property
  * while EXPLORE and OPTIMIZE outputs are human-review artefacts (kept under
  * `build/`, not committed). Override any default as shown above.
  */
-abstract class PunitExperimentExtension {
+abstract class PUnitExperimentExtension {
 
     /** Output directory for MEASURE specs. Default: `src/test/resources/punit/specs` (tracked in source). */
     abstract val specsDir: Property<String>

--- a/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
@@ -21,10 +21,10 @@ import java.net.URLClassLoader
  * - Registers `createSentinel` task to build an executable sentinel JAR
  * - Forwards `punit.*` system properties and supports `-Prun=` filter syntax
  */
-class PunitPlugin : Plugin<Project> {
+class PUnitPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
-        val extension = project.extensions.create("punit", PunitExperimentExtension::class.java).apply {
+        val extension = project.extensions.create("punit", PUnitExperimentExtension::class.java).apply {
             // Measure specs are inputs to subsequent @ProbabilisticTest runs
             // (including in CI), so they live alongside source and are intended
             // to be committed. Explore and Optimize outputs are human-review
@@ -47,7 +47,7 @@ class PunitPlugin : Plugin<Project> {
             isCanBeConsumed = false
             isCanBeResolved = true
         }
-        val punitVersion = loadPunitVersion()
+        val punitVersion = loadPUnitVersion()
         project.dependencies.add("punitSentinel",
             "org.javai:punit-sentinel:$punitVersion")
 
@@ -70,12 +70,12 @@ class PunitPlugin : Plugin<Project> {
                 "Shorthand for 'experiment' task")
 
             registerCreateSentinelTask(project, extension, sentinelConfig)
-            registerPunitReportTask(project, reportConfig)
-            registerPunitVerifyTask(project, reportConfig)
+            registerPUnitReportTask(project, reportConfig)
+            registerPUnitVerifyTask(project, reportConfig)
         }
     }
 
-    private fun configureTestTask(project: Project, extension: PunitExperimentExtension) {
+    private fun configureTestTask(project: Project, extension: PUnitExperimentExtension) {
         project.tasks.withType(Test::class.java).named("test").configure {
             useJUnitPlatform {
                 excludeTags("punit-experiment")
@@ -93,14 +93,14 @@ class PunitPlugin : Plugin<Project> {
                     project.layout.buildDirectory.dir("reports/punit/xml").get().asFile.absolutePath)
             }
 
-            forwardPunitSystemProperties(this)
+            forwardPUnitSystemProperties(this)
             applyRunFilter(project, this)
         }
     }
 
     private fun registerExperimentTask(
         project: Project,
-        extension: PunitExperimentExtension,
+        extension: PUnitExperimentExtension,
         taskName: String,
         taskDescription: String
     ) {
@@ -156,7 +156,7 @@ class PunitPlugin : Plugin<Project> {
 
             dependsOn("compileTestJava", "processTestResources")
 
-            forwardPunitSystemProperties(this)
+            forwardPUnitSystemProperties(this)
             applyRunFilter(project, this)
 
             // Track start time to detect which directories received output
@@ -200,7 +200,7 @@ class PunitPlugin : Plugin<Project> {
 
     private fun registerCreateSentinelTask(
         project: Project,
-        extension: PunitExperimentExtension,
+        extension: PUnitExperimentExtension,
         sentinelConfig: org.gradle.api.artifacts.Configuration
     ) {
         project.tasks.register("createSentinel", Jar::class.java).configure {
@@ -408,11 +408,11 @@ class PunitPlugin : Plugin<Project> {
         }
     }
 
-    private fun registerPunitReportTask(
+    private fun registerPUnitReportTask(
         project: Project,
         reportConfig: org.gradle.api.artifacts.Configuration
     ) {
-        project.tasks.register("punitReport", PunitReportTask::class.java).configure {
+        project.tasks.register("punitReport", PUnitReportTask::class.java).configure {
             description = "Generates an HTML report from PUnit test verdict XML files"
             group = "verification"
             xmlDir.set(project.layout.buildDirectory.dir("reports/punit/xml"))
@@ -421,11 +421,11 @@ class PunitPlugin : Plugin<Project> {
         }
     }
 
-    private fun registerPunitVerifyTask(
+    private fun registerPUnitVerifyTask(
         project: Project,
         reportConfig: org.gradle.api.artifacts.Configuration
     ) {
-        val verifyTask = project.tasks.register("punitVerify", PunitVerifyTask::class.java) {
+        val verifyTask = project.tasks.register("punitVerify", PUnitVerifyTask::class.java) {
             description = "Verifies that all probabilistic test verdicts passed"
             group = "verification"
             xmlDir.set(project.layout.buildDirectory.dir("reports/punit/xml"))
@@ -441,9 +441,9 @@ class PunitPlugin : Plugin<Project> {
         }
     }
 
-    private fun loadPunitVersion(): String = PunitVersion.VERSION
+    private fun loadPUnitVersion(): String = PUnitVersion.VERSION
 
-    private fun forwardPunitSystemProperties(task: Test) {
+    private fun forwardPUnitSystemProperties(task: Test) {
         System.getProperties()
             .filter { (k, _) -> k.toString().startsWith("punit.") }
             .forEach { (k, v) -> task.systemProperty(k.toString(), v.toString()) }

--- a/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitReportTask.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitReportTask.kt
@@ -12,7 +12,7 @@ import java.net.URLClassLoader
  * Uses classpath isolation via [URLClassLoader] to invoke [ReportGenerator]
  * from the punit-report module without a compile-time dependency.
  */
-abstract class PunitReportTask : DefaultTask() {
+abstract class PUnitReportTask : DefaultTask() {
 
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitVerifyTask.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitVerifyTask.kt
@@ -18,7 +18,7 @@ import java.net.URLClassLoader
  * Wired into the `check` lifecycle so `./gradlew check` catches
  * verdict failures even when individual sample failures are suppressed.
  */
-abstract class PunitVerifyTask : DefaultTask() {
+abstract class PUnitVerifyTask : DefaultTask() {
 
     @get:Internal
     abstract val xmlDir: DirectoryProperty

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineEmitter.java
@@ -33,7 +33,7 @@ import org.javai.punit.engine.covariate.CovariateResolver;
  * {@link BaselineRecord} on disk, by way of the engine's
  * {@link BaselineWriter}.
  *
- * <p>Called from {@link Punit.MeasureBuilder#run} after the engine
+ * <p>Called from {@link PUnit.MeasureBuilder#run} after the engine
  * finishes its sampling loop. The record carries both
  * {@link PassRateStatistics} and {@link LatencyStatistics} so any
  * future empirical criterion (CR02 or CR03 today, future kinds
@@ -64,7 +64,7 @@ final class BaselineEmitter {
     static void emit(Experiment experiment, Path baselineDir) {
         if (experiment.kind() != Experiment.Kind.MEASURE) {
             // Only MEASURE produces a baseline. The only caller is
-            // Punit.MeasureBuilder.run(), which by construction passes a
+            // PUnit.MeasureBuilder.run(), which by construction passes a
             // MEASURE experiment — reaching this branch is a programming
             // error, not a runtime condition.
             throw new IllegalArgumentException(

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/BaselineProviderResolver.java
@@ -8,8 +8,8 @@ import org.javai.punit.engine.baseline.YamlBaselineProvider;
 
 /**
  * Resolves the {@link BaselineProvider} consumed by
- * {@link Punit#testing}-style empirical criteria and emitted to by
- * {@link Punit#measuring}-style experiments. Directory resolution
+ * {@link PUnit#testing}-style empirical criteria and emitted to by
+ * {@link PUnit#measuring}-style experiments. Directory resolution
  * delegates to {@link BaselineResolver#defaultDir()} — the same
  * implementation any other consumer (e.g.
  * {@link org.javai.punit.power.PowerAnalysis}) calls — so framework
@@ -26,14 +26,14 @@ import org.javai.punit.engine.baseline.YamlBaselineProvider;
  * </ol>
  *
  * <p>A future revision can layer a JUnit configuration-parameter
- * lookup in between when {@link Punit} gains an
+ * lookup in between when {@link PUnit} gains an
  * {@code ExtensionContext}-aware overload. Not needed for 1.0.
  *
  * <p>When no candidate resolves to an existing directory, the
  * provider's lookups return empty and empirical criteria yield
  * {@code INCONCLUSIVE} per the resolver contract. Measure
  * experiments still run; their baseline write is silently skipped
- * (see {@link Punit.MeasureBuilder#run}).
+ * (see {@link PUnit.MeasureBuilder#run}).
  */
 final class BaselineProviderResolver {
 

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/EmpiricalTestComposer.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/EmpiricalTestComposer.java
@@ -20,7 +20,7 @@ import org.javai.punit.api.typed.spec.TypedSpec;
  * sample count.
  *
  * <p>This is the bridge that lets
- * {@link Punit#testing(java.util.function.Supplier)} accept just a
+ * {@link PUnit#testing(java.util.function.Supplier)} accept just a
  * baseline supplier — every other parameter is implicit, derived
  * from the baseline by reference at compose time. The integrity
  * guarantee follows by construction: the test's {@link Sampling}
@@ -44,7 +44,7 @@ final class EmpiricalTestComposer {
                     "empirical probabilistic test must be paired with a MEASURE-flavour "
                             + "Experiment, got " + baseline.kind()
                             + ". Pass a method reference to a method whose body returns "
-                            + "Punit.measuring(...).build().");
+                            + "PUnit.measuring(...).build().");
         }
         return baseline.dispatch(new Spec.Dispatcher<>() {
             @Override

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
@@ -69,9 +69,9 @@ import org.opentest4j.TestAbortedException;
  * {@link Experiment} value supplies the baseline a probabilistic
  * test compares against.
  */
-public final class Punit {
+public final class PUnit {
 
-    private Punit() { }
+    private PUnit() { }
 
     // ── Sampling-bound factories ────────────────────────────────────
 
@@ -592,7 +592,7 @@ public final class Punit {
 
     /**
      * Builder for the empirical probabilistic-test entry point —
-     * {@link Punit#testing(Supplier)}. Pulls sampling and factors
+     * {@link PUnit#testing(Supplier)}. Pulls sampling and factors
      * from the baseline supplier; the author specifies only the
      * sample count and criterion.
      */
@@ -620,9 +620,9 @@ public final class Punit {
             Objects.requireNonNull(criterion, "criterion");
             if (!criterion.isEmpirical()) {
                 throw new IllegalArgumentException(
-                        "Punit.testing(supplier) only accepts empirical criteria; "
+                        "PUnit.testing(supplier) only accepts empirical criteria; "
                                 + "got contractual " + criterion.name()
-                                + ". Use Punit.testing(sampling, factors) for contractual tests.");
+                                + ". Use PUnit.testing(sampling, factors) for contractual tests.");
             }
             this.criterion = criterion;
             return this;

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/package-info.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/package-info.java
@@ -2,8 +2,8 @@
  * JUnit 5 extensions for the typed-compositional authoring model.
  *
  * <p>The extensions in this package drive the new
- * {@link org.javai.punit.api.PunitTest @PunitTest} and
- * {@link org.javai.punit.api.PunitExperiment @PunitExperiment}
+ * {@link org.javai.punit.api.PUnitTest @PUnitTest} and
+ * {@link org.javai.punit.api.PUnitExperiment @PUnitExperiment}
  * annotations through the typed
  * {@link org.javai.punit.engine.Engine}, translating the engine's
  * results back to JUnit's pass / fail / aborted semantics.

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/ContractRefIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/ContractRefIntegrationTest.java
@@ -6,7 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
-import org.javai.punit.junit5.testsubjects.PunitSubjects;
+import org.javai.punit.junit5.testsubjects.PUnitSubjects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +49,7 @@ class ContractRefIntegrationTest {
     @Test
     @DisplayName("transparentStats output includes the contract reference")
     void renderedInTransparentStats() {
-        Events events = run(PunitSubjects.ContractRefPassingTest.class);
+        Events events = run(PUnitSubjects.ContractRefPassingTest.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
 
         String stderr = capturedErr.toString(StandardCharsets.UTF_8);
@@ -59,7 +59,7 @@ class ContractRefIntegrationTest {
     @Test
     @DisplayName("failure message includes the contract reference")
     void renderedInFailureMessage() {
-        Events events = run(PunitSubjects.ContractRefFailingTest.class);
+        Events events = run(PUnitSubjects.ContractRefFailingTest.class);
         events.assertStatistics(stats -> stats.started(1).failed(1));
 
         String failureMessage = events.failed().stream()

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateMisalignmentTrichotomyTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateMisalignmentTrichotomyTest.java
@@ -15,7 +15,7 @@ import org.junit.platform.testkit.engine.Events;
 
 /**
  * Pins the covariate-misalignment trichotomy that
- * {@link Punit#translate} encodes:
+ * {@link PUnit#translate} encodes:
  *
  * <ul>
  *   <li><b>Case 1: legitimate INCONCLUSIVE.</b> No candidate

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/CovariateRoundTripTest.java
@@ -121,7 +121,7 @@ class CovariateRoundTripTest {
         Events testEvents = run(CovariateSubjects.TestWithMatchingCovariate.class);
 
         // The failed-event payload carries the diagnostic that the
-        // empirical Punit.testing(...) translates from the test result.
+        // empirical PUnit.testing(...) translates from the test result.
         // It should mention the rejection reason for the EU baseline.
         testEvents.failed()
                 .assertThatEvents()

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
@@ -52,7 +52,7 @@ class MeasureToTestRoundTripTest {
     // ── Emission side: @Experiment writes the baseline file ────────
 
     @Test
-    @DisplayName("Punit.measuring(...).run() writes a baseline YAML when a baseline directory is configured")
+    @DisplayName("PUnit.measuring(...).run() writes a baseline YAML when a baseline directory is configured")
     void measureWritesBaseline(@TempDir Path baselineDir) throws IOException {
         System.setProperty(BaselineProviderResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
 
@@ -86,7 +86,7 @@ class MeasureToTestRoundTripTest {
     @Test
     @DisplayName("full pipeline: emission → resolution → assertion in two JUnit invocations")
     void fullRoundTrip(@TempDir Path baselineDir) throws IOException {
-        // Phase 1 — emit a baseline via Punit.measuring(...).run().
+        // Phase 1 — emit a baseline via PUnit.measuring(...).run().
         // The use case here passes always; the recorded rate will be 1.0,
         // which is too tight a threshold for a Wilson-bound test to clear.
         // We overwrite with a hand-written 0.5 baseline so Phase 2 can pass.

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitJunitIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitJunitIntegrationTest.java
@@ -2,7 +2,7 @@ package org.javai.punit.junit5;
 
 import java.nio.file.Path;
 
-import org.javai.punit.junit5.testsubjects.PunitSubjects;
+import org.javai.punit.junit5.testsubjects.PUnitSubjects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,8 +14,8 @@ import org.junit.platform.testkit.engine.Events;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
-@DisplayName("@ProbabilisticTest / @Experiment + Punit factories — JUnit-driven typed-engine outcomes")
-class PunitJunitIntegrationTest {
+@DisplayName("@ProbabilisticTest / @Experiment + PUnit factories — JUnit-driven typed-engine outcomes")
+class PUnitJunitIntegrationTest {
 
     private static final String JUNIT_ENGINE_ID = "junit-jupiter";
 
@@ -50,14 +50,14 @@ class PunitJunitIntegrationTest {
     @Test
     @DisplayName("contractual PASS surfaces as a JUnit pass")
     void contractualPass() {
-        Events events = run(PunitSubjects.PassingContractualTest.class);
+        Events events = run(PUnitSubjects.PassingContractualTest.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 
     @Test
     @DisplayName("contractual FAIL surfaces as AssertionFailedError")
     void contractualFail() {
-        Events events = run(PunitSubjects.FailingContractualTest.class);
+        Events events = run(PUnitSubjects.FailingContractualTest.class);
         events.assertStatistics(stats -> stats.started(1).failed(1));
         events.failed()
                 .assertThatEvents()
@@ -76,7 +76,7 @@ class PunitJunitIntegrationTest {
     @Test
     @DisplayName("empirical INCONCLUSIVE (no baseline resolved) surfaces as TestAbortedException")
     void empiricalInconclusive() {
-        Events events = run(PunitSubjects.InconclusiveEmpiricalTest.class);
+        Events events = run(PUnitSubjects.InconclusiveEmpiricalTest.class);
         events.assertStatistics(stats -> stats.started(1).aborted(1));
         events.aborted()
                 .assertThatEvents()
@@ -92,36 +92,36 @@ class PunitJunitIntegrationTest {
     // ── @Experiment path ───────────────────────────────────────────
 
     @Test
-    @DisplayName("@Experiment Punit.measuring(...).run() returns normally")
+    @DisplayName("@Experiment PUnit.measuring(...).run() returns normally")
     void measureExperimentRuns() {
-        Events events = run(PunitSubjects.PassingMeasureExperiment.class);
+        Events events = run(PUnitSubjects.PassingMeasureExperiment.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 
     @Test
-    @DisplayName("@Experiment Punit.exploring(...).grid(...).run() returns normally")
+    @DisplayName("@Experiment PUnit.exploring(...).grid(...).run() returns normally")
     void exploreExperimentRuns() {
-        Events events = run(PunitSubjects.PassingExploreExperiment.class);
+        Events events = run(PUnitSubjects.PassingExploreExperiment.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 
     // ── Empirical-supplier path ────────────────────────────────────
 
     @Test
-    @DisplayName("Punit.testing(supplier).samples(N).criterion(...).assertPasses() derives from baseline")
+    @DisplayName("PUnit.testing(supplier).samples(N).criterion(...).assertPasses() derives from baseline")
     void empiricalSupplierDerivesFromBaseline() {
         // Without an on-disk baseline the resolver returns EMPTY, so the
         // criterion yields INCONCLUSIVE → aborted. The path itself works
         // (factors and sampling derived from supplier; only sample count
         // specified at test side).
-        Events events = run(PunitSubjects.EmpiricalSupplierTest.class);
+        Events events = run(PUnitSubjects.EmpiricalSupplierTest.class);
         events.assertStatistics(stats -> stats.started(1).aborted(1));
     }
 
     @Test
-    @DisplayName("Punit.testing(supplier) rejects a non-MEASURE supplier with IllegalArgumentException")
+    @DisplayName("PUnit.testing(supplier) rejects a non-MEASURE supplier with IllegalArgumentException")
     void empiricalSupplierRejectsNonMeasure() {
-        Events events = run(PunitSubjects.EmpiricalSupplierBadKindTest.class);
+        Events events = run(PUnitSubjects.EmpiricalSupplierBadKindTest.class);
         events.assertStatistics(stats -> stats.started(1).failed(1));
         events.failed()
                 .assertThatEvents()

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/TransparentStatsIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/TransparentStatsIntegrationTest.java
@@ -6,7 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
-import org.javai.punit.junit5.testsubjects.PunitSubjects;
+import org.javai.punit.junit5.testsubjects.PUnitSubjects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +16,7 @@ import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.Events;
 
 /**
- * Integration test for {@code Punit.TestBuilder.transparentStats()}:
+ * Integration test for {@code PUnit.TestBuilder.transparentStats()}:
  * verifies that opting in produces the verbose statistical analysis
  * on stderr and that off-by-default tests do not.
  */
@@ -43,7 +43,7 @@ class TransparentStatsIntegrationTest {
     @Test
     @DisplayName("transparentStats() builder method renders the verbose breakdown to stderr")
     void rendersVerboseBreakdown() {
-        Events events = run(PunitSubjects.TransparentStatsTest.class);
+        Events events = run(PUnitSubjects.TransparentStatsTest.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
 
         String stderr = capturedErr.toString(StandardCharsets.UTF_8);
@@ -60,7 +60,7 @@ class TransparentStatsIntegrationTest {
     @Test
     @DisplayName("default (transparentStats off) emits no verbose breakdown")
     void noOutputWhenDisabled() {
-        Events events = run(PunitSubjects.PassingContractualTest.class);
+        Events events = run(PUnitSubjects.PassingContractualTest.class);
         events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
 
         String stderr = capturedErr.toString(StandardCharsets.UTF_8);

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -12,7 +12,7 @@ import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.covariate.Covariate;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
-import org.javai.punit.junit5.Punit;
+import org.javai.punit.junit5.PUnit;
 
 /**
  * Test subjects for {@link org.javai.punit.junit5.CovariateRoundTripTest}.
@@ -71,7 +71,7 @@ public final class CovariateSubjects {
     public static final class MeasureWithCovariate {
         @Experiment
         void measureBaseline() {
-            Punit.measuring(sampling(100), new NoFactors())
+            PUnit.measuring(sampling(100), new NoFactors())
                     .experimentId("measureBaseline")
                     .run();
         }
@@ -92,7 +92,7 @@ public final class CovariateSubjects {
             // assert resolution-time correctness: when the baseline
             // matches we get a real verdict (not INCONCLUSIVE), and
             // when it doesn't we get INCONCLUSIVE.
-            Punit.testing(sampling(20), new NoFactors())
+            PUnit.testing(sampling(20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>empirical()
                             .atConfidence(0.50))
                     .assertPasses();

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -6,7 +6,7 @@ import org.javai.punit.api.typed.Sampling;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
-import org.javai.punit.junit5.Punit;
+import org.javai.punit.junit5.PUnit;
 
 /**
  * Subjects for {@code FeasibilityIntegrationTest}. The hosting test
@@ -50,7 +50,7 @@ public final class FeasibilitySubjects {
         void shouldPass() {
             // Baseline rate 0.50; n=50 against rate 0.50 has min Wilson
             // lower bound at observed=1.0 ≈ 0.949 — well above 0.50 → feasible.
-            Punit.testing(sampling(50), new NoFactors())
+            PUnit.testing(sampling(50), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -66,7 +66,7 @@ public final class FeasibilitySubjects {
             // Baseline rate 0.95; n=10 against rate 0.95 has max Wilson
             // lower bound at observed=1.0 ≈ 0.787 — below 0.95 → infeasible.
             // Default intent is VERIFICATION → throw IllegalStateException.
-            Punit.testing(sampling(10), new NoFactors())
+            PUnit.testing(sampling(10), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -82,7 +82,7 @@ public final class FeasibilitySubjects {
             // Same configuration as VerificationInfeasible — n=10 against
             // baseline 0.95 — but explicitly SMOKE intent. Run proceeds;
             // a warning is printed to stderr.
-            Punit.testing(sampling(10), new NoFactors())
+            PUnit.testing(sampling(10), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>empirical())
                     .intent(TestIntent.SMOKE)
                     .assertPasses();

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -7,10 +7,10 @@ import org.javai.punit.api.typed.Sampling;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
-import org.javai.punit.junit5.Punit;
+import org.javai.punit.junit5.PUnit;
 
 /**
- * Test subjects for {@link org.javai.punit.junit5.PunitJunitIntegrationTest}.
+ * Test subjects for {@link org.javai.punit.junit5.PUnitJunitIntegrationTest}.
  *
  * <p>Lives under {@code testsubjects/} so the project's test-discovery
  * exclusion (per the existing punit convention) keeps these out of
@@ -21,9 +21,9 @@ import org.javai.punit.junit5.Punit;
  * {@link GridPoint} for the explore subject, which needs distinct
  * values to populate a grid.
  */
-public final class PunitSubjects {
+public final class PUnitSubjects {
 
-    private PunitSubjects() { }
+    private PUnitSubjects() { }
 
     /**
      * Empty factors record for subjects that don't exercise factors-
@@ -75,7 +75,7 @@ public final class PunitSubjects {
     public static final class PassingContractualTest {
         @ProbabilisticTest
         void passes() {
-            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .assertPasses();
         }
@@ -85,7 +85,7 @@ public final class PunitSubjects {
     public static final class TransparentStatsTest {
         @ProbabilisticTest
         void passesWithTransparentStats() {
-            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .transparentStats()
                     .assertPasses();
@@ -101,7 +101,7 @@ public final class PunitSubjects {
     public static final class ContractRefPassingTest {
         @ProbabilisticTest
         void passesWithContractRef() {
-            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .contractRef("Acme API SLA v3.2 §2.1")
                     .transparentStats()
@@ -118,7 +118,7 @@ public final class PunitSubjects {
     public static final class ContractRefFailingTest {
         @ProbabilisticTest
         void failsWithContractRef() {
-            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysFails(), 20), new NoFactors())
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysFails(), 20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .contractRef("Acme API SLA v3.2 §2.1")
                     .assertPasses();
@@ -129,7 +129,7 @@ public final class PunitSubjects {
     public static final class FailingContractualTest {
         @ProbabilisticTest
         void fails() {
-            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysFails(), 20), new NoFactors())
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysFails(), 20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .assertPasses();
         }
@@ -143,7 +143,7 @@ public final class PunitSubjects {
     public static final class InconclusiveEmpiricalTest {
         @ProbabilisticTest
         void inconclusive() {
-            Punit.testing(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -155,7 +155,7 @@ public final class PunitSubjects {
     public static final class PassingMeasureExperiment {
         @Experiment
         void measure() {
-            Punit.measuring(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 100), new NoFactors()).run();
+            PUnit.measuring(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 100), new NoFactors()).run();
         }
     }
 
@@ -163,24 +163,24 @@ public final class PunitSubjects {
     public static final class PassingExploreExperiment {
         @Experiment
         void explore() {
-            Punit.exploring(sampling(PunitSubjects.<GridPoint>alwaysPasses(), 5))
+            PUnit.exploring(sampling(PUnitSubjects.<GridPoint>alwaysPasses(), 5))
                     .grid(new GridPoint("alt-1"), new GridPoint("alt-2"))
                     .run();
         }
     }
 
-    // ── Empirical-supplier subjects (Punit.testing(Supplier)) ──────
+    // ── Empirical-supplier subjects (PUnit.testing(Supplier)) ──────
 
     /**
      * The baseline supplier — a non-test method returning a built
      * {@link org.javai.punit.api.typed.spec.Experiment} for the
-     * {@link Punit#testing(java.util.function.Supplier)} entry point.
+     * {@link PUnit#testing(java.util.function.Supplier)} entry point.
      * The same builder produces both a baseline-running
      * {@code @Experiment} method and the supplier the test consumes.
      */
     public static final class EmpiricalSupplierTest {
         private org.javai.punit.api.typed.spec.Experiment baseline() {
-            return Punit.measuring(sampling(PunitSubjects.<NoFactors>alwaysPasses(), 100), new NoFactors()).build();
+            return PUnit.measuring(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 100), new NoFactors()).build();
         }
 
         @ProbabilisticTest
@@ -189,7 +189,7 @@ public final class PunitSubjects {
             // The point of this subject is to exercise the supplier-derivation
             // path: factors and sampling come from baseline(), only samples is
             // specified at the test side.
-            Punit.testing(this::baseline)
+            PUnit.testing(this::baseline)
                     .samples(20)
                     .criterion(BernoulliPassRate.<Boolean>empirical())
                     .assertPasses();
@@ -202,14 +202,14 @@ public final class PunitSubjects {
      */
     public static final class EmpiricalSupplierBadKindTest {
         private org.javai.punit.api.typed.spec.Experiment exploreBaseline() {
-            return Punit.exploring(sampling(PunitSubjects.<GridPoint>alwaysPasses(), 5))
+            return PUnit.exploring(sampling(PUnitSubjects.<GridPoint>alwaysPasses(), 5))
                     .grid(new GridPoint("alt"))
                     .build();
         }
 
         @ProbabilisticTest
         void rejectsNonMeasureSupplier() {
-            Punit.testing(this::exploreBaseline)
+            PUnit.testing(this::exploreBaseline)
                     .samples(20)
                     .criterion(BernoulliPassRate.<Boolean>empirical())
                     .assertPasses();

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -6,7 +6,7 @@ import org.javai.punit.api.typed.Sampling;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
-import org.javai.punit.junit5.Punit;
+import org.javai.punit.junit5.PUnit;
 
 /**
  * Subjects for {@code MeasureToTestRoundTripTest}.
@@ -45,7 +45,7 @@ public final class RoundTripSubjects {
     public static final class PassingMeasure {
         @Experiment
         void measure() {
-            Punit.measuring(sampling(50), new NoFactors())
+            PUnit.measuring(sampling(50), new NoFactors())
                     .experimentId("baseline-v1")
                     .run();
         }
@@ -54,7 +54,7 @@ public final class RoundTripSubjects {
     public static final class EmpiricalAgainstBaseline {
         @ProbabilisticTest
         void shouldPass() {
-            Punit.testing(sampling(20), new NoFactors())
+            PUnit.testing(sampling(20), new NoFactors())
                     .criterion(BernoulliPassRate.<Boolean>empirical())
                     .assertPasses();
         }

--- a/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
@@ -13,7 +13,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdict.FunctionalDimension;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.LatencyDimension;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.Misalignment;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.PercentileAssertion;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.javai.punit.verdict.VerdictTextRenderer;
 
 /**
@@ -41,9 +41,9 @@ final class HtmlReportWriter {
     static String generate(List<ProbabilisticTestVerdict> verdicts) {
         Instant now = Instant.now();
         long totalTests = verdicts.size();
-        long passed = verdicts.stream().filter(v -> v.punitVerdict() == PunitVerdict.PASS).count();
-        long failed = verdicts.stream().filter(v -> v.punitVerdict() == PunitVerdict.FAIL).count();
-        long inconclusive = verdicts.stream().filter(v -> v.punitVerdict() == PunitVerdict.INCONCLUSIVE).count();
+        long passed = verdicts.stream().filter(v -> v.punitVerdict() == PUnitVerdict.PASS).count();
+        long failed = verdicts.stream().filter(v -> v.punitVerdict() == PUnitVerdict.FAIL).count();
+        long inconclusive = verdicts.stream().filter(v -> v.punitVerdict() == PUnitVerdict.INCONCLUSIVE).count();
 
         Map<String, List<ProbabilisticTestVerdict>> grouped = groupVerdicts(verdicts);
 
@@ -159,7 +159,7 @@ final class HtmlReportWriter {
         html.append("<pre class=\"level2\">").append(escape(VerdictTextRenderer.renderSummary(verdict))).append("</pre>\n");
 
         // Operator guidance for inconclusive verdicts
-        if (verdict.punitVerdict() == PunitVerdict.INCONCLUSIVE && !verdict.covariates().aligned()) {
+        if (verdict.punitVerdict() == PUnitVerdict.INCONCLUSIVE && !verdict.covariates().aligned()) {
             appendMisalignmentGuidance(html, verdict);
         }
 
@@ -251,7 +251,7 @@ final class HtmlReportWriter {
         return grouped;
     }
 
-    private static String punitCssClass(PunitVerdict verdict) {
+    private static String punitCssClass(PUnitVerdict verdict) {
         return switch (verdict) {
             case PASS -> "punit-pass";
             case FAIL -> "punit-fail";

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictVerifier.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictVerifier.java
@@ -9,14 +9,14 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 
 /**
  * Reads verdict XML files and determines whether all probabilistic tests passed.
  *
  * <p>This is the enforcement point for CI pipelines. It reads the structured
  * verdict XMLs produced during test execution and fails if any verdict is
- * {@link PunitVerdict#FAIL}.
+ * {@link PUnitVerdict#FAIL}.
  *
  * <p>Designed to be invoked by the {@code punitVerify} Gradle task, mirroring
  * the JaCoCo pattern: test execution produces data, a separate verification
@@ -53,7 +53,7 @@ public final class VerdictVerifier {
      * @param verdict          the PUnit verdict
      */
     public record FailedVerdict(String testName, double observedPassRate,
-                                double minPassRate, PunitVerdict verdict) {}
+                                double minPassRate, PUnitVerdict verdict) {}
 
     /**
      * Verifies all verdict XMLs in the given directory.
@@ -70,7 +70,7 @@ public final class VerdictVerifier {
 
         List<FailedVerdict> failures = new ArrayList<>();
         for (ProbabilisticTestVerdict verdict : verdicts) {
-            if (verdict.punitVerdict() == PunitVerdict.FAIL) {
+            if (verdict.punitVerdict() == PUnitVerdict.FAIL) {
                 String testName = verdict.identity().className() + "."
                         + verdict.identity().methodName();
                 failures.add(new FailedVerdict(

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictXmlReader.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictXmlReader.java
@@ -18,7 +18,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -27,7 +27,7 @@ import org.w3c.dom.NodeList;
  * Deserialises a {@link ProbabilisticTestVerdict} from RP07 verdict XML.
  *
  * <p>Reads the {@code http://javai.org/verdict/1.0} format and maps it back
- * to the punit verdict model. Punit-specific fields not present in RP07
+ * to the punit verdict model. PUnit-specific fields not present in RP07
  * (pacing, environment, expiration, correlation ID) receive default values.
  *
  * <p>Uses DOM parsing since individual verdict files are small.
@@ -75,9 +75,9 @@ public final class VerdictXmlReader {
         Map<String, String> environment = readEnvironment(root);
 
         Element verdictEl = firstElement(root, "verdict");
-        PunitVerdict punitVerdict = PunitVerdict.valueOf(verdictEl.getAttribute("value"));
+        PUnitVerdict punitVerdict = PUnitVerdict.valueOf(verdictEl.getAttribute("value"));
         String verdictReason = optionalAttribute(verdictEl, "reason").orElse("");
-        boolean junitPassed = punitVerdict != PunitVerdict.FAIL;
+        boolean junitPassed = punitVerdict != PUnitVerdict.FAIL;
 
         return new ProbabilisticTestVerdict(
                 correlationId, timestamp, identity, execution,

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
@@ -9,7 +9,7 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 
 /**
  * Serialises a {@link ProbabilisticTestVerdict} to verdict XML using the
@@ -19,7 +19,7 @@ import org.javai.punit.verdict.PunitVerdict;
  * and {@code verdict-1.0.xsd} schema defined in the orchestrator at
  * {@code javai-orchestrator/inventory/catalog/reporting/RP07-verdict-xml-interchange/}.
  *
- * <p>Punit-specific extensions not in RP07 (pacing, environment, expiration,
+ * <p>PUnit-specific extensions not in RP07 (pacing, environment, expiration,
  * correlation ID, JUnit pass status) are not serialised. The verdict model in
  * punit-core remains unchanged — this class maps from the punit record to the
  * cross-project XML format.

--- a/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
@@ -21,7 +21,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdict.SpecProvenance;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.StatisticalAnalysis;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.Termination;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.TestIdentity;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,7 +105,7 @@ class HtmlReportWriterTest {
 
         @Test
         @DisplayName("JUnit FAIL with PUnit PASS renders divergent CSS classes")
-        void junitFailWithPunitPassRendersDivergentClasses() {
+        void junitFailWithPUnitPassRendersDivergentClasses() {
             ProbabilisticTestVerdict verdict = divergentVerdict();
 
             String html = HtmlReportWriter.generate(List.of(verdict));
@@ -467,15 +467,15 @@ class HtmlReportWriterTest {
     // ── Helpers ──────────────────────────────────────────────────────────
 
     private ProbabilisticTestVerdict passingVerdict() {
-        return minimalVerdict("shouldPass", true, PunitVerdict.PASS);
+        return minimalVerdict("shouldPass", true, PUnitVerdict.PASS);
     }
 
     private ProbabilisticTestVerdict failingVerdict() {
-        return minimalVerdict("shouldFail", false, PunitVerdict.FAIL);
+        return minimalVerdict("shouldFail", false, PUnitVerdict.FAIL);
     }
 
     private ProbabilisticTestVerdict inconclusiveVerdict() {
-        return minimalVerdict("shouldBeInconclusive", false, PunitVerdict.INCONCLUSIVE);
+        return minimalVerdict("shouldBeInconclusive", false, PUnitVerdict.INCONCLUSIVE);
     }
 
     private ProbabilisticTestVerdict divergentVerdict() {
@@ -493,12 +493,12 @@ class HtmlReportWriterTest {
                 new CostSummary(0, 0, 0, TokenMode.NONE, Optional.empty(), Optional.empty()),
                 Optional.empty(), Optional.empty(),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
-                Map.of(), false, PunitVerdict.PASS,
+                Map.of(), false, PUnitVerdict.PASS,
                 "0.8000 >= 0.7000"
         );
     }
 
-    private ProbabilisticTestVerdict minimalVerdict(String methodName, boolean passed, PunitVerdict punitVerdict) {
+    private ProbabilisticTestVerdict minimalVerdict(String methodName, boolean passed, PUnitVerdict punitVerdict) {
         return new ProbabilisticTestVerdict(
                 "v:test01",
                 Instant.parse("2026-03-11T14:30:00Z"),
@@ -514,9 +514,9 @@ class HtmlReportWriterTest {
                 Optional.empty(), Optional.empty(),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(), passed, punitVerdict,
-                punitVerdict == PunitVerdict.PASS
+                punitVerdict == PUnitVerdict.PASS
                         ? "0.9500 >= 0.9000"
-                        : punitVerdict == PunitVerdict.INCONCLUSIVE
+                        : punitVerdict == PUnitVerdict.INCONCLUSIVE
                                 ? "covariate misalignment"
                                 : "0.9500 < 0.9000"
         );
@@ -583,7 +583,7 @@ class HtmlReportWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithMethodName(String methodName) {
-        return minimalVerdict(methodName, true, PunitVerdict.PASS);
+        return minimalVerdict(methodName, true, PUnitVerdict.PASS);
     }
 
     private ProbabilisticTestVerdict verdictWithProvenance() {
@@ -601,7 +601,7 @@ class HtmlReportWriterTest {
     }
 
     private ProbabilisticTestVerdict inconclusiveVerdictWithMisalignment() {
-        ProbabilisticTestVerdict base = minimalVerdict("shouldBeInconclusive", false, PunitVerdict.INCONCLUSIVE);
+        ProbabilisticTestVerdict base = minimalVerdict("shouldBeInconclusive", false, PUnitVerdict.INCONCLUSIVE);
         CovariateStatus cov = new CovariateStatus(false,
                 List.of(new Misalignment("model", "gpt-4", "gpt-4o")),
                 Map.of(), Map.of());

--- a/punit-report/src/test/java/org/javai/punit/report/ReportGeneratorTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/ReportGeneratorTest.java
@@ -17,7 +17,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -139,7 +139,7 @@ class ReportGeneratorTest {
                 new CostSummary(0, 0, 0, TokenMode.NONE, Optional.empty(), Optional.empty()),
                 Optional.empty(), Optional.empty(),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
-                Map.of(), true, PunitVerdict.PASS,
+                Map.of(), true, PUnitVerdict.PASS,
                 "0.9500 >= 0.9000"
         );
     }
@@ -159,7 +159,7 @@ class ReportGeneratorTest {
                 new CostSummary(0, 0, 0, TokenMode.NONE, Optional.empty(), Optional.empty()),
                 Optional.empty(), Optional.empty(),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
-                Map.of(), false, PunitVerdict.FAIL,
+                Map.of(), false, PUnitVerdict.FAIL,
                 "0.8000 < 0.9000"
         );
     }

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictTextRendererTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictTextRendererTest.java
@@ -22,7 +22,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdict.SpecProvenance;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.StatisticalAnalysis;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.Termination;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.TestIdentity;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.javai.punit.verdict.VerdictTextRenderer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -185,14 +185,14 @@ class VerdictTextRendererTest {
     // ── Helpers ──────────────────────────────────────────────────────────
 
     private ProbabilisticTestVerdict passingVerdict() {
-        return minimalVerdict(true, PunitVerdict.PASS);
+        return minimalVerdict(true, PUnitVerdict.PASS);
     }
 
     private ProbabilisticTestVerdict failingVerdict() {
-        return minimalVerdict(false, PunitVerdict.FAIL);
+        return minimalVerdict(false, PUnitVerdict.FAIL);
     }
 
-    private ProbabilisticTestVerdict minimalVerdict(boolean passed, PunitVerdict punitVerdict) {
+    private ProbabilisticTestVerdict minimalVerdict(boolean passed, PUnitVerdict punitVerdict) {
         int successes = passed ? 95 : 80;
         int failures = passed ? 5 : 20;
         double observedRate = passed ? 0.95 : 0.80;
@@ -211,14 +211,14 @@ class VerdictTextRendererTest {
                 Optional.empty(), Optional.empty(),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(), passed, punitVerdict,
-                punitVerdict == PunitVerdict.PASS
+                punitVerdict == PUnitVerdict.PASS
                         ? String.format("%.4f >= %.4f", observedRate, 0.9)
                         : String.format("%.4f < %.4f", observedRate, 0.9)
         );
     }
 
     private ProbabilisticTestVerdict budgetExhaustedVerdict() {
-        ProbabilisticTestVerdict base = minimalVerdict(false, PunitVerdict.FAIL);
+        ProbabilisticTestVerdict base = minimalVerdict(false, PUnitVerdict.FAIL);
         return new ProbabilisticTestVerdict(
                 base.correlationId(), base.timestamp(), base.identity(),
                 new ExecutionSummary(100, 50, 40, 10, 0.9, 0.8, 5000,
@@ -228,7 +228,7 @@ class VerdictTextRendererTest {
                 base.pacing(), base.provenance(),
                 new Termination(TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED,
                         Optional.of("Time budget exceeded")),
-                base.environmentMetadata(), false, PunitVerdict.FAIL,
+                base.environmentMetadata(), false, PUnitVerdict.FAIL,
                 "budget exhausted"
         );
     }
@@ -337,7 +337,7 @@ class VerdictTextRendererTest {
     }
 
     private ProbabilisticTestVerdict verdictWithMisalignment() {
-        ProbabilisticTestVerdict base = minimalVerdict(false, PunitVerdict.INCONCLUSIVE);
+        ProbabilisticTestVerdict base = minimalVerdict(false, PUnitVerdict.INCONCLUSIVE);
         CovariateStatus cov = new CovariateStatus(false,
                 List.of(new Misalignment("model", "gpt-4", "gpt-4o")),
                 Map.of(), Map.of());

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictVerifierTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictVerifierTest.java
@@ -15,7 +15,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,8 +34,8 @@ class VerdictVerifierTest {
         @Test
         @DisplayName("passes when all verdicts pass")
         void allPass(@TempDir Path dir) throws Exception {
-            writeVerdict(dir, "test1.xml", createVerdict("Test1", "method1", true, PunitVerdict.PASS, 0.95, 0.90));
-            writeVerdict(dir, "test2.xml", createVerdict("Test2", "method2", true, PunitVerdict.PASS, 1.0, 0.80));
+            writeVerdict(dir, "test1.xml", createVerdict("Test1", "method1", true, PUnitVerdict.PASS, 0.95, 0.90));
+            writeVerdict(dir, "test2.xml", createVerdict("Test2", "method2", true, PUnitVerdict.PASS, 1.0, 0.80));
 
             VerdictVerifier.VerificationResult result = verifier.verify(dir);
 
@@ -47,8 +47,8 @@ class VerdictVerifierTest {
         @Test
         @DisplayName("fails when any verdict fails")
         void anyFail(@TempDir Path dir) throws Exception {
-            writeVerdict(dir, "test1.xml", createVerdict("Test1", "method1", true, PunitVerdict.PASS, 0.95, 0.90));
-            writeVerdict(dir, "test2.xml", createVerdict("Test2", "method2", false, PunitVerdict.FAIL, 0.70, 0.90));
+            writeVerdict(dir, "test1.xml", createVerdict("Test1", "method1", true, PUnitVerdict.PASS, 0.95, 0.90));
+            writeVerdict(dir, "test2.xml", createVerdict("Test2", "method2", false, PUnitVerdict.FAIL, 0.70, 0.90));
 
             VerdictVerifier.VerificationResult result = verifier.verify(dir);
 
@@ -84,8 +84,8 @@ class VerdictVerifierTest {
         @Test
         @DisplayName("includes all failed tests")
         void includesAllFailures(@TempDir Path dir) throws Exception {
-            writeVerdict(dir, "test1.xml", createVerdict("Cls1", "m1", false, PunitVerdict.FAIL, 0.70, 0.90));
-            writeVerdict(dir, "test2.xml", createVerdict("Cls2", "m2", false, PunitVerdict.FAIL, 0.50, 0.80));
+            writeVerdict(dir, "test1.xml", createVerdict("Cls1", "m1", false, PUnitVerdict.FAIL, 0.70, 0.90));
+            writeVerdict(dir, "test2.xml", createVerdict("Cls2", "m2", false, PUnitVerdict.FAIL, 0.50, 0.80));
 
             VerdictVerifier.VerificationResult result = verifier.verify(dir);
             String message = verifier.formatFailureMessage(result);
@@ -105,7 +105,7 @@ class VerdictVerifierTest {
 
     private ProbabilisticTestVerdict createVerdict(
             String className, String methodName,
-            boolean passed, PunitVerdict punitVerdict,
+            boolean passed, PUnitVerdict punitVerdict,
             double observedPassRate, double minPassRate) {
 
         int successes = (int) (observedPassRate * 100);
@@ -130,7 +130,7 @@ class VerdictVerifierTest {
                 Map.of(),
                 passed,
                 punitVerdict,
-                punitVerdict == PunitVerdict.PASS
+                punitVerdict == PUnitVerdict.PASS
                         ? String.format("%.4f >= %.4f", observedPassRate, minPassRate)
                         : String.format("%.4f < %.4f", observedPassRate, minPassRate)
         );

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictXmlReaderTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictXmlReaderTest.java
@@ -19,7 +19,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ class VerdictXmlReaderTest {
         @Test
         @DisplayName("preserves timestamp")
         void preservesTimestamp() throws Exception {
-            ProbabilisticTestVerdict original = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict original = minimalVerdict(true, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -47,7 +47,7 @@ class VerdictXmlReaderTest {
         @Test
         @DisplayName("preserves identity via RP07 mapping")
         void preservesIdentity() throws Exception {
-            ProbabilisticTestVerdict original = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict original = minimalVerdict(true, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -59,7 +59,7 @@ class VerdictXmlReaderTest {
         @Test
         @DisplayName("preserves execution summary")
         void preservesExecution() throws Exception {
-            ProbabilisticTestVerdict original = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict original = minimalVerdict(true, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -76,18 +76,18 @@ class VerdictXmlReaderTest {
         @Test
         @DisplayName("preserves verdict")
         void preservesVerdict() throws Exception {
-            ProbabilisticTestVerdict original = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict original = minimalVerdict(true, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
-            assertThat(result.punitVerdict()).isEqualTo(PunitVerdict.PASS);
+            assertThat(result.punitVerdict()).isEqualTo(PUnitVerdict.PASS);
             assertThat(result.verdictReason()).isEqualTo("0.9500 >= 0.9000");
         }
 
         @Test
         @DisplayName("preserves statistics")
         void preservesStatistics() throws Exception {
-            ProbabilisticTestVerdict original = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict original = minimalVerdict(true, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -101,7 +101,7 @@ class VerdictXmlReaderTest {
         @Test
         @DisplayName("preserves correlation ID")
         void preservesCorrelationId() throws Exception {
-            ProbabilisticTestVerdict original = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict original = minimalVerdict(true, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -111,7 +111,7 @@ class VerdictXmlReaderTest {
         @Test
         @DisplayName("optional fields absent when not provided")
         void optionalFieldsAbsent() throws Exception {
-            ProbabilisticTestVerdict original = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict original = minimalVerdict(true, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -326,7 +326,7 @@ class VerdictXmlReaderTest {
             assertThat(result.latency()).isPresent();
             assertThat(result.provenance()).isPresent();
             assertThat(result.statistics().baseline()).isPresent();
-            assertThat(result.punitVerdict()).isEqualTo(PunitVerdict.PASS);
+            assertThat(result.punitVerdict()).isEqualTo(PUnitVerdict.PASS);
         }
     }
 
@@ -338,7 +338,7 @@ class VerdictXmlReaderTest {
         return reader.read(new ByteArrayInputStream(baos.toByteArray()));
     }
 
-    private ProbabilisticTestVerdict minimalVerdict(boolean passed, PunitVerdict punitVerdict) {
+    private ProbabilisticTestVerdict minimalVerdict(boolean passed, PUnitVerdict punitVerdict) {
         return new ProbabilisticTestVerdict(
                 "v:test01",
                 Instant.parse("2026-03-11T14:30:00Z"),
@@ -358,14 +358,14 @@ class VerdictXmlReaderTest {
                 Map.of(),
                 passed,
                 punitVerdict,
-                punitVerdict == PunitVerdict.PASS ? "0.9500 >= 0.9000"
-                        : punitVerdict == PunitVerdict.INCONCLUSIVE ? "covariate misalignment"
+                punitVerdict == PUnitVerdict.PASS ? "0.9500 >= 0.9000"
+                        : punitVerdict == PUnitVerdict.INCONCLUSIVE ? "covariate misalignment"
                         : "0.8000 < 0.9000"
         );
     }
 
     private ProbabilisticTestVerdict verdictWithFunctional() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         return new ProbabilisticTestVerdict(
                 base.correlationId(), base.timestamp(), base.identity(), base.execution(),
                 Optional.of(new FunctionalDimension(95, 5, 0.95)),
@@ -377,7 +377,7 @@ class VerdictXmlReaderTest {
     }
 
     private ProbabilisticTestVerdict verdictWithLatency() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         LatencyDimension latency = new LatencyDimension(
                 90, 100, false, Optional.empty(),
                 120, 340, 420, 810, 1250,
@@ -396,7 +396,7 @@ class VerdictXmlReaderTest {
     }
 
     private ProbabilisticTestVerdict verdictWithSkippedLatency() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         LatencyDimension latency = new LatencyDimension(
                 0, 100, true, Optional.of("No successes"),
                 0, 0, 0, 0, 0,
@@ -413,7 +413,7 @@ class VerdictXmlReaderTest {
     }
 
     private ProbabilisticTestVerdict verdictWithBaseline() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         StatisticalAnalysis stats = new StatisticalAnalysis(
                 0.95, 0.0218, 0.8948, 0.9798,
                 Optional.of(2.29), Optional.of(0.011),
@@ -434,7 +434,7 @@ class VerdictXmlReaderTest {
     }
 
     private ProbabilisticTestVerdict verdictWithMisalignment() {
-        ProbabilisticTestVerdict base = minimalVerdict(false, PunitVerdict.INCONCLUSIVE);
+        ProbabilisticTestVerdict base = minimalVerdict(false, PUnitVerdict.INCONCLUSIVE);
         CovariateStatus cov = new CovariateStatus(false,
                 List.of(new Misalignment("model", "gpt-4", "gpt-4o")),
                 Map.of(), Map.of());
@@ -449,7 +449,7 @@ class VerdictXmlReaderTest {
     }
 
     private ProbabilisticTestVerdict verdictWithProvenance() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         ExpirationStatus expiringStatus = ExpirationStatus.expiringSoon(
                 java.time.Duration.ofDays(7), 0.20);
         SpecProvenance prov = new SpecProvenance("SLA", "SLA-PAY-001", "payment-gateway.yaml",
@@ -466,7 +466,7 @@ class VerdictXmlReaderTest {
     }
 
     private ProbabilisticTestVerdict verdictWithBudgetExhaustion() {
-        ProbabilisticTestVerdict base = minimalVerdict(false, PunitVerdict.FAIL);
+        ProbabilisticTestVerdict base = minimalVerdict(false, PUnitVerdict.FAIL);
         return new ProbabilisticTestVerdict(
                 base.correlationId(), base.timestamp(), base.identity(), base.execution(),
                 base.functional(), base.latency(),
@@ -474,13 +474,13 @@ class VerdictXmlReaderTest {
                 base.pacing(), base.provenance(),
                 new Termination(TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED,
                         Optional.of("Time budget exceeded")),
-                base.environmentMetadata(), false, PunitVerdict.FAIL,
+                base.environmentMetadata(), false, PUnitVerdict.FAIL,
                 "budget exhausted"
         );
     }
 
     private ProbabilisticTestVerdict verdictWithUseCaseId() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         TestIdentity identity = new TestIdentity(
                 "com.example.MyTest", "shouldPass", Optional.of("payment-gateway"));
         return new ProbabilisticTestVerdict(
@@ -522,7 +522,7 @@ class VerdictXmlReaderTest {
                 Optional.of(pacing), Optional.of(prov),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of("environment", "staging"),
-                true, PunitVerdict.PASS,
+                true, PUnitVerdict.PASS,
                 "0.9500 >= 0.9000"
         );
     }

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictXmlSinkTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictXmlSinkTest.java
@@ -16,7 +16,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -107,7 +107,7 @@ class VerdictXmlSinkTest {
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of(),
                 true,
-                PunitVerdict.PASS,
+                PUnitVerdict.PASS,
                 "0.9500 >= 0.9000"
         );
     }

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictXmlWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictXmlWriterTest.java
@@ -26,7 +26,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -46,7 +46,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("serialises to RP07 verdict-record root element")
         void rp07RootElement() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element root = doc.getDocumentElement();
@@ -60,7 +60,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("includes identity with use-case-id and test-name")
         void includesIdentity() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element identity = firstElement(doc, "identity");
@@ -72,7 +72,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("includes execution summary attributes")
         void includesExecution() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element exec = firstElement(doc, "execution");
@@ -87,7 +87,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("includes verdict element with value and reason")
         void includesVerdictElement() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element v = firstElement(doc, "verdict");
@@ -100,7 +100,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("omits functional element when absent")
         void omitsFunctionalWhenAbsent() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             NodeList nodes = doc.getElementsByTagNameNS(VerdictXmlWriter.NAMESPACE, "functional");
@@ -111,7 +111,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("omits latency element when absent")
         void omitsLatencyWhenAbsent() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             NodeList nodes = doc.getElementsByTagNameNS(VerdictXmlWriter.NAMESPACE, "latency");
@@ -122,7 +122,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("omits pacing and environment when absent")
         void omitsPacingAndEnvironmentWhenAbsent() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
 
@@ -133,7 +133,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("includes correlation-id attribute")
         void includesCorrelationId() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element root = doc.getDocumentElement();
@@ -207,7 +207,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("serialises statistical analysis with threshold and origin")
         void serialisesStatistics() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element stats = firstElement(doc, "statistics");
@@ -243,7 +243,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("serialises aligned covariates")
         void serialisesAligned() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element cov = firstElement(doc, "covariates");
@@ -327,7 +327,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("omits environment element when metadata is empty")
         void omitsWhenEmpty() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             NodeList nodes = doc.getElementsByTagNameNS(VerdictXmlWriter.NAMESPACE, "environment");
@@ -343,7 +343,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("serialises completed termination")
         void serialisesCompleted() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element term = firstElement(doc, "termination");
@@ -372,7 +372,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("serialises cost in RP07 format")
         void serialisesCost() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element cost = firstElement(doc, "cost");
@@ -381,7 +381,7 @@ class VerdictXmlWriterTest {
             assertThat(cost.hasAttribute("total-tokens")).isTrue();
             assertThat(cost.hasAttribute("avg-time-per-sample-ms")).isTrue();
             assertThat(cost.hasAttribute("avg-tokens-per-sample")).isTrue();
-            // Punit-specific budget attributes should be absent
+            // PUnit-specific budget attributes should be absent
             assertThat(cost.hasAttribute("method-tokens")).isFalse();
             assertThat(cost.hasAttribute("token-mode")).isFalse();
         }
@@ -413,7 +413,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("minimal verdict validates against RP07 XSD")
         void minimalVerdictValidatesAgainstXsd() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             String xml = writeToString(verdict);
 
@@ -449,7 +449,7 @@ class VerdictXmlWriterTest {
         @Test
         @DisplayName("falls back to class-name when use-case-id absent")
         void fallsBackToClassName() throws Exception {
-            ProbabilisticTestVerdict verdict = minimalVerdict(true, PunitVerdict.PASS);
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element identity = firstElement(doc, "identity");
@@ -460,7 +460,7 @@ class VerdictXmlWriterTest {
 
     // ── Helpers ──────────────────────────────────────────────────────────
 
-    private ProbabilisticTestVerdict minimalVerdict(boolean passed, PunitVerdict punitVerdict) {
+    private ProbabilisticTestVerdict minimalVerdict(boolean passed, PUnitVerdict punitVerdict) {
         String verdictReason = switch (punitVerdict) {
             case PASS -> "0.9500 >= 0.9000";
             case FAIL -> "0.9500 < 0.9000";
@@ -490,7 +490,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithFunctional() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         return new ProbabilisticTestVerdict(
                 base.correlationId(), base.timestamp(), base.identity(), base.execution(),
                 Optional.of(new FunctionalDimension(95, 5, 0.95)),
@@ -502,7 +502,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithLatency() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         LatencyDimension latency = new LatencyDimension(
                 90, 100, false, Optional.empty(),
                 120, 340, 420, 810, 1250,
@@ -521,7 +521,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithSkippedLatency() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         LatencyDimension latency = new LatencyDimension(
                 0, 100, true, Optional.of("No successes"),
                 0, 0, 0, 0, 0,
@@ -538,7 +538,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithBaseline() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         StatisticalAnalysis stats = new StatisticalAnalysis(
                 0.95, 0.0218, 0.8948, 0.9798,
                 Optional.of(2.29), Optional.of(0.011),
@@ -559,7 +559,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithMisalignment() {
-        ProbabilisticTestVerdict base = minimalVerdict(false, PunitVerdict.INCONCLUSIVE);
+        ProbabilisticTestVerdict base = minimalVerdict(false, PUnitVerdict.INCONCLUSIVE);
         CovariateStatus cov = new CovariateStatus(false,
                 List.of(new Misalignment("model", "gpt-4", "gpt-4o")),
                 Map.of(), Map.of());
@@ -574,7 +574,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithProvenance() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         ExpirationStatus expiringStatus = ExpirationStatus.expiringSoon(
                 java.time.Duration.ofDays(7), 0.20);
         SpecProvenance prov = new SpecProvenance("SLA", "SLA-PAY-001", "payment-gateway.yaml",
@@ -591,7 +591,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithBudgetExhaustion() {
-        ProbabilisticTestVerdict base = minimalVerdict(false, PunitVerdict.FAIL);
+        ProbabilisticTestVerdict base = minimalVerdict(false, PUnitVerdict.FAIL);
         return new ProbabilisticTestVerdict(
                 base.correlationId(), base.timestamp(), base.identity(), base.execution(),
                 base.functional(), base.latency(),
@@ -599,13 +599,13 @@ class VerdictXmlWriterTest {
                 base.pacing(), base.provenance(),
                 new Termination(TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED,
                         Optional.of("Time budget exceeded")),
-                base.environmentMetadata(), false, PunitVerdict.FAIL,
+                base.environmentMetadata(), false, PUnitVerdict.FAIL,
                 "budget exhausted"
         );
     }
 
     private ProbabilisticTestVerdict verdictWithUseCaseId() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         TestIdentity identity = new TestIdentity(
                 "com.example.MyTest", "shouldPass", Optional.of("payment-gateway"));
         return new ProbabilisticTestVerdict(
@@ -619,7 +619,7 @@ class VerdictXmlWriterTest {
     }
 
     private ProbabilisticTestVerdict verdictWithCaveats() {
-        ProbabilisticTestVerdict base = minimalVerdict(true, PunitVerdict.PASS);
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
         StatisticalAnalysis stats = new StatisticalAnalysis(
                 0.95, 0.0218, 0.8948, 0.9798,
                 Optional.of(2.29), Optional.of(0.011),
@@ -665,7 +665,7 @@ class VerdictXmlWriterTest {
                 Optional.of(pacing), Optional.of(prov),
                 new Termination(TerminationReason.COMPLETED, Optional.empty()),
                 Map.of("environment", "staging"),
-                true, PunitVerdict.PASS,
+                true, PUnitVerdict.PASS,
                 "0.9500 >= 0.9000"
         );
     }

--- a/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelTestExecutorTest.java
+++ b/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelTestExecutorTest.java
@@ -13,7 +13,7 @@ import org.javai.punit.spec.registry.LayeredSpecRepository;
 import org.javai.punit.statistics.ThresholdDeriver;
 import org.javai.punit.usecase.UseCaseFactory;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
-import org.javai.punit.verdict.PunitVerdict;
+import org.javai.punit.verdict.PUnitVerdict;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -148,7 +148,7 @@ class SentinelTestExecutorTest {
                     method, annotation, sentinel, factory,
                     PassingSentinel.class, Optional.of("stub-use-case"));
 
-            assertThat(verdict.punitVerdict()).isEqualTo(PunitVerdict.PASS);
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.PASS);
         }
 
         @Test
@@ -163,7 +163,7 @@ class SentinelTestExecutorTest {
                     method, annotation, sentinel, factory,
                     FailingSentinel.class, Optional.of("failing-use-case"));
 
-            assertThat(verdict.punitVerdict()).isEqualTo(PunitVerdict.FAIL);
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.FAIL);
         }
 
         @Test


### PR DESCRIPTION
## Summary

The brand has always been **PUnit** (probabilistic unit), in the spirit of **JUnit** (Java unit). Type names had drifted to `Punit` in places — the entry-point class itself, half a dozen support classes, and a scattering of method names. This PR aligns every Java/Kotlin identifier and prose mention to the `PUnit` form.

### What changed

- **11 file renames** (6 Java, 5 Kotlin): `Punit` → `PUnit`, `PunitSubjects`, `PunitJunitIntegrationTest`, `PunitVerdict`, `PunitApiVisibilityTest`, `PunitApiArchitectureTest`, `PunitPlugin`, `PunitReportTask`, `PunitVerifyTask`, `PunitExperimentExtension`, `PunitPluginFunctionalTest`.
- **Identifier rename across all Java/Kotlin sources:** plain `Punit` → `PUnit` substring rename, picking up class names, method names (`loadPunitVersion`, `derivePunitVerdict`, `getPunitEnvironment`, …), and prose mentions in javadoc.
- `PunitVersion` generator in `punit-gradle-plugin/build.gradle.kts` now emits `PUnitVersion.kt` with the matching object name.

### What did NOT change (by convention)

- Java package paths (`org.javai.punit.*`) — lowercase, language convention.
- Maven groupId / artifactId — lowercase.
- Repository name, plugin id (`org.javai.punit`), module directory names (`punit-junit5`, `punit-core`, …) — all lowercase by convention.
- User-facing strings already in `PUnit` form (`PUnit PASSED:`, etc.) — untouched.

## Test plan

- [x] `./gradlew build` — full suite green
- [x] `./gradlew :punit-gradle-plugin:functionalTest` — plugin functional tests green
- [x] `git grep -E '\bPunit\b'` returns zero matches in source (excluding `build/` and `.gradle/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)