### PR TITLE
ProbabilisticTestResult: add EngineRunSummary for run-level scalars

### DIFF
--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineLookup.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/BaselineLookup.java
@@ -37,34 +37,53 @@ import org.javai.punit.api.typed.covariate.CovariateProfile;
  * @param baselineProfile  the matched baseline's covariate profile,
  *                         when one was selected; otherwise empty
  * @param notes            rejection / fallback reasons; possibly empty
+ * @param sourceFile       filename of the matched baseline, when a
+ *                         candidate matched; surfaces to RP07 verdict
+ *                         XML's {@code <provenance spec-filename>} for
+ *                         audit traceability. Empty otherwise.
  */
 public record BaselineLookup<S extends BaselineStatistics>(
         Optional<S> selected,
         CovariateProfile baselineProfile,
-        List<String> notes) {
+        List<String> notes,
+        Optional<String> sourceFile) {
 
     public BaselineLookup {
         Objects.requireNonNull(selected, "selected");
         Objects.requireNonNull(baselineProfile, "baselineProfile");
         Objects.requireNonNull(notes, "notes");
+        Objects.requireNonNull(sourceFile, "sourceFile");
         notes = List.copyOf(notes);
     }
 
     /**
+     * Backward-compatible constructor that omits {@link #sourceFile()}.
+     * Defaults to {@link Optional#empty()}.
+     */
+    public BaselineLookup(
+            Optional<S> selected,
+            CovariateProfile baselineProfile,
+            List<String> notes) {
+        this(selected, baselineProfile, notes, Optional.empty());
+    }
+
+    /**
      * @return an empty lookup ({@link Optional#empty()} selected,
-     *         empty profile, no notes)
+     *         empty profile, no notes, no source file)
      */
     public static <S extends BaselineStatistics> BaselineLookup<S> empty() {
-        return new BaselineLookup<>(Optional.empty(), CovariateProfile.empty(), List.of());
+        return new BaselineLookup<>(
+                Optional.empty(), CovariateProfile.empty(), List.of(), Optional.empty());
     }
 
     /**
      * @return a lookup that wraps an existing {@code Optional<S>} with
-     *         no profile + no notes — convenience for default-method
-     *         delegates
+     *         no profile + no notes + no source file — convenience for
+     *         default-method delegates
      */
     public static <S extends BaselineStatistics> BaselineLookup<S> of(
             Optional<S> selected) {
-        return new BaselineLookup<>(selected, CovariateProfile.empty(), List.of());
+        return new BaselineLookup<>(
+                selected, CovariateProfile.empty(), List.of(), Optional.empty());
     }
 }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/EngineRunSummary.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/EngineRunSummary.java
