### PR TITLE
Step 5b (verdict text): render failuresByPostcondition in JUnit assertion message

### DIFF
--- a/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
@@ -236,7 +236,8 @@ public final class PUnit {
         return false;
     }
 
-    private static String formatMessage(ProbabilisticTestResult result) {
+    // Package-private for direct unit testing; not part of the public API.
+    static String formatMessage(ProbabilisticTestResult result) {
         StringBuilder sb = new StringBuilder();
         sb.append(result.verdict());
         List<EvaluatedCriterion> evaluated = result.criterionResults();

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
@@ -18,6 +18,8 @@ import org.javai.punit.api.typed.spec.EngineResult;
 import org.javai.punit.api.typed.spec.EvaluatedCriterion;
 import org.javai.punit.api.typed.spec.Experiment;
 import org.javai.punit.api.typed.spec.FactorsStepper;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
 import org.javai.punit.api.typed.spec.ProbabilisticTest;
 import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
 import org.javai.punit.api.typed.spec.Scorer;
@@ -289,6 +291,32 @@ public final class PUnit {
                     first = false;
                 }
                 sb.append('\n');
+            }
+        }
+        // Per-postcondition failure breakdown — when the contract has
+        // clauses and any of them tripped, surface the histogram so
+        // the developer sees which clause failed, how many times, and
+        // a small bounded set of input/reason exemplars. This is the
+        // diagnostic that turns "the test failed" into "this specific
+        // clause failed because the LLM produced X for input Y."
+        if (!result.failuresByPostcondition().isEmpty()) {
+            sb.append('\n').append("  Postcondition failures:").append('\n');
+            // Sort clauses by descending count so the most-common
+            // failure mode appears first.
+            var ordered = result.failuresByPostcondition().entrySet().stream()
+                    .sorted((a, b) -> Integer.compare(b.getValue().count(), a.getValue().count()))
+                    .toList();
+            for (var entry : ordered) {
+                FailureCount bucket = entry.getValue();
+                sb.append("    - \"").append(entry.getKey()).append("\" → ")
+                        .append(bucket.count()).append(" failures").append('\n');
+                int shown = 0;
+                for (FailureExemplar ex : bucket.exemplars()) {
+                    if (shown == 2) break;   // cap shown exemplars at 2 per clause
+                    sb.append("        e.g. \"").append(ex.input()).append("\" → ")
+                            .append(ex.reason()).append('\n');
+                    shown++;
+                }
             }
         }
         // Author-supplied audit pointer to the document the threshold

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitFormatMessageTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitFormatMessageTest.java
@@ -1,0 +1,129 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
+import org.javai.punit.api.typed.spec.CriterionResult;
+import org.javai.punit.api.typed.spec.CriterionRole;
+import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Focused tests for {@link PUnit#formatMessage(ProbabilisticTestResult)}.
+ * The method is package-private so these tests can call it directly with
+ * synthetic results, without standing up the engine.
+ */
+@DisplayName("PUnit.formatMessage — JUnit assertion-message rendering")
+class PUnitFormatMessageTest {
+
+    record Factors(String label) {}
+
+    private static final FactorBundle FACTORS = FactorBundle.of(new Factors("test"));
+
+    private static EvaluatedCriterion failingCriterion() {
+        return new EvaluatedCriterion(
+                new CriterionResult(
+                        "bernoulli-pass-rate",
+                        Verdict.FAIL,
+                        "observed=0.6500, threshold=0.9000",
+                        Map.of()),
+                CriterionRole.REQUIRED);
+    }
+
+    private static ProbabilisticTestResult resultWith(
+            Map<String, FailureCount> histogram) {
+        return new ProbabilisticTestResult(
+                Verdict.FAIL,
+                FACTORS,
+                List.of(failingCriterion()),
+                TestIntent.VERIFICATION,
+                List.of(),
+                CovariateAlignment.none(),
+                Optional.empty(),
+                histogram);
+    }
+
+    @Test
+    @DisplayName("empty histogram → no Postcondition failures section")
+    void emptyHistogramOmitsSection() {
+        var result = resultWith(Map.of());
+        String message = PUnit.formatMessage(result);
+
+        assertThat(message).doesNotContain("Postcondition failures");
+    }
+
+    @Test
+    @DisplayName("non-empty histogram → section appears with clause name and count")
+    void nonEmptyHistogramRendersSection() {
+        var hist = Map.of(
+                "Valid JSON", new FailureCount(8, List.of(
+                        new FailureExemplar("Add 2 apples", "Invalid JSON: trailing commentary"),
+                        new FailureExemplar("Clear the basket", "Invalid JSON: unexpected end of input"),
+                        new FailureExemplar("Remove the milk", "Invalid JSON: malformed brace"))));
+        String message = PUnit.formatMessage(resultWith(hist));
+
+        assertThat(message).contains("Postcondition failures:");
+        assertThat(message).contains("\"Valid JSON\" → 8 failures");
+        assertThat(message).contains("e.g. \"Add 2 apples\" → Invalid JSON: trailing commentary");
+        assertThat(message).contains("e.g. \"Clear the basket\" → Invalid JSON: unexpected end of input");
+    }
+
+    @Test
+    @DisplayName("displayed exemplars capped at 2 per clause")
+    void exemplarsCappedAtTwo() {
+        var hist = Map.of(
+                "Valid JSON", new FailureCount(3, List.of(
+                        new FailureExemplar("a", "first"),
+                        new FailureExemplar("b", "second"),
+                        new FailureExemplar("c", "third"))));
+        String message = PUnit.formatMessage(resultWith(hist));
+
+        assertThat(message).contains("e.g. \"a\" → first");
+        assertThat(message).contains("e.g. \"b\" → second");
+        assertThat(message).doesNotContain("\"c\" → third");
+    }
+
+    @Test
+    @DisplayName("clauses sorted by descending count — most common first")
+    void clausesSortedByDescendingCount() {
+        var hist = Map.of(
+                "Less common clause", new FailureCount(2, List.of(
+                        new FailureExemplar("x", "less"))),
+                "Most common clause", new FailureCount(10, List.of(
+                        new FailureExemplar("y", "most"))),
+                "Middle clause", new FailureCount(5, List.of(
+                        new FailureExemplar("z", "middle"))));
+        String message = PUnit.formatMessage(resultWith(hist));
+
+        int mostIdx = message.indexOf("\"Most common clause\"");
+        int middleIdx = message.indexOf("\"Middle clause\"");
+        int lessIdx = message.indexOf("\"Less common clause\"");
+
+        assertThat(mostIdx).isPositive();
+        assertThat(middleIdx).isGreaterThan(mostIdx);
+        assertThat(lessIdx).isGreaterThan(middleIdx);
+    }
+
+    @Test
+    @DisplayName("clause with zero exemplars: count line appears, no e.g. lines")
+    void clauseWithoutExemplars() {
+        var hist = Map.of(
+                "Synthetic clause", new FailureCount(0, List.of()));
+        String message = PUnit.formatMessage(resultWith(hist));
+
+        assertThat(message).contains("\"Synthetic clause\" → 0 failures");
+        // No exemplars rendered for a bucket with empty exemplar list
+        assertThat(message).doesNotContain("e.g.");
+    }
+}


### PR DESCRIPTION
## Summary

First slice of Step 5b — surfaces the per-postcondition failure histogram in the JUnit assertion message produced by the typed-pipeline `assertPasses()` when the verdict fails.

`PUnit.formatMessage(ProbabilisticTestResult)` already showed the verdict, criterion results, warnings, covariate alignment, and contract reference. It now also includes a "Postcondition failures" block when the contract has clauses and any of them tripped:

```
FAIL
  [REQUIRED] bernoulli-pass-rate → FAIL: observed=0.6500, threshold=0.9000

  Observed covariates: llm_model=gpt-4o-mini, temperature=0.3
  Postcondition failures:
    - "Valid JSON" → 8 failures
        e.g. "Add 2 apples" → Invalid JSON: trailing commentary
        e.g. "Clear the basket" → Invalid JSON: unexpected end of input
    - "All actions valid for context" → 3 failures
        e.g. "Add 3 oranges and 2 bananas" → Invalid action 'append' for context SHOP

  Contract: Acme API SLA v3.2 §2.1
```

Clauses sorted by descending count (most-common first); each shows the count + up to two input/reason exemplars. The 3-per-clause cap from the engine remains; the assertion message caps displayed exemplars at 2 to keep the failure output scannable.

### What's deferred to later Step 5b PRs

- Transparent stats output rendering — the verbose statistics section.
- RP07 XML `<postcondition-failures>` element in verdict serialisation.
- Explore-experiment diff output grouping by postcondition.

This is the highest-traffic surface (every developer running a typed-pipeline test reads this on failure); the others can land independently.

## Test plan

- [x] `./gradlew compileJava compileTestJava` — green
- [x] `./gradlew test` — green (all ~700+ punit tests pass; no existing tests asserted on the absence of this section)
- [ ] Reviewer pulls the branch and runs locally
- [ ] Reviewer inspects an actual failing typed-pipeline test (e.g. ShoppingBasketDiagnosticsTest in punitexamples) and confirms the new section appears, formatted reasonably, only when the histogram is non-empty
- [ ] Reviewer confirms passing tests don't render the section (it's gated on `!result.failuresByPostcondition().isEmpty()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)