### PR TITLE
PUnit: emit RP07 verdict XML via TypedVerdictSinkBus

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/verdict/TypedVerdictSinkBus.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/TypedVerdictSinkBus.java
@@ -1,0 +1,139 @@
+package org.javai.punit.verdict;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.javai.punit.reporting.CompositeVerdictSink;
+
+/**
+ * Singleton-style registry of {@link VerdictSink}s that the typed
+ * pipeline's {@code PUnit.assertPasses(...)} dispatches to after a
+ * verdict is produced.
+ *
+ * <p>The bus holds an ordered list of sinks. By default, the list
+ * contains the framework's "primary" sink (configured via
+ * {@link #installDefaultSink(Supplier)}); tests and embedders can
+ * extend with {@link #register(VerdictSink)} or replace the entire
+ * list with {@link #replaceAll(VerdictSink...)}.
+ *
+ * <h2>Default sink</h2>
+ *
+ * <p>The default sink is supplied externally — typically by
+ * {@code punit-report} installing a
+ * {@code VerdictXmlSink(ReportConfiguration.resolve())} during JUnit
+ * extension bootstrap. The bus does not import {@code punit-report}
+ * directly because that would invert the module dependency direction
+ * (report depends on core, not the other way round).
+ *
+ * <h2>Test isolation</h2>
+ *
+ * <p>Tests should call {@link #reset()} in a {@code @BeforeEach} or
+ * {@code @AfterEach} hook to clear registered sinks. The default sink
+ * is re-supplied by the next caller that calls
+ * {@link #installDefaultSink(Supplier)} (idempotent if the sink is
+ * stateless).
+ */
+public final class TypedVerdictSinkBus {
+
+    private static final List<VerdictSink> SINKS = new ArrayList<>();
+    private static Supplier<VerdictSink> defaultSupplier;
+    private static boolean defaultInstalled;
+
+    private TypedVerdictSinkBus() { }
+
+    /**
+     * Configures the default sink supplier, lazy-evaluated on first
+     * dispatch. Idempotent — calling repeatedly has no effect once a
+     * default is in place. Callers that want to override should use
+     * {@link #replaceAll(VerdictSink...)}.
+     *
+     * @param supplier supplier whose {@code get} returns the default
+     *                 sink instance; called once, lazily
+     */
+    public static synchronized void installDefaultSink(Supplier<VerdictSink> supplier) {
+        Objects.requireNonNull(supplier, "supplier");
+        if (defaultSupplier == null) {
+            defaultSupplier = supplier;
+        }
+    }
+
+    /**
+     * Registers an additional sink. The bus dispatches to all
+     * registered sinks (and the default, if installed) in registration
+     * order.
+     *
+     * @param sink the sink to add
+     */
+    public static synchronized void register(VerdictSink sink) {
+        Objects.requireNonNull(sink, "sink");
+        SINKS.add(sink);
+    }
+
+    /**
+     * Clears all registered sinks (including the default). Used by
+     * tests for clean isolation. After {@code reset()},
+     * {@link #installDefaultSink(Supplier)} can re-install the default
+     * for the next test.
+     */
+    public static synchronized void reset() {
+        SINKS.clear();
+        defaultSupplier = null;
+        defaultInstalled = false;
+    }
+
+    /**
+     * Replaces the entire sink list with the supplied sinks, ignoring
+     * any previously installed default. Used by tests that need
+     * exclusive control over which sinks fire.
+     *
+     * @param sinks the sinks to install; may be empty (suppresses all
+     *              dispatch)
+     */
+    public static synchronized void replaceAll(VerdictSink... sinks) {
+        SINKS.clear();
+        defaultInstalled = true;   // suppress default installation
+        defaultSupplier = null;
+        for (VerdictSink s : sinks) {
+            Objects.requireNonNull(s, "sink");
+            SINKS.add(s);
+        }
+    }
+
+    /**
+     * Dispatches the verdict to every registered sink. The default
+     * sink (if any) is materialised on first call and prepended to
+     * the list. Failures in individual sinks are isolated by
+     * {@link CompositeVerdictSink}'s logging-and-continue semantics.
+     *
+     * @param verdict the verdict to dispatch
+     */
+    public static synchronized void dispatch(ProbabilisticTestVerdict verdict) {
+        Objects.requireNonNull(verdict, "verdict");
+        installDefaultIfNeeded();
+        if (SINKS.isEmpty()) {
+            return;
+        }
+        new CompositeVerdictSink(List.copyOf(SINKS)).accept(verdict);
+    }
+
+    private static void installDefaultIfNeeded() {
+        if (!defaultInstalled && defaultSupplier != null) {
+            VerdictSink defaultSink = defaultSupplier.get();
+            if (defaultSink != null) {
+                SINKS.add(0, defaultSink);
+            }
+            defaultInstalled = true;
+        }
+    }
+
+    /**
+     * @return the number of sinks currently registered (excluding the
+     *         default until first dispatch materialises it). Test
+     *         observability only.
+     */
+    public static synchronized int registeredCount() {
+        return SINKS.size();
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/verdict/TypedVerdictSinkBusTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/TypedVerdictSinkBusTest.java
@@ -1,0 +1,195 @@
+package org.javai.punit.verdict;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
+import org.javai.punit.model.TerminationReason;
+import org.javai.punit.model.UseCaseAttributes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TypedVerdictSinkBus")
+class TypedVerdictSinkBusTest {
+
+    @BeforeEach
+    void resetBus() {
+        TypedVerdictSinkBus.reset();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        TypedVerdictSinkBus.reset();
+    }
+
+    @Test
+    @DisplayName("dispatch with no sinks is a no-op")
+    void dispatchWithNoSinks() {
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        assertThat(TypedVerdictSinkBus.registeredCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("registered sink receives dispatched verdicts")
+    void registeredSinkReceives() {
+        List<ProbabilisticTestVerdict> received = new ArrayList<>();
+        TypedVerdictSinkBus.register(received::add);
+
+        ProbabilisticTestVerdict verdict = stubVerdict();
+        TypedVerdictSinkBus.dispatch(verdict);
+
+        assertThat(received).containsExactly(verdict);
+    }
+
+    @Test
+    @DisplayName("multiple registered sinks all receive in registration order")
+    void multipleSinksAllReceive() {
+        AtomicInteger first = new AtomicInteger();
+        AtomicInteger second = new AtomicInteger();
+        TypedVerdictSinkBus.register(v -> first.incrementAndGet());
+        TypedVerdictSinkBus.register(v -> second.incrementAndGet());
+
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        assertThat(first.get()).isEqualTo(2);
+        assertThat(second.get()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("default sink supplier is materialised on first dispatch")
+    void defaultSinkLazy() {
+        AtomicInteger supplierCalled = new AtomicInteger();
+        AtomicInteger sinkAccepts = new AtomicInteger();
+        TypedVerdictSinkBus.installDefaultSink(() -> {
+            supplierCalled.incrementAndGet();
+            return v -> sinkAccepts.incrementAndGet();
+        });
+
+        // Supplier not yet called
+        assertThat(supplierCalled.get()).isZero();
+
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        // Materialised on first dispatch
+        assertThat(supplierCalled.get()).isEqualTo(1);
+        assertThat(sinkAccepts.get()).isEqualTo(1);
+
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        // Not re-materialised
+        assertThat(supplierCalled.get()).isEqualTo(1);
+        assertThat(sinkAccepts.get()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("installDefaultSink is idempotent — first install wins")
+    void installDefaultSinkIdempotent() {
+        AtomicInteger firstSupplier = new AtomicInteger();
+        AtomicInteger secondSupplier = new AtomicInteger();
+        TypedVerdictSinkBus.installDefaultSink(() -> {
+            firstSupplier.incrementAndGet();
+            return v -> { };
+        });
+        TypedVerdictSinkBus.installDefaultSink(() -> {
+            secondSupplier.incrementAndGet();
+            return v -> { };
+        });
+
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        assertThat(firstSupplier.get()).isEqualTo(1);
+        assertThat(secondSupplier.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("replaceAll suppresses default and installs only the supplied sinks")
+    void replaceAllSuppressesDefault() {
+        AtomicInteger defaultSink = new AtomicInteger();
+        AtomicInteger replacement = new AtomicInteger();
+        TypedVerdictSinkBus.installDefaultSink(() -> v -> defaultSink.incrementAndGet());
+        TypedVerdictSinkBus.replaceAll(v -> replacement.incrementAndGet());
+
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        assertThat(defaultSink.get()).isZero();
+        assertThat(replacement.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("replaceAll with empty array suppresses all dispatch")
+    void replaceAllEmpty() {
+        AtomicInteger anySink = new AtomicInteger();
+        TypedVerdictSinkBus.installDefaultSink(() -> v -> anySink.incrementAndGet());
+        TypedVerdictSinkBus.replaceAll();
+
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        assertThat(anySink.get()).isZero();
+    }
+
+    @Test
+    @DisplayName("a throwing sink does not prevent other sinks from receiving")
+    void throwingSinkIsolated() {
+        AtomicInteger goodSink = new AtomicInteger();
+        TypedVerdictSinkBus.register(v -> { throw new RuntimeException("boom"); });
+        TypedVerdictSinkBus.register(v -> goodSink.incrementAndGet());
+
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+
+        assertThat(goodSink.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("reset clears registered sinks and the default-installed flag")
+    void resetClears() {
+        AtomicInteger registered = new AtomicInteger();
+        TypedVerdictSinkBus.register(v -> registered.incrementAndGet());
+        assertThat(TypedVerdictSinkBus.registeredCount()).isEqualTo(1);
+
+        TypedVerdictSinkBus.reset();
+
+        assertThat(TypedVerdictSinkBus.registeredCount()).isZero();
+        TypedVerdictSinkBus.dispatch(stubVerdict());
+        assertThat(registered.get()).isZero();
+    }
+
+    private static ProbabilisticTestVerdict stubVerdict() {
+        return new ProbabilisticTestVerdict(
+                "v:test01",
+                Instant.parse("2026-04-30T00:00:00Z"),
+                new ProbabilisticTestVerdict.TestIdentity(
+                        "com.example.MyTest", "stub", Optional.empty()),
+                new ProbabilisticTestVerdict.ExecutionSummary(
+                        10, 10, 10, 0, 0.9, 1.0, 100,
+                        Optional.empty(), TestIntent.VERIFICATION, 0.95,
+                        UseCaseAttributes.DEFAULT),
+                Optional.empty(),
+                Optional.empty(),
+                new ProbabilisticTestVerdict.StatisticalAnalysis(
+                        0.95, 0.0, 0.9, 1.0,
+                        Optional.empty(), Optional.empty(),
+                        Optional.empty(), Optional.empty(), List.of()),
+                ProbabilisticTestVerdict.CovariateStatus.allAligned(),
+                new ProbabilisticTestVerdict.CostSummary(
+                        0, 0, 0, TokenMode.NONE, Optional.empty(), Optional.empty()),
+                Optional.empty(),
+                Optional.empty(),
+                new ProbabilisticTestVerdict.Termination(
+                        TerminationReason.COMPLETED, Optional.empty()),
+                Map.of(),
+                true,
+                PUnitVerdict.PASS,
+                "stub");
+    }
+}

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/PUnit.java
@@ -31,8 +31,14 @@ import org.javai.punit.engine.Engine;
 import org.javai.punit.engine.baseline.ProfileBoundBaselineProvider;
 import org.javai.punit.engine.covariate.CovariateResolver;
 import org.javai.punit.engine.criteria.Feasibility;
+import org.javai.punit.report.ReportConfiguration;
+import org.javai.punit.report.VerdictXmlSink;
 import org.javai.punit.reporting.TypedTransparentStatsRenderer;
 import org.javai.punit.statistics.transparent.TransparentStatsConfig;
+import org.javai.punit.verdict.ProbabilisticTestVerdict;
+import org.javai.punit.verdict.TypedRunMetadata;
+import org.javai.punit.verdict.TypedVerdictAdapter;
+import org.javai.punit.verdict.TypedVerdictSinkBus;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
@@ -190,6 +196,28 @@ public final class PUnit {
                 return ProfileBoundBaselineProvider.bind(provider, profile, declarations);
             }
         });
+    }
+
+    /**
+     * Adapts the typed result to a {@link ProbabilisticTestVerdict} and
+     * dispatches it through {@link TypedVerdictSinkBus}. Identity comes
+     * from {@link TypedTestIdentityResolver} (stack walk for the nearest
+     * {@link org.javai.punit.api.ProbabilisticTest @ProbabilisticTest}
+     * frame); falls back to {@code (useCaseId, useCaseId)} when the
+     * resolver finds no annotated frame (e.g. hand-driven tests).
+     *
+     * <p>Installs the default sink — {@link VerdictXmlSink} reading
+     * {@link ReportConfiguration#resolve()} — on first call. Idempotent;
+     * tests can override via {@link TypedVerdictSinkBus#replaceAll}.
+     */
+    private static void emitVerdict(ProbabilisticTestResult result, String fallbackUseCaseId) {
+        TypedVerdictSinkBus.installDefaultSink(
+                () -> new VerdictXmlSink(ReportConfiguration.resolve()));
+        TypedRunMetadata meta = TypedTestIdentityResolver.resolve()
+                .orElseGet(() -> TypedRunMetadata.of(
+                        fallbackUseCaseId, fallbackUseCaseId, fallbackUseCaseId));
+        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(result, meta);
+        TypedVerdictSinkBus.dispatch(verdict);
     }
 
     private static void translate(ProbabilisticTestResult result) {
@@ -584,6 +612,7 @@ public final class PUnit {
                                     observed, typed.covariates().baseline()))
                     .withContractRef(contractRef);
             maybeRenderTransparentStats(stamped);
+            emitVerdict(stamped, sampling.useCaseFactory().apply(factors).id());
             translate(stamped);
         }
 
@@ -711,6 +740,7 @@ public final class PUnit {
                                     observed, typed.covariates().baseline()))
                     .withContractRef(contractRef);
             maybeRenderTransparentStats(spec, stamped);
+            emitVerdict(stamped, resolveUseCaseId(spec));
             translate(stamped);
         }
 
@@ -749,7 +779,12 @@ public final class PUnit {
             if (!TransparentStatsConfig.resolve(transparentStatsOverride).enabled()) {
                 return;
             }
-            String testIdentity = spec.dispatch(
+            System.err.println(TypedTransparentStatsRenderer.render(
+                    resolveUseCaseId(spec), result));
+        }
+
+        private String resolveUseCaseId(ProbabilisticTest spec) {
+            return spec.dispatch(
                     new org.javai.punit.api.typed.spec.Spec.Dispatcher<String>() {
                         @Override
                         public <FT, IT, OT> String apply(
@@ -758,7 +793,6 @@ public final class PUnit {
                             return typed.useCaseFactory().apply(factors).id();
                         }
                     });
-            System.err.println(TypedTransparentStatsRenderer.render(testIdentity, result));
         }
     }
 }

--- a/punit-junit5/src/main/java/org/javai/punit/junit5/TypedTestIdentityResolver.java
+++ b/punit-junit5/src/main/java/org/javai/punit/junit5/TypedTestIdentityResolver.java
@@ -1,0 +1,62 @@
+package org.javai.punit.junit5;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.verdict.TypedRunMetadata;
+
+/**
+ * Resolves the {@code className} / {@code methodName} of the typed
+ * test currently executing, by walking the stack to find the
+ * nearest {@link ProbabilisticTest @ProbabilisticTest}-annotated
+ * method.
+ *
+ * <p>The typed pipeline's {@code PUnit} entry-point is a static facade
+ * called from inside test bodies — there is no JUnit
+ * {@code ExtensionContext} available at that call site. A stack walk
+ * is the cheapest and least-invasive way to recover identity without
+ * making the author pass it explicitly on every {@code .assertPasses()}
+ * call.
+ *
+ * <p>The resolver is intentionally lenient: it returns
+ * {@link Optional#empty()} when no annotated frame is found (e.g. when
+ * called outside a JUnit-driven typed test, such as a hand-written
+ * integration test or a REPL demo). Callers should fall back to a
+ * generic identity in that case.
+ */
+final class TypedTestIdentityResolver {
+
+    private TypedTestIdentityResolver() { }
+
+    /**
+     * @return the identity of the nearest enclosing
+     *         {@link ProbabilisticTest @ProbabilisticTest}-annotated
+     *         method on the current call stack, or
+     *         {@link Optional#empty()} if none is found
+     */
+    static Optional<TypedRunMetadata> resolve() {
+        return StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+                .walk(frames -> frames
+                        .map(TypedTestIdentityResolver::asMetadata)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .findFirst());
+    }
+
+    private static Optional<TypedRunMetadata> asMetadata(StackWalker.StackFrame frame) {
+        Class<?> declaring = frame.getDeclaringClass();
+        String methodName = frame.getMethodName();
+        // Match by name only — overload disambiguation isn't worth the
+        // complexity here. Multiple overloads of the same JUnit test
+        // method are vanishingly rare; a stack frame's method name maps
+        // back to at most one annotated method 99.9% of the time.
+        for (Method m : declaring.getDeclaredMethods()) {
+            if (m.getName().equals(methodName)
+                    && m.isAnnotationPresent(ProbabilisticTest.class)) {
+                return Optional.of(TypedRunMetadata.of(declaring.getName(), methodName));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitVerdictXmlEmissionIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitVerdictXmlEmissionIntegrationTest.java
@@ -1,0 +1,123 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.javai.punit.junit5.testsubjects.PUnitSubjects;
+import org.javai.punit.verdict.TypedVerdictSinkBus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * End-to-end emission test: drives a real typed test through the JUnit
+ * platform and asserts that the XML verdict file lands on disk at the
+ * configured path.
+ */
+@DisplayName("PUnit verdict XML emission via TypedVerdictSinkBus")
+class PUnitVerdictXmlEmissionIntegrationTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+    private static final String DIR_PROPERTY = "punit.report.dir";
+    private static final String BASELINE_DIR_PROPERTY = BaselineProviderResolver.BASELINE_DIR_PROPERTY;
+
+    @TempDir Path reportDir;
+    @TempDir Path baselineDir;
+    private String savedReportDir;
+    private String savedBaselineDir;
+
+    @BeforeEach
+    void configurePaths() {
+        savedReportDir = System.getProperty(DIR_PROPERTY);
+        savedBaselineDir = System.getProperty(BASELINE_DIR_PROPERTY);
+        System.setProperty(DIR_PROPERTY, reportDir.toString());
+        System.setProperty(BASELINE_DIR_PROPERTY, baselineDir.toString());
+        // Reset the bus so the default sink is re-installed against
+        // the freshly-set report dir property.
+        TypedVerdictSinkBus.reset();
+    }
+
+    @AfterEach
+    void restorePaths() {
+        TypedVerdictSinkBus.reset();
+        restore(DIR_PROPERTY, savedReportDir);
+        restore(BASELINE_DIR_PROPERTY, savedBaselineDir);
+    }
+
+    @Test
+    @DisplayName("contractual PASS produces an RP07 XML file at {className}.{methodName}.xml")
+    void contractualPassEmitsXmlFile() throws Exception {
+        Events events = run(PUnitSubjects.PassingContractualTest.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+
+        Path expected = reportDir.resolve(
+                PUnitSubjects.PassingContractualTest.class.getName() + ".passes.xml");
+        assertThat(expected).exists();
+
+        String xml = Files.readString(expected);
+        assertThat(xml).contains("<verdict-record")
+                .contains("xmlns=\"http://javai.org/verdict/1.0\"")
+                .contains("test-name=\"passes\"")
+                .contains("value=\"PASS\"");
+    }
+
+    @Test
+    @DisplayName("contractual FAIL produces an XML file even when the test fails")
+    void contractualFailEmitsXmlFile() throws Exception {
+        Events events = run(PUnitSubjects.FailingContractualTest.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(0).failed(1));
+
+        // The XML file should be present regardless of the JUnit verdict
+        // — emission happens before translate(), so a FAIL verdict also
+        // lands on disk.
+        try (Stream<Path> files = Files.list(reportDir)) {
+            assertThat(files.count()).isGreaterThanOrEqualTo(1L);
+        }
+        Path expected = reportDir.resolve(
+                PUnitSubjects.FailingContractualTest.class.getName() + ".fails.xml");
+        assertThat(expected).exists();
+        String xml = Files.readString(expected);
+        assertThat(xml).contains("value=\"FAIL\"");
+    }
+
+    @Test
+    @DisplayName("disabled report config (-Dpunit.report.enabled=false) suppresses emission")
+    void disabledReportSuppressesEmission() throws Exception {
+        String savedEnabled = System.getProperty("punit.report.enabled");
+        System.setProperty("punit.report.enabled", "false");
+        TypedVerdictSinkBus.reset();
+        try {
+            Events events = run(PUnitSubjects.PassingContractualTest.class);
+            events.assertStatistics(stats -> stats.started(1).succeeded(1));
+
+            try (Stream<Path> files = Files.list(reportDir)) {
+                assertThat(files.count()).isZero();
+            }
+        } finally {
+            restore("punit.report.enabled", savedEnabled);
+        }
+    }
+
+    private Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+
+    private static void restore(String key, String saved) {
+        if (saved == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, saved);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR 5 (the last functional piece) of the typed-pipeline → RP07 wiring plan. With this merged, **every typed `@ProbabilisticTest` automatically emits an RP07 XML verdict file** at `build/reports/punit/xml/{className}.{methodName}.xml`, matching the legacy pipeline's output by default.

## Architecture

| Type | Location | Role |
|------|----------|------|
| `TypedVerdictSinkBus` | `punit-core/verdict` (new) | Static-style sink registry. Lazy default-sink installation, plug-replaceable for tests, isolation via `CompositeVerdictSink`. |
| `TypedTestIdentityResolver` | `punit-junit5` (new) | Stack walk via `java.lang.StackWalker` to find the nearest `@ProbabilisticTest`-annotated frame. Returns the test's `(className, methodName)`; falls back to `Optional.empty()` for hand-driven tests. |
| `PUnit.assertPasses` (both paths) | `punit-junit5` (modified) | Adds `emitVerdict(stamped, fallback)` between `maybeRenderTransparentStats` and `translate`. The default sink (`VerdictXmlSink(ReportConfiguration.resolve())`) is installed idempotently on first call. |

## Default behaviour and configuration

Default-on, parity with legacy. Every typed `@ProbabilisticTest` produces XML at `build/reports/punit/xml/{className}.{methodName}.xml`. Override the directory with `-Dpunit.report.dir=...` or `PUNIT_REPORT_DIR=...`; suppress entirely with `-Dpunit.report.enabled=false`.

## Test plan

- [x] `TypedVerdictSinkBusTest` (9 cases): no-sink no-op, registered sink receives, multiple sinks in registration order, default sink lazy materialisation, idempotent install, `replaceAll` suppresses default, empty `replaceAll` suppresses all, throwing sink isolated, `reset` clears state.
- [x] `PUnitVerdictXmlEmissionIntegrationTest` (3 cases): drives `PassingContractualTest` via JUnit TestKit, asserts XML lands at expected path with `value="PASS"`; `FailingContractualTest` emits XML on FAIL (emit happens before `translate`); `punit.report.enabled=false` suppresses emission.
- [x] `./gradlew test` — full punit suite green.

## What remains

PR 6 (final): documentation of the new emission path (CHANGELOG + REPORTING docs) and a fidelity test asserting which fields are typed-derived vs. defaulted (e.g. `<cost>` budgets are 0, JUnit-pass status is defaulted true).