### PR TITLE
TypedVerdictAdapter: ProbabilisticTestResult → ProbabilisticTestVerdict

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/verdict/TypedRunMetadata.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/TypedRunMetadata.java
@@ -1,0 +1,83 @@
+package org.javai.punit.verdict;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Per-run metadata that the typed pipeline doesn't carry on its
+ * result but the RP07 verdict XML requires — test identity, optional
+ * correlation ID, and a bag of environment metadata.
+ *
+ * <p>Built at the JUnit-extension boundary (where {@code className} and
+ * {@code methodName} are knowable via stack walk or the test extension
+ * context) and threaded into {@link TypedVerdictAdapter} alongside the
+ * {@link org.javai.punit.api.typed.spec.ProbabilisticTestResult result}
+ * itself. The result captures what happened in the run; this metadata
+ * captures who ran it and where.
+ *
+ * <p>{@link #correlationId()} and {@link #environmentMetadata()} are
+ * optional. The adapter generates a UUID-fragment correlation ID when
+ * absent (matching the legacy verdict builder's behaviour) and treats
+ * empty environment metadata as the absence of an {@code <environment>}
+ * element rather than an empty one.
+ *
+ * @param className           the test class's fully-qualified name;
+ *                            non-blank
+ * @param methodName          the test method name; non-blank
+ * @param useCaseId           the use-case identifier, when known; surfaces
+ *                            on the verdict's {@code <identity use-case-id>}
+ *                            attribute and falls back to {@code className}
+ *                            when absent (mirroring the legacy pipeline's
+ *                            behaviour)
+ * @param correlationId       opaque correlation ID for distributed
+ *                            tracing; absent → adapter generates one
+ * @param environmentMetadata free-form key/value pairs surfaced as
+ *                            {@code <environment>} entries; empty →
+ *                            adapter omits the section
+ */
+public record TypedRunMetadata(
+        String className,
+        String methodName,
+        Optional<String> useCaseId,
+        Optional<String> correlationId,
+        Map<String, String> environmentMetadata) {
+
+    public TypedRunMetadata {
+        Objects.requireNonNull(className, "className");
+        Objects.requireNonNull(methodName, "methodName");
+        Objects.requireNonNull(useCaseId, "useCaseId");
+        Objects.requireNonNull(correlationId, "correlationId");
+        Objects.requireNonNull(environmentMetadata, "environmentMetadata");
+        if (className.isBlank()) {
+            throw new IllegalArgumentException("className must not be blank");
+        }
+        if (methodName.isBlank()) {
+            throw new IllegalArgumentException("methodName must not be blank");
+        }
+        environmentMetadata = Map.copyOf(environmentMetadata);
+    }
+
+    /**
+     * Convenience for the common case of class + method only —
+     * defaults useCaseId, correlationId, and environmentMetadata to
+     * empty.
+     */
+    public static TypedRunMetadata of(String className, String methodName) {
+        return new TypedRunMetadata(
+                className, methodName,
+                Optional.empty(), Optional.empty(), Map.of());
+    }
+
+    /**
+     * Convenience adding a use-case identifier; correlationId and
+     * environmentMetadata default to empty.
+     */
+    public static TypedRunMetadata of(String className, String methodName, String useCaseId) {
+        Optional<String> wrapped = (useCaseId == null || useCaseId.isBlank())
+                ? Optional.empty()
+                : Optional.of(useCaseId);
+        return new TypedRunMetadata(
+                className, methodName, wrapped, Optional.empty(), Map.of());
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/verdict/TypedVerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/TypedVerdictAdapter.java
@@ -1,0 +1,240 @@
+package org.javai.punit.verdict;
+
+import java.util.List;
+import java.util.Map;
+
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.spec.EngineRunSummary;
+import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
+import org.javai.punit.model.TerminationReason;
+import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder.LatencyInput;
+import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder.MisalignmentInput;
+
+/**
+ * Adapts a typed-pipeline {@link ProbabilisticTestResult} to the legacy
+ * XML-bound {@link ProbabilisticTestVerdict} shape so the
+ * {@link org.javai.punit.report.VerdictXmlWriter VerdictXmlWriter} (and
+ * the HTML report) can serialise the typed pipeline's runs to RP07.
+ *
+ * <p>The adapter is a thin field-mapping function — it does not perform
+ * statistical computation, judgement, or rendering. It reads the typed
+ * result's components and the supplied {@link TypedRunMetadata}, and
+ * delegates to {@link ProbabilisticTestVerdictBuilder} for the heavy
+ * lifting (Wilson-score CI, baseline-derivation narrative, verdict-reason
+ * synthesis).
+ *
+ * <h2>Field provenance</h2>
+ *
+ * <ul>
+ *   <li><b>Identity</b> — from {@code TypedRunMetadata}.</li>
+ *   <li><b>Execution</b> — from {@code result.engineSummary()}; the
+ *       observed pass rate is computed from successes/total. The
+ *       threshold is lifted from the first {@code BernoulliPassRate}
+ *       criterion's detail map (key {@code "threshold"}); falls back
+ *       to 0.0 when no such criterion exists.</li>
+ *   <li><b>Functional dimension</b> — from
+ *       {@code engineSummary.successes()} / {@code .failures()}.</li>
+ *   <li><b>Latency</b> — from {@code engineSummary.latencyResult()},
+ *       observed-only (no per-percentile assertions). Skipped when
+ *       {@code sampleCount() == 0}.</li>
+ *   <li><b>Statistics</b> — derived by the builder from the execution
+ *       summary at the configured confidence.</li>
+ *   <li><b>Covariates</b> — from {@code result.covariates()}.</li>
+ *   <li><b>Cost</b> — only {@code methodTokensConsumed} populated;
+ *       budgets and {@link TokenMode} default to "unlimited / NONE"
+ *       because the typed pipeline doesn't surface per-method budgets
+ *       on the result today.</li>
+ *   <li><b>Provenance</b> — threshold origin from the first
+ *       {@code BernoulliPassRate} criterion's {@code "origin"} detail
+ *       key; contract reference from
+ *       {@link ProbabilisticTestResult#contractRef()}; spec filename
+ *       from {@code engineSummary.baselineFilename()}.</li>
+ *   <li><b>Termination</b> — typed
+ *       {@link org.javai.punit.api.typed.spec.TerminationReason} mapped
+ *       to the richer core enum; details kept null.</li>
+ *   <li><b>Postcondition failures</b> — pass-through from
+ *       {@link ProbabilisticTestResult#failuresByPostcondition()}.</li>
+ *   <li><b>Verdict</b> — typed {@link Verdict#PASS} maps to
+ *       {@code passedStatistically=true}; {@link Verdict#FAIL} and
+ *       {@link Verdict#INCONCLUSIVE} both map to false (the builder's
+ *       covariate-alignment logic decides FAIL vs INCONCLUSIVE).</li>
+ * </ul>
+ *
+ * <h2>What the adapter cannot fill</h2>
+ *
+ * <p>Some {@link ProbabilisticTestVerdict} components have no analogue
+ * on a typed pipeline run today: budget snapshots, pacing configuration,
+ * spec expiration, JUnit-pass status. The adapter produces a verdict with
+ * those left at their builder defaults. Field-level fidelity is captured
+ * in the test suite; renderers are tolerant of absent optional fields.
+ */
+public final class TypedVerdictAdapter {
+
+    private TypedVerdictAdapter() { }
+
+    /**
+     * Build a {@link ProbabilisticTestVerdict} from a typed result and
+     * the per-run metadata.
+     *
+     * @param result the typed pipeline's result
+     * @param meta   the run metadata captured at the JUnit boundary
+     * @return a fully populated legacy verdict, ready for XML/HTML
+     *         serialisation
+     */
+    public static ProbabilisticTestVerdict adapt(
+            ProbabilisticTestResult result, TypedRunMetadata meta) {
+
+        EngineRunSummary engine = result.engineSummary();
+        ProbabilisticTestVerdictBuilder b = new ProbabilisticTestVerdictBuilder();
+
+        // Envelope
+        meta.correlationId().ifPresent(b::correlationId);
+        b.environmentMetadata(meta.environmentMetadata());
+
+        // Identity
+        b.identity(
+                meta.className(),
+                meta.methodName(),
+                meta.useCaseId().orElse(null));
+
+        // Execution
+        double threshold = scanDoubleDetail(result.criterionResults(), "threshold").orElse(0.0);
+        double observed = engine.samplesExecuted() == 0
+                ? 0.0
+                : (double) engine.successes() / (double) engine.samplesExecuted();
+        b.execution(
+                engine.plannedSamples(),
+                engine.samplesExecuted(),
+                engine.successes(),
+                engine.failures(),
+                threshold,
+                observed,
+                engine.elapsedMs());
+        b.intent(result.intent(), engine.confidence());
+
+        // Functional + latency dimensions
+        b.functionalDimension(engine.successes(), engine.failures());
+        LatencyInput latencyInput = toLatencyInput(engine);
+        if (latencyInput != null) {
+            b.latencyDimension(latencyInput);
+        }
+
+        // Covariates
+        CovariateAlignment alignment = result.covariates();
+        b.covariateProfiles(
+                alignment.baseline().values(),
+                alignment.observed().values());
+        b.misalignments(toMisalignmentInputs(alignment));
+
+        // Cost — typed pipeline has no per-method budget surface yet;
+        // pass tokensConsumed and zero budgets / NONE token mode.
+        b.cost(engine.tokensConsumed(), 0L, 0L, TokenMode.NONE);
+
+        // Provenance
+        ThresholdOrigin origin = scanThresholdOrigin(result.criterionResults());
+        if (origin != null || result.contractRef().isPresent() || engine.baselineFilename().isPresent()) {
+            b.provenance(
+                    origin,
+                    result.contractRef().orElse(null),
+                    engine.baselineFilename().orElse(null));
+        }
+
+        // Termination
+        b.termination(
+                mapTerminationReason(engine.terminationReason()),
+                null);
+
+        // Postcondition failure histogram
+        b.postconditionFailures(result.failuresByPostcondition());
+
+        // Verdict
+        b.passedStatistically(result.verdict() == Verdict.PASS);
+        // The typed pipeline carries no JUnit-pass concept on the
+        // result; default true (the legacy field is meaningless outside
+        // the legacy JUnit context).
+        b.junitPassed(true);
+
+        return b.build();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private static java.util.Optional<Double> scanDoubleDetail(
+            List<EvaluatedCriterion> evaluated, String key) {
+        for (EvaluatedCriterion ec : evaluated) {
+            Object v = ec.result().detail().get(key);
+            if (v instanceof Number n) {
+                return java.util.Optional.of(n.doubleValue());
+            }
+        }
+        return java.util.Optional.empty();
+    }
+
+    private static ThresholdOrigin scanThresholdOrigin(List<EvaluatedCriterion> evaluated) {
+        for (EvaluatedCriterion ec : evaluated) {
+            Object v = ec.result().detail().get("origin");
+            if (v instanceof String s && !s.isBlank()) {
+                try {
+                    return ThresholdOrigin.valueOf(s);
+                } catch (IllegalArgumentException ignored) {
+                    // Detail map carried a non-enum value; treat as
+                    // unspecified rather than throwing.
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static LatencyInput toLatencyInput(EngineRunSummary engine) {
+        LatencyResult lat = engine.latencyResult();
+        if (lat.sampleCount() == 0) {
+            return null;
+        }
+        // Typed pipeline emits observed-only latency — no per-percentile
+        // assertions, no caveats. Successful samples = engine.successes;
+        // dimension failures = 0 (latency is not asserted on the typed
+        // path today).
+        return new LatencyInput(
+                engine.successes(),
+                engine.samplesExecuted(),
+                false,                                 // skipped
+                null,                                  // skipReason
+                lat.p50().toMillis(),
+                lat.p90().toMillis(),
+                lat.p95().toMillis(),
+                lat.p99().toMillis(),
+                -1L,                                   // maxMs unavailable
+                List.of(),                             // assertions
+                List.of(),                             // caveats
+                engine.successes(),                    // dimensionSuccesses
+                0);                                    // dimensionFailures
+    }
+
+    private static List<MisalignmentInput> toMisalignmentInputs(CovariateAlignment alignment) {
+        if (alignment.aligned() || alignment.mismatches().isEmpty()) {
+            return List.of();
+        }
+        return alignment.mismatches().stream()
+                .map(m -> new MisalignmentInput(
+                        m.covariateKey(),
+                        m.baseline() == null ? "" : m.baseline(),
+                        m.observed() == null ? "" : m.observed()))
+                .toList();
+    }
+
+    private static TerminationReason mapTerminationReason(
+            org.javai.punit.api.typed.spec.TerminationReason typed) {
+        return switch (typed) {
+            case COMPLETED -> TerminationReason.COMPLETED;
+            case TIME_BUDGET -> TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED;
+            case TOKEN_BUDGET -> TerminationReason.METHOD_TOKEN_BUDGET_EXHAUSTED;
+        };
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/verdict/TypedVerdictAdapterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/TypedVerdictAdapterTest.java
@@ -1,0 +1,391 @@
+package org.javai.punit.verdict;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.spec.CriterionResult;
+import org.javai.punit.api.typed.spec.CriterionRole;
+import org.javai.punit.api.typed.spec.EngineRunSummary;
+import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+import org.javai.punit.model.TerminationReason;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TypedVerdictAdapter")
+class TypedVerdictAdapterTest {
+
+    private record Factors() { }
+
+    @Nested
+    @DisplayName("identity and envelope")
+    class IdentityAndEnvelope {
+
+        @Test
+        @DisplayName("populates className/methodName/useCaseId from metadata")
+        void identityFromMetadata() {
+            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+                    minimalResult(Verdict.PASS),
+                    new TypedRunMetadata(
+                            "com.example.MyTest", "shouldPass",
+                            Optional.of("payment-gateway"),
+                            Optional.of("v:abc123"),
+                            Map.of("region", "EU")));
+
+            assertThat(verdict.identity().className()).isEqualTo("com.example.MyTest");
+            assertThat(verdict.identity().methodName()).isEqualTo("shouldPass");
+            assertThat(verdict.identity().useCaseId()).contains("payment-gateway");
+            assertThat(verdict.correlationId()).isEqualTo("v:abc123");
+            assertThat(verdict.environmentMetadata()).containsEntry("region", "EU");
+        }
+
+        @Test
+        @DisplayName("absent correlationId triggers builder's UUID-fragment generation")
+        void absentCorrelationIdGetsGenerated() {
+            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+                    minimalResult(Verdict.PASS),
+                    TypedRunMetadata.of("com.example.MyTest", "shouldPass"));
+
+            assertThat(verdict.correlationId()).isNotEmpty().startsWith("v:");
+        }
+    }
+
+    @Nested
+    @DisplayName("execution and intent")
+    class ExecutionAndIntent {
+
+        @Test
+        @DisplayName("threads samples/successes/failures/elapsed and computes observed pass rate")
+        void executionFields() {
+            ProbabilisticTestResult result = resultWithEngineSummary(
+                    Verdict.PASS,
+                    new EngineRunSummary(
+                            100, 95, 90, 5, 1500L, 0L, 0,
+                            LatencyResult.empty(),
+                            org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                            0.95,
+                            Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.execution().plannedSamples()).isEqualTo(100);
+            assertThat(verdict.execution().samplesExecuted()).isEqualTo(95);
+            assertThat(verdict.execution().successes()).isEqualTo(90);
+            assertThat(verdict.execution().failures()).isEqualTo(5);
+            assertThat(verdict.execution().elapsedMs()).isEqualTo(1500L);
+            // observed = 90/95 ≈ 0.9474
+            assertThat(verdict.execution().observedPassRate())
+                    .isCloseTo(0.9474, org.assertj.core.data.Offset.offset(0.001));
+            assertThat(verdict.execution().resolvedConfidence()).isEqualTo(0.95);
+        }
+
+        @Test
+        @DisplayName("threshold pulled from BernoulliPassRate criterion's detail map")
+        void thresholdFromCriterionDetail() {
+            ProbabilisticTestResult result = resultWithCriteria(
+                    Verdict.PASS,
+                    Map.of("threshold", 0.99, "origin", "SLA"));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.execution().minPassRate()).isEqualTo(0.99);
+        }
+
+        @Test
+        @DisplayName("intent is preserved")
+        void intentPreserved() {
+            ProbabilisticTestResult result = new ProbabilisticTestResult(
+                    Verdict.PASS, FactorBundle.of(new Factors()),
+                    List.of(), TestIntent.SMOKE, List.of(),
+                    CovariateAlignment.none(), Optional.empty(), Map.of(),
+                    EngineRunSummary.empty());
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.execution().intent()).isEqualTo(TestIntent.SMOKE);
+        }
+    }
+
+    @Nested
+    @DisplayName("verdict mapping")
+    class VerdictMapping {
+
+        @Test
+        @DisplayName("PASS verdict produces passedStatistically=true and PUnitVerdict.PASS")
+        void passVerdict() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.PASS));
+
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.PASS);
+        }
+
+        @Test
+        @DisplayName("FAIL verdict with aligned covariates produces PUnitVerdict.FAIL")
+        void failVerdict() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.FAIL));
+
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.FAIL);
+        }
+
+        @Test
+        @DisplayName("INCONCLUSIVE with covariate misalignment produces PUnitVerdict.INCONCLUSIVE")
+        void inconclusiveVerdict() {
+            CovariateProfile baseline = CovariateProfile.of(Map.of("model", "gpt-4"));
+            CovariateProfile observed = CovariateProfile.of(Map.of("model", "gpt-4o"));
+            CovariateAlignment misaligned = CovariateAlignment.compute(observed, baseline);
+
+            ProbabilisticTestResult result = new ProbabilisticTestResult(
+                    Verdict.INCONCLUSIVE, FactorBundle.of(new Factors()),
+                    List.of(), TestIntent.VERIFICATION, List.of(),
+                    misaligned, Optional.empty(), Map.of(),
+                    EngineRunSummary.empty());
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
+            assertThat(verdict.covariates().aligned()).isFalse();
+            assertThat(verdict.covariates().misalignments()).hasSize(1);
+            assertThat(verdict.covariates().misalignments().get(0).covariateKey())
+                    .isEqualTo("model");
+        }
+    }
+
+    @Nested
+    @DisplayName("latency dimension")
+    class LatencyDimension {
+
+        @Test
+        @DisplayName("populates observed percentiles when latency has samples")
+        void populatesPercentiles() {
+            LatencyResult lat = new LatencyResult(
+                    Duration.ofMillis(120), Duration.ofMillis(340),
+                    Duration.ofMillis(420), Duration.ofMillis(810),
+                    50);
+            ProbabilisticTestResult result = resultWithEngineSummary(
+                    Verdict.PASS,
+                    new EngineRunSummary(
+                            50, 50, 48, 2, 1000L, 0L, 0,
+                            lat,
+                            org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                            0.95,
+                            Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.latency()).isPresent();
+            assertThat(verdict.latency().get().p50Ms()).isEqualTo(120L);
+            assertThat(verdict.latency().get().p90Ms()).isEqualTo(340L);
+            assertThat(verdict.latency().get().p95Ms()).isEqualTo(420L);
+            assertThat(verdict.latency().get().p99Ms()).isEqualTo(810L);
+            assertThat(verdict.latency().get().maxMs()).isEqualTo(-1L);
+            assertThat(verdict.latency().get().assertions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("omits latency when sampleCount is zero")
+        void skipsLatencyWhenEmpty() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.PASS));
+
+            assertThat(verdict.latency()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("postcondition failures")
+    class PostconditionFailures {
+
+        @Test
+        @DisplayName("threads histogram through to verdict")
+        void histogramThreaded() {
+            LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+            hist.put("Response not empty", new FailureCount(2, List.of(
+                    new FailureExemplar("instr-1", "blank"))));
+            hist.put("Valid JSON", new FailureCount(8, List.of()));
+
+            ProbabilisticTestResult result = new ProbabilisticTestResult(
+                    Verdict.FAIL, FactorBundle.of(new Factors()),
+                    List.of(), TestIntent.VERIFICATION, List.of(),
+                    CovariateAlignment.none(), Optional.empty(), hist,
+                    EngineRunSummary.empty());
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.postconditionFailures()).hasSize(2);
+            assertThat(verdict.postconditionFailures()).containsKeys(
+                    "Response not empty", "Valid JSON");
+            assertThat(verdict.postconditionFailures().get("Valid JSON").count())
+                    .isEqualTo(8);
+        }
+
+        @Test
+        @DisplayName("empty histogram yields empty postconditionFailures map")
+        void emptyHistogram() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.PASS));
+
+            assertThat(verdict.postconditionFailures()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("provenance")
+    class Provenance {
+
+        @Test
+        @DisplayName("populates from contractRef + threshold origin + baseline filename")
+        void populatesProvenance() {
+            ProbabilisticTestResult base = resultWithCriteria(
+                    Verdict.PASS,
+                    Map.of("threshold", 0.99, "origin", "SLA"));
+            ProbabilisticTestResult result = new ProbabilisticTestResult(
+                    base.verdict(), base.factors(), base.criterionResults(),
+                    base.intent(), base.warnings(),
+                    base.covariates(),
+                    Optional.of("Payment Provider SLA v2.3, Section 4.1"),
+                    base.failuresByPostcondition(),
+                    new EngineRunSummary(
+                            50, 50, 50, 0, 100L, 0L, 0,
+                            LatencyResult.empty(),
+                            org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                            0.95,
+                            Optional.of("payment-gateway-1fbf-54c6-86a6.yaml")));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.provenance()).isPresent();
+            assertThat(verdict.provenance().get().thresholdOriginName()).isEqualTo("SLA");
+            assertThat(verdict.provenance().get().contractRef())
+                    .isEqualTo("Payment Provider SLA v2.3, Section 4.1");
+            assertThat(verdict.provenance().get().specFilename())
+                    .isEqualTo("payment-gateway-1fbf-54c6-86a6.yaml");
+        }
+
+        @Test
+        @DisplayName("omits provenance when no origin, contractRef, or filename")
+        void omitsWhenAbsent() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.PASS));
+
+            assertThat(verdict.provenance()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("termination reason mapping")
+    class TerminationMapping {
+
+        @Test
+        @DisplayName("COMPLETED → COMPLETED")
+        void completed() {
+            ProbabilisticTestVerdict verdict = adapt(resultWithTermination(
+                    org.javai.punit.api.typed.spec.TerminationReason.COMPLETED));
+            assertThat(verdict.termination().reason()).isEqualTo(TerminationReason.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("TIME_BUDGET → METHOD_TIME_BUDGET_EXHAUSTED")
+        void timeBudget() {
+            ProbabilisticTestVerdict verdict = adapt(resultWithTermination(
+                    org.javai.punit.api.typed.spec.TerminationReason.TIME_BUDGET));
+            assertThat(verdict.termination().reason())
+                    .isEqualTo(TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED);
+        }
+
+        @Test
+        @DisplayName("TOKEN_BUDGET → METHOD_TOKEN_BUDGET_EXHAUSTED")
+        void tokenBudget() {
+            ProbabilisticTestVerdict verdict = adapt(resultWithTermination(
+                    org.javai.punit.api.typed.spec.TerminationReason.TOKEN_BUDGET));
+            assertThat(verdict.termination().reason())
+                    .isEqualTo(TerminationReason.METHOD_TOKEN_BUDGET_EXHAUSTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("cost")
+    class Cost {
+
+        @Test
+        @DisplayName("threads tokensConsumed; budgets default to zero / TokenMode.NONE")
+        void costFromEngineSummary() {
+            ProbabilisticTestResult result = resultWithEngineSummary(
+                    Verdict.PASS,
+                    new EngineRunSummary(
+                            10, 10, 10, 0, 100L, 1234L, 0,
+                            LatencyResult.empty(),
+                            org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                            0.95,
+                            Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.cost().methodTokensConsumed()).isEqualTo(1234L);
+            assertThat(verdict.cost().methodTimeBudgetMs()).isZero();
+            assertThat(verdict.cost().methodTokenBudget()).isZero();
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private static ProbabilisticTestVerdict adapt(ProbabilisticTestResult result) {
+        return TypedVerdictAdapter.adapt(
+                result,
+                TypedRunMetadata.of("com.example.MyTest", "shouldPass"));
+    }
+
+    private static ProbabilisticTestResult minimalResult(Verdict v) {
+        return new ProbabilisticTestResult(
+                v, FactorBundle.of(new Factors()),
+                List.of(), TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
+    }
+
+    private static ProbabilisticTestResult resultWithEngineSummary(
+            Verdict v, EngineRunSummary engine) {
+        return new ProbabilisticTestResult(
+                v, FactorBundle.of(new Factors()),
+                List.of(), TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                engine);
+    }
+
+    private static ProbabilisticTestResult resultWithCriteria(
+            Verdict v, Map<String, Object> detail) {
+        CriterionResult cr = new CriterionResult(
+                "bernoulli-pass-rate",
+                v,
+                "stub explanation",
+                detail);
+        return new ProbabilisticTestResult(
+                v, FactorBundle.of(new Factors()),
+                List.of(new EvaluatedCriterion(cr, CriterionRole.REQUIRED)),
+                TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
+    }
+
+    private static ProbabilisticTestResult resultWithTermination(
+            org.javai.punit.api.typed.spec.TerminationReason reason) {
+        return resultWithEngineSummary(
+                Verdict.PASS,
+                new EngineRunSummary(
+                        50, 50, 50, 0, 100L, 0L, 0,
+                        LatencyResult.empty(),
+                        reason,
+                        0.95,
+                        Optional.empty()));
+    }
+}

--- a/punit-report/src/test/java/org/javai/punit/report/TypedVerdictAdapterIntegrationTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/TypedVerdictAdapterIntegrationTest.java
@@ -1,0 +1,173 @@
+package org.javai.punit.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
+import org.javai.punit.api.typed.covariate.CovariateProfile;
+import org.javai.punit.api.typed.spec.CriterionResult;
+import org.javai.punit.api.typed.spec.CriterionRole;
+import org.javai.punit.api.typed.spec.EngineRunSummary;
+import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+import org.javai.punit.verdict.ProbabilisticTestVerdict;
+import org.javai.punit.verdict.TypedRunMetadata;
+import org.javai.punit.verdict.TypedVerdictAdapter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration test: typed result → adapter →
+ * {@link VerdictXmlWriter} → XSD validation. Lives in punit-report
+ * because that's where the writer and XSD resource are; punit-core
+ * has the adapter unit tests but cannot reach the writer module.
+ */
+@DisplayName("TypedVerdictAdapter ↔ VerdictXmlWriter round-trip")
+class TypedVerdictAdapterIntegrationTest {
+
+    private record Factors() { }
+
+    @Test
+    @DisplayName("PASS verdict round-trips and validates against verdict-1.0.xsd")
+    void passRoundTrips() throws Exception {
+        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+                richResult(Verdict.PASS),
+                new TypedRunMetadata(
+                        "com.example.PaymentTest", "shouldMeetSla",
+                        Optional.of("payment-gateway"),
+                        Optional.empty(),
+                        Map.of("region", "EU")));
+
+        String xml = serialise(verdict);
+
+        validateAgainstSchema(xml);
+
+        // Spot-check key fields rendered through to XML.
+        assertThat(xml).contains("use-case-id=\"payment-gateway\"");
+        assertThat(xml).contains("test-name=\"shouldMeetSla\"");
+        assertThat(xml).contains("planned-samples=\"100\"");
+        assertThat(xml).contains("samples-executed=\"100\"");
+        assertThat(xml).contains("successes=\"95\"");
+        assertThat(xml).contains("failures=\"5\"");
+        assertThat(xml).contains("intent=\"VERIFICATION\"");
+        assertThat(xml).contains("<postcondition-failures>");
+        assertThat(xml).contains("description=\"Response not empty\"");
+        assertThat(xml).contains("description=\"Valid JSON\"");
+        assertThat(xml).contains("origin=\"SLA\"");
+        assertThat(xml).contains("spec-filename=\"payment-gateway.yaml\"");
+        assertThat(xml).contains("contract-ref=\"SLA-PAY-001\"");
+        assertThat(xml).contains("region");
+        assertThat(xml).contains("EU");
+        assertThat(xml).contains("value=\"PASS\"");
+    }
+
+    @Test
+    @DisplayName("FAIL verdict round-trips and validates against verdict-1.0.xsd")
+    void failRoundTrips() throws Exception {
+        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+                richResult(Verdict.FAIL),
+                TypedRunMetadata.of("com.example.PaymentTest", "shouldMeetSla", "payment-gateway"));
+
+        String xml = serialise(verdict);
+        validateAgainstSchema(xml);
+        assertThat(xml).contains("value=\"FAIL\"");
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE verdict (covariate misalignment) round-trips and validates")
+    void inconclusiveRoundTrips() throws Exception {
+        CovariateProfile baseline = CovariateProfile.of(Map.of("model", "gpt-4"));
+        CovariateProfile observed = CovariateProfile.of(Map.of("model", "gpt-4o"));
+        CovariateAlignment misaligned = CovariateAlignment.compute(observed, baseline);
+
+        ProbabilisticTestResult result = new ProbabilisticTestResult(
+                Verdict.INCONCLUSIVE, FactorBundle.of(new Factors()),
+                List.of(), TestIntent.VERIFICATION, List.of(),
+                misaligned, Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
+
+        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+                result,
+                TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+
+        String xml = serialise(verdict);
+        validateAgainstSchema(xml);
+        assertThat(xml).contains("value=\"INCONCLUSIVE\"");
+        assertThat(xml).contains("<misalignment");
+        assertThat(xml).contains("key=\"model\"");
+        assertThat(xml).contains("baseline-value=\"gpt-4\"");
+        assertThat(xml).contains("observed-value=\"gpt-4o\"");
+    }
+
+    // ── Fixture ─────────────────────────────────────────────────────
+
+    private static ProbabilisticTestResult richResult(Verdict v) {
+        LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+        hist.put("Response not empty", new FailureCount(2, List.of(
+                new FailureExemplar("instr-1", "blank"))));
+        hist.put("Valid JSON", new FailureCount(8, List.of(
+                new FailureExemplar("instr-7", "missing actions"))));
+
+        CriterionResult cr = new CriterionResult(
+                "bernoulli-pass-rate", v,
+                "observed=0.9500, threshold=0.9500 (origin=SLA) over 100 samples",
+                Map.of("threshold", 0.95, "origin", "SLA",
+                        "observed", 0.95, "successes", 95,
+                        "failures", 5, "total", 100));
+
+        return new ProbabilisticTestResult(
+                v, FactorBundle.of(new Factors()),
+                List.of(new EvaluatedCriterion(cr, CriterionRole.REQUIRED)),
+                TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(),
+                Optional.of("SLA-PAY-001"),
+                hist,
+                new EngineRunSummary(
+                        100, 100, 95, 5, 1500L, 12_345L, 0,
+                        new LatencyResult(
+                                Duration.ofMillis(120), Duration.ofMillis(340),
+                                Duration.ofMillis(420), Duration.ofMillis(810),
+                                100),
+                        org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                        0.95,
+                        Optional.of("payment-gateway.yaml")));
+    }
+
+    private static String serialise(ProbabilisticTestVerdict verdict) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new VerdictXmlWriter().write(verdict, baos);
+        return baos.toString(StandardCharsets.UTF_8);
+    }
+
+    private void validateAgainstSchema(String xml) throws Exception {
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        try (InputStream xsdStream = getClass().getResourceAsStream("/org/javai/punit/report/verdict-1.0.xsd")) {
+            assertThat(xsdStream).as("XSD resource must be available").isNotNull();
+            Schema schema = factory.newSchema(new StreamSource(xsdStream));
+            Validator validator = schema.newValidator();
+            validator.validate(new StreamSource(
+                    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR 4 of the typed-pipeline → RP07 wiring plan. Adds the adapter that maps the typed pipeline's `ProbabilisticTestResult` (now carrying `EngineRunSummary` from #100) plus a per-run metadata envelope into the legacy XML-bound `ProbabilisticTestVerdict`. With this in place, typed-pipeline runs can flow through `VerdictXmlWriter` and `HtmlReportWriter` to emit RP07 XML and the HTML report — pending the sink-bus + JUnit wiring of PR 5.

## Architecture

| Type | Location | Role |
|------|----------|------|
| `TypedRunMetadata` | `punit-core/verdict` (new) | Record carrying className, methodName, useCaseId, correlationId, environmentMetadata — fields the typed pipeline doesn't have on the result but RP07 needs. Built at the JUnit-extension boundary in PR 5. |
| `TypedVerdictAdapter` | `punit-core/verdict` (new) | Static `adapt(result, meta) → ProbabilisticTestVerdict`. Field-mapping only; delegates to `ProbabilisticTestVerdictBuilder` for statistical computation, Wilson CI, threshold-derivation narrative, etc. |

The adapter lives in `punit-core` (next to `ProbabilisticTestVerdict`), not `punit-report` — putting it in the report module would force the report module to depend on `punit-api/typed/spec`, which it shouldn't (the report module's job is rendering, not source-shape conversion).

## Field provenance

- **Identity** → `TypedRunMetadata`
- **Execution** → `engineSummary` (samples / elapsed); threshold from first `BernoulliPassRate` criterion's `"threshold"` detail; observed pass rate computed
- **Functional dimension** → `engineSummary.successes/failures`
- **Latency** → `engineSummary.latencyResult` (observed-only; no per-percentile assertions); skipped when sample count is zero
- **Statistics** → builder derives from execution at the engine's `confidence`
- **Covariates** → `result.covariates()`: both profiles and any misalignments
- **Cost** → `engineSummary.tokensConsumed`; budgets default to 0 / `TokenMode.NONE` (typed pipeline doesn't surface budgets)
- **Provenance** → `contractRef` from result, threshold origin from first criterion's `"origin"` detail, spec filename from `engineSummary.baselineFilename`
- **Termination** → typed enum (3-value) mapped to richer core enum (TIME_BUDGET → METHOD_TIME_BUDGET_EXHAUSTED, etc.)
- **Postcondition failures** → pass-through from `result.failuresByPostcondition()`
- **Verdict** → typed `Verdict.PASS` ⇒ `passedStatistically=true`; the builder's covariate-alignment logic decides `PUnitVerdict` (FAIL vs INCONCLUSIVE)

## Test plan

- [x] **`TypedVerdictAdapterTest`** (punit-core) — 16 unit cases: identity & envelope (4), execution & intent (3), verdict mapping for PASS/FAIL/INCONCLUSIVE (3), latency populated/skipped (2), postcondition-failures threading (2), provenance populated/omitted (2), all three termination reason mappings (3), cost (1).
- [x] **`TypedVerdictAdapterIntegrationTest`** (punit-report) — 3 round-trip cases: PASS / FAIL / INCONCLUSIVE drive adapter → `VerdictXmlWriter` → `verdict-1.0.xsd` validation; spot-check key fields render through to XML (use-case-id, planned-samples, postcondition-failures, origin, spec-filename, contract-ref, environment, verdict value).
- [x] `./gradlew test` — full punit suite green.

## What remains

PR 5 (next): sink bus (`TypedVerdictSinkBus`) + `PUnit.assertPasses` wiring + `TypedTestIdentityResolver` (stack walk for class/method) + TestKit integration test that the typed pipeline actually emits XML when configured. PR 6: docs + fidelity test.