### PR TITLE
RP07 typed-pipeline: docs + fidelity test (closes the wiring plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Typed pipeline emits RP07 XML verdicts.** Every typed `@ProbabilisticTest` now produces an `{className}.{methodName}.xml` file under `build/reports/punit/xml/` (configurable via `punit.report.dir` / `PUNIT_REPORT_DIR`, suppressible with `punit.report.enabled=false`). The default behaviour matches the legacy pipeline. The HTML report (`./gradlew punitReport`) consumes these files identically. Some fields don't have a typed-pipeline analogue and render at builder defaults — see Part 11 of the user guide for the full fidelity table.
+- **`<postcondition-failures>` element on RP07 verdict XML.** Per-clause failure histograms produced by the typed pipeline now surface in verdict XML (each clause shows its description, count, and up to three retained input/reason exemplars) and in the HTML report (nested table per test row). The legacy pipeline does not yet populate the histogram; its verdicts continue to omit the section.
+- **`EngineRunSummary` on `ProbabilisticTestResult`.** Run-level scalars (planned/executed samples, elapsed, tokens, latency, termination, confidence, matched baseline filename) are now carried on the typed result. Existing call sites compile unchanged via a back-compat constructor that defaults the summary to empty.
+- **`BaselineLookup.sourceFile`.** The matched baseline's filename is threaded from `BaselineResolver` through `Spec.conclude` so it can populate the verdict XML's `<provenance spec-filename>` attribute.
+
 ### Removed (breaking)
 - **`@FactorSetter`, `@FactorGetter` annotations.** Previously deprecated in 0.6.0. Factor values for EXPLORE and OPTIMIZE experiments must be supplied via `UseCaseProvider.registerWithFactors(...)`; mutable-setter patterns are no longer supported.
 - **`UseCaseProvider.registerAutoWired(...)`** (and the parallel `UseCaseFactory.registerAutoWired(...)`). Previously deprecated in 0.6.0. Use `registerWithFactors(...)` instead.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -2350,6 +2350,32 @@ XML verdict collection is enabled by default. The following properties control r
 ./gradlew test -Dpunit.report.enabled=false
 ```
 
+### Typed Pipeline Emission
+
+Both authoring paths emit RP07 XML to the same directory using the same configuration knobs. The legacy `@ProbabilisticTest(...)` annotation path and the typed compositional `PUnit.testing(...).assertPasses()` path produce one file per test invocation, named `{className}.{methodName}.xml`.
+
+The typed pipeline reads test identity by walking the JVM stack to find the nearest `@ProbabilisticTest`-annotated method. When run outside JUnit (for example, a hand-driven integration test that calls `PUnit.testing(...)` directly), the resolver falls back to the use-case identifier in place of `className`/`methodName`. This keeps emission working for non-JUnit usage at the cost of less informative filenames.
+
+A few RP07 fields do not have a direct analogue on a typed-pipeline run today and render at framework defaults rather than with values from the run. The table below makes the distinction explicit so downstream tooling knows what to trust:
+
+| RP07 element / attribute            | Typed pipeline behaviour                                                                                                                                            |
+|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<identity use-case-id>`            | The use case's `id()`. Falls back to `className` if `id()` returns blank (matching the legacy pipeline's behaviour).                                                |
+| `<execution planned-samples>`       | From `Sampling.samples()`.                                                                                                                                          |
+| `<execution warmup>`                | Not surfaced. Builder default (omitted attribute).                                                                                                                  |
+| `<execution applied-multiplier>`    | Not surfaced. The typed pipeline doesn't apply the legacy `samplesMultiplier`.                                                                                      |
+| `<provenance spec-filename>`        | Populated for empirical criteria that resolve a baseline. Absent when only contractual criteria run.                                                                |
+| `<provenance contract-ref>`         | From `.contractRef(...)` on the test builder when set; absent otherwise.                                                                                            |
+| `<cost total-tokens>`               | From the engine's per-sample token tracker.                                                                                                                         |
+| `<cost ...-budget>`                 | Always `0` (= unlimited). The typed pipeline doesn't surface per-method budget configuration on the verdict.                                                        |
+| `<pacing>`                          | Omitted. Pacing configuration isn't surfaced on the verdict from the typed pipeline.                                                                                |
+| `<latency>`                         | Observed-only — `<observed>` percentiles populated, `<evaluations>` empty (typed pipeline doesn't yet emit per-percentile latency assertions).                      |
+| `<postcondition-failures>`          | Populated from the typed pipeline's per-clause failure histogram. The legacy pipeline omits this section entirely (it doesn't compute the histogram).               |
+| `<termination>`                     | Mapped from the typed `TerminationReason` enum: `COMPLETED` → `COMPLETED`, `TIME_BUDGET` → `METHOD_TIME_BUDGET_EXHAUSTED`, `TOKEN_BUDGET` → `METHOD_TOKEN_BUDGET_EXHAUSTED`. |
+| `correlation-id` (on root)          | Auto-generated `v:xxxxxx` UUID-fragment unless explicitly supplied via `TypedRunMetadata.correlationId`.                                                            |
+
+Custom verdict sinks (Slack notifiers, observability webhooks, archive uploaders) can be plugged in via `TypedVerdictSinkBus.register(VerdictSink)`. The framework's default `VerdictXmlSink` is installed automatically; calling `register(...)` adds your sink alongside it. Tests that need exclusive control can use `TypedVerdictSinkBus.replaceAll(...)`.
+
 ---
 
 ## Appendices

