### PR TITLE
Step 5b (transparent stats): render failuresByPostcondition in verbose output

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/TypedTransparentStatsRenderer.java
@@ -9,6 +9,8 @@ import org.javai.punit.api.typed.covariate.CovariateAlignment;
 import org.javai.punit.api.typed.covariate.CovariateProfile;
 import org.javai.punit.api.typed.spec.CriterionResult;
 import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
 import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
 import org.javai.punit.api.typed.spec.Verdict;
 
@@ -86,6 +88,8 @@ public final class TypedTransparentStatsRenderer {
         for (EvaluatedCriterion entry : result.criterionResults()) {
             renderCriterion(sb, entry);
         }
+
+        renderPostconditionFailures(sb, result.failuresByPostcondition());
 
         if (!result.warnings().isEmpty()) {
             sb.append("  Notes\n");
@@ -258,5 +262,34 @@ public final class TypedTransparentStatsRenderer {
             out.put(cr.criterionName(), cr.detail());
         }
         return out;
+    }
+
+    /**
+     * Renders the per-postcondition failure histogram. Empty when the
+     * contract has no clauses, or when every clause held on every
+     * sample. Clauses are presented in descending count order so the
+     * most-common failure mode appears first; each clause shows its
+     * count and every retained exemplar (engine cap of 3 per clause).
+     */
+    private static void renderPostconditionFailures(
+            StringBuilder sb, Map<String, FailureCount> byClause) {
+        if (byClause.isEmpty()) {
+            return;
+        }
+        sb.append("  Postcondition failures\n");
+        var ordered = byClause.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue().count(), a.getValue().count()))
+                .toList();
+        for (var entry : ordered) {
+            FailureCount bucket = entry.getValue();
+            sb.append("    ").append(entry.getKey())
+                    .append(" — ").append(bucket.count()).append(" failure")
+                    .append(bucket.count() == 1 ? "" : "s").append('\n');
+            for (FailureExemplar ex : bucket.exemplars()) {
+                sb.append("      • ").append(ex.input())
+                        .append(" → ").append(ex.reason()).append('\n');
+            }
+        }
+        sb.append('\n');
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/reporting/TypedTransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/reporting/TypedTransparentStatsRendererTest.java
@@ -301,4 +301,89 @@ class TypedTransparentStatsRendererTest {
         assertThat(snapshot.get("percentile-latency"))
                 .containsEntry("p99", "PT0.010S");
     }
