### PR TITLE
RP07: emit <postcondition-failures> in XML and HTML reports

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
@@ -1,12 +1,14 @@
 package org.javai.punit.verdict;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.spec.FailureCount;
 import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
 import org.javai.punit.model.ExpirationStatus;
 import org.javai.punit.model.TerminationReason;
@@ -38,8 +40,47 @@ public record ProbabilisticTestVerdict(
         Map<String, String> environmentMetadata,
         boolean junitPassed,
         PUnitVerdict punitVerdict,
-        String verdictReason
+        String verdictReason,
+        Map<String, FailureCount> postconditionFailures
 ) {
+
+    public ProbabilisticTestVerdict {
+        // Preserve insertion order — clauses appear in the order the
+        // contract declared them. Map.copyOf does not guarantee order;
+        // unmodifiableMap(LinkedHashMap) does.
+        postconditionFailures = postconditionFailures != null
+                ? Collections.unmodifiableMap(new LinkedHashMap<>(postconditionFailures))
+                : Map.of();
+    }
+
+    /**
+     * Backward-compatible constructor for the 16-component shape that
+     * predates the per-postcondition failure histogram. Defaults the
+     * histogram to an empty map. Used by test fixtures and any
+     * legacy producer that doesn't yet thread the histogram through.
+     */
+    public ProbabilisticTestVerdict(
+            String correlationId,
+            Instant timestamp,
+            TestIdentity identity,
+            ExecutionSummary execution,
+            Optional<FunctionalDimension> functional,
+            Optional<LatencyDimension> latency,
+            StatisticalAnalysis statistics,
+            CovariateStatus covariates,
+            CostSummary cost,
+            Optional<PacingSummary> pacing,
+            Optional<SpecProvenance> provenance,
+            Termination termination,
+            Map<String, String> environmentMetadata,
+            boolean junitPassed,
+            PUnitVerdict punitVerdict,
+            String verdictReason) {
+        this(correlationId, timestamp, identity, execution, functional, latency,
+                statistics, covariates, cost, pacing, provenance, termination,
+                environmentMetadata, junitPassed, punitVerdict, verdictReason,
+                Map.of());
+    }
 
     // ── TestIdentity ──────────────────────────────────────────────────────
 

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.spec.FailureCount;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.controls.budget.CostBudgetMonitor;
 import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
@@ -101,6 +102,9 @@ public class ProbabilisticTestVerdictBuilder {
     // ── Verdicts ──────────────────────────────────────────────────────────
     private boolean junitPassed;
     private boolean passedStatistically;
+
+    // ── Postcondition failure histogram ───────────────────────────────────
+    private Map<String, FailureCount> postconditionFailures = Map.of();
 
     // ── Builder methods ───────────────────────────────────────────────────
 
@@ -248,6 +252,24 @@ public class ProbabilisticTestVerdictBuilder {
         return this;
     }
 
+    /**
+     * Per-postcondition failure histogram, keyed by clause description.
+     * Iteration order is preserved (the typed pipeline delivers a
+     * {@link java.util.LinkedHashMap}); the writer renders clauses in
+     * the order the contract declared them.
+     *
+     * @param postconditionFailures the histogram; {@code null} maps to
+     *                              an empty map
+     */
+    public ProbabilisticTestVerdictBuilder postconditionFailures(
+            Map<String, FailureCount> postconditionFailures) {
+        this.postconditionFailures = postconditionFailures != null
+                ? java.util.Collections.unmodifiableMap(
+                        new java.util.LinkedHashMap<>(postconditionFailures))
+                : Map.of();
+        return this;
+    }
+
     // ── Build ─────────────────────────────────────────────────────────────
 
     public ProbabilisticTestVerdict build() {
@@ -269,7 +291,8 @@ public class ProbabilisticTestVerdictBuilder {
                 id, Instant.now(),
                 identity, execution, functional, latency, statistics,
                 covariates, cost, pacing, provenance, termination,
-                environmentMetadata, junitPassed, punitVerdict, verdictReason
+                environmentMetadata, junitPassed, punitVerdict, verdictReason,
+                postconditionFailures
         );
     }
 

--- a/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
@@ -7,6 +7,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.ExecutionSummary;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.FunctionalDimension;
@@ -169,6 +171,9 @@ final class HtmlReportWriter {
         html.append("<pre class=\"level3\">").append(VerdictTextRenderer.renderStatisticalAnalysisHtml(verdict)).append("</pre>\n");
         html.append("</details>\n");
 
+        // Per-clause failure histogram (only when non-empty)
+        appendPostconditionFailures(html, verdict.postconditionFailures());
+
         html.append("</details>\n");
         html.append("</td>\n");
 
@@ -224,6 +229,47 @@ final class HtmlReportWriter {
         html.append("Re-run experiment to regenerate baseline: <code>./gradlew exp -Prun=")
                 .append(escape(simpleClassName)).append("</code>\n");
         html.append("</div>\n");
+    }
+
+    /**
+     * Renders the per-clause failure histogram as a nested {@code <details>}
+     * block. Clauses appear in declaration order. Each row shows the clause
+     * description, total count, and any retained exemplars. Omitted entirely
+     * when the histogram is empty (clean run, or contract with no clauses).
+     */
+    private static void appendPostconditionFailures(
+            StringBuilder html, Map<String, FailureCount> byClause) {
+        if (byClause == null || byClause.isEmpty()) {
+            return;
+        }
+        html.append("<details>\n");
+        html.append("<summary>Postcondition Failures</summary>\n");
+        html.append("<table class=\"postcondition-failures\">\n");
+        html.append("<thead><tr><th>Clause</th><th>Count</th><th>Exemplars</th></tr></thead>\n");
+        html.append("<tbody>\n");
+        for (Map.Entry<String, FailureCount> entry : byClause.entrySet()) {
+            FailureCount bucket = entry.getValue();
+            html.append("<tr>\n");
+            html.append("<td class=\"clause\">").append(escape(entry.getKey())).append("</td>\n");
+            html.append("<td class=\"count\">").append(bucket.count()).append("</td>\n");
+            html.append("<td class=\"exemplars\">");
+            if (bucket.exemplars().isEmpty()) {
+                html.append("<span class=\"no-exemplars\">(no exemplars retained)</span>");
+            } else {
+                html.append("<ul>\n");
+                for (FailureExemplar ex : bucket.exemplars()) {
+                    html.append("<li><code>").append(escape(ex.input()))
+                            .append("</code> &rarr; ").append(escape(ex.reason()))
+                            .append("</li>\n");
+                }
+                html.append("</ul>");
+            }
+            html.append("</td>\n");
+            html.append("</tr>\n");
+        }
+        html.append("</tbody>\n");
+        html.append("</table>\n");
+        html.append("</details>\n");
     }
 
     private static void appendLatencyCell(StringBuilder html, LatencyDimension lat,
@@ -402,6 +448,45 @@ final class HtmlReportWriter {
                     background: var(--bg-white);
                     padding: 0.1rem 0.4rem;
                     border-radius: 3px;
+                }
+                table.postcondition-failures {
+                    margin: 0.5rem 0 0.5rem 1.5rem;
+                    border-collapse: collapse;
+                    font-size: 0.8125rem;
+                    background: var(--bg-white);
+                }
+                table.postcondition-failures th,
+                table.postcondition-failures td {
+                    padding: 0.4rem 0.6rem;
+                    border: 1px solid var(--border-color);
+                    vertical-align: top;
+                    text-align: left;
+                }
+                table.postcondition-failures th {
+                    background: #f8f9fa;
+                    font-weight: 600;
+                    color: var(--text-muted);
+                }
+                table.postcondition-failures td.clause { font-weight: 500; }
+                table.postcondition-failures td.count {
+                    text-align: right;
+                    font-variant-numeric: tabular-nums;
+                    color: var(--fail-color);
+                    font-weight: 600;
+                }
+                table.postcondition-failures td.exemplars ul {
+                    margin: 0;
+                    padding-left: 1rem;
+                }
+                table.postcondition-failures td.exemplars li { margin: 0.1rem 0; }
+                table.postcondition-failures td.exemplars code {
+                    background: #f3f4f6;
+                    padding: 0.05rem 0.3rem;
+                    border-radius: 3px;
+                }
+                table.postcondition-failures .no-exemplars {
+                    color: var(--text-muted);
+                    font-style: italic;
                 }
                 .assumptions {
                     margin-bottom: 1.5rem;

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
@@ -7,6 +7,8 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
 import org.javai.punit.verdict.PUnitVerdict;
@@ -82,6 +84,7 @@ public final class VerdictXmlWriter {
         writeWarnings(w, v.statistics());
         v.pacing().ifPresent(p -> writePacingUnchecked(w, p));
         writeEnvironment(w, v.environmentMetadata());
+        writePostconditionFailures(w, v.postconditionFailures());
         writeVerdictElement(w, v);
 
         w.writeEndElement();
@@ -278,6 +281,35 @@ public final class VerdictXmlWriter {
             w.writeStartElement("entry");
             w.writeAttribute("key", entry.getKey());
             w.writeAttribute("value", entry.getValue());
+            w.writeEndElement();
+        }
+        w.writeEndElement();
+    }
+
+    /**
+     * Emits {@code <postcondition-failures>} per the RP07 schema. Iteration
+     * order of the map is preserved so clauses appear in the order the
+     * contract declared them (the typed pipeline delivers a
+     * {@link java.util.LinkedHashMap}). The writer emits whatever exemplars
+     * the producer retained — the engine caps the list at three per clause.
+     */
+    private void writePostconditionFailures(XMLStreamWriter w, Map<String, FailureCount> byClause)
+            throws XMLStreamException {
+        if (byClause == null || byClause.isEmpty()) {
+            return;
+        }
+        w.writeStartElement("postcondition-failures");
+        for (Map.Entry<String, FailureCount> entry : byClause.entrySet()) {
+            FailureCount bucket = entry.getValue();
+            w.writeStartElement("clause");
+            w.writeAttribute("description", entry.getKey());
+            w.writeAttribute("count", Integer.toString(bucket.count()));
+            for (FailureExemplar ex : bucket.exemplars()) {
+                w.writeStartElement("exemplar");
+                w.writeAttribute("input", ex.input());
+                w.writeAttribute("reason", ex.reason());
+                w.writeEndElement();
+            }
             w.writeEndElement();
         }
         w.writeEndElement();

--- a/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
@@ -2,10 +2,13 @@ package org.javai.punit.report;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
 import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
 import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
@@ -464,6 +467,76 @@ class HtmlReportWriterTest {
         }
     }
 
+    @Nested
+    @DisplayName("postcondition failures section")
+    class PostconditionFailuresSection {
+
+        @Test
+        @DisplayName("renders nested details with table when histogram is non-empty")
+        void rendersTableWhenPopulated() {
+            String html = HtmlReportWriter.generate(List.of(verdictWithPostconditionFailures()));
+
+            assertThat(html).contains("<summary>Postcondition Failures</summary>");
+            assertThat(html).contains("<table class=\"postcondition-failures\">");
+            assertThat(html).contains("<th>Clause</th>");
+            assertThat(html).contains("<th>Count</th>");
+            assertThat(html).contains("<th>Exemplars</th>");
+        }
+
+        @Test
+        @DisplayName("clauses appear in declaration (insertion) order")
+        void clausesInDeclarationOrder() {
+            String html = HtmlReportWriter.generate(List.of(verdictWithPostconditionFailures()));
+
+            int firstIdx = html.indexOf("Response not empty");
+            int secondIdx = html.indexOf("Valid JSON");
+            assertThat(firstIdx).isPositive();
+            assertThat(secondIdx).isGreaterThan(firstIdx);
+        }
+
+        @Test
+        @DisplayName("exemplars rendered as bullet list with code-formatted input")
+        void exemplarsRenderedAsList() {
+            String html = HtmlReportWriter.generate(List.of(verdictWithPostconditionFailures()));
+
+            assertThat(html).contains("<code>instr-7</code>");
+            assertThat(html).contains("missing actions");
+        }
+
+        @Test
+        @DisplayName("section omitted entirely when histogram is empty")
+        void omittedWhenEmpty() {
+            String html = HtmlReportWriter.generate(List.of(passingVerdict()));
+
+            assertThat(html).doesNotContain("Postcondition Failures");
+            assertThat(html).doesNotContain("table class=\"postcondition-failures\"");
+        }
+
+        @Test
+        @DisplayName("CSS includes postcondition-failures rules")
+        void cssRulesPresent() {
+            String html = HtmlReportWriter.generate(List.of(verdictWithPostconditionFailures()));
+
+            assertThat(html).contains("table.postcondition-failures");
+            assertThat(html).contains(".postcondition-failures td.count");
+        }
+
+        @Test
+        @DisplayName("escapes XML special characters in clause and exemplar fields")
+        void escapesSpecialCharacters() {
+            LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+            hist.put("clause with <chevrons> & \"quotes\"", new FailureCount(1, List.of(
+                    new FailureExemplar("input <bad>", "reason has \" & < & >"))));
+            ProbabilisticTestVerdict verdict = postconditionFailuresVerdict(hist);
+
+            String html = HtmlReportWriter.generate(List.of(verdict));
+
+            assertThat(html).contains("clause with &lt;chevrons&gt; &amp; &quot;quotes&quot;");
+            assertThat(html).contains("input &lt;bad&gt;");
+            assertThat(html).contains("reason has &quot; &amp; &lt; &amp; &gt;");
+        }
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
 
     private ProbabilisticTestVerdict passingVerdict() {
@@ -597,6 +670,31 @@ class HtmlReportWriterTest {
                 base.pacing(), Optional.of(prov), base.termination(),
                 base.environmentMetadata(), base.junitPassed(), base.punitVerdict(),
                 base.verdictReason()
+        );
+    }
+
+    private ProbabilisticTestVerdict verdictWithPostconditionFailures() {
+        LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+        hist.put("Response not empty", new FailureCount(2, List.of(
+                new FailureExemplar("instr-1", "blank"),
+                new FailureExemplar("instr-2", "blank"))));
+        hist.put("Valid JSON", new FailureCount(8, List.of(
+                new FailureExemplar("instr-7", "missing actions"),
+                new FailureExemplar("instr-9", "unexpected token"),
+                new FailureExemplar("instr-12", "trailing comma"))));
+        return postconditionFailuresVerdict(hist);
+    }
+
+    private ProbabilisticTestVerdict postconditionFailuresVerdict(
+            Map<String, FailureCount> hist) {
+        ProbabilisticTestVerdict base = passingVerdict();
+        return new ProbabilisticTestVerdict(
+                base.correlationId(), base.timestamp(), base.identity(), base.execution(),
+                base.functional(), base.latency(), base.statistics(), base.covariates(),
+                base.cost(), base.pacing(), base.provenance(), base.termination(),
+                base.environmentMetadata(), base.junitPassed(), base.punitVerdict(),
+                base.verdictReason(),
+                hist
         );
     }
 

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictXmlWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictXmlWriterTest.java
@@ -19,7 +19,11 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
+import java.util.LinkedHashMap;
+
 import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
 import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
 import org.javai.punit.model.ExpirationStatus;
 import org.javai.punit.model.TerminationReason;
@@ -407,6 +411,112 @@ class VerdictXmlWriterTest {
     }
 
     @Nested
+    @DisplayName("postcondition failures")
+    class PostconditionFailures {
+
+        @Test
+        @DisplayName("emits clauses in declaration (insertion) order with retained exemplars")
+        void emitsClausesInDeclarationOrder() throws Exception {
+            LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+            hist.put("Response not empty", new FailureCount(2, List.of(
+                    new FailureExemplar("instr-1", "blank"),
+                    new FailureExemplar("instr-2", "blank"))));
+            hist.put("Valid JSON", new FailureCount(8, List.of(
+                    new FailureExemplar("instr-7", "missing actions"),
+                    new FailureExemplar("instr-9", "unexpected token"),
+                    new FailureExemplar("instr-12", "trailing comma"))));
+            ProbabilisticTestVerdict verdict = verdictWithPostconditionFailures(hist);
+
+            Document doc = writeAndParse(verdict);
+            Element section = firstElement(doc, "postcondition-failures");
+            NodeList clauses = section.getElementsByTagNameNS(VerdictXmlWriter.NAMESPACE, "clause");
+
+            assertThat(clauses.getLength()).isEqualTo(2);
+            // Declaration (insertion) order is preserved — not sorted by count
+            assertThat(((Element) clauses.item(0)).getAttribute("description"))
+                    .isEqualTo("Response not empty");
+            assertThat(((Element) clauses.item(0)).getAttribute("count")).isEqualTo("2");
+            assertThat(((Element) clauses.item(1)).getAttribute("description"))
+                    .isEqualTo("Valid JSON");
+            assertThat(((Element) clauses.item(1)).getAttribute("count")).isEqualTo("8");
+
+            NodeList exemplars0 = ((Element) clauses.item(0))
+                    .getElementsByTagNameNS(VerdictXmlWriter.NAMESPACE, "exemplar");
+            assertThat(exemplars0.getLength()).isEqualTo(2);
+            assertThat(((Element) exemplars0.item(0)).getAttribute("input")).isEqualTo("instr-1");
+            assertThat(((Element) exemplars0.item(0)).getAttribute("reason")).isEqualTo("blank");
+
+            NodeList exemplars1 = ((Element) clauses.item(1))
+                    .getElementsByTagNameNS(VerdictXmlWriter.NAMESPACE, "exemplar");
+            assertThat(exemplars1.getLength()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("omits postcondition-failures element when histogram is empty")
+        void omitsWhenEmpty() throws Exception {
+            ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
+
+            Document doc = writeAndParse(verdict);
+            NodeList section = doc.getElementsByTagNameNS(
+                    VerdictXmlWriter.NAMESPACE, "postcondition-failures");
+
+            assertThat(section.getLength()).isZero();
+        }
+
+        @Test
+        @DisplayName("escapes XML special characters in input and reason attributes")
+        void escapesXmlSpecialChars() throws Exception {
+            LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+            hist.put("clause with <chevrons> & \"quotes\"", new FailureCount(1, List.of(
+                    new FailureExemplar("input <bad>", "reason has \" & < & >"))));
+            ProbabilisticTestVerdict verdict = verdictWithPostconditionFailures(hist);
+
+            // writeAndParse round-trips the XML; the parser will fail if
+            // the writer didn't escape correctly.
+            Document doc = writeAndParse(verdict);
+            Element clause = (Element) doc.getElementsByTagNameNS(
+                    VerdictXmlWriter.NAMESPACE, "clause").item(0);
+            Element exemplar = (Element) clause.getElementsByTagNameNS(
+                    VerdictXmlWriter.NAMESPACE, "exemplar").item(0);
+
+            assertThat(clause.getAttribute("description"))
+                    .isEqualTo("clause with <chevrons> & \"quotes\"");
+            assertThat(exemplar.getAttribute("input")).isEqualTo("input <bad>");
+            assertThat(exemplar.getAttribute("reason")).isEqualTo("reason has \" & < & >");
+        }
+
+        @Test
+        @DisplayName("clause with zero exemplars renders count without children")
+        void clauseWithZeroExemplars() throws Exception {
+            LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+            hist.put("noisy clause", new FailureCount(42, List.of()));
+            ProbabilisticTestVerdict verdict = verdictWithPostconditionFailures(hist);
+
+            Document doc = writeAndParse(verdict);
+            Element clause = (Element) doc.getElementsByTagNameNS(
+                    VerdictXmlWriter.NAMESPACE, "clause").item(0);
+
+            assertThat(clause.getAttribute("count")).isEqualTo("42");
+            NodeList exemplars = clause.getElementsByTagNameNS(
+                    VerdictXmlWriter.NAMESPACE, "exemplar");
+            assertThat(exemplars.getLength()).isZero();
+        }
+
+        @Test
+        @DisplayName("verdict with postcondition failures validates against RP07 XSD")
+        void validatesAgainstXsd() throws Exception {
+            LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+            hist.put("Response not empty", new FailureCount(3, List.of(
+                    new FailureExemplar("a", "blank"))));
+            ProbabilisticTestVerdict verdict = verdictWithPostconditionFailures(hist);
+
+            String xml = writeToString(verdict);
+
+            validateAgainstSchema(xml);
+        }
+    }
+
+    @Nested
     @DisplayName("schema validation")
     class SchemaValidation {
 
@@ -615,6 +725,19 @@ class VerdictXmlWriterTest {
                 base.pacing(), base.provenance(), base.termination(),
                 base.environmentMetadata(), base.junitPassed(), base.punitVerdict(),
                 base.verdictReason()
+        );
+    }
+
+    private ProbabilisticTestVerdict verdictWithPostconditionFailures(
+            Map<String, FailureCount> hist) {
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
+        return new ProbabilisticTestVerdict(
+                base.correlationId(), base.timestamp(), base.identity(), base.execution(),
+                base.functional(), base.latency(), base.statistics(), base.covariates(),
+                base.cost(), base.pacing(), base.provenance(), base.termination(),
+                base.environmentMetadata(), base.junitPassed(), base.punitVerdict(),
+                base.verdictReason(),
+                hist
         );
     }
 


### PR DESCRIPTION
## Summary

Closes the gap left by PR #96 / orchestrator PR #17: the RP07 schema declared `<postcondition-failures>` but neither verdict reporter (XML or HTML) was emitting it. This PR adds both. It is the first chunk of the typed-pipeline → RP07 wiring plan.

## Changes

### `ProbabilisticTestVerdict` (punit-core)

- Adds a 17th component: `Map<String, FailureCount> postconditionFailures`.
- Back-compat 16-arg constructor defaults to empty so 50+ existing fixture call sites compile unchanged.
- Insertion order preserved via `Collections.unmodifiableMap(new LinkedHashMap<>(input))` — the RP07 README mandates clauses in declaration order, and `Map.copyOf` does not guarantee order per its spec.

### `ProbabilisticTestVerdictBuilder` (punit-core)

- New builder method `postconditionFailures(Map<String, FailureCount>)`.

### `VerdictXmlWriter` (punit-report)

- Emits `<postcondition-failures>` between `<environment>` and `<verdict>`. Each clause renders its `description`, `count`, and retained `<exemplar>` children (engine cap of 3 per clause).

### `HtmlReportWriter` (punit-report)

- Renders a nested `<details>` section with a three-column table (Clause / Count / Exemplars). Section is omitted when the histogram is empty — clean runs stay terse.
- New CSS for the table.

## Test plan

- [x] `VerdictXmlWriterTest`: declaration-order preservation, exemplars retained, XML special-character escaping, omission when empty, zero-exemplar clause renders count, RP07 XSD validation passes with the section.
- [x] `HtmlReportWriterTest`: section renders, declaration order preserved, exemplars in code-formatted bullets, section omitted when empty, CSS rules present, HTML escaping.
- [x] `./gradlew test` — full punit suite green.

## Note on legacy pipeline

The legacy `SampleResultAggregator` does not currently populate the histogram, so verdicts produced by the legacy pipeline will continue to render with the section omitted. The typed-pipeline → `ProbabilisticTestVerdict` adapter (next PR in the plan) will populate it from the typed result's `failuresByPostcondition`.