### PR TITLE
Step 5 finish: FactorsStepper.IterationResult carries failuresByPostcondition + flattened exemplars

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
@@ -418,7 +418,20 @@ public final class Experiment implements Spec {
 
         @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
             double score = scorer.score(summary);
-            history.add(new IterationResult<>(config.factors(), score));
+            history.add(new IterationResult<>(
+                    config.factors(),
+                    score,
+                    summary.failuresByPostcondition(),
+                    flattenExemplars(summary.failuresByPostcondition())));
+        }
+
+        private static List<FailureExemplar> flattenExemplars(
+                Map<String, FailureCount> byClause) {
+            List<FailureExemplar> all = new ArrayList<>();
+            for (FailureCount bucket : byClause.values()) {
+                all.addAll(bucket.exemplars());
+            }
+            return List.copyOf(all);
         }
 
         @Override public EngineResult conclude(BaselineProvider provider) {

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/FactorsStepper.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/FactorsStepper.java
@@ -1,6 +1,8 @@
 package org.javai.punit.api.typed.spec;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Produces the next factors for an {@link Experiment} iteration
@@ -29,9 +31,47 @@ public interface FactorsStepper<FT> {
     /**
      * One entry in the optimize history fed to {@link #next}.
      *
+     * <p>{@link #failuresByPostcondition()} carries the per-clause
+     * failure counts and bounded exemplars from the iteration's
+     * {@link SampleSummary}, so a meta-LLM driving the search can
+     * compose a meaningful improvement prompt that says <em>which</em>
+     * postconditions tripped and <em>what inputs</em> tripped them.
+     *
+     * <p>{@link #failureExemplars()} is a bounded flattened view of
+     * the same data — the union of all per-clause exemplars across
+     * all clauses, useful when the search wants to see "concrete
+     * failed samples" without bucketing.
+     *
      * @param factors the factors evaluated in that iteration
-     * @param score the score produced by the {@link Scorer} for that iteration
+     * @param score the score produced by the {@link Scorer}
+     * @param failuresByPostcondition per-clause failure counts +
+     *                                bounded exemplars
+     * @param failureExemplars        flattened bounded view across
+     *                                all clauses
      * @param <FT> the factor record type
      */
-    record IterationResult<FT>(FT factors, double score) {}
+    record IterationResult<FT>(
+            FT factors,
+            double score,
+            Map<String, FailureCount> failuresByPostcondition,
+            List<FailureExemplar> failureExemplars) {
+
+        public IterationResult {
+            Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
+            Objects.requireNonNull(failureExemplars, "failureExemplars");
+            failuresByPostcondition = Map.copyOf(failuresByPostcondition);
+            failureExemplars = List.copyOf(failureExemplars);
+        }
+
+        /**
+         * Backward-compatible constructor that defaults the histogram
+         * and exemplar list to empty. Used by call sites that haven't
+         * yet migrated to the canonical 4-field shape; the engine
+         * constructs results via the canonical constructor with
+         * populated histograms.
+         */
+        public IterationResult(FT factors, double score) {
+            this(factors, score, Map.of(), List.of());
+        }
+    }
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/PostconditionFailureHistogramTest.java
@@ -157,6 +157,43 @@ class PostconditionFailureHistogramTest {
         assertThat(result.failuresByPostcondition().get("evenFails").count()).isEqualTo(2);
     }
 
+    @Test
+    @DisplayName("Optimize stepper sees the histogram on each IterationResult")
+    void optimizeIterationCarriesHistogram() {
+        Sampling<Factors, Integer, Integer> sampling = Sampling
+                .<Factors, Integer, Integer>builder()
+                .useCaseFactory(f -> new TwoClauseUseCase())
+                .inputs(1, 2)
+                .samples(2)
+                .build();
+
+        // Minimal stepper: produce one more candidate, then stop.
+        var seenHistograms = new java.util.ArrayList<java.util.Map<String, FailureCount>>();
+        org.javai.punit.api.typed.spec.FactorsStepper<Factors> stepper =
+                (current, history) -> {
+                    history.forEach(h -> seenHistograms.add(h.failuresByPostcondition()));
+                    return history.size() >= 2 ? null : current;
+                };
+
+        Experiment spec = Experiment.optimizing(sampling)
+                .initialFactors(new Factors())
+                .stepper(stepper)
+                .maximize(s -> 1.0 / (1.0 + s.failures()))
+                .maxIterations(2)
+                .noImprovementWindow(10)
+                .experimentId("hist-test")
+                .build();
+
+        new Engine().run(spec);
+
+        // The stepper saw at least one IterationResult with a populated histogram.
+        assertThat(seenHistograms).isNotEmpty();
+        var lastSeen = seenHistograms.get(seenHistograms.size() - 1);
+        assertThat(lastSeen).containsKeys("alwaysFails", "evenFails");
+        assertThat(lastSeen.get("alwaysFails").count()).isEqualTo(2);
+        assertThat(lastSeen.get("evenFails").count()).isEqualTo(1);   // input 2
+    }
+
     // Suppress the (unused) ExperimentResult import — it's referenced by the test bodies above
     @SuppressWarnings("unused") private static final Class<?> KEEP_IMPORT = ExperimentResult.class;
     @SuppressWarnings("unused") private static final Class<?> KEEP_IMPORT_LIST = List.class;


### PR DESCRIPTION
## Summary

Closes the directive's **Step 5** data-collection surface. Builds on #92.

`FactorsStepper.IterationResult` gains two fields:

- `failuresByPostcondition: Map<String, FailureCount>` — the per-clause histogram from the iteration's `SampleSummary`.
- `failureExemplars: List<FailureExemplar>` — flattened union of per-clause exemplars across all clauses (per-clause cap of 3 already enforced upstream; flat-list size = ∑ exemplars-per-clause).

A backward-compatible 2-arg constructor preserves the prior `(factors, score)` shape for existing call sites.

`Experiment.optimizing`'s `consume()` builds the populated `IterationResult` by reading `summary.failuresByPostcondition()` directly.

### What this enables

The optimize search — including meta-LLM-driven steppers like the planned `ShoppingBasketOptimizePrompt` (Step 6) — can now see, per iteration, **which postconditions tripped** and **what inputs tripped them**. The meta-prompt template can render a "most common failure" section, closing the long-standing memory pin (`optimize stepper needs failure detail`).

### What's still deferred to Step 5b

The rendering layer:

- Verdict text + transparent stats output of the histogram on `ProbabilisticTestResult`.
- RP07 XML `<postcondition-failures>` block in verdict serialisation.
- Explore-experiment diff output grouping failures by postcondition.

The data is now collected and exposed on every result type the directive specifies; the renderers can land independently as a follow-up PR.

## Test plan

- [x] One new engine-integration test (`optimizeIterationCarriesHistogram`) pins that the optimize stepper sees the histogram on each `IterationResult`
- [x] `./gradlew test` — green (all ~700+ punit tests pass)
- [x] `./gradlew build -x :punit-gradle-plugin:test` — green (ArchUnit module-isolation checks intact)
- [ ] Reviewer pulls the branch and runs locally
- [ ] Reviewer confirms the flatten-exemplars semantics: union of per-clause exemplars; no dedup; size = ∑ per-clause counts (capped at 3 each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)