### PR TITLE
Step 4: SampleClassification + engine dispatches the right apply form

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/DurationViolation.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/DurationViolation.java
@@ -1,0 +1,28 @@
+package org.javai.punit.api.typed.spec;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Records that a sample exceeded the use case's declared
+ * per-sample wall-clock bound. Surfaced on
+ * {@link SampleClassification} when the bound is set on the
+ * {@link org.javai.punit.api.typed.UseCase#maxLatency() use case}
+ * and the actual sample duration exceeds it.
+ *
+ * <p>A violation is an additional facet of a sample, not a verdict
+ * on its own — postcondition results and (optional) match status
+ * are still collected. The framework's reporters and the verdict
+ * machinery decide what to do with violations; the classifier just
+ * records them.
+ *
+ * @param observed the wall-clock duration the sample took
+ * @param max the declared maximum the use case permitted
+ */
+public record DurationViolation(Duration observed, Duration max) {
+
+    public DurationViolation {
+        Objects.requireNonNull(observed, "observed");
+        Objects.requireNonNull(max, "max");
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleClassification.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleClassification.java
@@ -1,0 +1,152 @@
+package org.javai.punit.api.typed.spec;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.javai.punit.api.typed.MatchResult;
+import org.javai.punit.api.typed.PostconditionResult;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.javai.outcome.Outcome;
+
+/**
+ * The engine's per-sample classification — what was observed about
+ * one sample, in the form the aggregator and downstream reporters
+ * read.
+ *
+ * <p>Built from a {@link UseCaseOutcome} plus the
+ * {@link UseCase#maxLatency() use case's max-latency bound}. The
+ * classifier (a static helper) reads everything it needs from those
+ * two sources; it does not consult the {@link
+ * org.javai.punit.api.typed.Contract Contract} for evaluation
+ * because postcondition results are already pre-evaluated and
+ * carried on the outcome.
+ *
+ * <p>Two shapes:
+ *
+ * <ul>
+ *   <li>**Apply-level failure**: when the use case's
+ *       {@link org.javai.punit.api.typed.Contract#invoke invoke}
+ *       returned {@link Outcome.Fail}, postcondition evaluation is
+ *       skipped — there is no value to evaluate. The classification
+ *       carries the failure name and message, plus the duration and
+ *       tokens.
+ *   <li>**Apply-level success**: postcondition results are present
+ *       (possibly empty when the contract has no clauses), the
+ *       optional match result reflects an instance-conformance
+ *       check if matching was configured, and the optional duration
+ *       violation reflects the per-sample max-latency bound.
+ * </ul>
+ *
+ * @param applyFailureName    when the apply call itself failed,
+ *                            the {@link org.javai.outcome.Failure}
+ *                            id name; empty otherwise
+ * @param applyFailureMessage when the apply call itself failed,
+ *                            the failure message; empty otherwise
+ * @param postconditionResults pre-evaluated per-clause results;
+ *                            empty when {@link #applyFailed()}
+ * @param durationViolation   present when the sample exceeded the
+ *                            use case's {@link
+ *                            UseCase#maxLatency() declared max}
+ * @param match               the instance-conformance match result,
+ *                            if matching was configured for this run
+ * @param duration            the wall-clock time the sample took
+ * @param tokens              the cost the sample consumed
+ */
+public record SampleClassification(
+        Optional<String> applyFailureName,
+        Optional<String> applyFailureMessage,
+        List<PostconditionResult> postconditionResults,
+        Optional<DurationViolation> durationViolation,
+        Optional<MatchResult> match,
+        Duration duration,
+        long tokens) {
+
+    public SampleClassification {
+        Objects.requireNonNull(applyFailureName, "applyFailureName");
+        Objects.requireNonNull(applyFailureMessage, "applyFailureMessage");
+        Objects.requireNonNull(postconditionResults, "postconditionResults");
+        Objects.requireNonNull(durationViolation, "durationViolation");
+        Objects.requireNonNull(match, "match");
+        Objects.requireNonNull(duration, "duration");
+        if (tokens < 0) {
+            throw new IllegalArgumentException("tokens must be non-negative, got " + tokens);
+        }
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("duration must be non-negative, got " + duration);
+        }
+        postconditionResults = List.copyOf(postconditionResults);
+    }
+
+    /** Whether the sample's apply call returned an Outcome.Fail (no value produced). */
+    public boolean applyFailed() {
+        return applyFailureName.isPresent();
+    }
+
+    /**
+     * Build a classification for an apply-level failure — postcondition
+     * results, match, and duration-violation are all empty.
+     */
+    public static SampleClassification failedAtApply(
+            String name, String message, Duration duration, long tokens) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(message, "message");
+        return new SampleClassification(
+                Optional.of(name),
+                Optional.of(message),
+                List.of(),
+                Optional.empty(),
+                Optional.empty(),
+                duration,
+                tokens);
+    }
+
+    /**
+     * Build a classification for a successful apply call — the
+     * postcondition results, optional match, optional duration
+     * violation, duration, and tokens together describe what was
+     * observed.
+     */
+    public static SampleClassification from(
+            List<PostconditionResult> postconditionResults,
+            Optional<DurationViolation> durationViolation,
+            Optional<MatchResult> match,
+            Duration duration,
+            long tokens) {
+        return new SampleClassification(
+                Optional.empty(),
+                Optional.empty(),
+                postconditionResults,
+                durationViolation,
+                match,
+                duration,
+                tokens);
+    }
+
+    /**
+     * Classify one sample. Reads the outcome's pre-evaluated
+     * postcondition results and match; reads the use case's
+     * max-latency bound to detect a duration violation.
+     */
+    public static <I, O> SampleClassification classify(
+            UseCase<?, I, O> useCase, UseCaseOutcome<I, O> outcome) {
+        if (outcome.result() instanceof Outcome.Fail<O> f) {
+            return failedAtApply(
+                    f.failure().id().name(),
+                    f.failure().message(),
+                    outcome.duration(),
+                    outcome.tokens());
+        }
+        Optional<DurationViolation> violation = useCase.maxLatency()
+                .filter(max -> outcome.duration().compareTo(max) > 0)
+                .map(max -> new DurationViolation(outcome.duration(), max));
+        return from(
+                outcome.postconditionResults(),
+                violation,
+                outcome.match(),
+                outcome.duration(),
+                outcome.tokens());
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleExecutor.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/SampleExecutor.java
@@ -1,9 +1,11 @@
 package org.javai.punit.api.typed.spec;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
 import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.ValueMatcher;
 
 /**
  * How samples are dispatched to the use case's {@code apply()} method.
@@ -29,11 +31,24 @@ public interface SampleExecutor {
      * successive invocations (so a call with {@code cycleStart = k}
      * reads input {@code inputs.get((k) % inputs.size())} first).
      *
+     * <p>When {@code expected} is non-empty and {@code matcher} is
+     * present, the executor dispatches to the use case's matching
+     * {@code apply} form (form 3) per sample, pairing each input
+     * with its expected value. Otherwise it dispatches to the
+     * input-only form (form 1).
+     *
      * <p>Before each sample, the executor consults {@code stopRequested}
      * and halts when it returns true.
      *
      * @param useCase the use case instance
      * @param inputs the inputs to cycle through (non-empty)
+     * @param expected the expected values paired with inputs by
+     *                 round-robin index; empty when no
+     *                 instance-conformance matching is configured.
+     *                 When non-empty, must be the same length as
+     *                 {@code inputs}
+     * @param matcher the matcher to use against {@code expected};
+     *                must be present iff {@code expected} is non-empty
      * @param sampleCount the upper bound on samples to run; must be
      *                    non-negative
      * @param cycleStart the starting cycle index (so warmup can set this
@@ -48,6 +63,8 @@ public interface SampleExecutor {
     <FT, IT, OT> void runSamples(
             UseCase<FT, IT, OT> useCase,
             List<IT> inputs,
+            List<OT> expected,
+            Optional<ValueMatcher<OT>> matcher,
             int sampleCount,
             int cycleStart,
             SampleObserver<OT> observer,

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/SampleClassificationTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/SampleClassificationTest.java
@@ -1,0 +1,193 @@
+package org.javai.punit.api.typed.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.typed.Contract;
+import org.javai.punit.api.typed.ContractBuilder;
+import org.javai.punit.api.typed.MatchResult;
+import org.javai.punit.api.typed.PostconditionResult;
+import org.javai.punit.api.typed.TokenTracker;
+import org.javai.punit.api.typed.UseCase;
+import org.javai.punit.api.typed.UseCaseOutcome;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SampleClassification — engine's per-sample summary")
+class SampleClassificationTest {
+
+    record Factors() {}
+
+    /** Use case stand-in with no max-latency bound. */
+    private static final UseCase<Factors, String, Integer> USE_CASE = new UseCase<>() {
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+    };
+
+    private static UseCaseOutcome<String, Integer> outcomeOk(int value, Duration duration, long tokens) {
+        return new UseCaseOutcome<>(
+                Outcome.ok(value), USE_CASE,
+                List.of(), Optional.empty(),
+                tokens, duration);
+    }
+
+    private static UseCaseOutcome<String, Integer> outcomeOkWith(
+            List<PostconditionResult> results, Optional<MatchResult> match,
+            Duration duration, long tokens) {
+        return new UseCaseOutcome<>(
+                Outcome.ok(0), USE_CASE,
+                results, match,
+                tokens, duration);
+    }
+
+    private static UseCaseOutcome<String, Integer> outcomeFail(
+            String name, String message, Duration duration, long tokens) {
+        return new UseCaseOutcome<>(
+                Outcome.fail(name, message), USE_CASE,
+                List.of(), Optional.empty(),
+                tokens, duration);
+    }
+
+    @Nested
+    @DisplayName("classify")
+    class Classify {
+
+        @Test
+        @DisplayName("apply-level Outcome.Fail produces failedAtApply classification")
+        void applyFail() {
+            var outcome = outcomeFail("llm-error", "boom", Duration.ofMillis(50), 0L);
+
+            SampleClassification c = SampleClassification.classify(USE_CASE, outcome);
+
+            assertThat(c.applyFailed()).isTrue();
+            assertThat(c.applyFailureName()).contains("llm-error");
+            assertThat(c.applyFailureMessage()).contains("boom");
+            assertThat(c.postconditionResults()).isEmpty();
+            assertThat(c.match()).isEmpty();
+            assertThat(c.durationViolation()).isEmpty();
+            assertThat(c.duration()).isEqualTo(Duration.ofMillis(50));
+        }
+
+        @Test
+        @DisplayName("apply-level Outcome.Ok with no max-latency yields no duration violation")
+        void okNoMaxLatency() {
+            var outcome = outcomeOk(42, Duration.ofSeconds(5), 100L);
+
+            SampleClassification c = SampleClassification.classify(USE_CASE, outcome);
+
+            assertThat(c.applyFailed()).isFalse();
+            assertThat(c.durationViolation()).isEmpty();
+            assertThat(c.duration()).isEqualTo(Duration.ofSeconds(5));
+            assertThat(c.tokens()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("apply-level Outcome.Ok exceeding max-latency surfaces a DurationViolation")
+        void okExceedingMaxLatency() {
+            UseCase<Factors, String, Integer> bounded = new UseCase<>() {
+                @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) { return Outcome.ok(0); }
+                @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+                @Override public Optional<Duration> maxLatency() {
+                    return Optional.of(Duration.ofMillis(100));
+                }
+            };
+            var outcome = new UseCaseOutcome<>(
+                    Outcome.ok(0), bounded, List.<PostconditionResult>of(), Optional.<MatchResult>empty(),
+                    0L, Duration.ofMillis(250));
+
+            SampleClassification c = SampleClassification.classify(bounded, outcome);
+
+            assertThat(c.durationViolation()).isPresent();
+            assertThat(c.durationViolation().get().observed()).isEqualTo(Duration.ofMillis(250));
+            assertThat(c.durationViolation().get().max()).isEqualTo(Duration.ofMillis(100));
+        }
+
+        @Test
+        @DisplayName("apply-level Outcome.Ok at exactly max-latency does not violate")
+        void okAtMaxLatencyExact() {
+            UseCase<Factors, String, Integer> bounded = new UseCase<>() {
+                @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) { return Outcome.ok(0); }
+                @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+                @Override public Optional<Duration> maxLatency() {
+                    return Optional.of(Duration.ofMillis(100));
+                }
+            };
+            var outcome = new UseCaseOutcome<>(
+                    Outcome.ok(0), bounded, List.<PostconditionResult>of(), Optional.<MatchResult>empty(),
+                    0L, Duration.ofMillis(100));
+
+            SampleClassification c = SampleClassification.classify(bounded, outcome);
+
+            assertThat(c.durationViolation()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("postcondition results are pre-evaluated and surfaced unchanged")
+        void postconditionResultsCarried() {
+            var results = List.of(
+                    PostconditionResult.passed("first"),
+                    PostconditionResult.failed("second", "tripped"));
+            var outcome = outcomeOkWith(results, Optional.empty(), Duration.ofMillis(20), 5L);
+
+            SampleClassification c = SampleClassification.classify(USE_CASE, outcome);
+
+            assertThat(c.postconditionResults()).hasSize(2);
+            assertThat(c.postconditionResults().get(1).failed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("match status is forwarded from the outcome")
+        void matchForwarded() {
+            var match = MatchResult.fail("equals", 1, 2, "1 != 2");
+            var outcome = outcomeOkWith(List.of(), Optional.of(match), Duration.ofMillis(1), 0L);
+
+            SampleClassification c = SampleClassification.classify(USE_CASE, outcome);
+
+            assertThat(c.match()).contains(match);
+        }
+    }
+
+    @Nested
+    @DisplayName("validation")
+    class Validation {
+
+        @Test
+        @DisplayName("negative tokens are rejected")
+        void rejectsNegativeTokens() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> SampleClassification.failedAtApply(
+                            "x", "y", Duration.ZERO, -1L));
+        }
+
+        @Test
+        @DisplayName("negative duration is rejected")
+        void rejectsNegativeDuration() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> SampleClassification.failedAtApply(
+                            "x", "y", Duration.ofMillis(-1), 0L));
+        }
+
+        @Test
+        @DisplayName("postcondition list is defensively copied")
+        void postconditionResultsCopied() {
+            var mutable = new java.util.ArrayList<PostconditionResult>();
+            mutable.add(PostconditionResult.passed("a"));
+
+            SampleClassification c = SampleClassification.from(
+                    mutable, Optional.empty(), Optional.empty(),
+                    Duration.ZERO, 0L);
+
+            mutable.add(PostconditionResult.failed("b", "intruder"));
+
+            assertThat(c.postconditionResults()).hasSize(1);
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/Engine.java
@@ -17,6 +17,7 @@ import org.javai.punit.api.typed.spec.BaselineProvider;
 import org.javai.punit.api.typed.spec.Configuration;
 import org.javai.punit.api.typed.spec.EngineResult;
 import org.javai.punit.api.typed.spec.ExceptionPolicy;
+import org.javai.punit.api.typed.spec.SampleClassification;
 import org.javai.punit.api.typed.spec.SampleExecutor;
 import org.javai.punit.api.typed.spec.SampleObserver;
 import org.javai.punit.api.typed.spec.SampleSummary;
@@ -101,9 +102,7 @@ public final class Engine {
         Aggregator<IT, OT> agg = new Aggregator<>(
                 useCase,
                 cfg.inputs(),
-                cfg.expected(),
                 cycleStart,
-                spec.matcher(),
                 spec.exceptionPolicy(),
                 spec.maxExampleFailures(),
                 tracker);
@@ -112,6 +111,8 @@ public final class Engine {
         executor.runSamples(
                 useCase,
                 cfg.inputs(),
+                cfg.expected(),
+                spec.matcher(),
                 cfg.samples(),
                 cycleStart,
                 agg,
@@ -130,9 +131,7 @@ public final class Engine {
 
         private final UseCase<?, IT, OT> useCase;
         private final List<IT> inputs;
-        private final List<OT> expected;
         private final int cycleStart;
-        private final Optional<ValueMatcher<OT>> matcher;
         private final ExceptionPolicy exceptionPolicy;
         private final int maxExampleFailures;
         private final BudgetTracker tracker;
@@ -152,17 +151,13 @@ public final class Engine {
 
         Aggregator(UseCase<?, IT, OT> useCase,
                    List<IT> inputs,
-                   List<OT> expected,
                    int cycleStart,
-                   Optional<ValueMatcher<OT>> matcher,
                    ExceptionPolicy exceptionPolicy,
                    int maxExampleFailures,
                    BudgetTracker tracker) {
             this.useCase = useCase;
             this.inputs = inputs;
-            this.expected = expected;
             this.cycleStart = cycleStart;
-            this.matcher = matcher;
             this.exceptionPolicy = exceptionPolicy;
             this.maxExampleFailures = maxExampleFailures;
             this.tracker = tracker;
@@ -170,10 +165,11 @@ public final class Engine {
 
         @Override
         public void onSample(int index, UseCaseOutcome<?, OT> outcome, Duration elapsed) {
-            // outcome already carries duration from Contract.apply; ignore
-            // the executor's measurement (which is essentially the same).
-            UseCaseOutcome<?, OT> withMatch = maybeAttachMatch(index, outcome);
-            record(index, withMatch);
+            // The outcome already carries duration, tokens, postcondition
+            // results, and the optional match (set by Contract.apply form 3
+            // when the executor is configured for matching). The classifier
+            // adds the optional duration violation by reading useCase.maxLatency().
+            record(index, outcome, classify(outcome));
         }
 
         @Override
@@ -197,11 +193,22 @@ public final class Engine {
                     Optional.empty(),
                     0L,
                     elapsed);
-            record(index, synthetic);
+            record(index, synthetic, classify(synthetic));
         }
 
-        private void record(int index, UseCaseOutcome<?, OT> stamped) {
-            tracker.recordSampleTokens(stamped.tokens());
+        private SampleClassification classify(UseCaseOutcome<?, OT> outcome) {
+            // SampleClassification.classify wants UseCaseOutcome<I, OT>; the
+            // wildcard at this site is safe because all outcomes flowing
+            // through this aggregator come from the executor, which only
+            // produces UseCaseOutcome<IT, OT>.
+            @SuppressWarnings("unchecked")
+            UseCaseOutcome<IT, OT> typed = (UseCaseOutcome<IT, OT>) outcome;
+            return SampleClassification.classify(useCase, typed);
+        }
+
+        private void record(int index, UseCaseOutcome<?, OT> stamped,
+                            SampleClassification classification) {
+            tracker.recordSampleTokens(classification.tokens());
             allForLatency.add(stamped);
             trials.add(trialFor(index, stamped));
             boolean ok = stamped.value().isOk();
@@ -217,7 +224,7 @@ public final class Engine {
                     failuresDropped++;
                 }
             }
-            tokensConsumed += stamped.tokens() + tracker.tokenCharge();
+            tokensConsumed += classification.tokens() + tracker.tokenCharge();
         }
 
         private <I> Trial<IT, OT> trialFor(int index, UseCaseOutcome<I, OT> stamped) {
@@ -232,31 +239,6 @@ public final class Engine {
         private IT inputForIndex(int index) {
             int cycleIndex = (cycleStart + index) % inputs.size();
             return inputs.get(cycleIndex);
-        }
-
-        private UseCaseOutcome<?, OT> maybeAttachMatch(int index, UseCaseOutcome<?, OT> outcome) {
-            if (expected.isEmpty() || matcher.isEmpty()) {
-                return outcome;
-            }
-            if (!(outcome.result() instanceof org.javai.outcome.Outcome.Ok<OT> ok)) {
-                return outcome;   // can't compare against expected if no value produced
-            }
-            int cycleIndex = (cycleStart + index) % expected.size();
-            OT expectedValue = expected.get(cycleIndex);
-            OT actualValue = ok.value();
-            MatchResult result = matcher.get().match(expectedValue, actualValue);
-            return reconstructWithMatch(outcome, result);
-        }
-
-        private static <I, OT> UseCaseOutcome<I, OT> reconstructWithMatch(
-                UseCaseOutcome<I, OT> outcome, MatchResult match) {
-            return new UseCaseOutcome<>(
-                    outcome.result(),
-                    outcome.contract(),
-                    outcome.postconditionResults(),
-                    Optional.of(match),
-                    outcome.tokens(),
-                    outcome.duration());
         }
 
         SampleSummary<OT> toSummary(Duration elapsed) {

--- a/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
@@ -2,12 +2,14 @@ package org.javai.punit.engine;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
 import org.javai.punit.api.typed.Pacing;
 import org.javai.punit.api.typed.TokenTracker;
 import org.javai.punit.api.typed.UseCase;
 import org.javai.punit.api.typed.UseCaseOutcome;
+import org.javai.punit.api.typed.ValueMatcher;
 import org.javai.punit.api.typed.spec.SampleExecutor;
 import org.javai.punit.api.typed.spec.SampleObserver;
 
@@ -55,6 +57,8 @@ public final class SerialSampleExecutor implements SampleExecutor {
     public <FT, IT, OT> void runSamples(
             UseCase<FT, IT, OT> useCase,
             List<IT> inputs,
+            List<OT> expected,
+            Optional<ValueMatcher<OT>> matcher,
             int sampleCount,
             int cycleStart,
             SampleObserver<OT> observer,
@@ -66,10 +70,15 @@ public final class SerialSampleExecutor implements SampleExecutor {
         if (sampleCount < 0) {
             throw new IllegalArgumentException("sampleCount must be non-negative");
         }
+        if (!expected.isEmpty() && matcher.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "matcher is required when expected outputs are supplied");
+        }
 
         Pacing pacing = useCase.pacing();
         long minDelayMillis = pacing.effectiveMinDelayMillis();
         TokenTracker tracker = new InMemoryTokenTracker();
+        boolean matching = !expected.isEmpty();
 
         for (int i = 0; i < sampleCount; i++) {
             if (stopRequested.getAsBoolean()) {
@@ -81,11 +90,17 @@ public final class SerialSampleExecutor implements SampleExecutor {
                     return;
                 }
             }
-            IT input = inputs.get((cycleStart + i) % inputs.size());
+            int inputIndex = (cycleStart + i) % inputs.size();
+            IT input = inputs.get(inputIndex);
             long t0 = System.nanoTime();
             UseCaseOutcome<IT, OT> outcome;
             try {
-                outcome = useCase.apply(input, tracker);
+                if (matching) {
+                    OT expectedValue = expected.get(inputIndex % expected.size());
+                    outcome = useCase.apply(input, expectedValue, matcher.get(), tracker);
+                } else {
+                    outcome = useCase.apply(input, tracker);
+                }
             } catch (Throwable t) {
                 Duration elapsed = Duration.ofNanos(System.nanoTime() - t0);
                 observer.onDefect(i, t, elapsed);


### PR DESCRIPTION
## Summary

Implements **Step 4** of [`DIR-CONTRACT-ON-USECASE-punit`](../../../javai-orchestrator/blob/main/plan/directives/DIR-CONTRACT-ON-USECASE-punit.md). Builds on #88, #89, #90.

### New types

**`SampleClassification`** — the engine's per-sample summary, built from a `UseCaseOutcome` plus the use case's max-latency bound. Two shapes:

- **Apply-level failure** — when `Contract.invoke` returned `Outcome.Fail`, postcondition evaluation is skipped; the classification carries the failure name+message, duration, and tokens.
- **Apply-level success** — postcondition results (pre-evaluated on the outcome), optional `MatchResult`, optional `DurationViolation`, duration, tokens.

A static `SampleClassification.classify(useCase, outcome)` helper does the construction. Reads only the outcome and the use case's `maxLatency()` — does not consult the contract's clauses (those are already pre-evaluated and carried on the outcome).

**`DurationViolation`** — small record `(observed: Duration, max: Duration)` surfaced on the classification when the sample exceeded the use case's declared per-sample bound.

### Engine reshape

- `SampleExecutor.runSamples` signature gains `expected: List<OT>` and `matcher: Optional<ValueMatcher<OT>>` parameters.
- `SerialSampleExecutor` dispatches per sample to `Contract.apply` form 3 (`input + expected + matcher + tracker`) when matching is configured, and to form 1 (`input + tracker`) otherwise. The decision happens in the executor; the aggregator no longer reconstructs match post-hoc.
- `Engine.runConfig` passes `cfg.expected()` and `spec.matcher()` to the executor.
- `Engine.Aggregator` drops the `matcher`/`expected`/`maybeAttachMatch` plumbing. `onSample` classifies via `SampleClassification.classify` and feeds the classification into the existing `record()` logic. `onDefect` synthesises an outcome and classifies it the same way.

### What's deferred to Step 5

The aggregator's per-sample data still flows into `SampleSummary`'s existing fields (`outcomes`, `trials`, success/failure counts). Step 5 will surface the per-postcondition failure histogram (`failuresByPostcondition`) on the summary and downstream consumers (`ProbabilisticTestResult`, `FactorsStepper.IterationResult`, explore-experiment diff output).

## Test plan

- [x] `./gradlew :punit-api:test --tests "*SampleClassificationTest"` — 9 new cases pin classifier behaviour: apply-level fail, max-latency over/at-exact/under, postcondition forwarding, match forwarding, defensive copy of clauses, validation
- [x] `./gradlew test` — green (all ~700+ punit tests pass)
- [x] `./gradlew build -x :punit-gradle-plugin:test` — green (ArchUnit module-isolation checks intact)
- [x] `cd ../punitexamples && ./gradlew compileJava compileTestJava` — green
- [ ] Reviewer pulls the branch and runs the same locally for verification
- [ ] Reviewer confirms `SerialSampleExecutor`'s dispatch logic: empty `expected` ⇒ form 1; non-empty `expected` + matcher ⇒ form 3; mismatched length is a configuration error caught earlier (validated by `Configuration` constructor)
- [ ] Reviewer confirms the duration-violation semantics: observed > max ⇒ violation; observed == max ⇒ no violation (pinned by `okAtMaxLatencyExact`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)