+
+    @Nested
+    @DisplayName("Postcondition failures rendering")
+    class PostconditionFailures {
+
+        private ProbabilisticTestResult resultWithHistogram(
+                Map<String, org.javai.punit.api.typed.spec.FailureCount> hist) {
+            return new ProbabilisticTestResult(
+                    Verdict.FAIL, FactorBundle.empty(),
+                    List.of(criterion("bernoulli-pass-rate", Verdict.FAIL,
+                            "observed=0.65", Map.of())),
+                    TestIntent.VERIFICATION,
+                    List.of(),
+                    CovariateAlignment.none(),
+                    java.util.Optional.empty(),
+                    hist);
+        }
+
+        @Test
+        @DisplayName("empty histogram → no Postcondition failures section")
+        void emptyHistogramOmitsSection() {
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithHistogram(Map.of()));
+
+            assertThat(rendered).doesNotContain("Postcondition failures");
+        }
+
+        @Test
+        @DisplayName("non-empty histogram renders section with all retained exemplars")
+        void rendersSection() {
+            var hist = Map.of(
+                    "Valid JSON", new org.javai.punit.api.typed.spec.FailureCount(8, List.of(
+                            new org.javai.punit.api.typed.spec.FailureExemplar(
+                                    "Add 2 apples", "trailing commentary"),
+                            new org.javai.punit.api.typed.spec.FailureExemplar(
+                                    "Clear the basket", "unexpected end of input"),
+                            new org.javai.punit.api.typed.spec.FailureExemplar(
+                                    "Remove the milk", "malformed brace"))));
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithHistogram(hist));
+
+            assertThat(rendered).contains("Postcondition failures");
+            assertThat(rendered).contains("Valid JSON — 8 failures");
+            // All three retained exemplars are surfaced (engine cap of 3 per
+            // clause; transparent stats shows them all — no further truncation).
+            assertThat(rendered).contains("• Add 2 apples → trailing commentary");
+            assertThat(rendered).contains("• Clear the basket → unexpected end of input");
+            assertThat(rendered).contains("• Remove the milk → malformed brace");
+        }
+
+        @Test
+        @DisplayName("clauses sorted by descending count")
+        void sortedByDescendingCount() {
+            var hist = Map.of(
+                    "Less common", new org.javai.punit.api.typed.spec.FailureCount(2, List.of()),
+                    "Most common", new org.javai.punit.api.typed.spec.FailureCount(10, List.of()),
+                    "Middle", new org.javai.punit.api.typed.spec.FailureCount(5, List.of()));
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithHistogram(hist));
+
+            int mostIdx = rendered.indexOf("Most common");
+            int middleIdx = rendered.indexOf("Middle");
+            int lessIdx = rendered.indexOf("Less common");
+
+            assertThat(mostIdx).isPositive();
+            assertThat(middleIdx).isGreaterThan(mostIdx);
+            assertThat(lessIdx).isGreaterThan(middleIdx);
+        }
+
+        @Test
+        @DisplayName("count of 1 uses singular 'failure', > 1 uses plural")
+        void singularPluralAgreement() {
+            var hist = Map.of(
+                    "Single trip", new org.javai.punit.api.typed.spec.FailureCount(1, List.of()),
+                    "Multi trip", new org.javai.punit.api.typed.spec.FailureCount(5, List.of()));
+
+            String rendered = TypedTransparentStatsRenderer.render(
+                    "test", resultWithHistogram(hist));
+
+            assertThat(rendered).contains("Single trip — 1 failure\n");
+            assertThat(rendered).contains("Multi trip — 5 failures\n");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Second slice of Step 5b — surfaces the per-postcondition failure histogram in `TypedTransparentStatsRenderer`'s verbose output (the `transparentStats()` opt-in path).

The renderer already emitted: covariate alignment, criterion results, warnings, test intent, contract reference. It now also includes a "Postcondition failures" section between the criterion results and the warnings block:

```
  Postcondition failures
    Valid JSON — 8 failures
      • Add 2 apples → trailing commentary outside JSON
      • Clear the basket → unexpected end of input
      • Remove the milk → malformed brace
    All actions valid for context — 3 failures
      • Add 3 oranges and 2 bananas → Invalid action 'append' for context SHOP
```

Clauses sorted by descending count (most-common first); each clause shows count + every retained exemplar (engine cap of 3 per clause).

The transparent-stats path is the audit / compliance one — verbose by design — so we don't truncate exemplars further beyond the engine cap. The JUnit assertion-message path (`PUnit.formatMessage`, [#94](https://github.com/javai-org/punit/pull/94)) caps displayed exemplars at 2 for scannability; the transparent-stats path shows everything retained.

### What's left in Step 5b

- RP07 XML `<postcondition-failures>` element in verdict serialisation.
- Explore-experiment diff output grouping by postcondition.

## Test plan

- [x] 4 new test cases in `TypedTransparentStatsRendererTest$PostconditionFailures`: empty → no section, non-empty → all exemplars rendered, descending-count sort, singular/plural agreement
- [x] `./gradlew test` — green; existing renderer tests unaffected
- [ ] Reviewer pulls the branch and runs locally
- [ ] Reviewer confirms the section position (between criteria and warnings) reads naturally in the full transparent-stats output

🤖 Generated with [Claude Code](https://claude.com/claude-code)