### PR TITLE
Phase C class renames: drop "Typed" prefix from coexistence-label classes

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -2372,9 +2372,9 @@ A few RP07 fields do not have a direct analogue on a typed-pipeline run today an
 | `<latency>`                         | Observed-only — `<observed>` percentiles populated, `<evaluations>` empty (typed pipeline doesn't yet emit per-percentile latency assertions).                      |
 | `<postcondition-failures>`          | Populated from the typed pipeline's per-clause failure histogram. The legacy pipeline omits this section entirely (it doesn't compute the histogram).               |
 | `<termination>`                     | Mapped from the typed `TerminationReason` enum: `COMPLETED` → `COMPLETED`, `TIME_BUDGET` → `METHOD_TIME_BUDGET_EXHAUSTED`, `TOKEN_BUDGET` → `METHOD_TOKEN_BUDGET_EXHAUSTED`. |
-| `correlation-id` (on root)          | Auto-generated `v:xxxxxx` UUID-fragment unless explicitly supplied via `TypedRunMetadata.correlationId`.                                                            |
+| `correlation-id` (on root)          | Auto-generated `v:xxxxxx` UUID-fragment unless explicitly supplied via `RunMetadata.correlationId`.                                                            |
 
-Custom verdict sinks (Slack notifiers, observability webhooks, archive uploaders) can be plugged in via `TypedVerdictSinkBus.register(VerdictSink)`. The framework's default `VerdictXmlSink` is installed automatically; calling `register(...)` adds your sink alongside it. Tests that need exclusive control can use `TypedVerdictSinkBus.replaceAll(...)`.
+Custom verdict sinks (Slack notifiers, observability webhooks, archive uploaders) can be plugged in via `VerdictSinkBus.register(VerdictSink)`. The framework's default `VerdictXmlSink` is installed automatically; calling `register(...)` adds your sink alongside it. Tests that need exclusive control can use `VerdictSinkBus.replaceAll(...)`.
 
 ---
 

--- a/punit-core/src/main/java/org/javai/punit/reporting/TransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/TransparentStatsRenderer.java
@@ -61,12 +61,12 @@ import org.javai.punit.api.spec.Verdict;
  * <p>Output is plain text — readable in IDE test consoles,
  * surefire reports, and CI logs without further processing.
  */
