### PR TITLE
Step 3: reshape UseCaseOutcome to <I, O>; Sampling.Builder.matching(...)

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/Contract.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Contract.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.javai.outcome.Outcome;
+import org.javai.outcome.Outcome.Fail;
+import org.javai.outcome.Outcome.Ok;
 
 /**
  * The operational layer of a use case: how to invoke the service for
@@ -107,7 +109,7 @@ public interface Contract<I, O> {
      * <p>Concrete default; the framework dispatches to this form when
      * the test/experiment hasn't configured matching.
      */
-    default UseCaseOutcome<O> apply(I input, TokenTracker tracker) {
+    default UseCaseOutcome<I, O> apply(I input, TokenTracker tracker) {
         return runSample(input, tracker, Optional.empty());
     }
 
@@ -118,7 +120,7 @@ public interface Contract<I, O> {
      * form when the test/experiment configured an expected list but
      * no custom matcher.
      */
-    default UseCaseOutcome<O> apply(I input, O expected, TokenTracker tracker) {
+    default UseCaseOutcome<I, O> apply(I input, O expected, TokenTracker tracker) {
         return apply(input, expected, ValueMatcher.equality(), tracker);
     }
 
@@ -127,12 +129,12 @@ public interface Contract<I, O> {
      * Concrete default; the framework dispatches to this form when
      * the test/experiment configured matching with a custom matcher.
      */
-    default UseCaseOutcome<O> apply(I input, O expected, ValueMatcher<O> matcher, TokenTracker tracker) {
+    default UseCaseOutcome<I, O> apply(I input, O expected, ValueMatcher<O> matcher, TokenTracker tracker) {
         return runSample(input, tracker,
                 Optional.of(value -> matcher.match(expected, value)));
     }
 
-    private UseCaseOutcome<O> runSample(
+    private UseCaseOutcome<I, O> runSample(
             I input,
             TokenTracker tracker,
             Optional<Function<O, MatchResult>> matchStep) {
@@ -143,43 +145,28 @@ public interface Contract<I, O> {
         Duration duration = Duration.ofNanos(System.nanoTime() - start);
         long sampleTokens = Math.max(0L, tracker.totalTokens() - startTokens);
 
-        return switch (result) {
-            case Outcome.Ok<O> ok -> {
-                Optional<MatchResult> match = matchStep.map(step -> step.apply(ok.value()));
-                UseCaseOutcome<O> built = new UseCaseOutcome<>(
-                        ok.value(),
-                        contractEvaluator(),
-                        match,
-                        sampleTokens,
-                        duration);
-                yield built;
-            }
-            case Outcome.Fail<O> f -> {
-                UseCaseOutcome<O> built = UseCaseOutcome.<O>fail(
-                                f.failure().id().name(),
-                                f.failure().message())
-                        .withTokens(sampleTokens)
-                        .withDuration(duration);
-                yield built;
-            }
-        };
+        List<PostconditionResult> clauseResults = result instanceof Ok<O> ok
+                ? evaluateClauses(ok.value())
+                : List.of();   // postcondition evaluation skipped on apply-level failure
+
+        Optional<MatchResult> match = result instanceof Ok<O> ok2
+                ? matchStep.map(step -> step.apply(ok2.value()))
+                : Optional.empty();
+
+        return new UseCaseOutcome<>(
+                result,
+                this,
+                clauseResults,
+                match,
+                sampleTokens,
+                duration);
     }
 
-    private PostconditionEvaluator<O> contractEvaluator() {
-        List<Postcondition<O>> clauses = postconditions();
-        return new PostconditionEvaluator<>() {
-            @Override
-            public List<PostconditionResult> evaluate(O result) {
-                List<PostconditionResult> out = new ArrayList<>();
-                for (Postcondition<O> p : clauses) {
-                    out.addAll(p.evaluateAll(result));
-                }
-                return List.copyOf(out);
-            }
-            @Override
-            public int postconditionCount() {
-                return clauses.size();
-            }
-        };
+    private List<PostconditionResult> evaluateClauses(O value) {
+        List<PostconditionResult> out = new ArrayList<>();
+        for (Postcondition<O> p : postconditions()) {
+            out.addAll(p.evaluateAll(value));
+        }
+        return out;   // UseCaseOutcome canonical constructor defensive-copies
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Sampling.java
@@ -107,6 +107,8 @@ public final class Sampling<FT, IT, OT> {
     private final BudgetExhaustionPolicy budgetPolicy;
     private final ExceptionPolicy exceptionPolicy;
     private final int maxExampleFailures;
+    private final List<OT> expected;
+    private final Optional<ValueMatcher<OT>> matcher;
 
     private Sampling(Builder<FT, IT, OT> b) {
         this.useCaseFactory = b.useCaseFactory;
@@ -118,6 +120,8 @@ public final class Sampling<FT, IT, OT> {
         this.budgetPolicy = b.budgetPolicy;
         this.exceptionPolicy = b.exceptionPolicy;
         this.maxExampleFailures = b.maxExampleFailures;
+        this.expected = b.expected;
+        this.matcher = b.matcher;
     }
 
     public static <FT, IT, OT> Builder<FT, IT, OT> builder() {
@@ -226,6 +230,32 @@ public final class Sampling<FT, IT, OT> {
     }
 
     /**
+     * The expected output values, paired by index with {@link #inputs()}.
+     * Empty when no instance-conformance matching is configured.
+     *
+     * <p>Set via {@link Builder#matching(List)} /
+     * {@link Builder#matching(List, ValueMatcher)}. When non-empty,
+     * the engine pairs each input with its expected value at sample
+     * time and runs {@link #matcher()} (or
+     * {@link ValueMatcher#equality()}) to compare against the
+     * use case's produced value.
+     */
+    public List<OT> expected() {
+        return expected;
+    }
+
+    /**
+     * The matcher to use against {@link #expected()}, if configured.
+     * Defaults to {@link ValueMatcher#equality()} when
+     * {@link Builder#matching(List)} is used; explicitly supplied via
+     * {@link Builder#matching(List, ValueMatcher)} otherwise. Empty
+     * when {@link #expected()} is empty.
+     */
+    public Optional<ValueMatcher<OT>> matcher() {
+        return matcher;
+    }
+
+    /**
      * Returns a new sampling with the sample count replaced. Supports
      * the confidence-first authoring pattern:
      * {@code PowerAnalysis.sampleSize(...)} computes an {@code int},
@@ -251,6 +281,8 @@ public final class Sampling<FT, IT, OT> {
         b.budgetPolicy = this.budgetPolicy;
         b.exceptionPolicy = this.exceptionPolicy;
         b.maxExampleFailures = this.maxExampleFailures;
+        b.expected = this.expected;
+        b.matcher = this.matcher;
         return b;
     }
 
@@ -265,6 +297,8 @@ public final class Sampling<FT, IT, OT> {
         private BudgetExhaustionPolicy budgetPolicy = BudgetExhaustionPolicy.FAIL;
         private ExceptionPolicy exceptionPolicy = ExceptionPolicy.ABORT_TEST;
         private int maxExampleFailures = 10;
+        private List<OT> expected = List.of();
+        private Optional<ValueMatcher<OT>> matcher = Optional.empty();
 
         private Builder() {}
 
@@ -357,6 +391,47 @@ public final class Sampling<FT, IT, OT> {
                         "maxExampleFailures must be non-negative, got " + cap);
             }
             this.maxExampleFailures = cap;
+            return this;
+        }
+
+        /**
+         * Configures instance-conformance matching: pairs each input
+         * with the expected value at the same index, and uses the
+         * default {@link ValueMatcher#equality() equality matcher} to
+         * compare the use case's produced value against it.
+         *
+         * <p>For richer comparisons (case-insensitive string equality,
+         * JSON structural equivalence, …) use the
+         * {@link #matching(List, ValueMatcher) two-arg form}.
+         *
+         * @param expectedOutputs values paired by index with
+         *                        {@link #inputs(List)}; must be the
+         *                        same length as the input list at
+         *                        {@link #build()} time
+         * @throws NullPointerException if {@code expectedOutputs} is null
+         */
+        public Builder<FT, IT, OT> matching(List<OT> expectedOutputs) {
+            return matching(expectedOutputs, ValueMatcher.equality());
+        }
+
+        /**
+         * Configures instance-conformance matching with a custom
+         * matcher. The matcher is invoked per sample against
+         * {@code expected[i]} and the use case's produced value.
+         *
+         * @param expectedOutputs values paired by index with
+         *                        {@link #inputs(List)}; must be the
+         *                        same length as the input list at
+         *                        {@link #build()} time
+         * @param valueMatcher    the comparison function
+         * @throws NullPointerException if either argument is null
+         */
+        public Builder<FT, IT, OT> matching(List<OT> expectedOutputs,
+                                            ValueMatcher<OT> valueMatcher) {
+            Objects.requireNonNull(expectedOutputs, "expectedOutputs");
+            Objects.requireNonNull(valueMatcher, "matcher");
+            this.expected = List.copyOf(expectedOutputs);
+            this.matcher = Optional.of(valueMatcher);
             return this;
         }
 

--- a/punit-api/src/main/java/org/javai/punit/api/typed/UseCaseOutcome.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/UseCaseOutcome.java
@@ -8,85 +8,61 @@ import java.util.Optional;
 import org.javai.outcome.Outcome;
 
 /**
- * PUnit's per-sample outcome record. Wraps the raw result of a use
- * case invocation together with the {@link PostconditionEvaluator}
- * that classifies it against the service contract, the optional
- * {@link MatchResult} from an instance-conformance check, and a
- * first-class {@code tokens} count reporting the resource cost the
- * invocation consumed.
+ * The artefact assembled by {@link Contract#apply(Object, TokenTracker)}
+ * for one sample. Self-sufficient — every recipient (probabilistic test
+ * asserter, baseline writer, optimize meta-prompt builder, explore diff
+ * renderer) consumes it without reaching back to the use case for
+ * additional state.
  *
- * <h2>Lazy postcondition evaluation is deliberate</h2>
+ * <h2>Author-side note</h2>
  *
- * <p>Postcondition evaluation is lazy — the record stores the
- * <em>evaluator</em>, not the evaluated results. {@link #value()} and
- * {@link #evaluatePostconditions()} re-run the evaluator every call.
- * This matches the contract of the legacy
- * {@code org.javai.punit.contract.UseCaseOutcome} and exists so that:
+ * <p>Authors do not construct {@code UseCaseOutcome} directly. They
+ * implement {@link Contract#invoke(Object, TokenTracker) invoke}
+ * returning {@link Outcome.Ok} or {@link Outcome.Fail}; the framework's
+ * {@code apply} default wraps that with timing, cost diff, postcondition
+ * evaluation, and (for matching forms) the comparison step, then
+ * assembles this record.
+ *
+ * <h2>What it carries</h2>
  *
  * <ul>
- *   <li>the typed engine pays the evaluation cost once per sample
- *       (via a cached count in {@code SampleSummary.from(...)}), but</li>
- *   <li>downstream consumers — reporters, verdict sinks,
- *       Sentinel — can choose independently whether to enumerate
- *       postconditions for diagnostic output;</li>
- *   <li>authors whose postconditions involve expensive checks (a
- *       semantic-similarity call, a JSON parse, etc.) can memoise
- *       inside their own evaluator if they wish, without the outcome
- *       type dictating a caching policy.</li>
+ *   <li>{@link #result} — the outcome {@code invoke} returned: an
+ *       {@link Outcome.Ok} wrapping the produced value or an
+ *       {@link Outcome.Fail} describing an apply-level failure
+ *       (transport error, refusal, no value).</li>
+ *   <li>{@link #contract} — the {@link Contract} instance that judged
+ *       this sample. Recipients consult it for clause descriptions
+ *       and metadata; postcondition evaluation has already run, so
+ *       the consumer needn't re-evaluate.</li>
+ *   <li>{@link #postconditionResults} — the per-clause results of
+ *       evaluating the contract against the produced value. Empty
+ *       when {@code result} is {@link Outcome.Fail} (no value to
+ *       evaluate).</li>
+ *   <li>{@link #match} — the optional instance-conformance match
+ *       result, present when the test/experiment configured an
+ *       expected value via {@link Sampling.Builder#matching}.</li>
+ *   <li>{@link #tokens} — the per-sample cost recorded via
+ *       {@link TokenTracker} during {@code invoke}.</li>
+ *   <li>{@link #duration} — wall-clock time taken by
+ *       {@code invoke}.</li>
  * </ul>
  *
- * <h2>Success / failure classification</h2>
- *
- * <p>{@link #value()} derives the overall {@link Outcome}:
- * <ul>
- *   <li>If {@link #match} is present and
- *       {@link MatchResult#matches() matches()} is false, the outcome
- *       is {@link Outcome.Fail} with the match's diff as the reason —
- *       instance-conformance mismatch counts as a sample failure.</li>
- *   <li>Otherwise the postconditions are evaluated: all passing ⇒
- *       {@link Outcome#ok(Object)} wrapping the raw result; any
- *       failing ⇒ {@link Outcome.Fail} carrying the first failing
- *       postcondition's description and reason.</li>
- * </ul>
- *
- * <h2>Tokens as a first-class concept</h2>
- *
- * <p>The {@code tokens} field is the resource cost this invocation
- * consumed — tokens for LLM calls, request units for API calls, or
- * whatever the use case's domain measures. It is a first-class
- * record component rather than a metadata-map entry because the
- * framework's token-budget enforcement — the static charge declared
- * at spec time and the per-sample tally recorded here — depends on it
- * throughout the pipeline. Use cases that don't track a cost leave
- * it at zero.
- *
- * @param rawResult the raw value returned by the service (may be
- *                  {@code null} when the invocation has no value to
- *                  carry, e.g. for {@link #fail(String, String) fail}
- *                  outcomes)
- * @param postconditions the evaluator — must be non-null; use
- *                       {@link PostconditionEvaluator#trivial()} when
- *                       there is no contract
- * @param match instance-conformance match result; present when the
- *              engine (or use case) ran a {@link ValueMatcher},
- *              {@link Optional#empty()} otherwise
- * @param tokens the token cost consumed by this invocation; {@code 0}
- *               when the use case does not report a cost
- * @param duration the wall-clock time this invocation took; typically
- *                 filled in by the engine after {@code apply()}
- *                 returns. Authors creating outcomes by hand leave it
- *                 at {@link Duration#ZERO}.
- * @param <OT> the raw result type
+ * @param <I> the per-sample input type (binds {@link Contract}'s
+ *            input parameter so {@code Contract<I, O>} can be carried)
+ * @param <O> the per-sample output value type
  */
-public record UseCaseOutcome<OT>(
-        OT rawResult,
-        PostconditionEvaluator<OT> postconditions,
+public record UseCaseOutcome<I, O>(
+        Outcome<O> result,
+        Contract<I, O> contract,
+        List<PostconditionResult> postconditionResults,
         Optional<MatchResult> match,
         long tokens,
         Duration duration) {
 
     public UseCaseOutcome {
-        Objects.requireNonNull(postconditions, "postconditions");
+        Objects.requireNonNull(result, "result");
+        Objects.requireNonNull(contract, "contract");
+        Objects.requireNonNull(postconditionResults, "postconditionResults");
         Objects.requireNonNull(match, "match");
         Objects.requireNonNull(duration, "duration");
         if (tokens < 0) {
@@ -95,96 +71,44 @@ public record UseCaseOutcome<OT>(
         if (duration.isNegative()) {
             throw new IllegalArgumentException("duration must be non-negative, got " + duration);
         }
+        postconditionResults = List.copyOf(postconditionResults);
     }
 
     /**
-     * Derives the overall {@link Outcome} from match + postconditions.
-     * See class javadoc for the precedence rules.
+     * Derives the overall sample {@link Outcome} from the result, the
+     * match, and the postcondition results. Precedence:
+     *
+     * <ol>
+     *   <li>If {@link #result} is an {@link Outcome.Fail}, returns it
+     *       — apply-level failure short-circuits everything.</li>
+     *   <li>Else if {@link #match} is present and reports a mismatch,
+     *       returns {@code Outcome.fail("instance_conformance", …)}.</li>
+     *   <li>Else if any entry in {@link #postconditionResults} failed,
+     *       returns {@code Outcome.fail(description, reason)} carrying
+     *       the first failure.</li>
+     *   <li>Else returns {@link Outcome.Ok} wrapping the produced
+     *       value.</li>
+     * </ol>
+     *
+     * <p>This is a derivation, not a stored field — the data lives on
+     * {@link #result}, {@link #match}, and {@link #postconditionResults}.
      */
-    public Outcome<OT> value() {
+    public Outcome<O> value() {
+        if (result instanceof Outcome.Fail<O> f) {
+            return f;
+        }
         if (match.isPresent() && !match.get().matches()) {
             MatchResult m = match.get();
             return Outcome.fail(
                     "instance_conformance",
                     m.diff().orElse(m.description()));
         }
-        List<PostconditionResult> results = postconditions.evaluate(rawResult);
-        for (PostconditionResult r : results) {
+        for (PostconditionResult r : postconditionResults) {
             if (r.failed()) {
                 return Outcome.fail(r.description(),
                         r.failureReason().orElse("postcondition failed"));
             }
         }
-        return Outcome.ok(rawResult);
-    }
-
-    /** Full list of postcondition results. Re-evaluates on every call. */
-    public List<PostconditionResult> evaluatePostconditions() {
-        return postconditions.evaluate(rawResult);
-    }
-
-    /**
-     * Returns a copy of this outcome with {@code tokens} set to
-     * {@code n}.
-     */
-    public UseCaseOutcome<OT> withTokens(long n) {
-        return new UseCaseOutcome<>(rawResult, postconditions, match, n, duration);
-    }
-
-    /**
-     * Returns a copy of this outcome with a {@link MatchResult}
-     * attached. The engine calls this after running the spec's
-     * configured matcher against the expected value supplied for the
-     * sample; authors who perform comparison inside {@code apply}
-     * call it directly.
-     */
-    public UseCaseOutcome<OT> withMatch(MatchResult matchResult) {
-        Objects.requireNonNull(matchResult, "matchResult");
-        return new UseCaseOutcome<>(rawResult, postconditions, Optional.of(matchResult), tokens, duration);
-    }
-
-    /**
-     * Returns a copy of this outcome with {@code duration} set to the
-     * given value. Called by the engine immediately after the use
-     * case's {@code apply()} returns, so the aggregated summary can
-     * compute latency percentiles.
-     */
-    public UseCaseOutcome<OT> withDuration(Duration d) {
-        Objects.requireNonNull(d, "duration");
-        return new UseCaseOutcome<>(rawResult, postconditions, match, tokens, d);
-    }
-
-    // ── Contract-free convenience factories ──────────────────────────
-
-    /**
-     * Build a success outcome with no postconditions, no match, zero
-     * tokens, and zero duration.
-     *
-     * @param value the successful value; may be {@code null}
-     */
-    public static <OT> UseCaseOutcome<OT> ok(OT value) {
-        return new UseCaseOutcome<>(value, PostconditionEvaluator.trivial(), Optional.empty(),
-                0L, Duration.ZERO);
-    }
-
-    /**
-     * Build a failure outcome with no raw result, no match, zero
-     * tokens, and zero duration, carrying a single always-failing
-     * postcondition.
-     */
-    public static <OT> UseCaseOutcome<OT> fail(String name, String message) {
-        return new UseCaseOutcome<>(null, PostconditionEvaluator.alwaysFailing(name, message),
-                Optional.empty(), 0L, Duration.ZERO);
-    }
-
-    /**
-     * Build an outcome from a raw result and a
-     * {@link PostconditionEvaluator}. Match defaults to empty, tokens
-     * to zero, duration to zero; use {@link #withMatch(MatchResult)},
-     * {@link #withTokens(long)}, and {@link #withDuration(Duration)}
-     * to attach.
-     */
-    public static <OT> UseCaseOutcome<OT> of(OT rawResult, PostconditionEvaluator<OT> postconditions) {
-        return new UseCaseOutcome<>(rawResult, postconditions, Optional.empty(), 0L, Duration.ZERO);
+        return result;   // an Outcome.Ok
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleObserver.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleObserver.java
@@ -34,7 +34,7 @@ public interface SampleObserver<OT> {
      * @param outcome the wrapped outcome
      * @param elapsed the wall-clock time the invocation took
      */
-    void onSample(int index, UseCaseOutcome<OT> outcome, Duration elapsed);
+    void onSample(int index, UseCaseOutcome<?, OT> outcome, Duration elapsed);
 
     /**
      * Invoked when {@code useCase.apply(input)} throws. The default

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleSummary.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleSummary.java
@@ -49,7 +49,7 @@ import org.javai.punit.api.typed.UseCaseOutcome;
  * @param <OT> the outcome value type
  */
 public record SampleSummary<OT>(
-        List<UseCaseOutcome<OT>> outcomes,
+        List<UseCaseOutcome<?, OT>> outcomes,
         Duration elapsed,
         int successes,
         int failures,
@@ -101,13 +101,13 @@ public record SampleSummary<OT>(
      * directly with a populated trials list.
      */
     public static <OT> SampleSummary<OT> from(
-            List<UseCaseOutcome<OT>> outcomes,
+            List<UseCaseOutcome<?, OT>> outcomes,
             Duration elapsed,
             LatencyResult latencyResult,
             TerminationReason terminationReason) {
         int s = 0, f = 0;
         long tokens = 0L;
-        for (UseCaseOutcome<OT> o : outcomes) {
+        for (UseCaseOutcome<?, OT> o : outcomes) {
             if (o.value().isOk()) s++;
             else f++;
             tokens += o.tokens();
@@ -121,7 +121,7 @@ public record SampleSummary<OT>(
      * {@code latencyResult} to {@link LatencyResult#empty()} and
      * {@code terminationReason} to {@link TerminationReason#COMPLETED}.
      */
-    public static <OT> SampleSummary<OT> from(List<UseCaseOutcome<OT>> outcomes, Duration elapsed) {
+    public static <OT> SampleSummary<OT> from(List<UseCaseOutcome<?, OT>> outcomes, Duration elapsed) {
         return from(outcomes, elapsed, LatencyResult.empty(), TerminationReason.COMPLETED);
     }
 

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Trial.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Trial.java
@@ -23,7 +23,7 @@ import org.javai.punit.api.typed.UseCaseOutcome;
  * @param <IT>     the per-sample input type
  * @param <OT>     the per-sample outcome value type
  */
-public record Trial<IT, OT>(IT input, UseCaseOutcome<OT> outcome, Duration duration) {
+public record Trial<IT, OT>(IT input, UseCaseOutcome<IT, OT> outcome, Duration duration) {
 
     public Trial {
         Objects.requireNonNull(outcome, "outcome");

--- a/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/SamplingTest.java
@@ -271,6 +271,53 @@ class SamplingTest {
         assertThat(external.inputs()).containsExactly("a", "b");
     }
 
+    // ── matching(...) ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName(".matching(expectedOutputs) defaults to the equality matcher")
+    void matchingDefaultsEquality() {
+        Sampling<Factors, String, String> s = baseBuilder()
+                .matching(java.util.List.of("X", "Y"))
+                .build();
+
+        assertThat(s.expected()).containsExactly("X", "Y");
+        assertThat(s.matcher()).isPresent();
+    }
+
+    @Test
+    @DisplayName(".matching(expectedOutputs, matcher) carries both fields")
+    void matchingWithCustomMatcher() {
+        ValueMatcher<String> custom = ValueMatcher.equality();
+        Sampling<Factors, String, String> s = baseBuilder()
+                .matching(java.util.List.of("a", "b"), custom)
+                .build();
+
+        assertThat(s.expected()).containsExactly("a", "b");
+        assertThat(s.matcher()).contains(custom);
+    }
+
+    @Test
+    @DisplayName("default matcher is empty when matching not configured")
+    void matchingDefaultEmpty() {
+        Sampling<Factors, String, String> s = baseBuilder().build();
+        assertThat(s.expected()).isEmpty();
+        assertThat(s.matcher()).isEmpty();
+    }
+
+    @Test
+    @DisplayName(".matching(null) is rejected")
+    void matchingNullRejected() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> baseBuilder().matching(null));
+    }
+
+    @Test
+    @DisplayName(".matching(list, null) is rejected")
+    void matchingNullMatcherRejected() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> baseBuilder().matching(java.util.List.of("x"), null));
+    }
+
     @Test
     @DisplayName("Sampling.inputSupplier() returns the underlying supplier")
     void inputSupplierAccessor() {

--- a/punit-api/src/test/java/org/javai/punit/api/typed/UseCaseOutcomeTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/UseCaseOutcomeTest.java
@@ -5,135 +5,132 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Optional;
 
 import org.javai.outcome.Outcome;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("UseCaseOutcome")
+@DisplayName("UseCaseOutcome — recipient-facing artefact assembled by Contract.apply")
 class UseCaseOutcomeTest {
 
-    @Test
-    @DisplayName("ok() wraps a successful Outcome around the value")
-    void okWrapsValue() {
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.ok(42);
-        assertThat(outcome.value()).isInstanceOf(Outcome.Ok.class);
-        assertThat(outcome.value().getOrThrow()).isEqualTo(42);
-        assertThat(outcome.evaluatePostconditions()).isEmpty();
-    }
+    /** Stand-in contract used in the canonical-constructor tests. */
+    private static final Contract<String, Integer> CONTRACT = new Contract<>() {
+        @Override
+        public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+
+        @Override
+        public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+    };
 
     @Test
-    @DisplayName("fail() wraps a failure Outcome with the given name and message")
-    void failWrapsFailure() {
-        UseCaseOutcome<String> outcome = UseCaseOutcome.fail("bad_input", "empty string");
-        assertThat(outcome.value().isFail()).isTrue();
-        assertThat(outcome.evaluatePostconditions()).hasSize(1);
-        assertThat(outcome.evaluatePostconditions().get(0).failureMessage())
-                .contains("empty string");
-    }
+    @DisplayName("canonical constructor copies the postcondition list")
+    void postconditionResultsDefensivelyCopied() {
+        var mutable = new java.util.ArrayList<PostconditionResult>();
+        mutable.add(PostconditionResult.passed("a"));
 
-    @Test
-    @DisplayName("tokens default to zero and are record-accessible")
-    void tokensDefaultZero() {
-        assertThat(UseCaseOutcome.ok(1).tokens()).isZero();
-        assertThat(UseCaseOutcome.fail("x", "y").tokens()).isZero();
-    }
+        var outcome = new UseCaseOutcome<>(
+                Outcome.ok(5), CONTRACT, mutable, Optional.empty(), 0L, Duration.ZERO);
 
-    @Test
-    @DisplayName("withTokens attaches a token cost to the outcome")
-    void withTokensPropagates() {
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.ok(1).withTokens(256);
-        assertThat(outcome.tokens()).isEqualTo(256L);
-        // Value / postconditions are preserved across withTokens
-        assertThat(outcome.value().getOrThrow()).isEqualTo(1);
+        mutable.add(PostconditionResult.failed("b", "intruder"));   // mutate after
+
+        assertThat(outcome.postconditionResults()).hasSize(1);
+        assertThat(outcome.postconditionResults().get(0).description()).isEqualTo("a");
     }
 
     @Test
     @DisplayName("negative tokens are rejected")
     void rejectsNegativeTokens() {
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> UseCaseOutcome.ok(1).withTokens(-1));
-    }
-
-    @Test
-    @DisplayName("postconditions are evaluated lazily and re-evaluated on each call")
-    void lazyPostconditionEvaluation() {
-        AtomicInteger evalCount = new AtomicInteger();
-        PostconditionEvaluator<Integer> evaluator = new PostconditionEvaluator<>() {
-            @Override public List<PostconditionResult> evaluate(Integer result) {
-                evalCount.incrementAndGet();
-                return List.of(PostconditionResult.passed("non-negative"));
-            }
-            @Override public int postconditionCount() { return 1; }
-        };
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.of(3, evaluator);
-
-        assertThat(evalCount).hasValue(0);
-
-        outcome.value();
-        outcome.evaluatePostconditions();
-        outcome.value();
-
-        // Each call re-evaluates — no caching at the outcome level
-        assertThat(evalCount).hasValue(3);
-    }
-
-    @Test
-    @DisplayName("value() returns Fail when any postcondition fails, preserving the reason")
-    void valueReflectsPostconditionFailure() {
-        PostconditionEvaluator<Integer> evaluator = new PostconditionEvaluator<>() {
-            @Override public List<PostconditionResult> evaluate(Integer result) {
-                return List.of(
-                        PostconditionResult.passed("is integer"),
-                        PostconditionResult.failed("positive", "got " + result));
-            }
-            @Override public int postconditionCount() { return 2; }
-        };
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.of(-5, evaluator);
-
-        assertThat(outcome.value().isFail()).isTrue();
-        assertThat(((Outcome.Fail<Integer>) outcome.value()).failure().message())
-                .contains("got -5");
-    }
-
-    @Test
-    @DisplayName("duration defaults to Duration.ZERO for the convenience factories")
-    void durationDefaultsZero() {
-        assertThat(UseCaseOutcome.ok(1).duration()).isEqualTo(Duration.ZERO);
-        assertThat(UseCaseOutcome.fail("x", "y").duration()).isEqualTo(Duration.ZERO);
-    }
-
-    @Test
-    @DisplayName("withDuration attaches a measured duration to the outcome")
-    void withDurationPropagates() {
-        Duration d = Duration.ofMillis(125);
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.ok(1).withDuration(d);
-        assertThat(outcome.duration()).isEqualTo(d);
-        // Value / tokens preserved across withDuration
-        assertThat(outcome.value().getOrThrow()).isEqualTo(1);
-        assertThat(outcome.tokens()).isZero();
+                .isThrownBy(() -> new UseCaseOutcome<>(
+                        Outcome.ok(1), CONTRACT, List.of(), Optional.empty(),
+                        -1L, Duration.ZERO));
     }
 
     @Test
     @DisplayName("negative duration is rejected")
     void rejectsNegativeDuration() {
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> UseCaseOutcome.ok(1).withDuration(Duration.ofMillis(-1)));
+                .isThrownBy(() -> new UseCaseOutcome<>(
+                        Outcome.ok(1), CONTRACT, List.of(), Optional.empty(),
+                        0L, Duration.ofMillis(-1)));
     }
 
     @Test
-    @DisplayName("value() returns Ok when all postconditions pass, wrapping the raw result")
-    void valueOkWhenAllPass() {
-        PostconditionEvaluator<Integer> evaluator = new PostconditionEvaluator<>() {
-            @Override public List<PostconditionResult> evaluate(Integer result) {
-                return List.of(PostconditionResult.passed("non-null"));
-            }
-            @Override public int postconditionCount() { return 1; }
-        };
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.of(7, evaluator);
+    @DisplayName("null fields are rejected")
+    void rejectsNullFields() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new UseCaseOutcome<>(
+                        null, CONTRACT, List.of(), Optional.empty(), 0L, Duration.ZERO));
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new UseCaseOutcome<>(
+                        Outcome.ok(1), null, List.of(), Optional.empty(), 0L, Duration.ZERO));
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new UseCaseOutcome<>(
+                        Outcome.ok(1), CONTRACT, null, Optional.empty(), 0L, Duration.ZERO));
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new UseCaseOutcome<>(
+                        Outcome.ok(1), CONTRACT, List.of(), null, 0L, Duration.ZERO));
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new UseCaseOutcome<>(
+                        Outcome.ok(1), CONTRACT, List.of(), Optional.empty(), 0L, null));
+    }
+
+    @Test
+    @DisplayName("value() returns the apply-level Fail short-circuiting everything else")
+    void valueReturnsApplyLevelFail() {
+        Outcome<Integer> applyFail = Outcome.fail("apply-error", "boom");
+        var outcome = new UseCaseOutcome<>(
+                applyFail, CONTRACT,
+                List.of(PostconditionResult.passed("would-pass")),
+                Optional.empty(), 0L, Duration.ZERO);
+
+        assertThat(outcome.value()).isSameAs(applyFail);
+    }
+
+    @Test
+    @DisplayName("value() returns instance_conformance Fail when the match mismatched")
+    void valueReturnsMatchFail() {
+        var outcome = new UseCaseOutcome<>(
+                Outcome.ok(5), CONTRACT,
+                List.of(),
+                Optional.of(MatchResult.fail(
+                        "exact", 6, 5, "expected 6 got 5")),
+                0L, Duration.ZERO);
+
+        assertThat(outcome.value().isFail()).isTrue();
+        assertThat(((Outcome.Fail<Integer>) outcome.value()).failure().id().name())
+                .isEqualTo("instance_conformance");
+    }
+
+    @Test
+    @DisplayName("value() returns the first postcondition failure")
+    void valueReturnsFirstClauseFail() {
+        var outcome = new UseCaseOutcome<>(
+                Outcome.ok(5), CONTRACT,
+                List.of(
+                        PostconditionResult.passed("first ok"),
+                        PostconditionResult.failed("second-clause", "tripped"),
+                        PostconditionResult.failed("third-clause", "would also trip")),
+                Optional.empty(), 0L, Duration.ZERO);
+
+        assertThat(outcome.value().isFail()).isTrue();
+        assertThat(((Outcome.Fail<Integer>) outcome.value()).failure().message())
+                .contains("tripped");
+    }
+
+    @Test
+    @DisplayName("value() returns Ok when result is Ok and nothing else fails")
+    void valueReturnsOkWhenAllPass() {
+        var outcome = new UseCaseOutcome<>(
+                Outcome.ok(5), CONTRACT,
+                List.of(PostconditionResult.passed("all good")),
+                Optional.of(MatchResult.pass("exact", 5, 5)),
+                12L, Duration.ofMillis(7));
 
         assertThat(outcome.value().isOk()).isTrue();
-        assertThat(outcome.value().getOrThrow()).isEqualTo(7);
+        assertThat(outcome.value().getOrThrow()).isEqualTo(5);
     }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/PercentileLatencyTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/PercentileLatencyTest.java
@@ -7,10 +7,14 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.Contract;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.LatencyResult;
 import org.javai.punit.api.typed.LatencySpec;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,11 +24,18 @@ class PercentileLatencyTest {
 
     record Factors(String label) {}
 
+    private static final Contract<Object, String> STUB_CONTRACT = new Contract<>() {
+        @Override public Outcome<String> invoke(Object input, TokenTracker tracker) {
+            return Outcome.ok("ok");
+        }
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+    };
+
     private static SampleSummary<String> summary(LatencyResult latency, int successes, int failures) {
         int total = successes + failures;
-        var outcomes = new java.util.ArrayList<UseCaseOutcome<String>>(total);
-        for (int i = 0; i < successes; i++) outcomes.add(UseCaseOutcome.ok("ok"));
-        for (int i = 0; i < failures; i++) outcomes.add(UseCaseOutcome.fail("nope", "msg"));
+        var outcomes = new java.util.ArrayList<UseCaseOutcome<?, String>>(total);
+        for (int i = 0; i < successes; i++) outcomes.add(stubOutcome(Outcome.ok("ok")));
+        for (int i = 0; i < failures; i++) outcomes.add(stubOutcome(Outcome.fail("nope", "msg")));
         return new SampleSummary<>(
                 outcomes,
                 Duration.ofMillis(1),
@@ -32,6 +43,13 @@ class PercentileLatencyTest {
                 latency,
                 TerminationReason.COMPLETED,
                 List.of());
+    }
+
+    private static UseCaseOutcome<Object, String> stubOutcome(Outcome<String> result) {
+        return new UseCaseOutcome<>(
+                result, STUB_CONTRACT,
+                List.of(), Optional.empty(),
+                0L, Duration.ZERO);
     }
 
     private static LatencyResult observed(long p50, long p90, long p95, long p99, int n) {

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/TrialTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/TrialTest.java
@@ -5,8 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.typed.Contract;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,10 +19,28 @@ import org.junit.jupiter.api.Test;
 @DisplayName("Trial + SampleSummary.trials")
 class TrialTest {
 
+    /** Stand-in contract for outcome construction. */
+    private static final Contract<String, Integer> CONTRACT = new Contract<>() {
+        @Override
+        public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+
+        @Override
+        public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+    };
+
+    private static UseCaseOutcome<String, Integer> ok(int value) {
+        return new UseCaseOutcome<>(
+                Outcome.ok(value), CONTRACT,
+                List.of(), Optional.empty(),
+                0L, Duration.ZERO);
+    }
+
     @Test
     @DisplayName("Trial round-trips its components")
     void trialRoundTrip() {
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.ok(42);
+        UseCaseOutcome<String, Integer> outcome = ok(42);
         Trial<String, Integer> trial = new Trial<>("hello", outcome, Duration.ofMillis(7));
 
         assertThat(trial.input()).isEqualTo("hello");
@@ -28,7 +51,7 @@ class TrialTest {
     @Test
     @DisplayName("Trial accepts a null input — input is the only nullable component")
     void trialAllowsNullInput() {
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.ok(42);
+        UseCaseOutcome<String, Integer> outcome = ok(42);
         Trial<String, Integer> trial = new Trial<>(null, outcome, Duration.ZERO);
         assertThat(trial.input()).isNull();
     }
@@ -43,7 +66,7 @@ class TrialTest {
     @Test
     @DisplayName("Trial rejects a null duration")
     void trialRejectsNullDuration() {
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.ok(42);
+        UseCaseOutcome<String, Integer> outcome = ok(42);
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> new Trial<>("hello", outcome, null));
     }
@@ -51,14 +74,14 @@ class TrialTest {
     @Test
     @DisplayName("SampleSummary.trials() returns the supplied list")
     void summaryTrialsAccessor() {
-        UseCaseOutcome<Integer> ok = UseCaseOutcome.ok(1);
-        UseCaseOutcome<Integer> ok2 = UseCaseOutcome.ok(2);
+        UseCaseOutcome<String, Integer> ok1 = ok(1);
+        UseCaseOutcome<String, Integer> ok2 = ok(2);
         List<Trial<?, Integer>> trials = List.of(
-                new Trial<String, Integer>("a", ok, Duration.ofMillis(5)),
-                new Trial<String, Integer>("b", ok2, Duration.ofMillis(7)));
+                new Trial<>("a", ok1, Duration.ofMillis(5)),
+                new Trial<>("b", ok2, Duration.ofMillis(7)));
 
         SampleSummary<Integer> summary = new SampleSummary<>(
-                List.of(ok, ok2),
+                List.of(ok1, ok2),
                 Duration.ofMillis(12),
                 2, 0, 0L, 0,
                 LatencyResult.empty(),
@@ -73,14 +96,14 @@ class TrialTest {
     @Test
     @DisplayName("SampleSummary rejects a trials list whose size does not match successes + failures")
     void summaryRejectsMismatchedTrialCount() {
-        UseCaseOutcome<Integer> ok = UseCaseOutcome.ok(1);
+        UseCaseOutcome<String, Integer> okOutcome = ok(1);
         List<Trial<?, Integer>> oneTrial = List.of(
-                new Trial<String, Integer>("a", ok, Duration.ofMillis(5)));
+                new Trial<>("a", okOutcome, Duration.ofMillis(5)));
 
         // successes + failures = 2, but trials list has 1 entry
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new SampleSummary<>(
-                        List.of(ok, ok),
+                        List.of(okOutcome, okOutcome),
                         Duration.ofMillis(12),
                         2, 0, 0L, 0,
                         LatencyResult.empty(),
@@ -92,9 +115,9 @@ class TrialTest {
     @Test
     @DisplayName("SampleSummary accepts an empty trials list (back-compat path)")
     void summaryAcceptsEmptyTrials() {
-        UseCaseOutcome<Integer> ok = UseCaseOutcome.ok(1);
+        UseCaseOutcome<String, Integer> okOutcome = ok(1);
         SampleSummary<Integer> summary = new SampleSummary<>(
-                List.of(ok),
+                List.of(okOutcome),
                 Duration.ofMillis(5),
                 1, 0, 0L, 0,
                 LatencyResult.empty(),

--- a/punit-core/src/main/java/org/javai/punit/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/Engine.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.typed.LatencyResult;
 import org.javai.punit.api.typed.MatchResult;
 import org.javai.punit.api.typed.UseCase;
@@ -98,6 +99,7 @@ public final class Engine {
         BudgetTracker tracker = new BudgetTracker(
                 spec.timeBudget(), spec.tokenBudget(), spec.tokenCharge());
         Aggregator<IT, OT> agg = new Aggregator<>(
+                useCase,
                 cfg.inputs(),
                 cfg.expected(),
                 cycleStart,
@@ -126,6 +128,7 @@ public final class Engine {
      */
     private static final class Aggregator<IT, OT> implements SampleObserver<OT> {
 
+        private final UseCase<?, IT, OT> useCase;
         private final List<IT> inputs;
         private final List<OT> expected;
         private final int cycleStart;
@@ -138,8 +141,8 @@ public final class Engine {
         // from every sample so latency stats never skew on drop.
         // trials carries the full ordered (input, outcome, duration)
         // history regardless of the failure cap.
-        private final List<UseCaseOutcome<OT>> retained = new ArrayList<>();
-        private final List<UseCaseOutcome<OT>> allForLatency = new ArrayList<>();
+        private final List<UseCaseOutcome<?, OT>> retained = new ArrayList<>();
+        private final List<UseCaseOutcome<?, OT>> allForLatency = new ArrayList<>();
         private final List<Trial<?, OT>> trials = new ArrayList<>();
         private int successes = 0;
         private int failures = 0;
@@ -147,13 +150,15 @@ public final class Engine {
         private long tokensConsumed = 0L;
         private int failuresDropped = 0;
 
-        Aggregator(List<IT> inputs,
+        Aggregator(UseCase<?, IT, OT> useCase,
+                   List<IT> inputs,
                    List<OT> expected,
                    int cycleStart,
                    Optional<ValueMatcher<OT>> matcher,
                    ExceptionPolicy exceptionPolicy,
                    int maxExampleFailures,
                    BudgetTracker tracker) {
+            this.useCase = useCase;
             this.inputs = inputs;
             this.expected = expected;
             this.cycleStart = cycleStart;
@@ -164,10 +169,11 @@ public final class Engine {
         }
 
         @Override
-        public void onSample(int index, UseCaseOutcome<OT> outcome, Duration elapsed) {
-            UseCaseOutcome<OT> stamped = outcome.withDuration(elapsed);
-            stamped = maybeAttachMatch(index, stamped);
-            record(index, stamped, elapsed);
+        public void onSample(int index, UseCaseOutcome<?, OT> outcome, Duration elapsed) {
+            // outcome already carries duration from Contract.apply; ignore
+            // the executor's measurement (which is essentially the same).
+            UseCaseOutcome<?, OT> withMatch = maybeAttachMatch(index, outcome);
+            record(index, withMatch);
         }
 
         @Override
@@ -184,16 +190,20 @@ public final class Engine {
                 throw new RuntimeException(throwable);
             }
             // FAIL_SAMPLE: synthesise a failing outcome and continue.
-            UseCaseOutcome<OT> synthetic = UseCaseOutcome
-                    .<OT>fail("defect", throwable.toString())
-                    .withDuration(elapsed);
-            record(index, synthetic, elapsed);
+            UseCaseOutcome<IT, OT> synthetic = new UseCaseOutcome<>(
+                    Outcome.fail("defect", throwable.toString()),
+                    useCase,
+                    List.of(),
+                    Optional.empty(),
+                    0L,
+                    elapsed);
+            record(index, synthetic);
         }
 
-        private void record(int index, UseCaseOutcome<OT> stamped, Duration duration) {
+        private void record(int index, UseCaseOutcome<?, OT> stamped) {
             tracker.recordSampleTokens(stamped.tokens());
             allForLatency.add(stamped);
-            trials.add(new Trial<>(inputForIndex(index), stamped, duration));
+            trials.add(trialFor(index, stamped));
             boolean ok = stamped.value().isOk();
             if (ok) {
                 successes++;
@@ -210,20 +220,43 @@ public final class Engine {
             tokensConsumed += stamped.tokens() + tracker.tokenCharge();
         }
 
+        private <I> Trial<IT, OT> trialFor(int index, UseCaseOutcome<I, OT> stamped) {
+            // Trial<IT, OT> requires UseCaseOutcome<IT, OT>; the wildcard
+            // carrier in onSample loses that I; we know the executor only
+            // ever supplies UseCaseOutcome<IT, OT> so this is safe.
+            @SuppressWarnings("unchecked")
+            UseCaseOutcome<IT, OT> typed = (UseCaseOutcome<IT, OT>) stamped;
+            return new Trial<>(inputForIndex(index), typed, stamped.duration());
+        }
+
         private IT inputForIndex(int index) {
             int cycleIndex = (cycleStart + index) % inputs.size();
             return inputs.get(cycleIndex);
         }
 
-        private UseCaseOutcome<OT> maybeAttachMatch(int index, UseCaseOutcome<OT> outcome) {
+        private UseCaseOutcome<?, OT> maybeAttachMatch(int index, UseCaseOutcome<?, OT> outcome) {
             if (expected.isEmpty() || matcher.isEmpty()) {
                 return outcome;
             }
+            if (!(outcome.result() instanceof org.javai.outcome.Outcome.Ok<OT> ok)) {
+                return outcome;   // can't compare against expected if no value produced
+            }
             int cycleIndex = (cycleStart + index) % expected.size();
             OT expectedValue = expected.get(cycleIndex);
-            OT actualValue = outcome.rawResult();
+            OT actualValue = ok.value();
             MatchResult result = matcher.get().match(expectedValue, actualValue);
-            return outcome.withMatch(result);
+            return reconstructWithMatch(outcome, result);
+        }
+
+        private static <I, OT> UseCaseOutcome<I, OT> reconstructWithMatch(
+                UseCaseOutcome<I, OT> outcome, MatchResult match) {
+            return new UseCaseOutcome<>(
+                    outcome.result(),
+                    outcome.contract(),
+                    outcome.postconditionResults(),
+                    Optional.of(match),
+                    outcome.tokens(),
+                    outcome.duration());
         }
 
         SampleSummary<OT> toSummary(Duration elapsed) {

--- a/punit-core/src/main/java/org/javai/punit/engine/LatencyPercentileComputer.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/LatencyPercentileComputer.java
@@ -24,7 +24,7 @@ final class LatencyPercentileComputer {
 
     private LatencyPercentileComputer() {}
 
-    static <OT> LatencyResult computeFrom(List<UseCaseOutcome<OT>> outcomes) {
+    static <OT> LatencyResult computeFrom(List<UseCaseOutcome<?, OT>> outcomes) {
         if (outcomes.isEmpty()) {
             return LatencyResult.empty();
         }

--- a/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
@@ -83,7 +83,7 @@ public final class SerialSampleExecutor implements SampleExecutor {
             }
             IT input = inputs.get((cycleStart + i) % inputs.size());
             long t0 = System.nanoTime();
-            UseCaseOutcome<OT> outcome;
+            UseCaseOutcome<IT, OT> outcome;
             try {
                 outcome = useCase.apply(input, tracker);
             } catch (Throwable t) {

--- a/punit-core/src/test/java/org/javai/punit/architecture/PUnitApiVisibilityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/architecture/PUnitApiVisibilityTest.java
@@ -2,7 +2,10 @@ package org.javai.punit.architecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.javai.punit.api.typed.Contract;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +23,16 @@ class PUnitApiVisibilityTest {
     @Test
     @DisplayName("types from punit-api are visible and usable")
     void typesAreVisible() {
-        UseCaseOutcome<Integer> outcome = UseCaseOutcome.ok(42);
+        Contract<Object, Integer> contract = new Contract<>() {
+            @Override public org.javai.outcome.Outcome<Integer> invoke(Object input, TokenTracker tracker) {
+                return org.javai.outcome.Outcome.ok(42);
+            }
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        };
+        UseCaseOutcome<Object, Integer> outcome = new UseCaseOutcome<>(
+                org.javai.outcome.Outcome.ok(42), contract,
+                java.util.List.of(), java.util.Optional.empty(),
+                0L, java.time.Duration.ZERO);
         assertThat(outcome.value().isOk()).isTrue();
         assertThat(outcome.value().getOrThrow()).isEqualTo(42);
 

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -270,7 +270,7 @@ class EngineIntegrationTest {
         assertThat(summary.trials().get(3).input()).isEqualTo("a");
         assertThat(summary.trials().get(6).input()).isEqualTo("a");
         // LengthUseCase returns input.length()
-        assertThat(summary.trials().get(2).outcome().rawResult()).isEqualTo(3);
+        assertThat(summary.trials().get(2).outcome().result().getOrThrow()).isEqualTo(3);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/engine/criteria/BernoulliPassRateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/criteria/BernoulliPassRateTest.java
@@ -7,9 +7,13 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.Contract;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.CriterionResult;
 import org.javai.punit.api.typed.spec.EvaluationContext;
@@ -26,11 +30,18 @@ class BernoulliPassRateTest {
 
     record Factors(String label) {}
 
+    private static final Contract<Object, String> STUB_CONTRACT = new Contract<>() {
+        @Override public Outcome<String> invoke(Object input, TokenTracker tracker) {
+            return Outcome.ok("ok");
+        }
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+    };
+
     private static SampleSummary<String> summary(int successes, int failures) {
         int total = successes + failures;
-        var outcomes = new java.util.ArrayList<UseCaseOutcome<String>>(total);
-        for (int i = 0; i < successes; i++) outcomes.add(UseCaseOutcome.ok("ok"));
-        for (int i = 0; i < failures; i++) outcomes.add(UseCaseOutcome.fail("nope", "msg"));
+        var outcomes = new java.util.ArrayList<UseCaseOutcome<?, String>>(total);
+        for (int i = 0; i < successes; i++) outcomes.add(stubOutcome(Outcome.ok("ok")));
+        for (int i = 0; i < failures; i++) outcomes.add(stubOutcome(Outcome.fail("nope", "msg")));
         return new SampleSummary<>(
                 outcomes,
                 Duration.ofMillis(1),
@@ -38,6 +49,13 @@ class BernoulliPassRateTest {
                 LatencyResult.empty(),
                 TerminationReason.COMPLETED,
                 List.of());
+    }
+
+    private static UseCaseOutcome<Object, String> stubOutcome(Outcome<String> result) {
+        return new UseCaseOutcome<>(
+                result, STUB_CONTRACT,
+                List.of(), Optional.empty(),
+                0L, Duration.ZERO);
     }
 
     private static final String DEFAULT_IDENTITY = "sha256:test-default-identity";

--- a/punit-core/src/test/java/org/javai/punit/engine/criteria/CriterionResultDetailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/criteria/CriterionResultDetailTest.java
@@ -6,10 +6,14 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.Contract;
+import org.javai.punit.api.typed.ContractBuilder;
 import org.javai.punit.api.typed.FactorBundle;
 import org.javai.punit.api.typed.LatencyResult;
 import org.javai.punit.api.typed.LatencySpec;
+import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCaseOutcome;
 import org.javai.punit.api.typed.spec.BaselineStatistics;
 import org.javai.punit.api.typed.spec.CriterionResult;
@@ -35,9 +39,23 @@ class CriterionResultDetailTest {
 
     record Factors(String label) {}
 
+    private static final Contract<Object, Integer> STUB_CONTRACT = new Contract<>() {
+        @Override public Outcome<Integer> invoke(Object input, TokenTracker tracker) {
+            return Outcome.ok(0);
+        }
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+    };
+
+    private static UseCaseOutcome<Object, Integer> stubOutcome(int value) {
+        return new UseCaseOutcome<>(
+                Outcome.ok(value), STUB_CONTRACT,
+                List.of(), Optional.empty(),
+                0L, Duration.ZERO);
+    }
+
     private static SampleSummary<Integer> summaryWithLatency(LatencyResult latency) {
         return new SampleSummary<>(
-                List.of(UseCaseOutcome.ok(1), UseCaseOutcome.ok(2)),
+                List.of(stubOutcome(1), stubOutcome(2)),
                 Duration.ofMillis(10),
                 2, 0, 0L, 0,
                 latency,


### PR DESCRIPTION
## Summary

Implements **Step 3** of [`DIR-CONTRACT-ON-USECASE-punit`](../../../javai-orchestrator/blob/main/plan/directives/DIR-CONTRACT-ON-USECASE-punit.md). Builds on Steps 1 + 1b + 2 (already merged via #88, #89).

### `UseCaseOutcome` reshape

The record's type parameters move from `<OT>` to `<I, O>` so it can carry `Contract<I, O>`. Fields:

```java
public record UseCaseOutcome<I, O>(
        Outcome<O> result,
        Contract<I, O> contract,
        List<PostconditionResult> postconditionResults,
        Optional<MatchResult> match,
        long tokens,
        Duration duration) { ... }
```

The recipient consumes one self-sufficient artefact — no reaching back to the use case for clause names, no separate match attachment, no separate duration stamping. Defensive copy of `postconditionResults`, null-checks throughout, non-negative `tokens`/`duration`.

### What's gone

- **Author-facing factories** (`UseCaseOutcome.ok` / `.fail` / `.of`). Authors implement `Contract.invoke` returning `Outcome<O>`; the framework's `apply` defaults assemble the outcome.
- **Post-hoc setters** (`withTokens`, `withDuration`, `withMatch`). The outcome is fully formed when `apply` returns it.
- **Lazy `PostconditionEvaluator` field**. Replaced by the pre-evaluated `List<PostconditionResult>`. `PostconditionEvaluator` the type stays for now (no consumers in the typed pipeline) — may be removed later.

### What stays

`value()` is retained as a **derivation** (not a stored field). Same precedence as before:

1. apply-level `Outcome.Fail` → returns it (short-circuits everything else)
2. match present and mismatched → `Outcome.fail("instance_conformance", …)`
3. any postcondition failed → `Outcome.fail(description, reason)` of the first failure
4. otherwise → `Outcome.Ok` wrapping the produced value

### Engine reshape (minimum needed for build green)

Step 4 is where the engine's sample classifier gets its full reshape. This PR makes the **minimum** changes needed to keep the build green against the new outcome shape:

- `Engine.Aggregator` gains a `UseCase` reference so `onDefect` can construct a synthetic `UseCaseOutcome` with the contract bundled.
- `Aggregator.onSample` stops calling `withDuration` / `withMatch` — `Contract.apply` already provides duration; match is reconstructed via wildcard-capture helper when `expected`/`matcher` are configured.
- `SerialSampleExecutor`'s local `outcome` typed at `<IT, OT>`.
- `LatencyPercentileComputer.computeFrom` takes `List<UseCaseOutcome<?, OT>>`.

### `Sampling.Builder.matching(...)` (new API)

```java
sampling.matching(expectedOutputs)                          // equality matcher
sampling.matching(expectedOutputs, customMatcher)           // explicit matcher
```

Stored on `Sampling`, exposed via `Sampling.expected()` / `Sampling.matcher()`. The engine doesn't yet read matching from `Sampling` (it still reads from spec.matcher() and Configuration.expected()) — that wiring lands in Step 4. For now the API addition is forward-compat.

### Test rewrites

Tests that exercised the legacy outcome shape were rewritten to use the canonical constructor:

- `UseCaseOutcomeTest` — full rewrite around the new shape.
- `TrialTest`, `PercentileLatencyTest`, `BernoulliPassRateTest`, `CriterionResultDetailTest`, `PUnitApiVisibilityTest`, `EngineIntegrationTest` — adapted call sites (`UseCaseOutcome.ok(v)` → canonical-constructor stub + helper).

## Test plan

- [x] `./gradlew test` — green (all ~700+ punit tests pass)
- [x] `./gradlew build -x :punit-gradle-plugin:test` — green (ArchUnit module-isolation checks intact)
- [x] `cd ../punitexamples && ./gradlew compileJava compileTestJava` — green (composite-build sees the new punit shape)
- [x] `cd ../punitexamples && ./gradlew test` — 949 tests, 3 expected demonstration failures (unchanged from before Step 3; same threshold-violation modes documented in punitexamples/CLAUDE.md)
- [ ] Reviewer pulls the branch and runs the same locally for verification
- [ ] Reviewer confirms the `value()` derivation precedence matches the old behaviour (apply-fail → match-mismatch → first-clause-fail → ok)
- [ ] Reviewer confirms the engine flow: form 1 of `Contract.apply` is still the only one called by `SerialSampleExecutor`; the executor's match reconstruction is identical in behaviour to the old `withMatch` path
- [ ] Reviewer confirms `Sampling.Builder.matching(...)` is forward-compat: configured but not yet consumed by the engine; the existing `Experiment.MeasureBuilder.expectedOutputs(...)` flow is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)