--- a/punit-core/src/test/java/org/javai/punit/verdict/TypedVerdictAdapterFidelityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/TypedVerdictAdapterFidelityTest.java
@@ -1,0 +1,300 @@
+package org.javai.punit.verdict;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.typed.FactorBundle;
+import org.javai.punit.api.typed.LatencyResult;
+import org.javai.punit.api.typed.covariate.CovariateAlignment;
+import org.javai.punit.api.typed.spec.CriterionResult;
+import org.javai.punit.api.typed.spec.CriterionRole;
+import org.javai.punit.api.typed.spec.EngineRunSummary;
+import org.javai.punit.api.typed.spec.EvaluatedCriterion;
+import org.javai.punit.api.typed.spec.FailureCount;
+import org.javai.punit.api.typed.spec.FailureExemplar;
+import org.javai.punit.api.typed.spec.ProbabilisticTestResult;
+import org.javai.punit.api.typed.spec.Verdict;
+import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
+import org.javai.punit.model.TerminationReason;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Living documentation: each test pins one row of the
+ * "RP07 element / attribute → typed pipeline behaviour" table in
+ * {@code USER-GUIDE.md} Part 11 ("Typed Pipeline Emission") to an
+ * executable assertion. If a behaviour shifts and the doc gets
+ * out of sync, this test fails first.
+ *
+ * <p>Distinct from {@link TypedVerdictAdapterTest} which exercises
+ * field-level mapping; this fidelity suite asserts what's
+ * <em>defaulted</em>, not just what's mapped.
+ */
+@DisplayName("TypedVerdictAdapter fidelity (USER-GUIDE Part 11 table)")
+class TypedVerdictAdapterFidelityTest {
+
+    private record Factors() { }
+
+    @Nested
+    @DisplayName("typed-derived fields")
+    class TypedDerived {
+
+        @Test
+        @DisplayName("identity use-case-id falls back to className when use-case-id absent")
+        void identityFallback() {
+            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+                    minimalResult(),
+                    TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+
+            assertThat(verdict.identity().useCaseId()).isEmpty();
+            // VerdictXmlWriter falls back to className when useCaseId is absent;
+            // this is verified in VerdictXmlWriterTest. Here we pin the absence.
+        }
+
+        @Test
+        @DisplayName("execution planned-samples comes from EngineRunSummary.plannedSamples")
+        void plannedSamplesFromEngine() {
+            ProbabilisticTestResult result = withEngine(new EngineRunSummary(
+                    150, 100, 95, 5, 1500L, 0L, 0,
+                    LatencyResult.empty(),
+                    org.javai.punit.api.typed.spec.TerminationReason.TIME_BUDGET,
+                    0.95, Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.execution().plannedSamples()).isEqualTo(150);
+            assertThat(verdict.execution().samplesExecuted()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("provenance spec-filename comes from EngineRunSummary.baselineFilename")
+        void provenanceSpecFilenameFromEngine() {
+            ProbabilisticTestResult base = withCriterionDetail(
+                    Map.of("threshold", 0.99, "origin", "EMPIRICAL"));
+            ProbabilisticTestResult result = new ProbabilisticTestResult(
+                    base.verdict(), base.factors(), base.criterionResults(),
+                    base.intent(), base.warnings(), base.covariates(),
+                    base.contractRef(), base.failuresByPostcondition(),
+                    new EngineRunSummary(
+                            10, 10, 10, 0, 100L, 0L, 0,
+                            LatencyResult.empty(),
+                            org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                            0.95,
+                            Optional.of("payment-gateway-1fbf-54c6-86a6.yaml")));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.provenance()).isPresent();
+            assertThat(verdict.provenance().get().specFilename())
+                    .isEqualTo("payment-gateway-1fbf-54c6-86a6.yaml");
+        }
+
+        @Test
+        @DisplayName("postcondition-failures populated from result.failuresByPostcondition")
+        void postconditionFailuresPopulated() {
+            LinkedHashMap<String, FailureCount> hist = new LinkedHashMap<>();
+            hist.put("Valid JSON", new FailureCount(3, List.of(
+                    new FailureExemplar("input-1", "missing actions"))));
+            ProbabilisticTestResult result = new ProbabilisticTestResult(
+                    Verdict.FAIL, FactorBundle.of(new Factors()),
+                    List.of(), TestIntent.VERIFICATION, List.of(),
+                    CovariateAlignment.none(), Optional.empty(), hist,
+                    EngineRunSummary.empty());
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.postconditionFailures())
+                    .containsKey("Valid JSON")
+                    .extractingByKey("Valid JSON")
+                    .extracting(FailureCount::count).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("latency observed populated when sampleCount > 0")
+        void latencyObservedPopulated() {
+            LatencyResult lat = new LatencyResult(
+                    Duration.ofMillis(100), Duration.ofMillis(200),
+                    Duration.ofMillis(300), Duration.ofMillis(500),
+                    50);
+            ProbabilisticTestResult result = withEngine(new EngineRunSummary(
+                    50, 50, 50, 0, 1000L, 0L, 0, lat,
+                    org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                    0.95, Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.latency()).isPresent();
+            assertThat(verdict.latency().get().p50Ms()).isEqualTo(100L);
+            assertThat(verdict.latency().get().p95Ms()).isEqualTo(300L);
+        }
+    }
+
+    @Nested
+    @DisplayName("defaulted (no typed-pipeline analogue)")
+    class Defaulted {
+
+        @Test
+        @DisplayName("execution warmup not surfaced — UseCaseAttributes default warmup=0")
+        void warmupDefaulted() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult());
+
+            assertThat(verdict.execution().warmup()).isZero();
+            assertThat(verdict.execution().useCaseAttributes())
+                    .isEqualTo(org.javai.punit.model.UseCaseAttributes.DEFAULT);
+        }
+
+        @Test
+        @DisplayName("execution applied-multiplier absent")
+        void appliedMultiplierAbsent() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult());
+
+            assertThat(verdict.execution().appliedMultiplier()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("cost budgets default to 0 (unlimited) and TokenMode.NONE")
+        void costBudgetsDefaulted() {
+            ProbabilisticTestResult result = withEngine(new EngineRunSummary(
+                    10, 10, 10, 0, 100L, 1234L, 0,
+                    LatencyResult.empty(),
+                    org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                    0.95, Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.cost().methodTokensConsumed()).isEqualTo(1234L);
+            assertThat(verdict.cost().methodTimeBudgetMs()).isZero();
+            assertThat(verdict.cost().methodTokenBudget()).isZero();
+            assertThat(verdict.cost().tokenMode()).isEqualTo(TokenMode.NONE);
+            assertThat(verdict.cost().classBudget()).isEmpty();
+            assertThat(verdict.cost().suiteBudget()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("pacing absent")
+        void pacingAbsent() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult());
+
+            assertThat(verdict.pacing()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("latency evaluations empty (assertions list)")
+        void latencyEvaluationsEmpty() {
+            LatencyResult lat = new LatencyResult(
+                    Duration.ofMillis(100), Duration.ofMillis(200),
+                    Duration.ofMillis(300), Duration.ofMillis(500),
+                    50);
+            ProbabilisticTestResult result = withEngine(new EngineRunSummary(
+                    50, 50, 50, 0, 1000L, 0L, 0, lat,
+                    org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                    0.95, Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.latency().get().assertions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("correlation-id auto-generated when metadata supplies none")
+        void correlationIdGenerated() {
+            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+                    minimalResult(),
+                    TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+
+            assertThat(verdict.correlationId()).isNotEmpty().startsWith("v:");
+        }
+
+        @Test
+        @DisplayName("junitPassed defaulted to true (typed pipeline has no JUnit-pass concept)")
+        void junitPassedDefaulted() {
+            ProbabilisticTestVerdict verdict = adapt(minimalResult());
+
+            assertThat(verdict.junitPassed()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("termination reason mapping (rows of the table)")
+    class TerminationMapping {
+
+        @Test
+        @DisplayName("COMPLETED → COMPLETED")
+        void completed() {
+            assertMapping(
+                    org.javai.punit.api.typed.spec.TerminationReason.COMPLETED,
+                    TerminationReason.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("TIME_BUDGET → METHOD_TIME_BUDGET_EXHAUSTED")
+        void timeBudget() {
+            assertMapping(
+                    org.javai.punit.api.typed.spec.TerminationReason.TIME_BUDGET,
+                    TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED);
+        }
+
+        @Test
+        @DisplayName("TOKEN_BUDGET → METHOD_TOKEN_BUDGET_EXHAUSTED")
+        void tokenBudget() {
+            assertMapping(
+                    org.javai.punit.api.typed.spec.TerminationReason.TOKEN_BUDGET,
+                    TerminationReason.METHOD_TOKEN_BUDGET_EXHAUSTED);
+        }
+
+        private void assertMapping(
+                org.javai.punit.api.typed.spec.TerminationReason typed,
+                TerminationReason expectedCore) {
+            ProbabilisticTestResult result = withEngine(new EngineRunSummary(
+                    1, 1, 1, 0, 1L, 0L, 0,
+                    LatencyResult.empty(), typed, 0.95, Optional.empty()));
+
+            ProbabilisticTestVerdict verdict = adapt(result);
+
+            assertThat(verdict.termination().reason()).isEqualTo(expectedCore);
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private static ProbabilisticTestVerdict adapt(ProbabilisticTestResult result) {
+        return TypedVerdictAdapter.adapt(
+                result,
+                TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+    }
+
+    private static ProbabilisticTestResult minimalResult() {
+        return new ProbabilisticTestResult(
+                Verdict.PASS, FactorBundle.of(new Factors()),
+                List.of(), TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
+    }
+
+    private static ProbabilisticTestResult withEngine(EngineRunSummary engine) {
+        return new ProbabilisticTestResult(
+                Verdict.PASS, FactorBundle.of(new Factors()),
+                List.of(), TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                engine);
+    }
+
+    private static ProbabilisticTestResult withCriterionDetail(Map<String, Object> detail) {
+        CriterionResult cr = new CriterionResult(
+                "bernoulli-pass-rate", Verdict.PASS,
+                "stub", detail);
+        return new ProbabilisticTestResult(
+                Verdict.PASS, FactorBundle.of(new Factors()),
+                List.of(new EvaluatedCriterion(cr, CriterionRole.REQUIRED)),
+                TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
+    }
+}


### PR DESCRIPTION
## Summary

Final PR of the typed-pipeline → RP07 wiring plan. PRs #99 through #102 shipped the XML-emission machinery; this PR closes the docs and fidelity gap.

## Changes

### `CHANGELOG.md`

Adds an `### Added` subsection under `[Unreleased]`:
- Typed pipeline emits RP07 XML verdicts (default-on, configurable via the legacy properties)
- `<postcondition-failures>` element on RP07 XML and HTML report
- `EngineRunSummary` on `ProbabilisticTestResult`
- `BaselineLookup.sourceFile` for spec-filename traceability

### `docs/USER-GUIDE.md` Part 11

Adds a "Typed Pipeline Emission" subsection covering:
- Both authoring paths emit to the same directory using the same configuration knobs
- Stack-walk identity resolution (with fallback to use-case-id)
- A fidelity table mapping every RP07 element / attribute to what the typed pipeline actually does — distinguishing typed-derived fields from those that default at the builder
- Mention of `TypedVerdictSinkBus.register / replaceAll` for custom sinks

### `TypedVerdictAdapterFidelityTest` (new, 14 cases)

Living documentation that pins each row of the Part 11 table to an executable assertion, organised into three nested classes:
- **typed-derived fields** (5): identity fallback, planned-samples, provenance spec-filename, postcondition-failures threading, latency observed populated
- **defaulted fields** (6): warmup, applied-multiplier, cost budgets / TokenMode, pacing, latency evaluations empty, correlation-id auto-generated, junitPassed defaulted to true
- **termination mapping** (3): all three typed → core enum mappings

Distinct from `TypedVerdictAdapterTest`'s field-mapping coverage: this suite asserts what's *defaulted* (not just what's mapped), so a silent behavioural drift in the adapter fails this test before the doc rots.

## Test plan

- [x] `./gradlew :punit-core:test --tests "TypedVerdictAdapterFidelityTest"` — 14 cases pass.
- [x] `./gradlew test` — full punit suite green.

## Plan closure

With this merged, the typed-pipeline → RP07 wiring plan ships end-to-end:
- PR #99 — `<postcondition-failures>` in XML + HTML
- PR #100 — `EngineRunSummary` on `ProbabilisticTestResult`
- PR #101 — `TypedVerdictAdapter` + round-trip integration test
- PR #102 — `TypedVerdictSinkBus` + `PUnit.assertPasses` wiring + TestKit emission test
- **#this** — docs + fidelity test