### PR TITLE
Step 1b + Step 2: ContractBuilder, TokenTracker, UseCase extends Contract

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/Contract.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Contract.java
@@ -1,0 +1,185 @@
+package org.javai.punit.api.typed;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.javai.outcome.Outcome;
+
+/**
+ * The operational layer of a use case: how to invoke the service for
+ * one sample, and what counts as success when the service returns.
+ *
+ * <p>{@link UseCase} extends this interface, so an author writing
+ * {@code class MyUseCase implements UseCase<F, I, O>} satisfies both
+ * surfaces with one {@code implements} clause. The author overrides
+ * exactly two methods:
+ *
+ * <ul>
+ *   <li>{@link #invoke(Object, TokenTracker) invoke} — the service
+ *       call. Returns {@link Outcome.Ok} for a successful invocation
+ *       or {@link Outcome.Fail} for an expected business-level
+ *       failure. Records cost via the supplied
+ *       {@link TokenTracker}.</li>
+ *   <li>{@link #postconditions(ContractBuilder) postconditions} —
+ *       declares the contract's clauses by populating the supplied
+ *       builder with {@code ensure(...)} and {@code deriving(...)}
+ *       calls.</li>
+ * </ul>
+ *
+ * <p>The three {@code apply} forms are concrete defaults the
+ * framework dispatches to per sample. Authors do not override them.
+ * Each one wraps {@code invoke} with timing, cost diff, postcondition
+ * evaluation, and (for the matching forms) the comparison of the
+ * produced value against an expected value via a
+ * {@link ValueMatcher}.
+ *
+ * @param <I> the per-sample input type
+ * @param <O> the per-sample output value type
+ */
+public interface Contract<I, O> {
+
+    /**
+     * Invoke the service for one sample.
+     *
+     * <p>Return {@link Outcome.Ok} carrying the produced value for a
+     * successful invocation, or {@link Outcome.Fail} for an expected
+     * business-level failure (a contract violation, a service-returned
+     * error code, an explicit refusal). The framework counts
+     * {@code Ok} samples as candidates for postcondition evaluation
+     * and {@code Fail} samples as apply-level failures, preserving the
+     * full {@link org.javai.outcome.Failure} for diagnostics.
+     *
+     * <p>Throwing from this method is reserved for <em>defects</em> —
+     * programming mistakes, misconfiguration, catastrophe. A thrown
+     * exception bubbles out and aborts the run. Do not throw to
+     * signal a failed sample; return {@code Outcome.fail(name, msg)}.
+     *
+     * <p>Record cost via {@code tracker.recordTokens(n)}. The
+     * framework derives the per-sample token count by diffing
+     * {@link TokenTracker#totalTokens()} before and after this call.
+     * Authors with no cost to track simply omit the call.
+     *
+     * @param input   the per-sample input
+     * @param tracker the per-run cost channel
+     * @return the wrapped outcome
+     */
+    Outcome<O> invoke(I input, TokenTracker tracker);
+
+    /**
+     * Declare this contract's postcondition clauses by calling
+     * {@link ContractBuilder#ensure ensure} and
+     * {@link ContractBuilder#deriving deriving} on the supplied
+     * builder.
+     *
+     * <p>The framework constructs a fresh builder, calls this method
+     * to populate it, and reads the resulting clause list out via the
+     * no-arg {@link #postconditions()} accessor.
+     *
+     * <p>Use cases that genuinely have no acceptance criteria
+     * (smoke-test scaffolding, throwaway fixtures) leave the body
+     * empty — the explicit empty body marks the choice.
+     *
+     * @param b the builder to populate
+     */
+    void postconditions(ContractBuilder<O> b);
+
+    /**
+     * Resolves the contract's clauses to an immutable list. The
+     * framework hook; do not override. The default implementation
+     * builds a fresh {@link ContractBuilder}, calls
+     * {@link #postconditions(ContractBuilder)} to populate it, and
+     * returns the built list.
+     */
+    default List<Postcondition<O>> postconditions() {
+        ContractBuilder<O> b = new ContractBuilder<>();
+        postconditions(b);
+        return b.build();
+    }
+
+    /**
+     * Run one sample without an expected value or a matcher.
+     * Postconditions are evaluated against the produced value; no
+     * match step.
+     *
+     * <p>Concrete default; the framework dispatches to this form when
+     * the test/experiment hasn't configured matching.
+     */
+    default UseCaseOutcome<O> apply(I input, TokenTracker tracker) {
+        return runSample(input, tracker, Optional.empty());
+    }
+
+    /**
+     * Run one sample with an expected value, using the equality
+     * matcher ({@link ValueMatcher#equality()}) to compare produced
+     * vs expected. Concrete default; the framework dispatches to this
+     * form when the test/experiment configured an expected list but
+     * no custom matcher.
+     */
+    default UseCaseOutcome<O> apply(I input, O expected, TokenTracker tracker) {
+        return apply(input, expected, ValueMatcher.equality(), tracker);
+    }
+
+    /**
+     * Run one sample with an expected value and a custom matcher.
+     * Concrete default; the framework dispatches to this form when
+     * the test/experiment configured matching with a custom matcher.
+     */
+    default UseCaseOutcome<O> apply(I input, O expected, ValueMatcher<O> matcher, TokenTracker tracker) {
+        return runSample(input, tracker,
+                Optional.of(value -> matcher.match(expected, value)));
+    }
+
+    private UseCaseOutcome<O> runSample(
+            I input,
+            TokenTracker tracker,
+            Optional<Function<O, MatchResult>> matchStep) {
+
+        long startTokens = tracker.totalTokens();
+        long start = System.nanoTime();
+        Outcome<O> result = invoke(input, tracker);
+        Duration duration = Duration.ofNanos(System.nanoTime() - start);
+        long sampleTokens = Math.max(0L, tracker.totalTokens() - startTokens);
+
+        return switch (result) {
+            case Outcome.Ok<O> ok -> {
+                Optional<MatchResult> match = matchStep.map(step -> step.apply(ok.value()));
+                UseCaseOutcome<O> built = new UseCaseOutcome<>(
+                        ok.value(),
+                        contractEvaluator(),
+                        match,
+                        sampleTokens,
+                        duration);
+                yield built;
+            }
+            case Outcome.Fail<O> f -> {
+                UseCaseOutcome<O> built = UseCaseOutcome.<O>fail(
+                                f.failure().id().name(),
+                                f.failure().message())
+                        .withTokens(sampleTokens)
+                        .withDuration(duration);
+                yield built;
+            }
+        };
+    }
+
+    private PostconditionEvaluator<O> contractEvaluator() {
+        List<Postcondition<O>> clauses = postconditions();
+        return new PostconditionEvaluator<>() {
+            @Override
+            public List<PostconditionResult> evaluate(O result) {
+                List<PostconditionResult> out = new ArrayList<>();
+                for (Postcondition<O> p : clauses) {
+                    out.addAll(p.evaluateAll(result));
+                }
+                return List.copyOf(out);
+            }
+            @Override
+            public int postconditionCount() {
+                return clauses.size();
+            }
+        };
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/ContractBuilder.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/ContractBuilder.java
@@ -1,0 +1,97 @@
+package org.javai.punit.api.typed;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.javai.outcome.Outcome;
+
+/**
+ * Authoring surface for a contract's postcondition clauses. Authors
+ * never construct one directly — the framework supplies a fresh builder
+ * to the author's {@code postconditions(ContractBuilder<O>)} method and
+ * collects the result.
+ *
+ * <p>Two methods, both fluent: {@link #ensure ensure} adds a leaf
+ * clause, {@link #deriving deriving} adds a derivation whose nested
+ * clauses are populated through a sub-builder lambda.
+ *
+ * <pre>{@code
+ * @Override
+ * public void postconditions(ContractBuilder<BasketTranslation> b) {
+ *     b.ensure("Has actions", t ->
+ *             t.actions().isEmpty()
+ *                     ? Outcome.fail("empty-actions", "actions list was empty")
+ *                     : Outcome.ok())
+ *      .ensure("All actions known", ShoppingBasketUseCase::allKnown)
+ *      .deriving("Resolves to catalog SKUs",
+ *             t -> resolveAgainstCatalog(t.actions()),
+ *             sub -> sub
+ *                     .ensure("Every action mapped to a SKU", ...)
+ *                     .ensure("No duplicate SKUs", ...));
+ * }
+ * }</pre>
+ *
+ * @param <O> the value type the contract evaluates against (the use
+ *            case's output type)
+ */
+public final class ContractBuilder<O> {
+
+    private final List<Postcondition<O>> clauses = new ArrayList<>();
+
+    /**
+     * Add a leaf clause. The {@code check} returns
+     * {@link Outcome.Ok} when the aspect holds, or
+     * {@link Outcome.Fail} carrying a stable name and a free-text reason
+     * when it does not. Both name and reason are preserved on the
+     * resulting {@link PostconditionResult}.
+     *
+     * @param description human-readable description of what is checked
+     * @param check       the predicate, returning an outcome
+     * @return this builder
+     * @throws NullPointerException     if any argument is null
+     * @throws IllegalArgumentException if {@code description} is blank
+     */
+    public ContractBuilder<O> ensure(String description, PostconditionCheck<O> check) {
+        clauses.add(new Postcondition.Leaf<>(description, check));
+        return this;
+    }
+
+    /**
+     * Add a derivation: transform the value via {@code derive}, then
+     * evaluate the clauses populated on the supplied sub-builder
+     * against the derived value. If the derivation fails (returns
+     * {@link Outcome.Fail} or throws), the nested clauses are skipped
+     * and reported as failed with a "skipped: …" reason.
+     *
+     * @param description description of the derivation step
+     * @param derive      the transform, returning an outcome over the
+     *                    derived type
+     * @param nested      consumer that populates the sub-builder
+     * @param <D>         the derived value type
+     * @return this builder
+     * @throws NullPointerException     if any argument is null
+     * @throws IllegalArgumentException if {@code description} is blank
+     */
+    public <D> ContractBuilder<O> deriving(
+            String description,
+            Function<O, Outcome<D>> derive,
+            Consumer<ContractBuilder<D>> nested) {
+        Objects.requireNonNull(nested, "nested");
+        ContractBuilder<D> sub = new ContractBuilder<>();
+        nested.accept(sub);
+        clauses.add(new Postcondition.Derived<>(description, derive, sub.clauses));
+        return this;
+    }
+
+    /**
+     * Returns the accumulated clauses as an immutable list. Called by
+     * the framework after the author's {@code postconditions} method
+     * has populated the builder. Authors do not call this directly.
+     */
+    List<Postcondition<O>> build() {
+        return List.copyOf(clauses);
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Postcondition.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Postcondition.java
@@ -147,7 +147,7 @@ public sealed interface Postcondition<T>
             }
             return switch (result) {
                 case Outcome.Ok<?> ignored -> PostconditionResult.passed(description);
-                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f.failure().message());
+                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f);
             };
         }
 