@@ -1,0 +1,113 @@
+package org.javai.punit.api.typed.spec;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.javai.punit.api.typed.LatencyResult;
+
+/**
+ * Run-level scalar digest of a typed pipeline execution. Sits on
+ * {@link ProbabilisticTestResult} so consumers (verdict XML adapter,
+ * HTML report, audit dashboards) have a single typed bundle for the
+ * "what happened during the run" data — sample counts, timing, cost,
+ * latency, termination reason, baseline traceability.
+ *
+ * <p>This is a digest of {@link SampleSummary}, not a replacement for it.
+ * The summary's per-trial detail (the {@link UseCaseOutcome} list, the
+ * full {@link Trial} history) is still consumed inside {@code Spec.consume}
+ * for criterion evaluation; the {@code EngineRunSummary} preserves only
+ * the scalars that need to flow downstream after the spec has finished
+ * concluding.
+ *
+ * <p>{@link #plannedSamples()} differs from {@link #samplesExecuted()}
+ * when the run terminated early due to budget exhaustion. Together they
+ * tell a downstream consumer "we asked for N, we got M" — the difference
+ * matters for verdict-XML's {@code <execution planned-samples>} attribute
+ * and for any analysis of run completeness.
+ *
+ * <p>{@link #confidence()} is the statistical confidence level used by
+ * empirical criteria (default 0.95). Lifted to the run level so the
+ * verdict XML adapter and other consumers don't have to scrape it from
+ * a criterion's detail map.
+ *
+ * <p>{@link #baselineFilename()} carries the matched baseline file's name
+ * when an empirical criterion resolved against one — surfaced to the
+ * verdict XML's {@code <provenance spec-filename>} attribute for audit
+ * traceability. Empty when no empirical criterion ran or no baseline
+ * matched.
+ *
+ * @param plannedSamples     samples requested by the spec (from
+ *                           {@link Sampling#samples()}); non-negative
+ * @param samplesExecuted    samples actually executed (= successes +
+ *                           failures); non-negative; &le; plannedSamples
+ * @param successes          count of Ok-outcome samples; non-negative
+ * @param failures           count of Fail-outcome samples; non-negative
+ * @param elapsedMs          wall-clock time spent sampling, in
+ *                           milliseconds; non-negative
+ * @param tokensConsumed     sum of per-sample tokens plus the spec's
+ *                           static charge for each counted sample;
+ *                           non-negative
+ * @param failuresDropped    count of failing outcomes whose detail was
+ *                           elided due to {@link Sampling}'s
+ *                           {@code maxExampleFailures} cap; non-negative
+ * @param latencyResult      computed p50/p90/p95/p99 from the run's
+ *                           successful samples
+ * @param terminationReason  why the sample loop stopped
+ * @param confidence         statistical confidence level (1 − α) used
+ *                           by empirical criteria; in (0, 1)
+ * @param baselineFilename   filename of the matched baseline, when an
+ *                           empirical criterion resolved against one;
+ *                           {@link Optional#empty()} otherwise
+ */
+public record EngineRunSummary(
+        int plannedSamples,
+        int samplesExecuted,
+        int successes,
+        int failures,
+        long elapsedMs,
+        long tokensConsumed,
+        int failuresDropped,
+        LatencyResult latencyResult,
+        TerminationReason terminationReason,
+        double confidence,
+        Optional<String> baselineFilename) {
+
+    public EngineRunSummary {
+        Objects.requireNonNull(latencyResult, "latencyResult");
+        Objects.requireNonNull(terminationReason, "terminationReason");
+        Objects.requireNonNull(baselineFilename, "baselineFilename");
+        if (plannedSamples < 0 || samplesExecuted < 0
+                || successes < 0 || failures < 0) {
+            throw new IllegalArgumentException("counts must be non-negative");
+        }
+        if (elapsedMs < 0) {
+            throw new IllegalArgumentException("elapsedMs must be non-negative, got " + elapsedMs);
+        }
+        if (tokensConsumed < 0) {
+            throw new IllegalArgumentException("tokensConsumed must be non-negative, got " + tokensConsumed);
+        }
+        if (failuresDropped < 0) {
+            throw new IllegalArgumentException("failuresDropped must be non-negative, got " + failuresDropped);
+        }
+        if (Double.isNaN(confidence) || confidence <= 0.0 || confidence >= 1.0) {
+            throw new IllegalArgumentException(
+                    "confidence must be in (0, 1), got " + confidence);
+        }
+    }
+
+    /**
+     * Empty summary for tests and for call sites that don't carry
+     * engine-run data — defaults all scalars to zero, latency to
+     * {@link LatencyResult#empty()}, termination to
+     * {@link TerminationReason#COMPLETED}, confidence to 0.95, and
+     * {@link #baselineFilename()} to empty.
+     */
+    public static EngineRunSummary empty() {
+        return new EngineRunSummary(
+                0, 0, 0, 0, 0L, 0L, 0,
+                LatencyResult.empty(),
+                TerminationReason.COMPLETED,
+                0.95,
+                Optional.empty());
+    }
+}

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTest.java
@@ -189,6 +189,10 @@ public final class ProbabilisticTest implements Spec {
             // observed profile (post-stamped at the JUnit boundary).
             org.javai.punit.api.typed.covariate.CovariateProfile baselineProfile =
                     org.javai.punit.api.typed.covariate.CovariateProfile.empty();
+            // Same logic as baselineProfile: every empirical criterion
+            // that resolves for the same (useCaseId, factorsFingerprint)
+            // tuple sees the same baseline file, so first-non-empty wins.
+            Optional<String> baselineFilename = Optional.empty();
             for (Registered<OT> entry : registered) {
                 BaselineLookupCapture capture = new BaselineLookupCapture();
                 CriterionResult result = evaluate(
@@ -199,9 +203,13 @@ public final class ProbabilisticTest implements Spec {
                 if (baselineProfile.isEmpty() && !capture.profile.isEmpty()) {
                     baselineProfile = capture.profile;
                 }
+                if (baselineFilename.isEmpty() && capture.sourceFile.isPresent()) {
+                    baselineFilename = capture.sourceFile;
+                }
             }
 
             Verdict composed = Verdict.compose(evaluated);
+            EngineRunSummary engineSummary = buildEngineSummary(s, evaluated, baselineFilename);
             return new ProbabilisticTestResult(
                     composed, factorBundle, evaluated, intent,
                     List.copyOf(warnings),
@@ -209,7 +217,44 @@ public final class ProbabilisticTest implements Spec {
                             org.javai.punit.api.typed.covariate.CovariateProfile.empty(),
                             baselineProfile),
                     Optional.empty(),
-                    s.failuresByPostcondition());
+                    s.failuresByPostcondition(),
+                    engineSummary);
+        }
+
+        /**
+         * Build the engine-run summary from the captured
+         * {@link SampleSummary}, the evaluated criteria, and the
+         * matched-baseline source file. Confidence is lifted from the
+         * first criterion whose detail map carries a "confidence" entry
+         * (BernoulliPassRate); falls back to 0.95.
+         */
+        private EngineRunSummary buildEngineSummary(
+                SampleSummary<OT> s,
+                List<EvaluatedCriterion> evaluated,
+                Optional<String> baselineFilename) {
+            double confidence = scanConfidence(evaluated);
+            return new EngineRunSummary(
+                    sampling.samples(),
+                    s.total(),
+                    s.successes(),
+                    s.failures(),
+                    s.elapsed().toMillis(),
+                    s.tokensConsumed(),
+                    s.failuresDropped(),
+                    s.latencyResult(),
+                    s.terminationReason(),
+                    confidence,
+                    baselineFilename);
+        }
+
+        private static double scanConfidence(List<EvaluatedCriterion> evaluated) {
+            for (EvaluatedCriterion ec : evaluated) {
+                Object v = ec.result().detail().get("confidence");
+                if (v instanceof Number n) {
+                    return n.doubleValue();
+                }
+            }
+            return 0.95;
         }
 
         /**
@@ -225,6 +270,7 @@ public final class ProbabilisticTest implements Spec {
         private static final class BaselineLookupCapture {
             org.javai.punit.api.typed.covariate.CovariateProfile profile =
                     org.javai.punit.api.typed.covariate.CovariateProfile.empty();
+            Optional<String> sourceFile = Optional.empty();
         }
 
         private boolean anyEmpiricalCriterion() {
@@ -255,6 +301,7 @@ public final class ProbabilisticTest implements Spec {
                 resolved = lookup.selected();
                 warnings.addAll(lookup.notes());
                 capture.profile = lookup.baselineProfile();
+                capture.sourceFile = lookup.sourceFile();
             } else {
                 resolved = Optional.empty();
             }

--- a/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
+++ b/punit-api/src/main/java/org/javai/punit/api/typed/spec/ProbabilisticTestResult.java
@@ -63,7 +63,8 @@ public record ProbabilisticTestResult(
         List<String> warnings,
         CovariateAlignment covariates,
         Optional<String> contractRef,
-        Map<String, FailureCount> failuresByPostcondition) implements EngineResult {
+        Map<String, FailureCount> failuresByPostcondition,
+        EngineRunSummary engineSummary) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -74,6 +75,7 @@ public record ProbabilisticTestResult(
         Objects.requireNonNull(covariates, "covariates");
         Objects.requireNonNull(contractRef, "contractRef");
         Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
+        Objects.requireNonNull(engineSummary, "engineSummary");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);
         failuresByPostcondition = Map.copyOf(failuresByPostcondition);
@@ -91,7 +93,8 @@ public record ProbabilisticTestResult(
             TestIntent intent,
             List<String> warnings) {
         this(verdict, factors, criterionResults, intent, warnings,
-                CovariateAlignment.none(), Optional.empty(), Map.of());
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
     }
 
     /**
@@ -105,7 +108,8 @@ public record ProbabilisticTestResult(
             List<String> warnings,
             CovariateAlignment covariates) {
         this(verdict, factors, criterionResults, intent, warnings,
-                covariates, Optional.empty(), Map.of());
+                covariates, Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
     }
 
     /**
@@ -123,7 +127,27 @@ public record ProbabilisticTestResult(
             CovariateAlignment covariates,
             Optional<String> contractRef) {
         this(verdict, factors, criterionResults, intent, warnings,
-                covariates, contractRef, Map.of());
+                covariates, contractRef, Map.of(), EngineRunSummary.empty());
+    }
+
+    /**
+     * Convenience constructor preserving the pre-engineSummary shape:
+     * canonical fields through {@code failuresByPostcondition}, with
+     * an empty engine summary. Used by call sites that don't yet
+     * carry engine-run scalars through.
+     */
+    public ProbabilisticTestResult(
+            Verdict verdict,
+            FactorBundle factors,
+            List<EvaluatedCriterion> criterionResults,
+            TestIntent intent,
+            List<String> warnings,
+            CovariateAlignment covariates,
+            Optional<String> contractRef,
+            Map<String, FailureCount> failuresByPostcondition) {
+        this(verdict, factors, criterionResults, intent, warnings,
+                covariates, contractRef, failuresByPostcondition,
+                EngineRunSummary.empty());
     }
 
     /**
@@ -136,7 +160,7 @@ public record ProbabilisticTestResult(
     public ProbabilisticTestResult withCovariates(CovariateAlignment covariates) {
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
-                covariates, contractRef, failuresByPostcondition);
+                covariates, contractRef, failuresByPostcondition, engineSummary);
     }
 
     /**
@@ -156,6 +180,6 @@ public record ProbabilisticTestResult(
                 : Optional.of(contractRef);
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
-                covariates, wrapped, failuresByPostcondition);
+                covariates, wrapped, failuresByPostcondition, engineSummary);
     }
 }

--- a/punit-api/src/test/java/org/javai/punit/api/typed/spec/EngineRunSummaryTest.java
+++ b/punit-api/src/test/java/org/javai/punit/api/typed/spec/EngineRunSummaryTest.java
@@ -1,0 +1,123 @@
+package org.javai.punit.api.typed.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+
+import org.javai.punit.api.typed.LatencyResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("EngineRunSummary")
+class EngineRunSummaryTest {
+
+    @Test
+    @DisplayName("empty() yields all-zero scalars, default confidence, empty filename")
+    void emptyHasDefaults() {
+        EngineRunSummary s = EngineRunSummary.empty();
+
+        assertThat(s.plannedSamples()).isZero();
+        assertThat(s.samplesExecuted()).isZero();
+        assertThat(s.successes()).isZero();
+        assertThat(s.failures()).isZero();
+        assertThat(s.elapsedMs()).isZero();
+        assertThat(s.tokensConsumed()).isZero();
+        assertThat(s.failuresDropped()).isZero();
+        assertThat(s.latencyResult()).isEqualTo(LatencyResult.empty());
+        assertThat(s.terminationReason()).isEqualTo(TerminationReason.COMPLETED);
+        assertThat(s.confidence()).isEqualTo(0.95);
+        assertThat(s.baselineFilename()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("canonical constructor preserves all components")
+    void canonicalConstructor() {
+        EngineRunSummary s = new EngineRunSummary(
+                100, 95, 90, 5, 1500L, 12_345L, 2,
+                LatencyResult.empty(),
+                TerminationReason.TIME_BUDGET,
+                0.99,
+                Optional.of("baseline-foo.yaml"));
+
+        assertThat(s.plannedSamples()).isEqualTo(100);
+        assertThat(s.samplesExecuted()).isEqualTo(95);
+        assertThat(s.successes()).isEqualTo(90);
+        assertThat(s.failures()).isEqualTo(5);
+        assertThat(s.elapsedMs()).isEqualTo(1500L);
+        assertThat(s.tokensConsumed()).isEqualTo(12_345L);
+        assertThat(s.failuresDropped()).isEqualTo(2);
+        assertThat(s.terminationReason()).isEqualTo(TerminationReason.TIME_BUDGET);
+        assertThat(s.confidence()).isEqualTo(0.99);
+        assertThat(s.baselineFilename()).contains("baseline-foo.yaml");
+    }
+
+    @Test
+    @DisplayName("rejects negative counts")
+    void rejectsNegativeCounts() {
+        assertThatThrownBy(() -> new EngineRunSummary(
+                -1, 0, 0, 0, 0L, 0L, 0,
+                LatencyResult.empty(), TerminationReason.COMPLETED,
+                0.95, Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-negative");
+    }
+
+    @Test
+    @DisplayName("rejects negative elapsedMs")
+    void rejectsNegativeElapsed() {
+        assertThatThrownBy(() -> new EngineRunSummary(
+                0, 0, 0, 0, -1L, 0L, 0,
+                LatencyResult.empty(), TerminationReason.COMPLETED,
+                0.95, Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("elapsedMs");
+    }
+
+    @Test
+    @DisplayName("rejects confidence outside (0, 1)")
+    void rejectsConfidenceOutsideBounds() {
+        assertThatThrownBy(() -> new EngineRunSummary(
+                0, 0, 0, 0, 0L, 0L, 0,
+                LatencyResult.empty(), TerminationReason.COMPLETED,
+                0.0, Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("confidence must be in (0, 1)");
+
+        assertThatThrownBy(() -> new EngineRunSummary(
+                0, 0, 0, 0, 0L, 0L, 0,
+                LatencyResult.empty(), TerminationReason.COMPLETED,
+                1.0, Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("confidence must be in (0, 1)");
+
+        assertThatThrownBy(() -> new EngineRunSummary(
+                0, 0, 0, 0, 0L, 0L, 0,
+                LatencyResult.empty(), TerminationReason.COMPLETED,
+                Double.NaN, Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("confidence must be in (0, 1)");
+    }
+
+    @Test
+    @DisplayName("rejects null required components")
+    void rejectsNullComponents() {
+        assertThatThrownBy(() -> new EngineRunSummary(
+                0, 0, 0, 0, 0L, 0L, 0,
+                null, TerminationReason.COMPLETED, 0.95, Optional.empty()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("latencyResult");
+
+        assertThatThrownBy(() -> new EngineRunSummary(
+                0, 0, 0, 0, 0L, 0L, 0,
+                LatencyResult.empty(), null, 0.95, Optional.empty()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("terminationReason");
+
+        assertThatThrownBy(() -> new EngineRunSummary(
+                0, 0, 0, 0, 0L, 0L, 0,
+                LatencyResult.empty(), TerminationReason.COMPLETED, 0.95, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("baselineFilename");
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -147,13 +147,15 @@ public final class BaselineResolver {
         Optional<BaselineRecord> selected = report.selected();
         if (selected.isEmpty()) {
             return new BaselineLookup<>(
-                    Optional.empty(), CovariateProfile.empty(), report.notes());
+                    Optional.empty(), CovariateProfile.empty(), report.notes(),
+                    Optional.empty());
         }
+        Optional<String> sourceFile = Optional.of(selected.get().filename());
         CovariateProfile baselineProfile = selected.get().covariateProfile();
         BaselineStatistics entry = selected.get().statisticsByCriterionName().get(criterionName);
         if (entry == null) {
             return new BaselineLookup<>(
-                    Optional.empty(), baselineProfile, report.notes());
+                    Optional.empty(), baselineProfile, report.notes(), sourceFile);
         }
         if (!statisticsType.isInstance(entry)) {
             throw new IllegalStateException(
@@ -164,7 +166,8 @@ public final class BaselineResolver {
                             + " — write-side and read-side criterion kinds disagree");
         }
         return new BaselineLookup<>(
-                Optional.of(statisticsType.cast(entry)), baselineProfile, report.notes());
+                Optional.of(statisticsType.cast(entry)), baselineProfile, report.notes(),
+                sourceFile);
     }
 
     /**

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -95,6 +95,37 @@ class EngineIntegrationTest {
     }
 
     @Test
+    @DisplayName("ProbabilisticTestResult carries engine-run summary populated from SampleSummary")
+    void engineSummaryPopulated() {
+        Sampling<LlmFactors, Integer, Boolean> sampling = Sampling
+                .<LlmFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> new AlwaysPassesUseCase())
+                .inputs(1, 2, 3)
+                .samples(30)
+                .build();
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling, new LlmFactors("gpt-4o", 0.3))
+                .criterion(BernoulliPassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        var summary = result.engineSummary();
+        assertThat(summary.plannedSamples()).isEqualTo(30);
+        assertThat(summary.samplesExecuted()).isEqualTo(30);
+        assertThat(summary.successes()).isEqualTo(30);
+        assertThat(summary.failures()).isZero();
+        assertThat(summary.elapsedMs()).isGreaterThanOrEqualTo(0L);
+        assertThat(summary.terminationReason())
+                .isEqualTo(org.javai.punit.api.typed.spec.TerminationReason.COMPLETED);
+        // Contractual mode: confidence falls back to default 0.95 since
+        // BernoulliPassRate's contractual path doesn't surface confidence
+        // in detail map.
+        assertThat(summary.confidence()).isEqualTo(0.95);
+        assertThat(summary.baselineFilename()).isEmpty();
+    }
+
+    @Test
     @DisplayName("ProbabilisticTest with BernoulliPassRate.meeting() produces FAIL when observed below threshold")
     void contractualProducesFail() {
         Sampling<LlmFactors, Integer, Boolean> sampling = Sampling


### PR DESCRIPTION
## Summary

PR 2 of the typed-pipeline → RP07 wiring plan. Closes the data gap that made the next-PR adapter impossible: \`ProbabilisticTestResult\` previously discarded the per-run scalars the verdict XML needs (samples executed, elapsed time, token total, latency percentiles, termination reason, confidence level, matched baseline filename).

## Changes

### \`EngineRunSummary\` (new, in \`punit-api\`)

A digest of \`SampleSummary\` carrying the run-level scalars:

| Field | Source |
|------|------|
| \`plannedSamples\` | \`Sampling.samples()\` |
| \`samplesExecuted\` | \`SampleSummary.total()\` |
| \`successes\` / \`failures\` | \`SampleSummary\` |
| \`elapsedMs\` | \`SampleSummary.elapsed.toMillis()\` |
| \`tokensConsumed\` / \`failuresDropped\` | \`SampleSummary\` |
| \`latencyResult\` | \`SampleSummary.latencyResult()\` |
| \`terminationReason\` | \`SampleSummary.terminationReason()\` |
| \`confidence\` | scanned from criteria's detail map (BernoulliPassRate puts \`"confidence"\` there for empirical mode); default 0.95 |
| \`baselineFilename\` | threaded from \`BaselineLookup.sourceFile\` |

\`EngineRunSummary.empty()\` provides the all-defaults factory used by back-compat constructors and tests.

### \`ProbabilisticTestResult\` extension

Adds \`engineSummary\` as the 9th component with a back-compat 8-arg constructor that defaults it to \`EngineRunSummary.empty()\`. Existing test fixtures and producers compile unchanged.

### \`BaselineLookup\` extension

Adds \`sourceFile\` (\`Optional<String>\`) as the 4th component with a back-compat 3-arg constructor. \`BaselineResolver.lookup\` populates it from \`BaselineRecord.filename()\` when a candidate matches.

### \`Spec.conclude\` wiring

\`BaselineLookupCapture\` gains a \`sourceFile\` field; \`evaluate\` writes it from each criterion's lookup. Same first-non-empty-wins rule as the existing \`baselineProfile\` capture. \`buildEngineSummary\` constructs the summary; \`scanConfidence\` lifts the value from criteria details with 0.95 fallback.

## Test plan

- [x] \`EngineRunSummaryTest\`: \`empty()\` defaults, canonical-constructor preservation, validation (negative counts, negative elapsed, null components, confidence outside (0, 1) including NaN).
- [x] \`EngineIntegrationTest.engineSummaryPopulated\`: drives \`Engine.run\` end-to-end on a contractual BernoulliPassRate spec, asserts \`samplesExecuted=30\`, \`successes=30\`, \`failures=0\`, \`terminationReason=COMPLETED\`, default confidence 0.95, empty baseline filename.
- [x] \`./gradlew test\` — full punit suite green.

## What remains in the plan

PR 4 (next): \`TypedVerdictAdapter\` consumes the now-complete \`ProbabilisticTestResult\` to produce a \`ProbabilisticTestVerdict\`. PR 5: sink bus + \`PUnit.assertPasses\` wiring + identity resolution. PR 6: docs + fidelity test.