### PR TITLE
Step 5b (explore diff): per-config postcondition histograms in artefact message

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/Experiment.java
@@ -341,9 +341,53 @@ public final class Experiment implements Spec {
 
         @Override public EngineResult conclude(BaselineProvider provider) {
             Path dir = Paths.get("explorations", experimentId);
-            String message = "explore artefact (stage 2 placeholder); configurations="
-                    + perConfig.size();
-            return new ExperimentResult(message, dir);
+            StringBuilder message = new StringBuilder("explore artefact (stage 2 placeholder); configurations=")
+                    .append(perConfig.size());
+            renderPerConfigHistograms(message);
+            return new ExperimentResult(message.toString(), dir);
+        }
+
+        /**
+         * Renders the per-configuration postcondition-failure histograms
+         * as a "diff-style" appendix to the explore artefact message —
+         * one block per grid point, so readers see at a glance which
+         * configurations tripped which clauses. Configurations with no
+         * postcondition failures emit a one-line marker so the column
+         * structure stays visible.
+         *
+         * <p>This is a placeholder rendering until the typed-pipeline
+         * gains a real explore-diff output writer; once that lands, the
+         * same per-config data feeds into a structured artefact instead
+         * of an inline message string.
+         */
+        private void renderPerConfigHistograms(StringBuilder out) {
+            boolean anyHistogram = false;
+            for (var summary : perConfig.values()) {
+                if (!summary.failuresByPostcondition().isEmpty()) {
+                    anyHistogram = true;
+                    break;
+                }
+            }
+            if (!anyHistogram) {
+                return;
+            }
+            out.append('\n').append("Failure breakdown by configuration:");
+            for (var entry : perConfig.entrySet()) {
+                out.append('\n').append("  config=").append(entry.getKey()).append(':');
+                var hist = entry.getValue().failuresByPostcondition();
+                if (hist.isEmpty()) {
+                    out.append(" (no postcondition failures)");
+                    continue;
+                }
+                var ordered = hist.entrySet().stream()
+                        .sorted((a, b) -> Integer.compare(b.getValue().count(), a.getValue().count()))
+                        .toList();
+                for (var clause : ordered) {
+                    out.append('\n').append("    ").append(clause.getKey())
+                       .append(": ").append(clause.getValue().count()).append(" failure")
+                       .append(clause.getValue().count() == 1 ? "" : "s");
+                }
+            }
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/PostconditionFailureHistogramTest.java
@@ -194,6 +194,43 @@ class PostconditionFailureHistogramTest {
         assertThat(lastSeen.get("evenFails").count()).isEqualTo(1);   // input 2
     }
 
+    record GridFactors(String label) {}
+
+    /** A two-clause use case keyed on GridFactors so the explore test
+     *  can use distinct grid points. */
+    private static class GridTwoClauseUseCase implements UseCase<GridFactors, Integer, Integer> {
+        @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
+        @Override public void postconditions(ContractBuilder<Integer> b) {
+            b.ensure("alwaysFails", v -> Outcome.fail("alwaysFails", "input " + v));
+        }
+    }
+
+    @Test
+    @DisplayName("Explore artefact message renders per-config failure breakdown")
+    void exploreArtefactSurfacesPerConfigHistogram() {
+        var sampling = Sampling
+                .<GridFactors, Integer, Integer>builder()
+                .useCaseFactory(f -> new GridTwoClauseUseCase())
+                .inputs(1)
+                .samples(1)
+                .build();
+
+        Experiment spec = Experiment.exploring(sampling)
+                .grid(new GridFactors("alpha"), new GridFactors("beta"))
+                .build();
+
+        var result = (ExperimentResult) new Engine().run(spec);
+
+        assertThat(result.message())
+                .contains("configurations=2")
+                .contains("Failure breakdown by configuration:")
+                .contains("config=GridFactors[label=alpha]")
+                .contains("config=GridFactors[label=beta]")
+                .contains("alwaysFails: 1 failure");
+    }
+
     // Suppress the (unused) ExperimentResult import — it's referenced by the test bodies above
     @SuppressWarnings("unused") private static final Class<?> KEEP_IMPORT = ExperimentResult.class;
     @SuppressWarnings("unused") private static final Class<?> KEEP_IMPORT_LIST = List.class;


### PR DESCRIPTION
## Summary

Closes the explore-artefact slice of Step 5b. The `Experiment.exploring(sampling).grid(...)` artefact message now surfaces a per-configuration breakdown of postcondition failures, drawn from the histograms each `SampleSummary` already carries.

Format:

```
explore artefact (stage 2 placeholder); configurations=2
Failure breakdown by configuration:
  config=GridFactors[label=alpha]:
    alwaysFails: 1 failure
  config=GridFactors[label=beta]:
    alwaysFails: 1 failure
```

Empty histograms render as `(no postcondition failures)`. Clauses sort by descending count so the dominant failure mode appears first per configuration.

This is the last of the four Step 5b surfaces (verdict text #94, transparent stats #95, RP07 XML #96, explore diff — this PR).

## Test plan

- [x] `./gradlew test` — full punit suite green
- [x] New test `exploreArtefactSurfacesPerConfigHistogram` in `PostconditionFailureHistogramTest`: exercises a 2-config grid with a clause that always fails; asserts `configurations=2`, the section header, both `config=GridFactors[...]` lines, and the `alwaysFails: 1 failure` count
- [ ] Manual smoke against punitexamples (deferred — no exploring experiment in examples yet)