### PR TITLE
Add OptimizeBuilder.disableEarlyTermination()

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -620,6 +620,18 @@ public final class Experiment implements Spec {
             return this;
         }
 
+        /**
+         * Run the full {@code maxIterations} regardless of score progress.
+         * Use when the iteration count itself is the iteration plan
+         * (a fixed numeric sweep, a stepper that exhausts a finite set
+         * of values) and the no-improvement heuristic is not the right
+         * stopping signal.
+         */
+        public OptimizeBuilder<FT, IT, OT> disableEarlyTermination() {
+            this.noImprovementWindow = Integer.MAX_VALUE;
+            return this;
+        }
+
         public OptimizeBuilder<FT, IT, OT> experimentId(String id) {
             this.experimentId = Objects.requireNonNull(id, "experimentId");
             return this;
@@ -999,6 +1011,12 @@ public final class Experiment implements Spec {
                 throw new IllegalArgumentException("noImprovementWindow must be >= 1");
             }
             this.noImprovementWindow = n;
+            return this;
+        }
+
+        /** See {@link OptimizeBuilder#disableEarlyTermination()}. */
+        public InlineOptimizeBuilder<FT, IT, OT> disableEarlyTermination() {
+            this.noImprovementWindow = Integer.MAX_VALUE;
             return this;
         }
 

--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -621,11 +621,21 @@ public final class Experiment implements Spec {
         }
 
         /**
-         * Run the full {@code maxIterations} regardless of score progress.
-         * Use when the iteration count itself is the iteration plan
+         * Run the full {@code maxIterations} regardless of score
+         * progress. Disables the optimize loop's no-improvement-window
+         * heuristic so the run continues even when consecutive
+         * iterations fail to improve the score.
+         *
+         * <p>Use when the iteration count itself is the iteration plan
          * (a fixed numeric sweep, a stepper that exhausts a finite set
-         * of values) and the no-improvement heuristic is not the right
-         * stopping signal.
+         * of values) and the heuristic is not the right stopping
+         * signal.
+         *
+         * <p>Unrelated to the statistical early-termination of
+         * probabilistic tests, which short-circuits a sample loop
+         * once the verdict is mathematically determined. That
+         * mechanism lives on a different builder and is not affected
+         * by this method.
          */
         public OptimizeBuilder<FT, IT, OT> disableEarlyTermination() {
             this.noImprovementWindow = Integer.MAX_VALUE;

--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -496,6 +496,12 @@ public final class PUnit {
             return this;
         }
 
+        /** See {@link Experiment.OptimizeBuilder#disableEarlyTermination()}. */
+        public OptimizeBuilder<FT, IT, OT> disableEarlyTermination() {
+            delegate.disableEarlyTermination();
+            return this;
+        }
+
         public OptimizeBuilder<FT, IT, OT> experimentId(String id) {
             delegate.experimentId(id);
             return this;

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -367,6 +367,37 @@ class EngineIntegrationTest {
     }
 
     @Test
+    @DisplayName("disableEarlyTermination() runs to maxIterations even when scores are flat")
+    void disableEarlyTerminationRunsToMaxIterations() {
+        UseCase<LlmFactors, String, Integer> echo = new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input.length());
+            }
+        };
+        Sampling<LlmFactors, String, Integer> shape = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> echo)
+                .inputs("a")
+                .samples(1)
+                .build();
+        FactorsStepper<LlmFactors> alwaysAdvance = (current, history) ->
+                new LlmFactors(current.model(), current.temperature() + 0.01);
+        // Constant scorer: every iteration ties the previous, so the
+        // default no-improvement window would terminate the run early.
+        Experiment spec = Experiment.optimizing(shape)
+                .initialFactors(new LlmFactors("gpt-4o", 0.0))
+                .stepper(alwaysAdvance)
+                .maximize(s -> 0.5)
+                .maxIterations(8)
+                .disableEarlyTermination()
+                .build();
+
+        new Engine().run(spec);
+        assertThat(spec.history()).hasSize(8);
+    }
+
+    @Test
     @DisplayName("ProbabilisticTest threads its declared intent through to the result")
     void intentThreadsThroughToResult() {
         Sampling<LlmFactors, Integer, Boolean> sampling = Sampling


### PR DESCRIPTION
## Summary

- Adds `OptimizeBuilder.disableEarlyTermination()` to all three optimize builders (`Experiment.OptimizeBuilder`, `Experiment.InlineOptimizeBuilder`, `PUnit.OptimizeBuilder`).
- Replaces the magic-number incantation `noImprovementWindow(20) // disable early termination` with an explicit, intention-revealing call.
- Internal: sentinel value `Integer.MAX_VALUE` on the existing `noImprovementWindow` field — single field, single comparison in `AdaptiveIterator`. `iterationsSinceImprovement` is bounded by `maxIterations`, so the comparison never trips.

## Why

When the iteration count itself is the iteration plan — a fixed numeric sweep, a stepper that exhausts a finite set of values — the no-improvement heuristic is the wrong stopping signal. The current workaround is to set `noImprovementWindow(20)` (or any number larger than `maxIterations`), which only works by accident and reads as a magic incantation to anyone encountering it.

This is item 1 of `plan/directives/DIR-OPTIMIZE-API-DX-punit.md` (orchestrator). Items 2 (`NextFactor` typed stepper return) and 3 (stepper catalog) follow on subsequent PRs.

## Test plan

- [x] New unit test `disableEarlyTerminationRunsToMaxIterations` in `EngineIntegrationTest` — flat scores, `maxIterations(8)`, `disableEarlyTermination()` → asserts `history()` size is 8 (would terminate at ~6 under the default no-improvement window of 5).
- [x] `./gradlew :punit-core:build` passes.
- [x] `./gradlew build` passes (all four modules).
- [x] `noImprovementWindow(int)` retained for callers that genuinely want a finite window — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)