-public final class TypedTransparentStatsRenderer {
+public final class TransparentStatsRenderer {
 
     private static final String LABEL_INDENT = "      ";
     private static final int LABEL_WIDTH = 22;
 
-    private TypedTransparentStatsRenderer() { }
+    private TransparentStatsRenderer() { }
 
     /**
      * @param testIdentity the className.methodName the verdict

--- a/punit-core/src/main/java/org/javai/punit/verdict/RunMetadata.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/RunMetadata.java
@@ -12,7 +12,7 @@ import org.javai.punit.api.spec.ProbabilisticTestResult;
  *
  * <p>Built at the JUnit-extension boundary (where {@code className} and
  * {@code methodName} are knowable via stack walk or the test extension
- * context) and threaded into {@link TypedVerdictAdapter} alongside the
+ * context) and threaded into {@link VerdictAdapter} alongside the
  * {@link ProbabilisticTestResult result}
  * itself. The result captures what happened in the run; this metadata
  * captures who ran it and where.
@@ -37,14 +37,14 @@ import org.javai.punit.api.spec.ProbabilisticTestResult;
  *                            {@code <environment>} entries; empty →
  *                            adapter omits the section
  */
-public record TypedRunMetadata(
+public record RunMetadata(
         String className,
         String methodName,
         Optional<String> useCaseId,
         Optional<String> correlationId,
         Map<String, String> environmentMetadata) {
 
-    public TypedRunMetadata {
+    public RunMetadata {
         Objects.requireNonNull(className, "className");
         Objects.requireNonNull(methodName, "methodName");
         Objects.requireNonNull(useCaseId, "useCaseId");
@@ -64,8 +64,8 @@ public record TypedRunMetadata(
      * defaults useCaseId, correlationId, and environmentMetadata to
      * empty.
      */
-    public static TypedRunMetadata of(String className, String methodName) {
-        return new TypedRunMetadata(
+    public static RunMetadata of(String className, String methodName) {
+        return new RunMetadata(
                 className, methodName,
                 Optional.empty(), Optional.empty(), Map.of());
     }
@@ -74,11 +74,11 @@ public record TypedRunMetadata(
      * Convenience adding a use-case identifier; correlationId and
      * environmentMetadata default to empty.
      */
-    public static TypedRunMetadata of(String className, String methodName, String useCaseId) {
+    public static RunMetadata of(String className, String methodName, String useCaseId) {
         Optional<String> wrapped = (useCaseId == null || useCaseId.isBlank())
                 ? Optional.empty()
                 : Optional.of(useCaseId);
-        return new TypedRunMetadata(
+        return new RunMetadata(
                 className, methodName, wrapped, Optional.empty(), Map.of());
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
@@ -22,7 +22,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder.MisalignmentInput
  *
  * <p>The adapter is a thin field-mapping function — it does not perform
  * statistical computation, judgement, or rendering. It reads the typed
- * result's components and the supplied {@link TypedRunMetadata}, and
+ * result's components and the supplied {@link RunMetadata}, and
  * delegates to {@link ProbabilisticTestVerdictBuilder} for the heavy
  * lifting (Wilson-score CI, baseline-derivation narrative, verdict-reason
  * synthesis).
@@ -30,7 +30,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder.MisalignmentInput
  * <h2>Field provenance</h2>
  *
  * <ul>
- *   <li><b>Identity</b> — from {@code TypedRunMetadata}.</li>
+ *   <li><b>Identity</b> — from {@code RunMetadata}.</li>
  *   <li><b>Execution</b> — from {@code result.engineSummary()}; the
  *       observed pass rate is computed from successes/total. The
  *       threshold is lifted from the first {@code BernoulliPassRate}
@@ -72,9 +72,9 @@ import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder.MisalignmentInput
  * those left at their builder defaults. Field-level fidelity is captured
  * in the test suite; renderers are tolerant of absent optional fields.
  */
-public final class TypedVerdictAdapter {
+public final class VerdictAdapter {
 
-    private TypedVerdictAdapter() { }
+    private VerdictAdapter() { }
 
     /**
      * Build a {@link ProbabilisticTestVerdict} from a typed result and
@@ -86,7 +86,7 @@ public final class TypedVerdictAdapter {
      *         serialisation
      */
     public static ProbabilisticTestVerdict adapt(
-            ProbabilisticTestResult result, TypedRunMetadata meta) {
+            ProbabilisticTestResult result, RunMetadata meta) {
 
         EngineRunSummary engine = result.engineSummary();
         ProbabilisticTestVerdictBuilder b = new ProbabilisticTestVerdictBuilder();

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictSinkBus.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictSinkBus.java
@@ -35,13 +35,13 @@ import org.javai.punit.reporting.CompositeVerdictSink;
  * {@link #installDefaultSink(Supplier)} (idempotent if the sink is
  * stateless).
  */
-public final class TypedVerdictSinkBus {
+public final class VerdictSinkBus {
 
     private static final List<VerdictSink> SINKS = new ArrayList<>();
     private static Supplier<VerdictSink> defaultSupplier;
     private static boolean defaultInstalled;
 
-    private TypedVerdictSinkBus() { }
+    private VerdictSinkBus() { }
 
     /**
      * Configures the default sink supplier, lazy-evaluated on first

--- a/punit-core/src/test/java/org/javai/punit/architecture/EngineArchitectureTest.java
+++ b/punit-core/src/test/java/org/javai/punit/architecture/EngineArchitectureTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
  * {@code org.javai.punit.api.spec.Spec}.
  */
 @DisplayName("typed engine architecture rules")
-class TypedEngineArchitectureTest {
+class EngineArchitectureTest {
 
     private static JavaClasses engineClasses;
 

--- a/punit-core/src/test/java/org/javai/punit/reporting/TransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/reporting/TransparentStatsRendererTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("TypedTransparentStatsRenderer — verbose statistical breakdown")
-class TypedTransparentStatsRendererTest {
+@DisplayName("TransparentStatsRenderer — verbose statistical breakdown")
+class TransparentStatsRendererTest {
 
     private static ProbabilisticTestResult result(Verdict verdict, EvaluatedCriterion... evaluated) {
         return new ProbabilisticTestResult(
@@ -59,7 +59,7 @@ class TypedTransparentStatsRendererTest {
             detail.put("wilsonLowerBound", 0.929);
             detail.put("baselineSampleCount", 1000);
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "shopping-basket.testInstructionTranslation",
                     result(Verdict.FAIL, criterion(
                             "bernoulli-pass-rate", Verdict.FAIL,
@@ -107,7 +107,7 @@ class TypedTransparentStatsRendererTest {
                     "confidence", 0.95,
                     "wilsonLowerBound", 0.873);
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", result(Verdict.PASS, criterion(
                             "bernoulli-pass-rate", Verdict.PASS, "...", detail)));
 
@@ -132,7 +132,7 @@ class TypedTransparentStatsRendererTest {
                     "failures", 6,
                     "total", 100);
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", result(Verdict.PASS, criterion(
                             "bernoulli-pass-rate", Verdict.PASS, "...", detail)));
 
@@ -158,7 +158,7 @@ class TypedTransparentStatsRendererTest {
                     "p50", "PT0.001S",
                     "p99", "PT0.020S");
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", result(Verdict.PASS, criterion(
                             "percentile-latency", Verdict.PASS,
                             "p50=1ms, p99=20ms within limits", detail)));
@@ -185,7 +185,7 @@ class TypedTransparentStatsRendererTest {
                 TestIntent.VERIFICATION,
                 List.of("rejected file-A — CONFIGURATION mismatch on region (current=APAC, baseline=EU)"));
 
-        String rendered = TypedTransparentStatsRenderer.render(
+        String rendered = TransparentStatsRenderer.render(
                 "test", resultWithWarnings);
 
         assertThat(rendered)
@@ -218,7 +218,7 @@ class TypedTransparentStatsRendererTest {
                     "model_version", "v1")));
             CovariateAlignment alignment = CovariateAlignment.compute(profile, profile);
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithAlignment(alignment));
 
             assertThat(rendered)
@@ -242,7 +242,7 @@ class TypedTransparentStatsRendererTest {
                     "model_version", "v1")));
             CovariateAlignment alignment = CovariateAlignment.compute(observed, baseline);
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithAlignment(alignment));
 
             assertThat(rendered)
@@ -259,7 +259,7 @@ class TypedTransparentStatsRendererTest {
         @Test
         @DisplayName("empty alignment (no covariates declared, no baseline) renders no Covariates section")
         void emptyAlignmentRendersNothing() {
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithAlignment(CovariateAlignment.none()));
 
             assertThat(rendered).doesNotContain("Covariates");
@@ -272,7 +272,7 @@ class TypedTransparentStatsRendererTest {
             CovariateAlignment alignment = CovariateAlignment.compute(
                     observed, CovariateProfile.empty());
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithAlignment(alignment));
 
             assertThat(rendered)
@@ -293,7 +293,7 @@ class TypedTransparentStatsRendererTest {
                 criterion("bernoulli-pass-rate", Verdict.PASS, "ok", bernoulliDetail),
                 criterion("percentile-latency", Verdict.PASS, "ok", latencyDetail));
 
-        var snapshot = TypedTransparentStatsRenderer.snapshotCriteria(r);
+        var snapshot = TransparentStatsRenderer.snapshotCriteria(r);
 
         assertThat(snapshot.keySet())
                 .containsExactly("bernoulli-pass-rate", "percentile-latency");
@@ -324,7 +324,7 @@ class TypedTransparentStatsRendererTest {
         @Test
         @DisplayName("empty histogram → no Postcondition failures section")
         void emptyHistogramOmitsSection() {
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithHistogram(Map.of()));
 
             assertThat(rendered).doesNotContain("Postcondition failures");
@@ -342,7 +342,7 @@ class TypedTransparentStatsRendererTest {
                             new FailureExemplar(
                                     "Remove the milk", "malformed brace"))));
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithHistogram(hist));
 
             assertThat(rendered).contains("Postcondition failures");
@@ -362,7 +362,7 @@ class TypedTransparentStatsRendererTest {
                     "Most common", new FailureCount(10, List.of()),
                     "Middle", new FailureCount(5, List.of()));
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithHistogram(hist));
 
             int mostIdx = rendered.indexOf("Most common");
@@ -381,7 +381,7 @@ class TypedTransparentStatsRendererTest {
                     "Single trip", new FailureCount(1, List.of()),
                     "Multi trip", new FailureCount(5, List.of()));
 
-            String rendered = TypedTransparentStatsRenderer.render(
+            String rendered = TransparentStatsRenderer.render(
                     "test", resultWithHistogram(hist));
 
             assertThat(rendered).contains("Single trip — 1 failure\n");

--- a/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterFidelityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterFidelityTest.java
@@ -33,12 +33,12 @@ import org.junit.jupiter.api.Test;
  * executable assertion. If a behaviour shifts and the doc gets
  * out of sync, this test fails first.
  *
- * <p>Distinct from {@link TypedVerdictAdapterTest} which exercises
+ * <p>Distinct from {@link VerdictAdapterTest} which exercises
  * field-level mapping; this fidelity suite asserts what's
  * <em>defaulted</em>, not just what's mapped.
  */
-@DisplayName("TypedVerdictAdapter fidelity (USER-GUIDE Part 11 table)")
-class TypedVerdictAdapterFidelityTest {
+@DisplayName("VerdictAdapter fidelity (USER-GUIDE Part 11 table)")
+class VerdictAdapterFidelityTest {
 
     private record Factors() { }
 
@@ -49,9 +49,9 @@ class TypedVerdictAdapterFidelityTest {
         @Test
         @DisplayName("identity use-case-id falls back to className when use-case-id absent")
         void identityFallback() {
-            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+            ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(
                     minimalResult(),
-                    TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+                    RunMetadata.of("com.example.MyTest", "shouldRun"));
 
             assertThat(verdict.identity().useCaseId()).isEmpty();
             // VerdictXmlWriter falls back to className when useCaseId is absent;
@@ -205,9 +205,9 @@ class TypedVerdictAdapterFidelityTest {
         @Test
         @DisplayName("correlation-id auto-generated when metadata supplies none")
         void correlationIdGenerated() {
-            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+            ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(
                     minimalResult(),
-                    TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+                    RunMetadata.of("com.example.MyTest", "shouldRun"));
 
             assertThat(verdict.correlationId()).isNotEmpty().startsWith("v:");
         }
@@ -265,9 +265,9 @@ class TypedVerdictAdapterFidelityTest {
     // ── Helpers ─────────────────────────────────────────────────────
 
     private static ProbabilisticTestVerdict adapt(ProbabilisticTestResult result) {
-        return TypedVerdictAdapter.adapt(
+        return VerdictAdapter.adapt(
                 result,
-                TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+                RunMetadata.of("com.example.MyTest", "shouldRun"));
     }
 
     private static ProbabilisticTestResult minimalResult() {

--- a/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("TypedVerdictAdapter")
-class TypedVerdictAdapterTest {
+@DisplayName("VerdictAdapter")
+class VerdictAdapterTest {
 
     private record Factors() { }
 
@@ -38,9 +38,9 @@ class TypedVerdictAdapterTest {
         @Test
         @DisplayName("populates className/methodName/useCaseId from metadata")
         void identityFromMetadata() {
-            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+            ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(
                     minimalResult(Verdict.PASS),
-                    new TypedRunMetadata(
+                    new RunMetadata(
                             "com.example.MyTest", "shouldPass",
                             Optional.of("payment-gateway"),
                             Optional.of("v:abc123"),
@@ -56,9 +56,9 @@ class TypedVerdictAdapterTest {
         @Test
         @DisplayName("absent correlationId triggers builder's UUID-fragment generation")
         void absentCorrelationIdGetsGenerated() {
-            ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+            ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(
                     minimalResult(Verdict.PASS),
-                    TypedRunMetadata.of("com.example.MyTest", "shouldPass"));
+                    RunMetadata.of("com.example.MyTest", "shouldPass"));
 
             assertThat(verdict.correlationId()).isNotEmpty().startsWith("v:");
         }
@@ -339,9 +339,9 @@ class TypedVerdictAdapterTest {
     // ── Helpers ─────────────────────────────────────────────────────
 
     private static ProbabilisticTestVerdict adapt(ProbabilisticTestResult result) {
-        return TypedVerdictAdapter.adapt(
+        return VerdictAdapter.adapt(
                 result,
-                TypedRunMetadata.of("com.example.MyTest", "shouldPass"));
+                RunMetadata.of("com.example.MyTest", "shouldPass"));
     }
 
     private static ProbabilisticTestResult minimalResult(Verdict v) {

--- a/punit-core/src/test/java/org/javai/punit/verdict/VerdictSinkBusTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/VerdictSinkBusTest.java
@@ -18,35 +18,35 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("TypedVerdictSinkBus")
-class TypedVerdictSinkBusTest {
+@DisplayName("VerdictSinkBus")
+class VerdictSinkBusTest {
 
     @BeforeEach
     void resetBus() {
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
     }
 
     @AfterEach
     void cleanUp() {
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
     }
 
     @Test
     @DisplayName("dispatch with no sinks is a no-op")
     void dispatchWithNoSinks() {
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
-        assertThat(TypedVerdictSinkBus.registeredCount()).isZero();
+        assertThat(VerdictSinkBus.registeredCount()).isZero();
     }
 
     @Test
     @DisplayName("registered sink receives dispatched verdicts")
     void registeredSinkReceives() {
         List<ProbabilisticTestVerdict> received = new ArrayList<>();
-        TypedVerdictSinkBus.register(received::add);
+        VerdictSinkBus.register(received::add);
 
         ProbabilisticTestVerdict verdict = stubVerdict();
-        TypedVerdictSinkBus.dispatch(verdict);
+        VerdictSinkBus.dispatch(verdict);
 
         assertThat(received).containsExactly(verdict);
     }
@@ -56,11 +56,11 @@ class TypedVerdictSinkBusTest {
     void multipleSinksAllReceive() {
         AtomicInteger first = new AtomicInteger();
         AtomicInteger second = new AtomicInteger();
-        TypedVerdictSinkBus.register(v -> first.incrementAndGet());
-        TypedVerdictSinkBus.register(v -> second.incrementAndGet());
+        VerdictSinkBus.register(v -> first.incrementAndGet());
+        VerdictSinkBus.register(v -> second.incrementAndGet());
 
-        TypedVerdictSinkBus.dispatch(stubVerdict());
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
         assertThat(first.get()).isEqualTo(2);
         assertThat(second.get()).isEqualTo(2);
@@ -71,7 +71,7 @@ class TypedVerdictSinkBusTest {
     void defaultSinkLazy() {
         AtomicInteger supplierCalled = new AtomicInteger();
         AtomicInteger sinkAccepts = new AtomicInteger();
-        TypedVerdictSinkBus.installDefaultSink(() -> {
+        VerdictSinkBus.installDefaultSink(() -> {
             supplierCalled.incrementAndGet();
             return v -> sinkAccepts.incrementAndGet();
         });
@@ -79,13 +79,13 @@ class TypedVerdictSinkBusTest {
         // Supplier not yet called
         assertThat(supplierCalled.get()).isZero();
 
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
         // Materialised on first dispatch
         assertThat(supplierCalled.get()).isEqualTo(1);
         assertThat(sinkAccepts.get()).isEqualTo(1);
 
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
         // Not re-materialised
         assertThat(supplierCalled.get()).isEqualTo(1);
@@ -97,16 +97,16 @@ class TypedVerdictSinkBusTest {
     void installDefaultSinkIdempotent() {
         AtomicInteger firstSupplier = new AtomicInteger();
         AtomicInteger secondSupplier = new AtomicInteger();
-        TypedVerdictSinkBus.installDefaultSink(() -> {
+        VerdictSinkBus.installDefaultSink(() -> {
             firstSupplier.incrementAndGet();
             return v -> { };
         });
-        TypedVerdictSinkBus.installDefaultSink(() -> {
+        VerdictSinkBus.installDefaultSink(() -> {
             secondSupplier.incrementAndGet();
             return v -> { };
         });
 
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
         assertThat(firstSupplier.get()).isEqualTo(1);
         assertThat(secondSupplier.get()).isZero();
@@ -117,10 +117,10 @@ class TypedVerdictSinkBusTest {
     void replaceAllSuppressesDefault() {
         AtomicInteger defaultSink = new AtomicInteger();
         AtomicInteger replacement = new AtomicInteger();
-        TypedVerdictSinkBus.installDefaultSink(() -> v -> defaultSink.incrementAndGet());
-        TypedVerdictSinkBus.replaceAll(v -> replacement.incrementAndGet());
+        VerdictSinkBus.installDefaultSink(() -> v -> defaultSink.incrementAndGet());
+        VerdictSinkBus.replaceAll(v -> replacement.incrementAndGet());
 
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
         assertThat(defaultSink.get()).isZero();
         assertThat(replacement.get()).isEqualTo(1);
@@ -130,10 +130,10 @@ class TypedVerdictSinkBusTest {
     @DisplayName("replaceAll with empty array suppresses all dispatch")
     void replaceAllEmpty() {
         AtomicInteger anySink = new AtomicInteger();
-        TypedVerdictSinkBus.installDefaultSink(() -> v -> anySink.incrementAndGet());
-        TypedVerdictSinkBus.replaceAll();
+        VerdictSinkBus.installDefaultSink(() -> v -> anySink.incrementAndGet());
+        VerdictSinkBus.replaceAll();
 
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
         assertThat(anySink.get()).isZero();
     }
@@ -142,10 +142,10 @@ class TypedVerdictSinkBusTest {
     @DisplayName("a throwing sink does not prevent other sinks from receiving")
     void throwingSinkIsolated() {
         AtomicInteger goodSink = new AtomicInteger();
-        TypedVerdictSinkBus.register(v -> { throw new RuntimeException("boom"); });
-        TypedVerdictSinkBus.register(v -> goodSink.incrementAndGet());
+        VerdictSinkBus.register(v -> { throw new RuntimeException("boom"); });
+        VerdictSinkBus.register(v -> goodSink.incrementAndGet());
 
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        VerdictSinkBus.dispatch(stubVerdict());
 
         assertThat(goodSink.get()).isEqualTo(1);
     }
@@ -154,13 +154,13 @@ class TypedVerdictSinkBusTest {
     @DisplayName("reset clears registered sinks and the default-installed flag")
     void resetClears() {
         AtomicInteger registered = new AtomicInteger();
-        TypedVerdictSinkBus.register(v -> registered.incrementAndGet());
-        assertThat(TypedVerdictSinkBus.registeredCount()).isEqualTo(1);
+        VerdictSinkBus.register(v -> registered.incrementAndGet());
+        assertThat(VerdictSinkBus.registeredCount()).isEqualTo(1);
 
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
 
-        assertThat(TypedVerdictSinkBus.registeredCount()).isZero();
-        TypedVerdictSinkBus.dispatch(stubVerdict());
+        assertThat(VerdictSinkBus.registeredCount()).isZero();
+        VerdictSinkBus.dispatch(stubVerdict());
         assertThat(registered.get()).isZero();
     }
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitVerdictXmlEmissionIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PUnitVerdictXmlEmissionIntegrationTest.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 
 import org.javai.punit.junit5.testsubjects.PUnitSubjects;
 import org.javai.punit.engine.baseline.BaselineResolver;
-import org.javai.punit.verdict.TypedVerdictSinkBus;
+import org.javai.punit.verdict.VerdictSinkBus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +23,7 @@ import org.junit.platform.testkit.engine.Events;
  * platform and asserts that the XML verdict file lands on disk at the
  * configured path.
  */
-@DisplayName("PUnit verdict XML emission via TypedVerdictSinkBus")
+@DisplayName("PUnit verdict XML emission via VerdictSinkBus")
 class PUnitVerdictXmlEmissionIntegrationTest {
 
     private static final String JUNIT_ENGINE_ID = "junit-jupiter";
@@ -43,12 +43,12 @@ class PUnitVerdictXmlEmissionIntegrationTest {
         System.setProperty(BASELINE_DIR_PROPERTY, baselineDir.toString());
         // Reset the bus so the default sink is re-installed against
         // the freshly-set report dir property.
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
     }
 
     @AfterEach
     void restorePaths() {
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
         restore(DIR_PROPERTY, savedReportDir);
         restore(BASELINE_DIR_PROPERTY, savedBaselineDir);
     }
@@ -94,7 +94,7 @@ class PUnitVerdictXmlEmissionIntegrationTest {
     void disabledReportSuppressesEmission() throws Exception {
         String savedEnabled = System.getProperty("punit.report.enabled");
         System.setProperty("punit.report.enabled", "false");
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
         try {
             Events events = run(PUnitSubjects.PassingContractualTest.class);
             events.assertStatistics(stats -> stats.started(1).succeeded(1));

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictAdapterIntegrationTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictAdapterIntegrationTest.java
@@ -33,8 +33,8 @@ import org.javai.punit.api.spec.FailureExemplar;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
-import org.javai.punit.verdict.TypedRunMetadata;
-import org.javai.punit.verdict.TypedVerdictAdapter;
+import org.javai.punit.verdict.RunMetadata;
+import org.javai.punit.verdict.VerdictAdapter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -44,17 +44,17 @@ import org.junit.jupiter.api.Test;
  * because that's where the writer and XSD resource are; punit-core
  * has the adapter unit tests but cannot reach the writer module.
  */
-@DisplayName("TypedVerdictAdapter ↔ VerdictXmlWriter round-trip")
-class TypedVerdictAdapterIntegrationTest {
+@DisplayName("VerdictAdapter ↔ VerdictXmlWriter round-trip")
+class VerdictAdapterIntegrationTest {
 
     private record Factors() { }
 
     @Test
     @DisplayName("PASS verdict round-trips and validates against verdict-1.0.xsd")
     void passRoundTrips() throws Exception {
-        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+        ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(
                 richResult(Verdict.PASS),
-                new TypedRunMetadata(
+                new RunMetadata(
                         "com.example.PaymentTest", "shouldMeetSla",
                         Optional.of("payment-gateway"),
                         Optional.empty(),
@@ -86,9 +86,9 @@ class TypedVerdictAdapterIntegrationTest {
     @Test
     @DisplayName("FAIL verdict round-trips and validates against verdict-1.0.xsd")
     void failRoundTrips() throws Exception {
-        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+        ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(
                 richResult(Verdict.FAIL),
-                TypedRunMetadata.of("com.example.PaymentTest", "shouldMeetSla", "payment-gateway"));
+                RunMetadata.of("com.example.PaymentTest", "shouldMeetSla", "payment-gateway"));
 
         String xml = serialise(verdict);
         validateAgainstSchema(xml);
@@ -108,9 +108,9 @@ class TypedVerdictAdapterIntegrationTest {
                 misaligned, Optional.empty(), Map.of(),
                 EngineRunSummary.empty());
 
-        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(
+        ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(
                 result,
-                TypedRunMetadata.of("com.example.MyTest", "shouldRun"));
+                RunMetadata.of("com.example.MyTest", "shouldRun"));
 
         String xml = serialise(verdict);
         validateAgainstSchema(xml);

--- a/punit-runtime/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-runtime/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -34,12 +34,12 @@ import org.javai.punit.engine.covariate.CovariateResolver;
 import org.javai.punit.engine.criteria.Feasibility;
 import org.javai.punit.report.ReportConfiguration;
 import org.javai.punit.report.VerdictXmlSink;
-import org.javai.punit.reporting.TypedTransparentStatsRenderer;
+import org.javai.punit.reporting.TransparentStatsRenderer;
 import org.javai.punit.statistics.transparent.TransparentStatsConfig;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
-import org.javai.punit.verdict.TypedRunMetadata;
-import org.javai.punit.verdict.TypedVerdictAdapter;
-import org.javai.punit.verdict.TypedVerdictSinkBus;
+import org.javai.punit.verdict.RunMetadata;
+import org.javai.punit.verdict.VerdictAdapter;
+import org.javai.punit.verdict.VerdictSinkBus;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
@@ -201,24 +201,24 @@ public final class PUnit {
 
     /**
      * Adapts the typed result to a {@link ProbabilisticTestVerdict} and
-     * dispatches it through {@link TypedVerdictSinkBus}. Identity comes
-     * from {@link TypedTestIdentityResolver} (stack walk for the nearest
+     * dispatches it through {@link VerdictSinkBus}. Identity comes
+     * from {@link TestIdentityResolver} (stack walk for the nearest
      * {@link org.javai.punit.api.ProbabilisticTest @ProbabilisticTest}
      * frame); falls back to {@code (useCaseId, useCaseId)} when the
      * resolver finds no annotated frame (e.g. hand-driven tests).
      *
      * <p>Installs the default sink — {@link VerdictXmlSink} reading
      * {@link ReportConfiguration#resolve()} — on first call. Idempotent;
-     * tests can override via {@link TypedVerdictSinkBus#replaceAll}.
+     * tests can override via {@link VerdictSinkBus#replaceAll}.
      */
     private static void emitVerdict(ProbabilisticTestResult result, String fallbackUseCaseId) {
-        TypedVerdictSinkBus.installDefaultSink(
+        VerdictSinkBus.installDefaultSink(
                 () -> new VerdictXmlSink(ReportConfiguration.resolve()));
-        TypedRunMetadata meta = TypedTestIdentityResolver.resolve()
-                .orElseGet(() -> TypedRunMetadata.of(
+        RunMetadata meta = TestIdentityResolver.resolve()
+                .orElseGet(() -> RunMetadata.of(
                         fallbackUseCaseId, fallbackUseCaseId, fallbackUseCaseId));
-        ProbabilisticTestVerdict verdict = TypedVerdictAdapter.adapt(result, meta);
-        TypedVerdictSinkBus.dispatch(verdict);
+        ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(result, meta);
+        VerdictSinkBus.dispatch(verdict);
     }
 
     private static void translate(ProbabilisticTestResult result) {
@@ -622,7 +622,7 @@ public final class PUnit {
                 return;
             }
             String testIdentity = sampling.useCaseFactory().apply(factors).id();
-            System.err.println(TypedTransparentStatsRenderer.render(testIdentity, result));
+            System.err.println(TransparentStatsRenderer.render(testIdentity, result));
         }
 
         private List<String> preflightFeasibility() {
@@ -780,7 +780,7 @@ public final class PUnit {
             if (!TransparentStatsConfig.resolve(transparentStatsOverride).enabled()) {
                 return;
             }
-            System.err.println(TypedTransparentStatsRenderer.render(
+            System.err.println(TransparentStatsRenderer.render(
                     resolveUseCaseId(spec), result));
         }
 

--- a/punit-runtime/src/main/java/org/javai/punit/runtime/TestIdentityResolver.java
+++ b/punit-runtime/src/main/java/org/javai/punit/runtime/TestIdentityResolver.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.verdict.TypedRunMetadata;
+import org.javai.punit.verdict.RunMetadata;
 
 /**
  * Resolves the {@code className} / {@code methodName} of the typed
@@ -25,9 +25,9 @@ import org.javai.punit.verdict.TypedRunMetadata;
  * integration test or a REPL demo). Callers should fall back to a
  * generic identity in that case.
  */
-final class TypedTestIdentityResolver {
+final class TestIdentityResolver {
 
-    private TypedTestIdentityResolver() { }
+    private TestIdentityResolver() { }
 
     /**
      * @return the identity of the nearest enclosing
@@ -35,16 +35,16 @@ final class TypedTestIdentityResolver {
      *         method on the current call stack, or
      *         {@link Optional#empty()} if none is found
      */
-    static Optional<TypedRunMetadata> resolve() {
+    static Optional<RunMetadata> resolve() {
         return StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
                 .walk(frames -> frames
-                        .map(TypedTestIdentityResolver::asMetadata)
+                        .map(TestIdentityResolver::asMetadata)
                         .filter(Optional::isPresent)
                         .map(Optional::get)
                         .findFirst());
     }
 
-    private static Optional<TypedRunMetadata> asMetadata(StackWalker.StackFrame frame) {
+    private static Optional<RunMetadata> asMetadata(StackWalker.StackFrame frame) {
         Class<?> declaring = frame.getDeclaringClass();
         String methodName = frame.getMethodName();
         // Match by name only — overload disambiguation isn't worth the
@@ -54,7 +54,7 @@ final class TypedTestIdentityResolver {
         for (Method m : declaring.getDeclaredMethods()) {
             if (m.getName().equals(methodName)
                     && m.isAnnotationPresent(ProbabilisticTest.class)) {
-                return Optional.of(TypedRunMetadata.of(declaring.getName(), methodName));
+                return Optional.of(RunMetadata.of(declaring.getName(), methodName));
             }
         }
         return Optional.empty();

--- a/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelExecutor.java
+++ b/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelExecutor.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
-import org.javai.punit.verdict.TypedVerdictSinkBus;
+import org.javai.punit.verdict.VerdictSinkBus;
 import org.javai.punit.verdict.VerdictSink;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
@@ -18,7 +18,7 @@ import org.opentest4j.TestAbortedException;
  *
  * <p>Sentinel-side execution is structurally simpler than JUnit-side
  * execution: the framework's typed pipeline already separates verdict
- * emission ({@code TypedVerdictSinkBus.dispatch}) from JUnit-style
+ * emission ({@code VerdictSinkBus.dispatch}) from JUnit-style
  * translation ({@code AssertionFailedError} / {@code TestAbortedException}
  * throws). The executor:
  *
@@ -59,7 +59,7 @@ public class SentinelExecutor {
      */
     public Outcome execute(Class<?> sentinelClass, Method method) {
         Capturer capturer = new Capturer();
-        TypedVerdictSinkBus.replaceAll(capturer);
+        VerdictSinkBus.replaceAll(capturer);
         Throwable defect = null;
         try {
             Object instance = sentinelClass.getDeclaredConstructor().newInstance();

--- a/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelExecutorTest.java
+++ b/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelExecutorTest.java
@@ -14,7 +14,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.PUnitVerdict;
-import org.javai.punit.verdict.TypedVerdictSinkBus;
+import org.javai.punit.verdict.VerdictSinkBus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ import org.opentest4j.TestAbortedException;
  * Annotation-based filtering is the orchestrator's concern (see
  * {@code SentinelOrchestratorTest}).
  *
- * <p>Verdicts are stubbed by directly calling {@link TypedVerdictSinkBus#dispatch}
+ * <p>Verdicts are stubbed by directly calling {@link VerdictSinkBus#dispatch}
  * inside the subject methods, so the test exercises the executor's
  * sink-replacement and capture path without standing up the real engine.
  */
@@ -39,12 +39,12 @@ class SentinelExecutorTest {
 
     @BeforeEach
     void resetBus() {
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
     }
 
     @AfterEach
     void cleanUp() {
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
     }
 
     @Test
@@ -137,16 +137,16 @@ class SentinelExecutorTest {
         public StubSubject() { }
 
         public void dispatchesPass() {
-            TypedVerdictSinkBus.dispatch(stubVerdict(true));
+            VerdictSinkBus.dispatch(stubVerdict(true));
         }
 
         public void dispatchesFailAndThrows() {
-            TypedVerdictSinkBus.dispatch(stubVerdict(false));
+            VerdictSinkBus.dispatch(stubVerdict(false));
             throw new AssertionFailedError("simulated FAIL");
         }
 
         public void dispatchesInconclusiveAndAborts() {
-            TypedVerdictSinkBus.dispatch(stubVerdict(false));
+            VerdictSinkBus.dispatch(stubVerdict(false));
             throw new TestAbortedException("simulated INCONCLUSIVE");
         }
 
@@ -155,7 +155,7 @@ class SentinelExecutorTest {
         }
 
         public void dispatchesThenThrowsUnexpected() {
-            TypedVerdictSinkBus.dispatch(stubVerdict(true));
+            VerdictSinkBus.dispatch(stubVerdict(true));
             throw new IllegalStateException("simulated framework invariant violation");
         }
 

--- a/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelMainTest.java
+++ b/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelMainTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.javai.punit.verdict.TypedVerdictSinkBus;
+import org.javai.punit.verdict.VerdictSinkBus;
 
 /**
  * Tests for {@link SentinelMain}.
@@ -36,12 +36,12 @@ class SentinelMainTest {
 
     @BeforeEach
     void resetBus() {
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
     }
 
     @AfterEach
     void cleanUp() {
-        TypedVerdictSinkBus.reset();
+        VerdictSinkBus.reset();
     }
 
     @Nested

--- a/punit-sentinel/src/test/java/org/javai/punit/sentinel/testsubjects/SentinelTestSubjects.java
+++ b/punit-sentinel/src/test/java/org/javai/punit/sentinel/testsubjects/SentinelTestSubjects.java
@@ -13,7 +13,7 @@ import org.javai.punit.model.TerminationReason;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.PUnitVerdict;
-import org.javai.punit.verdict.TypedVerdictSinkBus;
+import org.javai.punit.verdict.VerdictSinkBus;
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -23,7 +23,7 @@ import org.opentest4j.AssertionFailedError;
  * <p>Each nested class declares a typed-pipeline annotated method
  * whose body dispatches a stubbed
  * {@link ProbabilisticTestVerdict} directly to
- * {@link TypedVerdictSinkBus} — bypassing the real engine. This
+ * {@link VerdictSinkBus} — bypassing the real engine. This
  * keeps the sentinel runtime tests focused on the framework's
  * verdict-capture and orchestration mechanics; engine-level
  * behaviour is exercised in {@code punit-core}.
@@ -32,7 +32,7 @@ import org.opentest4j.AssertionFailedError;
  * excludes these from JUnit's normal test discovery — the
  * {@code @ProbabilisticTest} meta-annotation would otherwise make
  * JUnit try to run them as plain tests, which would fire the
- * {@link TypedVerdictSinkBus} side-effect outside the sentinel
+ * {@link VerdictSinkBus} side-effect outside the sentinel
  * harness.
  */
 public final class SentinelTestSubjects {
@@ -45,7 +45,7 @@ public final class SentinelTestSubjects {
 
         @ProbabilisticTest
         public void emitsPass() {
-            TypedVerdictSinkBus.dispatch(stubVerdict(true));
+            VerdictSinkBus.dispatch(stubVerdict(true));
         }
     }
 
@@ -55,7 +55,7 @@ public final class SentinelTestSubjects {
 
         @ProbabilisticTest
         public void emitsFailAndThrows() {
-            TypedVerdictSinkBus.dispatch(stubVerdict(false));
+            VerdictSinkBus.dispatch(stubVerdict(false));
             throw new AssertionFailedError("simulated FAIL");
         }
     }
@@ -66,7 +66,7 @@ public final class SentinelTestSubjects {
 
         @Experiment
         public void emitsMeasurement() {
-            TypedVerdictSinkBus.dispatch(stubVerdict(true));
+            VerdictSinkBus.dispatch(stubVerdict(true));
         }
     }
 


### PR DESCRIPTION
## Summary

DIR-PUNIT-S8 §Phase C step 2. With legacy gone (#106) and typed packages flat in `api/*` (#107), the `Typed` prefix on infrastructure class names is no longer disambiguating.

**18 files changed, 140 insertions, 140 deletions.** All mechanical: file renames + word-boundary substitutions across consumers.

## Renames

**Main source (5):**

| From | To | Module |
|---|---|---|
| `TypedVerdictAdapter` | `VerdictAdapter` | punit-core |
| `TypedVerdictSinkBus` | `VerdictSinkBus` | punit-core |
| `TypedRunMetadata` | `RunMetadata` | punit-core |
| `TypedTestIdentityResolver` | `TestIdentityResolver` | punit-runtime |
| `TypedTransparentStatsRenderer` | `TransparentStatsRenderer` | punit-core |

**Test source (6):**

| From | To |
|---|---|
| `TypedVerdictAdapterTest` | `VerdictAdapterTest` |
| `TypedVerdictAdapterFidelityTest` | `VerdictAdapterFidelityTest` |
| `TypedVerdictSinkBusTest` | `VerdictSinkBusTest` |
| `TypedTransparentStatsRendererTest` | `TransparentStatsRendererTest` |
| `TypedEngineArchitectureTest` | `EngineArchitectureTest` |
| `TypedVerdictAdapterIntegrationTest` | `VerdictAdapterIntegrationTest` |

## Mechanics

Word-boundary `perl -i` substitutions across all `.java` / `.md` / `.kt` / `.kts` files. Word boundaries (`\b`) keep substring matches independent — e.g. `\bTypedVerdictAdapter\b` does not touch `TypedVerdictAdapterFidelityTest` because `Test` is a word character, not a boundary. After substitution, `git mv` on each renamed file.

## What stays "Typed"

**`TypedSpec` is intentionally not renamed.** There is already a public sealed `Spec` interface in the same package — the un-typed envelope sealed over `Experiment` and `ProbabilisticTest`. `TypedSpec<FT, IT, OT>` is the engine-facing typed strategy view of `Spec`, reached only via `Spec.dispatch(Spec.Dispatcher)`. The "Typed" prefix here is **semantic** (it describes the role: a typed view of an un-typed thing), not a coexistence label.

The 9 surviving `Typed*` mentions in main source are all `TypedSpec` usages — confirmed by grep.

## What Phase E will sweep

Two prose mentions of "Typed" remain in the test surface:
- A string literal `"Typed Pipeline Emission"` referencing `USER-GUIDE.md` Part 11. Phase E will rewrite that section as part of the docs sweep (the section title itself becomes obsolete once "the typed pipeline" is just "the pipeline").
- A nested test class `TypedDerived` inside `VerdictAdapterFidelityTest`. Internal-only, non-load-bearing.

## Test plan
- [x] `./gradlew clean test` — passes
- [x] `./gradlew :punit-gradle-plugin:functionalTest` — passes
- [x] No simple-name collisions in any package (`TypedSpec` and `Spec` continue to coexist as before)

## What unblocks
- **DIR-PUNIT-S8 Phase D** — punitexamples typed-prefix rename (smaller scope; mostly the import paths catching up)
- **DIR-PUNIT-S8 Phase E** — docs + memory pin sweep + remaining "legacy" prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)