@@ -189,7 +189,7 @@ public sealed interface Postcondition<T>
             }
             return switch (derived) {
                 case Outcome.Ok<D> ignored -> PostconditionResult.passed(description);
-                case Outcome.Fail<D> f -> PostconditionResult.failed(description, f.failure().message());
+                case Outcome.Fail<D> f -> PostconditionResult.failed(description, f);
             };
         }
 
@@ -215,7 +215,7 @@ public sealed interface Postcondition<T>
                     }
                 }
                 case Outcome.Fail<D> f -> {
-                    out.add(PostconditionResult.failed(description, f.failure().message()));
+                    out.add(PostconditionResult.failed(description, f));
                     appendSkipped(out);
                 }
             }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Postcondition.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Postcondition.java
@@ -1,0 +1,237 @@
+package org.javai.punit.api.typed;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.javai.outcome.Outcome;
+
+/**
+ * One named acceptance criterion on a {@link UseCase}'s output. A use
+ * case declares its postconditions via {@link UseCase#postconditions()};
+ * the framework evaluates each one against every successful sample and
+ * surfaces the per-postcondition results in the verdict, the report,
+ * and the optimize / explore feedback path.
+ *
+ * <h2>Authoring</h2>
+ *
+ * <p>The {@code ensure} factory mirrors Eiffel's design-by-contract
+ * vocabulary: each call declares one postcondition that the use case
+ * promises will hold for every successful invocation. The check is a
+ * predicate — the description label carries the failure semantics.
+ *
+ * <pre>{@code
+ * import static org.javai.punit.api.typed.Postcondition.ensure;
+ * import static org.javai.punit.api.typed.Postcondition.deriving;
+ *
+ * ensure("Response has actions", t -> !t.actions().isEmpty())
+ * ensure("All actions known",     ShoppingBasketUseCase::allKnown)
+ * }</pre>
+ *
+ * <p>Authors who need a richer failure reason — naming <em>which</em>
+ * input element tripped the check, embedding diagnostic data in the
+ * failure — construct a {@link Leaf} directly with a
+ * {@link PostconditionCheck} that returns
+ * {@code Outcome.fail("name", reason)}.
+ *
+ * <h2>Derivations</h2>
+ *
+ * <p>Postconditions that need to inspect a transformed view of the
+ * output (parsed JSON, normalised text, an extracted sub-record) use
+ * the {@link #deriving(String, Function, Postcondition[]) deriving}
+ * factory. The derivation runs first; its outcome contributes one
+ * postcondition result of its own; its nested {@code ensure}s only
+ * evaluate when the derivation succeeds.
+ *
+ * <pre>{@code
+ * deriving("Valid JSON", ChatResponse::parseJson,
+ *     ensure("Has operations array", JsonNode::hasOperations),
+ *     ensure("All operations valid", JsonNode::operationsValid))
+ * }</pre>
+ *
+ * @param <T> the type the postcondition evaluates
+ */
+public sealed interface Postcondition<T>
+        permits Postcondition.Leaf, Postcondition.Derived {
+
+    /** Human-readable description; non-blank. */
+    String description();
+
+    /**
+     * Evaluate this postcondition and return one summary result. For a
+     * derivation, this collapses the derivation's outcome to a single
+     * pass / fail; use {@link #evaluateAll(Object)} when the full
+     * vector (the derivation plus every nested postcondition) is
+     * wanted.
+     */
+    PostconditionResult evaluate(T value);
+
+    /**
+     * Evaluate this postcondition and return every contributing result.
+     * For a {@link Leaf} this is a singleton list; for a
+     * {@link Derived} it is the derivation's own result followed by
+     * the nested postconditions' results.
+     */
+    List<PostconditionResult> evaluateAll(T value);
+
+    // ── Authoring entry points ──────────────────────────────────────
+
+    /**
+     * Declare a postcondition from a predicate. On failure the
+     * description label is used as the reason — suitable when no
+     * further explanation is meaningful at the failure site. For
+     * richer failure reasons, construct {@link Leaf} directly with a
+     * {@link PostconditionCheck}.
+     */
+    static <T> Postcondition<T> ensure(String description, Predicate<T> predicate) {
+        Objects.requireNonNull(predicate, "predicate");
+        return new Leaf<>(description, value -> predicate.test(value)
+                ? Outcome.ok()
+                : Outcome.fail(description, "postcondition not satisfied"));
+    }
+
+    /**
+     * Declare a derivation: transform the output via {@code derive},
+     * then evaluate the {@code nested} postconditions against the
+     * derived value. On derivation failure (the function returns
+     * {@link Outcome.Fail} or throws), the nested postconditions are
+     * skipped and reported as failed with a "skipped: …" reason.
+     */
+    @SafeVarargs
+    static <T, D> Postcondition<T> deriving(
+            String description,
+            Function<T, Outcome<D>> derive,
+            Postcondition<D>... nested) {
+        Objects.requireNonNull(derive, "derive");
+        Objects.requireNonNull(nested, "nested");
+        return new Derived<>(description, derive, List.of(nested));
+    }
+
+    // ── Variants ────────────────────────────────────────────────────
+
+    /** A direct postcondition: one description, one check. */
+    record Leaf<T>(String description, PostconditionCheck<T> check)
+            implements Postcondition<T> {
+
+        public Leaf {
+            Objects.requireNonNull(description, "description");
+            Objects.requireNonNull(check, "check");
+            if (description.isBlank()) {
+                throw new IllegalArgumentException("description must not be blank");
+            }
+        }
+
+        @Override
+        public PostconditionResult evaluate(T value) {
+            Outcome<Void> result;
+            try {
+                result = check.check(value);
+            } catch (RuntimeException e) {
+                String reason = e.getMessage() != null
+                        ? e.getMessage()
+                        : e.getClass().getSimpleName();
+                return PostconditionResult.failed(description, reason);
+            }
+            return switch (result) {
+                case Outcome.Ok<?> ignored -> PostconditionResult.passed(description);
+                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f.failure().message());
+            };
+        }
+
+        @Override
+        public List<PostconditionResult> evaluateAll(T value) {
+            return List.of(evaluate(value));
+        }
+    }
+
+    /**
+     * A derivation: a transform from {@code T} to {@code D} that gates
+     * a list of nested postconditions over the derived value.
+     */
+    record Derived<T, D>(
+            String description,
+            Function<T, Outcome<D>> derive,
+            List<Postcondition<D>> nested) implements Postcondition<T> {
+
+        public Derived {
+            Objects.requireNonNull(description, "description");
+            Objects.requireNonNull(derive, "derive");
+            Objects.requireNonNull(nested, "nested");
+            if (description.isBlank()) {
+                throw new IllegalArgumentException("description must not be blank");
+            }
+            nested = List.copyOf(nested);
+        }
+
+        @Override
+        public PostconditionResult evaluate(T value) {
+            Outcome<D> derived;
+            try {
+                derived = derive.apply(value);
+            } catch (RuntimeException e) {
+                String reason = e.getMessage() != null
+                        ? e.getMessage()
+                        : e.getClass().getSimpleName();
+                return PostconditionResult.failed(description, reason);
+            }
+            return switch (derived) {
+                case Outcome.Ok<D> ignored -> PostconditionResult.passed(description);
+                case Outcome.Fail<D> f -> PostconditionResult.failed(description, f.failure().message());
+            };
+        }
+
+        @Override
+        public List<PostconditionResult> evaluateAll(T value) {
+            List<PostconditionResult> out = new ArrayList<>(1 + nested.size());
+            Outcome<D> derived;
+            try {
+                derived = derive.apply(value);
+            } catch (RuntimeException e) {
+                String reason = e.getMessage() != null
+                        ? e.getMessage()
+                        : e.getClass().getSimpleName();
+                out.add(PostconditionResult.failed(description, reason));
+                appendSkipped(out);
+                return out;
+            }
+            switch (derived) {
+                case Outcome.Ok<D> ok -> {
+                    out.add(PostconditionResult.passed(description));
+                    for (Postcondition<D> child : nested) {
+                        out.addAll(child.evaluateAll(ok.value()));
+                    }
+                }
+                case Outcome.Fail<D> f -> {
+                    out.add(PostconditionResult.failed(description, f.failure().message()));
+                    appendSkipped(out);
+                }
+            }
+            return out;
+        }
+
+        private void appendSkipped(List<PostconditionResult> out) {
+            String reason = "skipped: derivation '" + description + "' failed";
+            for (Postcondition<D> child : nested) {
+                appendSkippedRecursive(child, reason, out);
+            }
+        }
+
+        private static <D> void appendSkippedRecursive(
+                Postcondition<D> p, String reason, List<PostconditionResult> out) {
+            switch (p) {
+                case Leaf<D> leaf ->
+                        out.add(PostconditionResult.failed(leaf.description(), reason));
+                case Derived<D, ?> derived -> {
+                    out.add(PostconditionResult.failed(derived.description(), reason));
+                    for (Postcondition<?> grandchild : derived.nested()) {
+                        @SuppressWarnings("unchecked")
+                        Postcondition<Object> g = (Postcondition<Object>) grandchild;
+                        appendSkippedRecursive(g, reason, out);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Postcondition.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Postcondition.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import org.javai.outcome.Outcome;
 
@@ -17,24 +16,38 @@ import org.javai.outcome.Outcome;
  *
  * <h2>Authoring</h2>
  *
- * <p>The {@code ensure} factory mirrors Eiffel's design-by-contract
- * vocabulary: each call declares one postcondition that the use case
- * promises will hold for every successful invocation. The check is a
- * predicate — the description label carries the failure semantics.
+ * <p>The {@code ensure} factory is a nod to Eiffel's
+ * design-by-contract vocabulary, not a strict replication of it. Each
+ * call declares one postcondition that delivers an unopinionated
+ * evaluation of an aspect of the output. The check function returns
+ * an {@link Outcome.Ok} when the aspect holds, or an
+ * {@link Outcome.Fail} carrying the specific reason — what was
+ * observed, which element tripped the check, the diagnostic detail a
+ * downstream report or optimize-feedback histogram needs.
+ *
+ * <p>The verdict is not formed at the postcondition site. Each
+ * {@code ensure} produces a {@link PostconditionResult}; the
+ * framework collects all of them per sample, and the opinion (pass /
+ * fail) is taken later when the test or experiment asks for it. A
+ * postcondition's {@code Outcome.Fail} only manifests as a JUnit-style
+ * assertion failure when the test's {@code assertPasses()} (or
+ * equivalent) is invoked.
  *
  * <pre>{@code
  * import static org.javai.punit.api.typed.Postcondition.ensure;
  * import static org.javai.punit.api.typed.Postcondition.deriving;
  *
- * ensure("Response has actions", t -> !t.actions().isEmpty())
- * ensure("All actions known",     ShoppingBasketUseCase::allKnown)
- * }</pre>
+ * ensure("Response has actions", t -> t.actions().isEmpty()
+ *         ? Outcome.fail("empty", "actions list was empty")
+ *         : Outcome.ok())
  *
- * <p>Authors who need a richer failure reason — naming <em>which</em>
- * input element tripped the check, embedding diagnostic data in the
- * failure — construct a {@link Leaf} directly with a
- * {@link PostconditionCheck} that returns
- * {@code Outcome.fail("name", reason)}.
+ * ensure("All actions known", t -> {
+ *     var unknown = unknownActions(t);
+ *     return unknown.isEmpty()
+ *             ? Outcome.ok()
+ *             : Outcome.fail("unknown-action", "found: " + unknown);
+ * })
+ * }</pre>
  *
  * <h2>Derivations</h2>
  *
@@ -79,17 +92,15 @@ public sealed interface Postcondition<T>
     // ── Authoring entry points ──────────────────────────────────────
 
     /**
-     * Declare a postcondition from a predicate. On failure the
-     * description label is used as the reason — suitable when no
-     * further explanation is meaningful at the failure site. For
-     * richer failure reasons, construct {@link Leaf} directly with a
-     * {@link PostconditionCheck}.
+     * Declare a postcondition. The check function evaluates one aspect
+     * of the output and returns an {@link Outcome.Ok} if the aspect
+     * holds or an {@link Outcome.Fail} carrying the specific reason
+     * if it does not. The framework collects every postcondition's
+     * result per sample; whether a failure becomes an assertion
+     * failure is decided later by the test, not here.
      */
-    static <T> Postcondition<T> ensure(String description, Predicate<T> predicate) {
-        Objects.requireNonNull(predicate, "predicate");
-        return new Leaf<>(description, value -> predicate.test(value)
-                ? Outcome.ok()
-                : Outcome.fail(description, "postcondition not satisfied"));
+    static <T> Postcondition<T> ensure(String description, PostconditionCheck<T> check) {
+        return new Leaf<>(description, check);
     }
 
     /**

--- a/punit-api/src/main/java/org/javai/punit/api/typed/PostconditionCheck.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/PostconditionCheck.java
@@ -1,0 +1,20 @@
+package org.javai.punit.api.typed;
+
+import org.javai.outcome.Outcome;
+
+/**
+ * The check function carried by a {@link Postcondition}. Inspects a
+ * value of type {@code T} and returns an {@link Outcome.Ok} if the
+ * postcondition holds or an {@link Outcome.Fail} carrying the
+ * specific reason if it does not.
+ *
+ * <p>Authors who don't need a bespoke failure reason can construct
+ * postconditions from a plain {@link java.util.function.Predicate}
+ * via {@link Postcondition#of(String, java.util.function.Predicate)};
+ * the synthesised reason is just the postcondition's description.
+ */
+@FunctionalInterface
+public interface PostconditionCheck<T> {
+
+    Outcome<Void> check(T value);
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/PostconditionResult.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/PostconditionResult.java
@@ -45,6 +45,28 @@ public record PostconditionResult(String description, Outcome<?> outcome) {
     }
 
     /**
+     * The failure's symbolic name. For a failed result this is the
+     * {@code name} field of the {@link org.javai.outcome.Outcome.Fail
+     * Outcome.Fail} that produced the result — typically a stable
+     * identifier the author supplied when constructing
+     * {@code Outcome.fail(name, message)} (e.g. {@code "unknown-action"},
+     * {@code "empty-actions"}).
+     *
+     * <p>Aggregators can bucket on the name to distinguish multiple
+     * failure modes within a single clause description: one clause
+     * called {@code "All actions known"} may emit several distinct
+     * named failures across a run.
+     *
+     * @return the failure name, or empty if the postcondition passed
+     */
+    public Optional<String> failureName() {
+        return switch (outcome) {
+            case Outcome.Fail<?> f -> Optional.of(f.failure().id().name());
+            case Outcome.Ok<?> ignored -> Optional.empty();
+        };
+    }
+
+    /**
      * @return {@code "{description}: {reason}"} when failed,
      *         just {@code description} when passed
      */
@@ -58,8 +80,26 @@ public record PostconditionResult(String description, Outcome<?> outcome) {
         return new PostconditionResult(description, Outcome.ok());
     }
 
+    /**
+     * Construct a failed result with a synthetic failure (name is the
+     * description). Used for results that don't originate from an
+     * author-supplied {@link Outcome.Fail} — for example, derivation
+     * exceptions caught by the framework, or skipped-children entries
+     * where the parent derivation failed.
+     */
     public static PostconditionResult failed(String description, String reason) {
         Objects.requireNonNull(reason, "reason");
         return new PostconditionResult(description, Outcome.fail(description, reason));
+    }
+
+    /**
+     * Construct a failed result that preserves an author-supplied
+     * {@link Outcome.Fail}. Both the failure's name and its message
+     * survive into {@link #failureName()} and {@link #failureReason()}
+     * unchanged.
+     */
+    public static PostconditionResult failed(String description, Outcome.Fail<?> failure) {
+        Objects.requireNonNull(failure, "failure");
+        return new PostconditionResult(description, failure);
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/TokenTracker.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/TokenTracker.java
@@ -1,0 +1,44 @@
+package org.javai.punit.api.typed;
+
+/**
+ * Per-run cost channel. The framework creates one {@code TokenTracker}
+ * at the start of a run and threads it through every {@code apply}
+ * call; the author's service-call body writes to it via
+ * {@link #recordTokens(long)} when a sample's cost is known. The
+ * framework derives per-sample tokens by diffing
+ * {@link #totalTokens()} before and after each invocation.
+ *
+ * <h2>Token semantics</h2>
+ *
+ * <p>PUnit's notion of a "token" is deliberately open. LLM tokens are
+ * the obvious case, but a token can be any unit of cost the author
+ * chooses to track in their domain — dollars or cents for a paid
+ * third-party API, request counts for a rate-limited service,
+ * message bytes for a messaging-charge service, or upstream-service
+ * quota units. The framework only requires that the same unit be
+ * used consistently within a single run.
+ *
+ * <p>Authors that have no cost to record simply don't call
+ * {@link #recordTokens(long)}; per-sample tokens are then reported as
+ * zero. The interface has no notion of "absent" or "unknown" cost —
+ * zero means zero, not missing.
+ */
+public interface TokenTracker {
+
+    /**
+     * Record the cost — in tokens — of work performed during the
+     * current sample. The implementation accumulates the value into
+     * {@link #totalTokens()}; callers may invoke this any number of
+     * times within one sample (e.g. once per upstream request).
+     *
+     * @param n the number of tokens to add; must be non-negative
+     * @throws IllegalArgumentException if {@code n} is negative
+     */
+    void recordTokens(long n);
+
+    /**
+     * @return the cumulative token count recorded across every
+     *         {@code recordTokens} call so far in this run
+     */
+    long totalTokens();
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/TokenTracker.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/TokenTracker.java
@@ -1,5 +1,7 @@
 package org.javai.punit.api.typed;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * Per-run cost channel. The framework creates one {@code TokenTracker}
  * at the start of a run and threads it through every {@code apply}
@@ -41,4 +43,30 @@ public interface TokenTracker {
      *         {@code recordTokens} call so far in this run
      */
     long totalTokens();
+
+    /**
+     * Returns a fresh, thread-safe {@code TokenTracker} backed by an
+     * atomic counter. Used by the framework to construct the
+     * per-run tracker; equally usable from tests that need a simple
+     * concrete instance without depending on engine internals.
+     */
+    static TokenTracker create() {
+        return new TokenTracker() {
+            private final AtomicLong total = new AtomicLong();
+
+            @Override
+            public void recordTokens(long n) {
+                if (n < 0) {
+                    throw new IllegalArgumentException(
+                            "token count must be non-negative, got " + n);
+                }
+                total.addAndGet(n);
+            }
+
+            @Override
+            public long totalTokens() {
+                return total.get();
+            }
+        };
+    }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/UseCase.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/UseCase.java
@@ -1,23 +1,32 @@
 package org.javai.punit.api.typed;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.javai.outcome.Outcome;
 import org.javai.punit.api.typed.covariate.Covariate;
 
 /**
  * A stochastic service invocation expressed as a typed, three-parameter
- * function.
+ * function. The metadata layer of a use case: how the framework
+ * identifies it, what covariates it is sensitive to, what pacing and
+ * warmup it requires.
+ *
+ * <p>{@code UseCase} extends {@link Contract} — the operational layer
+ * that carries the service call ({@link Contract#invoke invoke}) and
+ * the acceptance criteria ({@link Contract#postconditions(ContractBuilder)
+ * postconditions}). An author writing one use case implements one
+ * interface and overrides three methods: {@code invoke},
+ * {@code postconditions(ContractBuilder)}, and whichever metadata
+ * methods diverge from the framework defaults.
  *
  * <p>{@code FT} is the factor record — the configuration the author has
  * chosen to vary. {@code IT} is the per-sample input. {@code OT} is the
- * per-sample output value type; it is wrapped in a
- * {@link UseCaseOutcome}, whose {@link UseCaseOutcome#value() value}
- * is an {@link org.javai.outcome.Outcome Outcome&lt;OT&gt;} so that the
- * use case can distinguish a produced value from an expected business
- * failure without abusing exceptions.
+ * per-sample output value type, wrapped in an {@link UseCaseOutcome}
+ * assembled by the framework's {@code apply} dispatch on
+ * {@link Contract}.
  *
  * <p>A {@code UseCase} is constructed by the framework once per factor
  * configuration (via the factory declared on the spec). Once
@@ -27,40 +36,34 @@ import org.javai.punit.api.typed.covariate.Covariate;
  *
  * <p>Implementations are free to keep internal caches, connection
  * handles, or other per-configuration state, but must not mutate such
- * state in a way that changes the behaviour observed by
- * {@link #apply(Object) apply}. Pre-existing caches and pools are fine;
- * live reconfiguration in response to sample outcomes is not.
+ * state in a way that changes the behaviour observed by {@code invoke}.
+ * Pre-existing caches and pools are fine; live reconfiguration in
+ * response to sample outcomes is not.
  *
  * @param <FT> the factor record type — typically a {@code record}
  * @param <IT> the per-sample input type
  * @param <OT> the per-sample output value type
  */
-public interface UseCase<FT, IT, OT> {
+public interface UseCase<FT, IT, OT> extends Contract<IT, OT> {
 
     /**
-     * Invokes the service for one sample.
+     * An optional per-sample wall-clock bound. When present, the engine
+     * records a duration violation for any sample whose
+     * {@link UseCaseOutcome#duration() duration} exceeds the bound. The
+     * sample's postcondition results are still collected; the violation
+     * is an additional facet, not a short-circuit.
      *
-     * <p>Return an outcome whose {@code value} is an {@link Outcome.Ok}
-     * for a successful invocation and an {@link Outcome.Fail} for an
-     * expected business-level failure (contract violation, validation
-     * error, service-returned error code). The engine counts
-     * {@code Ok} samples as successes and {@code Fail} samples as
-     * failures, preserving the full {@link org.javai.outcome.Failure}
-     * details in the {@code SampleSummary} for diagnostics.
+     * <p>Most use cases do not have a per-sample bound — aggregate
+     * latency claims (e.g. 95th-percentile under N ms) belong on the
+     * test via the {@code PercentileLatency} criterion. The two
+     * statements have two distinct homes.
      *
-     * <p>Throwing from this method is reserved for <em>defects</em> —
-     * {@code NullPointerException}, {@code IllegalStateException},
-     * {@code OutOfMemoryError}, and the like — conditions the author
-     * did not anticipate and that indicate a bug or catastrophe. A
-     * thrown exception bubbles out of the engine and aborts the run.
-     * Do not throw to signal a failed sample; return
-     * {@link UseCaseOutcome#fail(String, String)
-     * UseCaseOutcome.fail(...)} instead.
-     *
-     * @param input the per-sample input
-     * @return the wrapped outcome
+     * @return the per-sample latency bound; never null. The default is
+     *         {@link Optional#empty()}.
      */
-    UseCaseOutcome<OT> apply(IT input);
+    default Optional<Duration> maxLatency() {
+        return Optional.empty();
+    }
 
     /**
      * The stable identifier used in baseline filenames, logs, and

--- a/punit-api/src/test/java/org/javai/punit/api/typed/ContractBuilderTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/ContractBuilderTest.java
@@ -1,0 +1,143 @@
+package org.javai.punit.api.typed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.javai.outcome.Outcome;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ContractBuilder — accumulates clauses fluently")
+class ContractBuilderTest {
+
+    @Nested
+    @DisplayName("ensure")
+    class Ensures {
+
+        @Test
+        @DisplayName("a single ensure call yields one Leaf clause")
+        void singleEnsureYieldsOneLeaf() {
+            ContractBuilder<String> b = new ContractBuilder<>();
+
+            b.ensure("non-empty", s -> s.isEmpty()
+                    ? Outcome.fail("empty", "was empty")
+                    : Outcome.ok());
+
+            List<Postcondition<String>> clauses = b.build();
+
+            assertThat(clauses).hasSize(1);
+            assertThat(clauses.get(0)).isInstanceOf(Postcondition.Leaf.class);
+            assertThat(clauses.get(0).description()).isEqualTo("non-empty");
+        }
+
+        @Test
+        @DisplayName("multiple ensures chain in order")
+        void multipleEnsuresChain() {
+            List<Postcondition<Integer>> clauses = new ContractBuilder<Integer>()
+                    .ensure("positive", v -> v > 0 ? Outcome.ok() : Outcome.fail("non-positive", ""))
+                    .ensure("even",     v -> v % 2 == 0 ? Outcome.ok() : Outcome.fail("odd", ""))
+                    .ensure("small",    v -> v < 100 ? Outcome.ok() : Outcome.fail("too-big", ""))
+                    .build();
+
+            assertThat(clauses).extracting(Postcondition::description)
+                    .containsExactly("positive", "even", "small");
+        }
+
+        @Test
+        @DisplayName("blank description rejected at clause construction")
+        void blankDescriptionRejected() {
+            ContractBuilder<Object> b = new ContractBuilder<>();
+
+            assertThatThrownBy(() -> b.ensure("", v -> Outcome.ok()))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("the empty builder builds an empty clause list")
+        void emptyBuilder() {
+            assertThat(new ContractBuilder<String>().build()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("deriving")
+    class Derivations {
+
+        @Test
+        @DisplayName("the nested lambda's clauses are typed at the derived type")
+        void nestedClausesTypedAtDerived() {
+            List<Postcondition<String>> clauses = new ContractBuilder<String>()
+                    .deriving("length",
+                            s -> Outcome.ok(s.length()),
+                            sub -> sub
+                                    .ensure("positive length", (Integer n) -> n > 0
+                                            ? Outcome.ok()
+                                            : Outcome.fail("zero", "n=0"))
+                                    .ensure("at most 10", (Integer n) -> n <= 10
+                                            ? Outcome.ok()
+                                            : Outcome.fail("too-long", "n=" + n)))
+                    .build();
+
+            assertThat(clauses).hasSize(1);
+            Postcondition.Derived<?, ?> d = (Postcondition.Derived<?, ?>) clauses.get(0);
+            assertThat(d.description()).isEqualTo("length");
+            assertThat(d.nested()).extracting(Postcondition::description)
+                    .containsExactly("positive length", "at most 10");
+        }
+
+        @Test
+        @DisplayName("ensure and deriving compose in any order")
+        void mixedComposition() {
+            List<Postcondition<String>> clauses = new ContractBuilder<String>()
+                    .ensure("non-empty", s -> s.isEmpty()
+                            ? Outcome.fail("empty", "")
+                            : Outcome.ok())
+                    .deriving("length",
+                            s -> Outcome.ok(s.length()),
+                            sub -> sub.ensure("positive", (Integer n) -> n > 0
+                                    ? Outcome.ok()
+                                    : Outcome.fail("zero", "")))
+                    .ensure("starts upper", s -> Character.isUpperCase(s.charAt(0))
+                            ? Outcome.ok()
+                            : Outcome.fail("not-upper", ""))
+                    .build();
+
+            assertThat(clauses).extracting(Postcondition::description)
+                    .containsExactly("non-empty", "length", "starts upper");
+        }
+
+        @Test
+        @DisplayName("an empty nested lambda produces a derivation with no children")
+        void emptyNestedAllowed() {
+            List<Postcondition<String>> clauses = new ContractBuilder<String>()
+                    .deriving("length",
+                            s -> Outcome.ok(s.length()),
+                            sub -> { /* no clauses */ })
+                    .build();
+
+            assertThat(clauses).hasSize(1);
+            Postcondition.Derived<?, ?> d = (Postcondition.Derived<?, ?>) clauses.get(0);
+            assertThat(d.nested()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("build")
+    class Build {
+
+        @Test
+        @DisplayName("the returned list is immutable")
+        void buildReturnsImmutable() {
+            List<Postcondition<String>> clauses = new ContractBuilder<String>()
+                    .ensure("a", s -> Outcome.ok())
+                    .build();
+
+            assertThatThrownBy(() ->
+                    clauses.add(new Postcondition.Leaf<>("x", v -> Outcome.ok())))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+}

--- a/punit-api/src/test/java/org/javai/punit/api/typed/PostconditionTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/PostconditionTest.java
@@ -11,17 +11,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Postcondition — Eiffel-flavoured acceptance criteria")
+@DisplayName("Postcondition — unopinionated evaluation of one aspect")
 class PostconditionTest {
 
     @Nested
-    @DisplayName("ensure(predicate)")
-    class EnsurePredicate {
+    @DisplayName("ensure")
+    class Ensure {
 
         @Test
-        @DisplayName("predicate true → passed; description carried through")
+        @DisplayName("Outcome.ok → passed; description carried through")
         void passes() {
-            Postcondition<String> p = ensure("non-empty", s -> !s.isEmpty());
+            Postcondition<String> p = ensure("non-empty",
+                    s -> s.isEmpty()
+                            ? Outcome.fail("empty", "string was empty")
+                            : Outcome.ok());
 
             PostconditionResult r = p.evaluate("hello");
 
@@ -30,38 +33,12 @@ class PostconditionTest {
         }
 
         @Test
-        @DisplayName("predicate false → failed; synthesised reason")
-        void fails() {
-            Postcondition<String> p = ensure("non-empty", s -> !s.isEmpty());
-
-            PostconditionResult r = p.evaluate("");
-
-            assertThat(r.failed()).isTrue();
-            assertThat(r.description()).isEqualTo("non-empty");
-            assertThat(r.failureReason()).contains("postcondition not satisfied");
-        }
-
-        @Test
-        @DisplayName("evaluateAll on a leaf returns a singleton list")
-        void evaluateAllLeaf() {
-            Postcondition<String> p = ensure("non-empty", s -> !s.isEmpty());
-
-            List<PostconditionResult> results = p.evaluateAll("hello");
-
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0).passed()).isTrue();
-        }
-    }
-
-    @Nested
-    @DisplayName("Leaf with rich check")
-    class LeafRichCheck {
-
-        @Test
         @DisplayName("Outcome.fail's reason is preserved")
         void preservesFailureReason() {
-            Postcondition<Integer> p = new Postcondition.Leaf<>("positive",
-                    v -> v > 0 ? Outcome.ok() : Outcome.fail("negative", "got " + v));
+            Postcondition<Integer> p = ensure("positive",
+                    v -> v > 0
+                            ? Outcome.ok()
+                            : Outcome.fail("negative", "got " + v));
 
             PostconditionResult r = p.evaluate(-3);
 
@@ -72,7 +49,7 @@ class PostconditionTest {
         @Test
         @DisplayName("a thrown RuntimeException is captured as a failure")
         void thrownExceptionCaptured() {
-            Postcondition<Integer> p = new Postcondition.Leaf<>("checked", v -> {
+            Postcondition<Integer> p = ensure("checked", v -> {
                 throw new IllegalStateException("boom");
             });
 
@@ -80,6 +57,20 @@ class PostconditionTest {
 
             assertThat(r.failed()).isTrue();
             assertThat(r.failureReason()).contains("boom");
+        }
+
+        @Test
+        @DisplayName("evaluateAll on a leaf returns a singleton list")
+        void evaluateAllLeaf() {
+            Postcondition<String> p = ensure("non-empty",
+                    s -> s.isEmpty()
+                            ? Outcome.fail("empty", "")
+                            : Outcome.ok());
+
+            List<PostconditionResult> results = p.evaluateAll("hello");
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).passed()).isTrue();
         }
     }
 
@@ -92,8 +83,12 @@ class PostconditionTest {
         void derivationSucceeds() {
             Postcondition<String> p = deriving("parsed length",
                     s -> Outcome.ok(s.length()),
-                    ensure("at least 3", n -> n >= 3),
-                    ensure("at most 10", n -> n <= 10));
+                    ensure("at least 3", n -> n >= 3
+                            ? Outcome.ok()
+                            : Outcome.fail("too-short", "n=" + n)),
+                    ensure("at most 10", n -> n <= 10
+                            ? Outcome.ok()
+                            : Outcome.fail("too-long", "n=" + n)));
 
             List<PostconditionResult> results = p.evaluateAll("hello");
 
@@ -111,8 +106,8 @@ class PostconditionTest {
         void derivationFailsSkipsNested() {
             Postcondition<String> p = deriving("parsed",
                     s -> Outcome.<Integer>fail("parse-error", "malformed"),
-                    ensure("inner-1", (Integer n) -> true),
-                    ensure("inner-2", (Integer n) -> true));
+                    ensure("inner-1", (Integer n) -> Outcome.ok()),
+                    ensure("inner-2", (Integer n) -> Outcome.ok()));
 
             List<PostconditionResult> results = p.evaluateAll("garbage");
 
@@ -132,7 +127,7 @@ class PostconditionTest {
         void derivationThrowsSkipsNested() {
             Postcondition<String> p = deriving("parsed",
                     (String s) -> { throw new RuntimeException("kaboom"); },
-                    ensure("inner", (Integer n) -> true));
+                    ensure("inner", (Integer n) -> Outcome.ok()));
 
             List<PostconditionResult> results = p.evaluateAll("anything");
 
@@ -148,7 +143,7 @@ class PostconditionTest {
         void evaluateSingleCollapsesToDerivation() {
             Postcondition<String> p = deriving("parsed",
                     s -> Outcome.ok(s.length()),
-                    ensure("inner", (Integer n) -> false));
+                    ensure("inner", (Integer n) -> Outcome.fail("nope", "x")));
 
             PostconditionResult r = p.evaluate("hello");
 
@@ -161,7 +156,9 @@ class PostconditionTest {
         void nestedDerivationsSkipChain() {
             Postcondition<Integer> innerDerived = deriving("doubled",
                     n -> Outcome.ok(n * 2),
-                    ensure("doubled positive", (Integer d) -> d > 0));
+                    ensure("doubled positive", (Integer d) -> d > 0
+                            ? Outcome.ok()
+                            : Outcome.fail("non-positive", "d=" + d)));
 
             Postcondition<String> p = deriving("length",
                     s -> Outcome.<Integer>fail("err", "bad"),
@@ -187,7 +184,7 @@ class PostconditionTest {
         @DisplayName("blank description rejected")
         void blankDescriptionRejected() {
             org.assertj.core.api.Assertions.assertThatThrownBy(
-                    () -> ensure("", (Object v) -> true))
+                    () -> ensure("", (Object v) -> Outcome.ok()))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/PostconditionTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/PostconditionTest.java
@@ -1,0 +1,194 @@
+package org.javai.punit.api.typed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.javai.punit.api.typed.Postcondition.deriving;
+import static org.javai.punit.api.typed.Postcondition.ensure;
+
+import java.util.List;
+
+import org.javai.outcome.Outcome;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Postcondition — Eiffel-flavoured acceptance criteria")
+class PostconditionTest {
+
+    @Nested
+    @DisplayName("ensure(predicate)")
+    class EnsurePredicate {
+
+        @Test
+        @DisplayName("predicate true → passed; description carried through")
+        void passes() {
+            Postcondition<String> p = ensure("non-empty", s -> !s.isEmpty());
+
+            PostconditionResult r = p.evaluate("hello");
+
+            assertThat(r.passed()).isTrue();
+            assertThat(r.description()).isEqualTo("non-empty");
+        }
+
+        @Test
+        @DisplayName("predicate false → failed; synthesised reason")
+        void fails() {
+            Postcondition<String> p = ensure("non-empty", s -> !s.isEmpty());
+
+            PostconditionResult r = p.evaluate("");
+
+            assertThat(r.failed()).isTrue();
+            assertThat(r.description()).isEqualTo("non-empty");
+            assertThat(r.failureReason()).contains("postcondition not satisfied");
+        }
+
+        @Test
+        @DisplayName("evaluateAll on a leaf returns a singleton list")
+        void evaluateAllLeaf() {
+            Postcondition<String> p = ensure("non-empty", s -> !s.isEmpty());
+
+            List<PostconditionResult> results = p.evaluateAll("hello");
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).passed()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Leaf with rich check")
+    class LeafRichCheck {
+
+        @Test
+        @DisplayName("Outcome.fail's reason is preserved")
+        void preservesFailureReason() {
+            Postcondition<Integer> p = new Postcondition.Leaf<>("positive",
+                    v -> v > 0 ? Outcome.ok() : Outcome.fail("negative", "got " + v));
+
+            PostconditionResult r = p.evaluate(-3);
+
+            assertThat(r.failed()).isTrue();
+            assertThat(r.failureReason()).contains("got -3");
+        }
+
+        @Test
+        @DisplayName("a thrown RuntimeException is captured as a failure")
+        void thrownExceptionCaptured() {
+            Postcondition<Integer> p = new Postcondition.Leaf<>("checked", v -> {
+                throw new IllegalStateException("boom");
+            });
+
+            PostconditionResult r = p.evaluate(0);
+
+            assertThat(r.failed()).isTrue();
+            assertThat(r.failureReason()).contains("boom");
+        }
+    }
+
+    @Nested
+    @DisplayName("deriving(...)")
+    class Derivations {
+
+        @Test
+        @DisplayName("derivation succeeds → derivation pass + nested results")
+        void derivationSucceeds() {
+            Postcondition<String> p = deriving("parsed length",
+                    s -> Outcome.ok(s.length()),
+                    ensure("at least 3", n -> n >= 3),
+                    ensure("at most 10", n -> n <= 10));
+
+            List<PostconditionResult> results = p.evaluateAll("hello");
+
+            assertThat(results).hasSize(3);
+            assertThat(results.get(0).description()).isEqualTo("parsed length");
+            assertThat(results.get(0).passed()).isTrue();
+            assertThat(results.get(1).description()).isEqualTo("at least 3");
+            assertThat(results.get(1).passed()).isTrue();
+            assertThat(results.get(2).description()).isEqualTo("at most 10");
+            assertThat(results.get(2).passed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("derivation Outcome.fail → nested ensures reported as skipped")
+        void derivationFailsSkipsNested() {
+            Postcondition<String> p = deriving("parsed",
+                    s -> Outcome.<Integer>fail("parse-error", "malformed"),
+                    ensure("inner-1", (Integer n) -> true),
+                    ensure("inner-2", (Integer n) -> true));
+
+            List<PostconditionResult> results = p.evaluateAll("garbage");
+
+            assertThat(results).hasSize(3);
+            assertThat(results.get(0).failed()).isTrue();
+            assertThat(results.get(0).failureReason()).contains("malformed");
+            assertThat(results.get(1).failed()).isTrue();
+            assertThat(results.get(1).failureReason())
+                    .hasValueSatisfying(r -> assertThat(r).contains("skipped"));
+            assertThat(results.get(2).failed()).isTrue();
+            assertThat(results.get(2).failureReason())
+                    .hasValueSatisfying(r -> assertThat(r).contains("skipped"));
+        }
+
+        @Test
+        @DisplayName("derivation throws → derivation fails, nested skipped")
+        void derivationThrowsSkipsNested() {
+            Postcondition<String> p = deriving("parsed",
+                    (String s) -> { throw new RuntimeException("kaboom"); },
+                    ensure("inner", (Integer n) -> true));
+
+            List<PostconditionResult> results = p.evaluateAll("anything");
+
+            assertThat(results).hasSize(2);
+            assertThat(results.get(0).failed()).isTrue();
+            assertThat(results.get(0).failureReason()).contains("kaboom");
+            assertThat(results.get(1).failureReason())
+                    .hasValueSatisfying(r -> assertThat(r).contains("skipped"));
+        }
+
+        @Test
+        @DisplayName("evaluate (singular) collapses to derivation's own outcome")
+        void evaluateSingleCollapsesToDerivation() {
+            Postcondition<String> p = deriving("parsed",
+                    s -> Outcome.ok(s.length()),
+                    ensure("inner", (Integer n) -> false));
+
+            PostconditionResult r = p.evaluate("hello");
+
+            assertThat(r.passed()).isTrue();
+            assertThat(r.description()).isEqualTo("parsed");
+        }
+
+        @Test
+        @DisplayName("nested derivations propagate skips through every level")
+        void nestedDerivationsSkipChain() {
+            Postcondition<Integer> innerDerived = deriving("doubled",
+                    n -> Outcome.ok(n * 2),
+                    ensure("doubled positive", (Integer d) -> d > 0));
+
+            Postcondition<String> p = deriving("length",
+                    s -> Outcome.<Integer>fail("err", "bad"),
+                    innerDerived);
+
+            List<PostconditionResult> results = p.evaluateAll("anything");
+
+            assertThat(results).hasSize(3);
+            assertThat(results.get(0).description()).isEqualTo("length");
+            assertThat(results.get(0).failed()).isTrue();
+            assertThat(results.get(1).description()).isEqualTo("doubled");
+            assertThat(results.get(1).failed()).isTrue();
+            assertThat(results.get(2).description()).isEqualTo("doubled positive");
+            assertThat(results.get(2).failed()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("validation")
+    class Validation {
+
+        @Test
+        @DisplayName("blank description rejected")
+        void blankDescriptionRejected() {
+            org.assertj.core.api.Assertions.assertThatThrownBy(
+                    () -> ensure("", (Object v) -> true))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/punit-api/src/test/java/org/javai/punit/api/typed/PostconditionTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/PostconditionTest.java
@@ -47,6 +47,48 @@ class PostconditionTest {
         }
 
         @Test
+        @DisplayName("Outcome.fail's name is preserved (distinct from description)")
+        void preservesFailureName() {
+            Postcondition<Integer> p = ensure("positive",
+                    v -> v > 0
+                            ? Outcome.ok()
+                            : Outcome.fail("negative", "got " + v));
+
+            PostconditionResult r = p.evaluate(-3);
+
+            assertThat(r.failureName()).contains("negative");
+            assertThat(r.description()).isEqualTo("positive");
+        }
+
+        @Test
+        @DisplayName("a thrown exception fills failureName with the description (synthetic)")
+        void thrownExceptionUsesSyntheticName() {
+            Postcondition<Integer> p = ensure("checked", v -> {
+                throw new IllegalStateException("boom");
+            });
+
+            PostconditionResult r = p.evaluate(0);
+
+            assertThat(r.failed()).isTrue();
+            assertThat(r.failureName()).contains("checked");
+            assertThat(r.failureReason()).contains("boom");
+        }
+
+        @Test
+        @DisplayName("passed result has empty failureName")
+        void passedResultEmptyFailureName() {
+            Postcondition<String> p = ensure("non-empty",
+                    s -> s.isEmpty()
+                            ? Outcome.fail("empty", "was empty")
+                            : Outcome.ok());
+
+            PostconditionResult r = p.evaluate("hello");
+
+            assertThat(r.passed()).isTrue();
+            assertThat(r.failureName()).isEmpty();
+        }
+
+        @Test
         @DisplayName("a thrown RuntimeException is captured as a failure")
         void thrownExceptionCaptured() {
             Postcondition<Integer> p = ensure("checked", v -> {
@@ -149,6 +191,19 @@ class PostconditionTest {
 
             assertThat(r.passed()).isTrue();
             assertThat(r.description()).isEqualTo("parsed");
+        }
+
+        @Test
+        @DisplayName("derivation Outcome.fail preserves the failure name (not the description)")
+        void derivationFailPreservesFailureName() {
+            Postcondition<String> p = deriving("parsed",
+                    s -> Outcome.<Integer>fail("parse-error", "malformed"),
+                    ensure("inner", (Integer n) -> Outcome.ok()));
+
+            List<PostconditionResult> results = p.evaluateAll("garbage");
+
+            assertThat(results.get(0).failureName()).contains("parse-error");
+            assertThat(results.get(0).description()).isEqualTo("parsed");
         }
 
         @Test

--- a/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.typed.spec.BudgetExhaustionPolicy;
 import org.javai.punit.api.typed.spec.ExceptionPolicy;
 import org.junit.jupiter.api.DisplayName;
@@ -19,8 +20,11 @@ class SamplingTest {
         EchoUseCase(Factors factors) {}
 
         @Override
-        public UseCaseOutcome<String> apply(String input) {
-            return UseCaseOutcome.ok(input);
+        public void postconditions(ContractBuilder<String> b) { /* none */ }
+
+        @Override
+        public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
         }
 
         @Override

--- a/punit-api/src/test/java/org/javai/punit/api/typed/UseCaseTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/UseCaseTest.java
@@ -2,6 +2,7 @@ package org.javai.punit.api.typed;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.javai.outcome.Outcome;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -9,26 +10,30 @@ import org.junit.jupiter.api.Test;
 class UseCaseTest {
 
     private static class SimpleUseCase implements UseCase<Object, String, Integer> {
-        @Override public UseCaseOutcome<Integer> apply(String input) {
-            return UseCaseOutcome.ok(input.length());
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
         }
     }
 
     private static class ShoppingBasketUseCase implements UseCase<Object, String, String> {
-        @Override public UseCaseOutcome<String> apply(String input) {
-            return UseCaseOutcome.ok(input);
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
         }
     }
 
     private static class HTTPClientUseCase implements UseCase<Object, String, String> {
-        @Override public UseCaseOutcome<String> apply(String input) {
-            return UseCaseOutcome.ok(input);
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
         }
     }
 
     private static class PaymentGateway implements UseCase<Object, String, String> {
-        @Override public UseCaseOutcome<String> apply(String input) {
-            return UseCaseOutcome.ok(input);
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
         }
     }
 
@@ -81,9 +86,9 @@ class UseCaseTest {
     }
 
     @Test
-    @DisplayName("apply wraps the output value as an Ok outcome")
+    @DisplayName("apply produces an Ok outcome wrapping the invoke result")
     void applyWrapsOutputValue() {
-        var outcome = new SimpleUseCase().apply("hello");
+        var outcome = new SimpleUseCase().apply("hello", TokenTracker.create());
         assertThat(outcome.value().isOk()).isTrue();
         assertThat(outcome.value().getOrThrow()).isEqualTo(5);
     }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/ProbabilisticTestIntentTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/ProbabilisticTestIntentTest.java
@@ -3,10 +3,12 @@ package org.javai.punit.api.typed.spec;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +18,10 @@ class ProbabilisticTestIntentTest {
     record Factors(String label) {}
 
     private static final UseCase<Factors, String, String> ECHO = new UseCase<>() {
-        @Override public UseCaseOutcome<String> apply(String input) { return UseCaseOutcome.ok(input); }
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
     };
 
     private static Sampling<Factors, String, String> sampling() {

--- a/punit-core/src/main/java/org/javai/punit/engine/InMemoryTokenTracker.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/InMemoryTokenTracker.java
@@ -1,0 +1,31 @@
+package org.javai.punit.engine;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.javai.punit.api.typed.TokenTracker;
+
+/**
+ * Thread-safe in-memory {@link TokenTracker} used by the framework
+ * during a sampling run. One instance is created per run and threaded
+ * through every {@code apply} call.
+ *
+ * <p>Internal to the engine — authors interact only with the
+ * {@link TokenTracker} interface.
+ */
+public final class InMemoryTokenTracker implements TokenTracker {
+
+    private final AtomicLong total = new AtomicLong();
+
+    @Override
+    public void recordTokens(long n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("token count must be non-negative, got " + n);
+        }
+        total.addAndGet(n);
+    }
+
+    @Override
+    public long totalTokens() {
+        return total.get();
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
@@ -5,18 +5,25 @@ import java.util.List;
 import java.util.function.BooleanSupplier;
 
 import org.javai.punit.api.typed.Pacing;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.SampleExecutor;
 import org.javai.punit.api.typed.spec.SampleObserver;
 
 /**
- * One-at-a-time sample executor. Invokes {@code useCase.apply(input)}
- * on the calling thread and forwards outcomes along with the
- * wall-clock time taken. Consults the caller's early-stop predicate
- * between samples so the engine can enforce wall-clock and token
- * budgets, and honours the use case's declared {@link Pacing}
- * between samples.
+ * One-at-a-time sample executor. Invokes
+ * {@code useCase.apply(input, tracker)} on the calling thread and
+ * forwards outcomes along with the wall-clock time taken. Consults
+ * the caller's early-stop predicate between samples so the engine
+ * can enforce wall-clock and token budgets, and honours the use
+ * case's declared {@link Pacing} between samples.
+ *
+ * <p>Constructs one {@link TokenTracker} per {@code runSamples} call
+ * — that tracker spans every sample in the call, accumulating cost
+ * across the whole run. The contract's {@code apply} default diffs
+ * the tracker's total before and after each {@code invoke} to derive
+ * the per-sample cost recorded on the outcome.
  *
  * <h2>Pacing behaviour</h2>
  *
@@ -62,6 +69,7 @@ public final class SerialSampleExecutor implements SampleExecutor {
 
         Pacing pacing = useCase.pacing();
         long minDelayMillis = pacing.effectiveMinDelayMillis();
+        TokenTracker tracker = new InMemoryTokenTracker();
 
         for (int i = 0; i < sampleCount; i++) {
             if (stopRequested.getAsBoolean()) {
@@ -77,7 +85,7 @@ public final class SerialSampleExecutor implements SampleExecutor {
             long t0 = System.nanoTime();
             UseCaseOutcome<OT> outcome;
             try {
-                outcome = useCase.apply(input);
+                outcome = useCase.apply(input, tracker);
             } catch (Throwable t) {
                 Duration elapsed = Duration.ofNanos(System.nanoTime() - t0);
                 observer.onDefect(i, t, elapsed);

--- a/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
@@ -5,12 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
@@ -35,8 +38,9 @@ class EmpiricalEndToEndIntegrationTest {
     private static final String USE_CASE_ID = "always-passes-use-case";
 
     static class AlwaysPassesUseCase implements UseCase<Factors, Integer, Boolean> {
-        @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-            return UseCaseOutcome.ok(true);
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(true);
         }
         @Override public String id() { return USE_CASE_ID; }
     }

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -6,9 +6,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
@@ -40,8 +43,9 @@ class EngineIntegrationTest {
 
     /** Always returns the length of the input. Used as a deterministic sample. */
     private static class LengthUseCase implements UseCase<LlmFactors, String, Integer> {
-        @Override public UseCaseOutcome<Integer> apply(String input) {
-            return UseCaseOutcome.ok(input.length());
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
         }
     }
 
@@ -157,8 +161,9 @@ class EngineIntegrationTest {
     void instanceConformanceDrivesVerdict() {
         // Use case: mirror the input, but uppercase it (deliberately wrong for half).
         UseCase<LlmFactors, String, String> upperCase = new UseCase<>() {
-            @Override public UseCaseOutcome<String> apply(String input) {
-                return UseCaseOutcome.ok(input.toUpperCase());
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input.toUpperCase());
             }
         };
 
@@ -185,8 +190,9 @@ class EngineIntegrationTest {
     @DisplayName("expectations: custom matcher overrides equality default")
     void instanceConformanceUsesCustomMatcher() {
         UseCase<LlmFactors, String, String> returnSameCase = new UseCase<>() {
-            @Override public UseCaseOutcome<String> apply(String input) {
-                return UseCaseOutcome.ok(input);
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
             }
         };
 
@@ -219,8 +225,9 @@ class EngineIntegrationTest {
         Sampling<LlmFactors, String, String> sampling = Sampling
                 .<LlmFactors, String, String>builder()
                 .useCaseFactory(f -> new UseCase<LlmFactors, String, String>() {
-                    @Override public UseCaseOutcome<String> apply(String input) {
-                        return UseCaseOutcome.ok(input);
+                    @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+                    @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                        return Outcome.ok(input);
                     }
                 })
                 .inputs("a", "b")
@@ -271,8 +278,9 @@ class EngineIntegrationTest {
     void exploreSpecRunsEachFactorBundle() {
         var observedByModel = new java.util.LinkedHashMap<String, Integer>();
         UseCase<LlmFactors, String, Integer> counting = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(String input) {
-                return UseCaseOutcome.ok(0);
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(0);
             }
         };
         Sampling<LlmFactors, String, Integer> shape = Sampling
@@ -301,8 +309,9 @@ class EngineIntegrationTest {
     @DisplayName("Experiment.optimizing(shape) runs the stepper/scorer loop up to maxIterations")
     void optimizeSpecRunsIterationLoop() {
         UseCase<LlmFactors, String, Integer> echo = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(String input) {
-                return UseCaseOutcome.ok(input.length());
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input.length());
             }
         };
         Sampling<LlmFactors, String, Integer> shape = Sampling
@@ -357,9 +366,10 @@ class EngineIntegrationTest {
     private List<String> runAndRecord() {
         List<String> observed = new ArrayList<>();
         UseCase<LlmFactors, String, Integer> recording = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(String input) {
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 observed.add(input);
-                return UseCaseOutcome.ok(0);
+                return Outcome.ok(0);
             }
         };
         Sampling<LlmFactors, String, Integer> sampling = Sampling
@@ -376,21 +386,24 @@ class EngineIntegrationTest {
     // ── Test doubles ────────────────────────────────────────────────
 
     private static class AlwaysPassesUseCase implements UseCase<LlmFactors, Integer, Boolean> {
-        @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-            return UseCaseOutcome.ok(Boolean.TRUE);
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(Boolean.TRUE);
         }
     }
 
     /** Returns business-level Fail outcomes — the "contract didn't hold" signal. */
     private static class AlwaysReturnsFailUseCase implements UseCase<LlmFactors, Integer, Boolean> {
-        @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-            return UseCaseOutcome.fail("contract_violation", "scripted failure for input " + input);
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.fail("contract_violation", "scripted failure for input " + input);
         }
     }
 
     /** Throws — a defect, not a business-level failure. The engine aborts. */
     private static class DefectiveUseCase implements UseCase<LlmFactors, Integer, Boolean> {
-        @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             throw new IllegalStateException("simulated defect — this should abort the run");
         }
     }

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -4,12 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.LatencySpec;
 import org.javai.punit.api.typed.Pacing;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
@@ -51,11 +55,12 @@ class EngineResourceControlsAndLatencyIntegrationTest {
             this.scriptMillis = scriptMillis;
         }
 
-        @Override public UseCaseOutcome<Integer> apply(Integer input) {
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             long millis = scriptMillis[index % scriptMillis.length];
             index++;
             sleep(millis);
-            return UseCaseOutcome.ok(input);
+            return Outcome.ok(input);
         }
     }
 
@@ -69,9 +74,11 @@ class EngineResourceControlsAndLatencyIntegrationTest {
             this.tokens = tokens;
         }
 
-        @Override public UseCaseOutcome<Integer> apply(Integer input) {
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             sleep(sleepMillis);
-            return UseCaseOutcome.<Integer>ok(input).withTokens(tokens);
+            tracker.recordTokens(tokens);
+            return Outcome.ok(input);
         }
     }
 
@@ -109,8 +116,9 @@ class EngineResourceControlsAndLatencyIntegrationTest {
         // per outcome would be accounted post-sample; the *projection*
         // is static, so this scenario uses tokenCharge to model it.
         UseCase<Factors, Integer, Integer> zeroOutcomeTokens = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(Integer input) {
-                return UseCaseOutcome.ok(input);
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(input);
             }
         };
         Sampling<Factors, Integer, Integer> sampling = Sampling
@@ -137,8 +145,9 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("RC03: static token charge is accounted for each sample")
     void staticChargeAccountedEachSample() {
         UseCase<Factors, Integer, Integer> zeroCost = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(Integer input) {
-                return UseCaseOutcome.ok(input);
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(input);
             }
         };
         Sampling<Factors, Integer, Integer> sampling = Sampling
@@ -187,8 +196,9 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void maxRpsInsertsDelay() {
         // 10 RPS → 100ms min delay between samples.
         UseCase<Factors, Integer, Integer> pacingUc = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(Integer input) {
-                return UseCaseOutcome.ok(input);
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(input);
             }
             @Override public Pacing pacing() {
                 return Pacing.builder().maxRequestsPerSecond(10.0).build();
@@ -215,8 +225,9 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void mostRestrictiveWinsComposition() {
         // maxRps implies 100ms; min explicit 250ms should dominate.
         UseCase<Factors, Integer, Integer> pacingUc = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(Integer input) {
-                return UseCaseOutcome.ok(input);
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(input);
             }
             @Override public Pacing pacing() {
                 return Pacing.builder()
@@ -248,12 +259,13 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void failSampleCatchesAndCounts() {
         AtomicInteger n = new AtomicInteger();
         UseCase<Factors, Integer, Integer> flaky = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(Integer input) {
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 int i = n.incrementAndGet();
                 if (i % 2 == 0) {
                     throw new IllegalStateException("scripted defect " + i);
                 }
-                return UseCaseOutcome.ok(input);
+                return Outcome.ok(input);
             }
         };
         Sampling<Factors, Integer, Integer> sampling = Sampling
@@ -277,7 +289,8 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("RC13: ABORT_TEST (default) rethrows a thrown defect — preserves legacy behaviour")
     void abortTestRethrows() {
         UseCase<Factors, Integer, Integer> defective = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(Integer input) {
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 throw new IllegalStateException("never mind the exception policy, this is a defect");
             }
         };
@@ -300,8 +313,9 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("RC14: maxExampleFailures caps retained detail but not failure counts")
     void maxExampleFailuresCaps() {
         UseCase<Factors, Integer, Integer> failing = new UseCase<>() {
-            @Override public UseCaseOutcome<Integer> apply(Integer input) {
-                return UseCaseOutcome.fail("scripted", "boom");
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.fail("scripted", "boom");
             }
         };
         Sampling<Factors, Integer, Integer> sampling = Sampling
@@ -355,9 +369,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void percentileLatencyBreachProducesFail() {
         // 50ms sleeps, assert p50 ≤ 10ms.
         UseCase<Factors, Integer, Boolean> slow = new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
-                return UseCaseOutcome.ok(Boolean.TRUE);
+                return Outcome.ok(Boolean.TRUE);
             }
         };
         Sampling<Factors, Integer, Boolean> sampling = Sampling
@@ -387,9 +402,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("mixed criteria: functional PASS + latency FAIL composes to FAIL when both REQUIRED")
     void mixedCriteriaBothRequiredComposesToFail() {
         UseCase<Factors, Integer, Boolean> slow = new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
-                return UseCaseOutcome.ok(Boolean.TRUE);
+                return Outcome.ok(Boolean.TRUE);
             }
         };
         Sampling<Factors, Integer, Boolean> sampling = Sampling
@@ -415,9 +431,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("reportOnly latency: functional PASS + latency FAIL(report-only) composes to PASS")
     void reportOnlyLatencyExcludedFromComposition() {
         UseCase<Factors, Integer, Boolean> slow = new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
-                return UseCaseOutcome.ok(Boolean.TRUE);
+                return Outcome.ok(Boolean.TRUE);
             }
         };
         Sampling<Factors, Integer, Boolean> sampling = Sampling
@@ -447,9 +464,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("reportOnly functional: contract failures reported but excluded → latency criterion determines verdict")
     void reportOnlyFunctionalExcludedFromComposition() {
         UseCase<Factors, Integer, Boolean> fastButBroken = new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(5);
-                return UseCaseOutcome.fail("scripted", "functional fail intentional");
+                return Outcome.fail("scripted", "functional fail intentional");
             }
         };
         Sampling<Factors, Integer, Boolean> sampling = Sampling

--- a/punit-core/src/test/java/org/javai/punit/engine/InMemoryTokenTrackerTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/InMemoryTokenTrackerTest.java
@@ -1,0 +1,62 @@
+package org.javai.punit.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("InMemoryTokenTracker — accumulates per-run cost")
+class InMemoryTokenTrackerTest {
+
+    @Test
+    @DisplayName("a fresh tracker reports zero")
+    void freshIsZero() {
+        assertThat(new InMemoryTokenTracker().totalTokens()).isZero();
+    }
+
+    @Test
+    @DisplayName("recordTokens accumulates")
+    void accumulates() {
+        InMemoryTokenTracker t = new InMemoryTokenTracker();
+
+        t.recordTokens(7);
+        t.recordTokens(13);
+        t.recordTokens(0);
+
+        assertThat(t.totalTokens()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("recordTokens(0) is allowed")
+    void zeroAllowed() {
+        InMemoryTokenTracker t = new InMemoryTokenTracker();
+        t.recordTokens(0);
+        assertThat(t.totalTokens()).isZero();
+    }
+
+    @Test
+    @DisplayName("negative values are rejected")
+    void negativeRejected() {
+        InMemoryTokenTracker t = new InMemoryTokenTracker();
+
+        assertThatThrownBy(() -> t.recordTokens(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-negative");
+    }
+
+    @Test
+    @DisplayName("per-sample cost can be derived by diffing totalTokens()")
+    void diffYieldsPerSample() {
+        InMemoryTokenTracker t = new InMemoryTokenTracker();
+        t.recordTokens(50);   // earlier sample's cost
+
+        long start = t.totalTokens();
+        t.recordTokens(12);   // current sample
+        t.recordTokens(3);
+        long perSample = t.totalTokens() - start;
+
+        assertThat(perSample).isEqualTo(15);
+        assertThat(t.totalTokens()).isEqualTo(65);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/criteria/InlineSamplingFormTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/criteria/InlineSamplingFormTest.java
@@ -3,9 +3,11 @@ package org.javai.punit.engine.criteria;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.ContractBuilder;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.Experiment;
 import org.javai.punit.api.typed.spec.ProbabilisticTest;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +19,10 @@ class InlineSamplingFormTest {
     record Factors(String label) {}
 
     private static final UseCase<Factors, String, String> ECHO = new UseCase<>() {
-        @Override public UseCaseOutcome<String> apply(String input) { return UseCaseOutcome.ok(input); }
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
     };
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/power/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/power/PowerAnalysisTest.java
@@ -7,13 +7,16 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 import org.javai.punit.api.typed.spec.Experiment;
 import org.javai.punit.api.typed.spec.PassRateStatistics;
@@ -33,7 +36,10 @@ class PowerAnalysisTest {
     private static final String USE_CASE_ID = "echo-use-case";
 
     private static final UseCase<Factors, String, String> ECHO = new UseCase<>() {
-        @Override public UseCaseOutcome<String> apply(String input) { return UseCaseOutcome.ok(input); }
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
         @Override public String id() { return USE_CASE_ID; }
     };
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineEmitterTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/BaselineEmitterTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.file.Path;
 
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.Experiment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +20,9 @@ class BaselineEmitterTest {
     record NoFactors() { }
 
     private static final UseCase<NoFactors, Integer, Boolean> ALWAYS_PASSES = new UseCase<>() {
-        @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-            return UseCaseOutcome.ok(true);
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(true);
         }
     };
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -4,12 +4,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.CovariateCategory;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.covariate.Covariate;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
 import org.javai.punit.junit5.PUnit;
@@ -40,8 +42,9 @@ public final class CovariateSubjects {
      */
     private static UseCase<NoFactors, Integer, Boolean> covariateUseCase() {
         return new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-                return UseCaseOutcome.ok(true);
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(true);
             }
             @Override public String id() { return USE_CASE_ID; }
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -1,10 +1,12 @@
 package org.javai.punit.junit5.testsubjects;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
 import org.javai.punit.junit5.PUnit;
 
@@ -26,8 +28,9 @@ public final class FeasibilitySubjects {
 
     private static UseCase<NoFactors, Integer, Boolean> alwaysPasses() {
         return new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-                return UseCaseOutcome.ok(true);
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(true);
             }
             @Override public String id() { return USE_CASE_ID; }
         };

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -1,11 +1,13 @@
 package org.javai.punit.junit5.testsubjects;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
 import org.javai.punit.junit5.PUnit;
 
@@ -42,8 +44,9 @@ public final class PUnitSubjects {
 
     private static <F> UseCase<F, Integer, Boolean> alwaysPasses() {
         return new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-                return UseCaseOutcome.ok(true);
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(true);
             }
             // Anonymous-class getSimpleName() is "", which BaselineRecord
             // rejects as a blank useCaseId. Override with a stable id.
@@ -53,8 +56,9 @@ public final class PUnitSubjects {
 
     private static <F> UseCase<F, Integer, Boolean> alwaysFails() {
         return new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-                return UseCaseOutcome.fail("nope", "always fails");
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.fail("nope", "always fails");
             }
             @Override public String id() { return "always-fails-subject"; }
         };

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -1,10 +1,12 @@
 package org.javai.punit.junit5.testsubjects;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.Sampling;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
-import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.engine.criteria.BernoulliPassRate;
 import org.javai.punit.junit5.PUnit;
 
@@ -27,8 +29,9 @@ public final class RoundTripSubjects {
 
     private static UseCase<NoFactors, Integer, Boolean> useCase() {
         return new UseCase<>() {
-            @Override public UseCaseOutcome<Boolean> apply(Integer input) {
-                return UseCaseOutcome.ok(true);
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(true);
             }
             @Override public String id() { return USE_CASE_ID; }
         };


### PR DESCRIPTION
## Summary

Implements **Steps 1b and 2** of [`DIR-CONTRACT-ON-USECASE-punit`](../../../javai-orchestrator/blob/refactor/compositional-design/plan/directives/DIR-CONTRACT-ON-USECASE-punit.md). Two commits, each independently green-on-merge:

### `576810b` — Step 1b: `ContractBuilder` + `TokenTracker`; preserve failure name in `PostconditionResult`

- **`ContractBuilder<O>`** (new) — author-facing fluent surface for declaring postcondition clauses. `ensure(...)` adds a leaf; `deriving(name, fn, sub -> ...)` adds a derivation whose nested clauses are populated via a sub-builder lambda. Authors never see `List<Postcondition<O>>` and never call `.build()` — the framework does that.
- **`TokenTracker`** (new) — per-run cost channel. `recordTokens(long)` / `totalTokens()`. Tokens are an open cost-proxy abstraction (memory-pinned in the orchestrator) — LLM tokens are the obvious case but a token can proxy any cost the author chooses to track (dollars, request counts, message bytes…).
- **`InMemoryTokenTracker`** (new) — framework's atomic-counter implementation; `TokenTracker.create()` static factory exposes the same shape for tests.
- **`PostconditionResult.failureName()`** (new accessor) — exposes the symbolic name from `Outcome.Fail.id().name()`. `Postcondition.Leaf` and `Derived` evaluators now route author-supplied `Outcome.Fail` through a new `failed(description, Outcome.Fail<?>)` factory so the name survives instead of being overwritten by the clause description. Aggregators can distinguish multiple named failure modes within a single clause description.

No consumers in this commit — pure additions in `org.javai.punit.api.typed`.

### `b879a41` — Step 2: introduce `Contract<I, O>`; `UseCase extends Contract`; sweep test subjects

- **`Contract<I, O>`** (new interface) — the operational layer of a use case:
  - Abstract: `Outcome<O> invoke(I input, TokenTracker tracker)` and `void postconditions(ContractBuilder<O> b)`.
  - Default: `List<Postcondition<O>> postconditions()` (no-arg, framework hook).
  - Default: three `apply` forms the framework dispatches to per sample (input only / +expected / +expected+matcher). Each wraps `invoke` with timing, token diff, postcondition evaluation, and (for matching forms) matcher application, then assembles the `UseCaseOutcome` with `this` (the contract) bundled in.
- **`UseCase<F, I, O> extends Contract<I, O>`** — the author writes one `implements UseCase<...>` clause and overrides `invoke`, `postconditions(builder)`, and any metadata that diverges from defaults. `apply` is no longer on `UseCase`; the framework dispatches via the three Contract.apply defaults.
- **Engine wiring** — `SerialSampleExecutor` constructs a `TokenTracker` per `runSamples` call and threads it into `apply(input, tracker)`. Per-sample tokens are derived by diffing the tracker.
- **Sweep across 13 test-subject files** — drops `apply(I)` overrides; adds `invoke(I, TokenTracker)` returning `Outcome.ok(...)` of the existing return value; adds `postconditions(ContractBuilder<O>)` (empty body for test subjects without acceptance criteria). `Outcome.fail(...)` replaces `UseCaseOutcome.fail(...)` inside invoke bodies. Token-recording use cases (`SleepyUseCase`) call `tracker.recordTokens(n)` before returning.

The apply defaults bridge to today's `UseCaseOutcome` shape (`rawResult` + `PostconditionEvaluator` + `match` + `tokens` + `duration`). Step 3 will reshape the record to `<I, O>` with bundled fields (`input`, `contract`, `postconditionResults`).

## Test plan

- [x] `./gradlew :punit-api:test` — green
- [x] `./gradlew :punit-core:test` — green
- [x] `./gradlew :punit-junit5:test` — green
- [x] `./gradlew build -x :punit-gradle-plugin:test` — green (includes ArchUnit module-isolation checks)
- [ ] Reviewer pulls the branch and runs the same locally for verification
- [ ] Confirm Step 1b's `ContractBuilder` + `TokenTracker` tests pin the intended semantics (15 new test cases between the two new test classes)
- [ ] Confirm Step 1b's `Postcondition` failure-name preservation tests pass (4 new cases in `PostconditionTest`)
- [ ] Verify the test-subject sweep doesn't introduce semantic changes (every `Outcome.ok(value)` in `invoke` mirrors the prior `UseCaseOutcome.ok(value)` return)

🤖 Generated with [Claude Code](https://claude.com/claude-code)