### PR TITLE
Contract.invoke: Javadoc describes framework behaviour, drops policy-tone advice

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/Contract.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/Contract.java
@@ -46,23 +46,35 @@ public interface Contract<I, O> {
     /**
      * Invoke the service for one sample.
      *
-     * <p>Return {@link Outcome.Ok} carrying the produced value for a
-     * successful invocation, or {@link Outcome.Fail} for an expected
-     * business-level failure (a contract violation, a service-returned
-     * error code, an explicit refusal). The framework counts
-     * {@code Ok} samples as candidates for postcondition evaluation
-     * and {@code Fail} samples as apply-level failures, preserving the
-     * full {@link org.javai.outcome.Failure} for diagnostics.
+     * <h4>How the framework treats the return value</h4>
      *
-     * <p>Throwing from this method is reserved for <em>defects</em> —
-     * programming mistakes, misconfiguration, catastrophe. A thrown
-     * exception bubbles out and aborts the run. Do not throw to
-     * signal a failed sample; return {@code Outcome.fail(name, msg)}.
+     * <ul>
+     *   <li>{@link Outcome.Ok} — the framework treats the sample as a
+     *       candidate for postcondition evaluation. The carried value is
+     *       what each {@code ensure}/{@code deriving} clause sees.</li>
+     *   <li>{@link Outcome.Fail} — the framework treats the sample as an
+     *       apply-level failure. Postconditions are not evaluated (no
+     *       result was produced). The full {@link org.javai.outcome.Failure}
+     *       — symbolic name, message, optional cause — is preserved on
+     *       the {@link UseCaseOutcome} for diagnostics.</li>
+     * </ul>
      *
-     * <p>Record cost via {@code tracker.recordTokens(n)}. The
-     * framework derives the per-sample token count by diffing
-     * {@link TokenTracker#totalTokens()} before and after this call.
-     * Authors with no cost to track simply omit the call.
+     * <h4>How the framework treats a thrown exception</h4>
+     *
+     * <p>The framework does not catch exceptions thrown from this
+     * method. A thrown exception propagates out of the sample runner,
+     * out of the engine, and aborts the run. How an author handles
+     * exception-prone code inside this method body is their decision;
+     * the framework neither encourages nor discourages any particular
+     * pattern.
+     *
+     * <h4>Cost tracking</h4>
+     *
+     * <p>Call {@code tracker.recordTokens(n)} to record cost incurred
+     * during this invocation. The framework derives the per-sample
+     * token count by diffing {@link TokenTracker#totalTokens()} before
+     * and after the call. Authors with no cost to track simply omit
+     * the call.
      *
      * @param input   the per-sample input
      * @param tracker the per-run cost channel


### PR DESCRIPTION
## Summary

Recalibrates the Javadoc on \`Contract.invoke\` to describe **what the framework does** with the return value and a thrown exception, dropping the prescriptive tone of the earlier wording.

The earlier Javadoc said:
- "Throwing from this method is reserved for *defects* — programming mistakes, misconfiguration, catastrophe."
- "Do not throw to signal a failed sample; return \`Outcome.fail(name, msg)\`."

Both imposed authoring policy that punit has no business imposing. punit consumes Outcome at this API boundary because that is the framework's API; what philosophy an author adopts in their own service-call code — checked vs unchecked exceptions, adapter design, exception-handling pattern — is the author's choice.

## What the new Javadoc says

- **\`Outcome.Ok\`** → the framework evaluates postconditions against the carried value
- **\`Outcome.Fail\`** → the framework records an apply-level failure, postconditions are skipped, the \`Failure\` is preserved for diagnostics
- **Thrown exception** → propagates out of the sample runner and aborts the run; the framework does not catch
- **Cost tracking** → call \`tracker.recordTokens(n)\` if relevant; the engine diffs before and after

Authors decide how their own code handles failures. Some return Outcome from a clean adapter; others catch checked exceptions and translate; others let unchecked bubble. The framework is silent on which is right.

## Test plan

- [x] \`./gradlew :punit-api:compileJava :punit-core:compileJava :punit-junit5:compileJava\` — green
- [x] No code changes; documentation-only