### PR TITLE
Replace null-as-stop with NextFactor sealed return on FactorsStepper

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -544,9 +544,12 @@ public final class Experiment implements Spec {
                         return;
                     }
                     FT current = last.factors();
-                    FT candidate = stepper.next(current,
+                    NextFactor<FT> candidate = stepper.next(current,
                             Collections.unmodifiableList(history));
-                    next = candidate;
+                    switch (candidate) {
+                        case NextFactor.Continue<FT> c -> next = c.factor();
+                        case NextFactor.Stop<FT> s -> { /* leave next null; loop ends */ }
+                    }
                 }
             }
         }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/FactorsStepper.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/FactorsStepper.java
@@ -23,10 +23,11 @@ public interface FactorsStepper<FT> {
     /**
      * @param current the last factors evaluated
      * @param history the full iteration history in execution order
-     * @return the next factors to evaluate, or {@code null} to
+     * @return {@link NextFactor#next(Object)} carrying the next
+     *         factors to evaluate, or {@link NextFactor#stop()} to
      *         signal "no more candidates" (the optimiser will stop)
      */
-    FT next(FT current, List<IterationResult<FT>> history);
+    NextFactor<FT> next(FT current, List<IterationResult<FT>> history);
 
     /**
      * One entry in the optimize history fed to {@link #next}.

--- a/punit-core/src/main/java/org/javai/punit/api/spec/NextFactor.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/NextFactor.java
@@ -1,0 +1,38 @@
+package org.javai.punit.api.spec;
+
+import java.util.Objects;
+
+/**
+ * Result of a {@link FactorsStepper}'s decision for the next
+ * optimize iteration: either {@link Continue continue with the
+ * supplied next factors}, or {@link Stop stop the optimisation
+ * loop}.
+ *
+ * <p>Replaces the older {@code null}-as-stop convention so that
+ * "produce a candidate" and "give up" are distinguishable in the
+ * type system rather than via an implicit sentinel.
+ *
+ * @param <FT> the factor record type
+ */
+public sealed interface NextFactor<FT> {
+
+    /** The stepper proposes the supplied factors for the next iteration. */
+    record Continue<FT>(FT factor) implements NextFactor<FT> {
+        public Continue {
+            Objects.requireNonNull(factor, "factor");
+        }
+    }
+
+    /** The stepper has nothing more to propose; the optimiser stops. */
+    record Stop<FT>() implements NextFactor<FT> {}
+
+    /** Continue with the supplied factors. */
+    static <FT> NextFactor<FT> next(FT factor) {
+        return new Continue<>(factor);
+    }
+
+    /** Stop the optimisation loop. */
+    static <FT> NextFactor<FT> stop() {
+        return new Stop<>();
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -21,6 +21,7 @@ import org.javai.punit.api.spec.EngineResult;
 import org.javai.punit.api.spec.ExperimentResult;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.FactorsStepper;
+import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.Verdict;
@@ -352,8 +353,8 @@ class EngineIntegrationTest {
         // Stepper that walks temperature up by 0.1 each iteration, capping at 1.0.
         FactorsStepper<LlmFactors> stepper = (current, history) ->
                 current.temperature() >= 0.95
-                        ? null
-                        : new LlmFactors(current.model(), current.temperature() + 0.1);
+                        ? NextFactor.stop()
+                        : NextFactor.next(new LlmFactors(current.model(), current.temperature() + 0.1));
         Experiment spec = Experiment.optimizing(shape)
                 .initialFactors(new LlmFactors("gpt-4o", 0.0))
                 .stepper(stepper)
@@ -382,7 +383,7 @@ class EngineIntegrationTest {
                 .samples(1)
                 .build();
         FactorsStepper<LlmFactors> alwaysAdvance = (current, history) ->
-                new LlmFactors(current.model(), current.temperature() + 0.01);
+                NextFactor.next(new LlmFactors(current.model(), current.temperature() + 0.01));
         // Constant scorer: every iteration ties the previous, so the
         // default no-improvement window would terminate the run early.
         Experiment spec = Experiment.optimizing(shape)
@@ -395,6 +396,41 @@ class EngineIntegrationTest {
 
         new Engine().run(spec);
         assertThat(spec.history()).hasSize(8);
+    }
+
+    @Test
+    @DisplayName("NextFactor.stop() ends the optimize loop after the iteration that returned it — no final-iteration sample")
+    void nextFactorStopEndsRunCleanly() {
+        UseCase<LlmFactors, String, Integer> echo = new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input.length());
+            }
+        };
+        Sampling<LlmFactors, String, Integer> shape = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> echo)
+                .inputs("a")
+                .samples(1)
+                .build();
+        // Stop after exactly 3 iterations so we can pin the count precisely.
+        FactorsStepper<LlmFactors> stopAfterThree = (current, history) ->
+                history.size() >= 3
+                        ? NextFactor.stop()
+                        : NextFactor.next(new LlmFactors(current.model(), current.temperature() + 0.1));
+
+        Experiment spec = Experiment.optimizing(shape)
+                .initialFactors(new LlmFactors("gpt-4o", 0.0))
+                .stepper(stopAfterThree)
+                .maximize(s -> 0.5)
+                .maxIterations(20)             // headroom — Stop must take effect first
+                .disableEarlyTermination()     // rule out the no-improvement window as the cause
+                .build();
+
+        new Engine().run(spec);
+        // Initial factors + 2 stepper-produced advances = 3 iterations, then Stop.
+        // No 4th iteration is sampled even though maxIterations(20) would otherwise allow it.
+        assertThat(spec.history()).hasSize(3);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/PostconditionFailureHistogramTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.spec.FactorsStepper;
+import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.ContractBuilder;
@@ -176,7 +177,7 @@ class PostconditionFailureHistogramTest {
         FactorsStepper<Factors> stepper =
                 (current, history) -> {
                     history.forEach(h -> seenHistograms.add(h.failuresByPostcondition()));
-                    return history.size() >= 2 ? null : current;
+                    return history.size() >= 2 ? NextFactor.stop() : NextFactor.next(current);
                 };
 
         Experiment spec = Experiment.optimizing(sampling)

--- a/punit-core/src/test/java/org/javai/punit/engine/criteria/InlineSamplingFormTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/criteria/InlineSamplingFormTest.java
@@ -10,6 +10,7 @@ import org.javai.punit.api.ContractBuilder;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.UseCase;
 import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,7 +61,7 @@ class InlineSamplingFormTest {
                 .inputs("a")
                 .samples(5)
                 .initialFactors(new Factors("seed"))
-                .stepper((current, history) -> history.size() >= 3 ? null : new Factors(current.label() + "+"))
+                .stepper((current, history) -> history.size() >= 3 ? NextFactor.stop() : NextFactor.next(new Factors(current.label() + "+")))
                 .maximize(s -> 1.0)
                 .maxIterations(5)
                 .build();

--- a/punit-core/src/test/java/org/javai/punit/runtime/BaselineEmitterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/BaselineEmitterTest.java
@@ -10,6 +10,7 @@ import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.UseCase;
 import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.NextFactor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,7 +53,7 @@ class BaselineEmitterTest {
     void rejectsOptimize(@TempDir Path dir) {
         Experiment optimize = Experiment.optimizing(sampling())
                 .initialFactors(new NoFactors())
-                .stepper((current, history) -> history.size() >= 1 ? null : new NoFactors())
+                .stepper((current, history) -> history.size() >= 1 ? NextFactor.stop() : NextFactor.next(new NoFactors()))
                 .maximize(s -> 0.0)
                 .maxIterations(1)
                 .build();


### PR DESCRIPTION
## Summary

Replaces the `null = stop` convention on `FactorsStepper<FT>::next` with a sealed return type:

```java
public sealed interface NextFactor<FT> {
    record Continue<FT>(FT factor) implements NextFactor<FT> { ... }
    record Stop<FT>() implements NextFactor<FT> { ... }
    static <FT> NextFactor<FT> next(FT factor) { ... }
    static <FT> NextFactor<FT> stop() { ... }
}
```

Authors now write `NextFactor.stop()` and `NextFactor.next(factors)` explicitly. The optimize loop's `AdaptiveIterator` pattern-matches on the return — exhaustive over the sealed permits — so any future variant forces a compile-time decision rather than a silent fallthrough.

This is item 2 of `plan/directives/DIR-OPTIMIZE-API-DX-punit.md` (orchestrator). Item 1 (`disableEarlyTermination()`) shipped in #112; item 3 (enriched IterationResult + stepper catalog) follows.

## Why

The pre-existing `null`-as-stop sentinel asks readers to learn an undocumented invariant. The sealed type lets the contract say what it means in the type system itself, and pattern matching gives the engine an exhaustive switch the compiler can audit.

## Breaking change

`FactorsStepper::next` return type changes from `FT` to `NextFactor<FT>`. All five in-tree callers migrate in this PR. The single external caller — `ShoppingBasketOptimizePrompt` in `punitexamples` — follows in a companion PR.

## Test plan

- [x] New acceptance test `nextFactorStopEndsRunCleanly` in `EngineIntegrationTest` — Stop after exactly 3 iterations with `maxIterations(20)` and `disableEarlyTermination()` → asserts `history()` size is 3 (Stop is the only mechanism that could halt the loop at that count).
- [x] `./gradlew :punit-core:test` passes (every existing optimize test still passes after the migration — the existing `optimizeSpecRunsIterationLoop`, `disableEarlyTerminationRunsToMaxIterations`, the histogram test, the inline-sampling-form test, the BaselineEmitter rejection test).
- [x] `./gradlew build` passes (all four modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)