### PR TITLE
Add 0.7.0 breaking-change audit

### DIFF
--- a/plan/release/0.7.0-breaking-changes.md
+++ b/plan/release/0.7.0-breaking-changes.md
@@ -1,0 +1,258 @@
+# 0.7.0 breaking-change audit (v0.6.0 → main)
+
+**Status:** Phase 0 of `DIR-RELEASE-0.7.0-punit`. This file is the
+seed for every artefact in Phase 2 (CHANGELOG, MIGRATION,
+README sign-post, GitHub release body). Do not derive Phase 2
+content from anywhere else — if a change is missing here, fix
+this file first.
+
+**Range audited:** `v0.6.0` (`6b4d579`) → `main` (`2f4922c`),
+216 commits.
+
+**Scope:** the author-visible API surface, narrowed per the
+directive to:
+- `punit-core/src/main/java/org/javai/punit/api/**`
+- `punit-core/src/main/java/org/javai/punit/runtime/PUnit.java`
+
+Anything outside these paths is treated as internal and excluded
+from the table, even if technically reachable.
+
+**Build coordinates:** unchanged. Same artefact ids
+(`org.javai:punit-core`, `punit-junit5`, `punit-sentinel`,
+`punit-report`), same module set, same group. There is **no
+coordinate-rename migration story** — only an API migration story.
+
+## Macro shift (read first)
+
+v0.6.0 was an **annotation-driven, reflection-based** authoring
+surface: tests and experiments were declared by annotation
+attributes (`@ProbabilisticTest(samples=100, minPassRate=0.95,
+useCase=MyUseCase.class, …)`) on JUnit-discovered methods, and
+factor / input / covariate metadata travelled through parameter
+and class-level annotations (`@Factor`, `@FactorSource`, `@Input`,
+`@InputSource`, `@Config`, `@ConfigSource`, `@UseCase`,
+`@Sentinel`, `@CovariateSource`, `@FactorGetter`, `@FactorSetter`).
+A use case was a class implementing service-call methods plus a
+`ServiceContract` defined in the `org.javai.punit.contract`
+package; per-sample state was a `UseCaseOutcome<O>` (single type
+parameter) routed through the same `contract` package.
+
+0.7.0 is a **typed, builder-based** authoring surface. The macro
+shape:
+
+1. `@ProbabilisticTest` and `@Experiment` survive — but only as
+   bare marker annotations with **no attributes**. All
+   configuration moves to a typed builder invoked from inside the
+   method body.
+2. The new entry point `org.javai.punit.runtime.PUnit` provides
+   `testing(...)`, `measuring(...)`, `exploring(...)`, and
+   `optimizing(...)` factories that return typed builders.
+3. A use case is now an implementation of `UseCase<FT, I, O>` — a
+   typed three-parameter interface extending `Contract<I, O>`.
+   The factor record (`FT`), input type (`I`), and output type
+   (`O`) are part of the type. Postconditions are declared in
+   `postconditions(ContractBuilder<O>)` rather than in a separate
+   `ServiceContract`.
+4. Covariates move from annotation-declared sources
+   (`@CovariateSource`, `@Covariate`) to a **sealed `Covariate`
+   hierarchy** under `api/covariate/` (`DayOfWeekCovariate`,
+   `RegionCovariate`, `TimeOfDayCovariate`, `TimezoneCovariate`,
+   `CustomCovariate`), declared on the `UseCase` itself.
+5. Factors move from method-parameter `@Factor` annotations to a
+   **typed factor record** plus, where stepping is needed, a
+   `FactorsStepper<FT>` returning a sealed `NextFactor<FT>`.
+6. The legacy `org.javai.punit.contract` package is gone.
+   `Postcondition`, `PostconditionCheck`, `PostconditionEvaluator`,
+   `PostconditionResult`, `UseCaseOutcome`, `ServiceContract` either
+   relocated to `org.javai.punit.api` or were replaced by typed
+   equivalents (`Contract`, `ContractBuilder`).
+
+The dominant migration unit is therefore "rewrite each
+probabilistic test and each experiment from
+annotation-attribute style to typed-builder style." Single-symbol
+renames are minor compared to that shift.
+
+## Change table
+
+Classifications: **breaking** = source-incompatible or
+behaviour-incompatible at the author surface; **additive** = new
+surface area, no existing user code breaks because of it alone;
+**internal** = no author-visible effect but listed for audit
+completeness.
+
+Within categories rows are ordered roughly by how often the
+pattern appears in user code.
+
+### A. Authoring style (the macro break)
+
+| Old form | New form | Classification | User-visible symptom | Migration |
+|----------|----------|----------------|----------------------|-----------|
+| `@ProbabilisticTest(samples=…, minPassRate=…, confidence=…, useCase=…, intent=…, contractRef=…, latency=@Latency(…), tokenBudget=…, …)` (≈18 attributes) | `@ProbabilisticTest` (marker, no attributes) + method body builds spec via `PUnit.testing(useCase, sampling).samples(…).minPassRate(…)…build().assertPasses()` | breaking | Compile error: every annotation attribute the author specified is now "annotation type ProbabilisticTest does not have an attribute named X". | Rewrite each `@ProbabilisticTest`-annotated method body to the typed builder; see MIGRATION §A. |
+| `@MeasureExperiment(useCase=…, …)`, `@ExploreExperiment(useCase=…, …)`, `@OptimizeExperiment(useCase=…, …)` (three separate annotations with attribute sets each) | `@Experiment` (marker, no attributes) + method body builds spec via `PUnit.measuring(...)` / `PUnit.exploring(...)` / `PUnit.optimizing(...)` | breaking | Compile error: `@MeasureExperiment` / `@ExploreExperiment` / `@OptimizeExperiment` are gone; `@Experiment` exists but rejects the attributes. | Replace the annotation with `@Experiment`; rewrite the body to use the matching `PUnit.*` factory. |
+| Author writes a class with `@UseCase` annotation, methods returning `UseCaseOutcome<O>`, paired with a separately-defined `ServiceContract` in the `contract` package | Author writes `class MyUseCase implements UseCase<FT, I, O>` overriding `invoke(I, TokenTracker)` and `postconditions(ContractBuilder<O>)`; the typed `UseCase` carries metadata directly (id, covariates, pacing, warmup) | breaking | Compile error: `@UseCase` annotation is gone; `UseCase` is now a typed interface to implement; `ServiceContract` and `org.javai.punit.contract.*` no longer exist. | Convert each annotated use-case class to an `implements UseCase<FT, I, O>` class; lift contract postconditions into `postconditions(ContractBuilder<O>)`. |
+
+### B. Class-level annotation removals
+
+| Old form | New form | Classification | User-visible symptom | Migration |
+|----------|----------|----------------|----------------------|-----------|
+| `@UseCase("id")` / `@UseCase` on a class or method | Implement `UseCase<FT, I, O>`; override `id()` (or accept the simple class name default) | breaking | `cannot find symbol class UseCase` (when used as annotation). | See row A.3. |
+| `@Sentinel` on a method | No marker — sentinel module scans typed `UseCase` implementations directly | breaking | `cannot find symbol class Sentinel`. | Delete `@Sentinel`; the typed sentinel scanner picks up qualifying methods automatically. |
+| `@CovariateSource` annotation on a method | `UseCase.covariates()` returns a `List<Covariate>` from the `api/covariate/` sealed hierarchy | breaking | `cannot find symbol class CovariateSource`. | Override `covariates()` on the `UseCase` and return the typed covariate instances. |
+| `@FactorGetter` / `@FactorSetter` / `FactorAnnotations` (reflection-based factor accessors) | Factor record `FT` is a Java record; `FactorBundle.toFactorValues(FT)` produces canonical `FactorValue`s | breaking | `cannot find symbol class FactorGetter` / `FactorSetter` / `FactorAnnotations`. | Drop the annotations; declare factors as a `record FT(...)` and rely on `FactorBundle`. |
+
+### C. Parameter-level annotation removals
+
+The legacy parameter-level annotations remain *defined* in `api/`
+as `@interface`s (`@Factor`, `@FactorSource`, `@Input`,
+`@InputSource`, `@Config`, `@ConfigSource`, `@ControlFactor`,
+`@DayGroup`, `@RegionGroup`, `@Latency`, `@ExperimentDesign`,
+`@ExperimentGoal`) but **nothing on `main` consumes them** — no
+framework code references them and they are not part of the
+typed authoring surface. They should be considered withdrawn for
+authoring purposes even if they still type-check.
+
+| Old form | New form | Classification | User-visible symptom | Migration |
+|----------|----------|----------------|----------------------|-----------|
+| `void test(@Factor("model") String model, @Factor("temp") double temp)` | Factors are a record `record FT(String model, double temp)`; an explore/optimize spec drives the stepping. | breaking (effectively — annotations no longer wired) | Tests still compile but framework no longer respects parameter annotations; behaviour silently changes (factor sweeping does not happen). | Rewrite parameters as a factor record; supply factors via `Sampling.from(FT)` or `FactorsStepper`. |
+| `@Input(...)` / `@InputSource(...)` on parameters | Inputs supplied via `Sampling.matching(InputSupplier<I>, ValueMatcher<I,O>)` or via `InputSource` configuration on the typed builder | breaking (effectively) | As above. | Move input declaration into the typed `Sampling` builder. |
+| `@Config` / `@ConfigSource` / `@ControlFactor` / `@DayGroup` / `@RegionGroup` / `@Latency` / `@ExperimentDesign` / `@ExperimentGoal` parameter annotations | Equivalent fields on the typed builder or covariate API | breaking (effectively) | As above. | See per-attribute mapping in MIGRATION §C. |
+
+### D. Type shape changes (same name, different shape)
+
+| Old form | New form | Classification | User-visible symptom | Migration |
+|----------|----------|----------------|----------------------|-----------|
+| `org.javai.punit.api.UseCase` is `@interface UseCase { String value() default ""; }` | `org.javai.punit.api.UseCase<FT, I, O>` is `interface UseCase<FT, I, O> extends Contract<I, O>` | breaking | "annotation type UseCase cannot be applied" / "cannot resolve type parameters". | See row A.3. |
+| `org.javai.punit.contract.UseCaseOutcome<O>` (single type param, in `contract` package) | `org.javai.punit.api.UseCaseOutcome` (record, in `api` package; no type params on the record itself — `<I, O>` is captured via `Contract` and `Sampling.matching`) | breaking | Import error on `org.javai.punit.contract.UseCaseOutcome`; type-arg mismatch on usages. | Update imports; consume the new record fields (`result`, `match`, `tokens`, `duration`, postcondition results). |
+| `org.javai.punit.contract.ServiceContract` (loose contract type) | `org.javai.punit.api.Contract<I, O>` (typed interface, base of `UseCase<FT, I, O>`) | breaking | Import error; method-shape error. | Replace `ServiceContract` usages with `Contract<I, O>` or, more usually, fold them into the `UseCase` implementation directly via `postconditions(ContractBuilder<O>)`. |
+| `org.javai.punit.api.Covariate` is `@interface Covariate` (annotation) | `org.javai.punit.api.covariate.Covariate` is a `sealed` reference type with concrete subtypes (`DayOfWeekCovariate`, `RegionCovariate`, `TimeOfDayCovariate`, `TimezoneCovariate`, `CustomCovariate`) | breaking | "annotation type Covariate cannot be applied" / import errors. | See row B.3. |
+
+### E. Type movements (package change, no shape change)
+
+| Old form | New form | Classification | User-visible symptom | Migration |
+|----------|----------|----------------|----------------------|-----------|
+| `org.javai.punit.contract.Postcondition` | `org.javai.punit.api.Postcondition` | breaking | Import error. | Update imports; `Postcondition` is otherwise compatible. |
+| `org.javai.punit.contract.PostconditionCheck` | `org.javai.punit.api.PostconditionCheck` | breaking | Import error. | Update imports. |
+| `org.javai.punit.contract.PostconditionEvaluator` | `org.javai.punit.api.PostconditionEvaluator` | breaking | Import error. | Update imports. |
+| `org.javai.punit.contract.PostconditionResult` | `org.javai.punit.api.PostconditionResult` | breaking | Import error. | Update imports. |
+| `org.javai.punit.contract.match.*` (`JsonMatcher`, `JsonMatcherDelegate`, `ResultExtractor`, `StringMatcher`, `VerificationMatcher`) | Subsumed by `org.javai.punit.api.{ValueMatcher, MatchResult, Sampling}` plus value records in `api/` | breaking | Import error; matcher-shape mismatch. | Replace ad-hoc matchers with `Sampling.matching(InputSupplier, ValueMatcher)`; consume `MatchResult` from the new `UseCaseOutcome`. |
+| `org.javai.punit.contract.Derivation` / `DurationConstraint` / `DurationResult` / `AssertionScope` | Subsumed by `Contract` + `ContractBuilder` + `LatencySpec` / `LatencyResult` | breaking | Import error. | Express derivations as additional `postconditions(ContractBuilder<O>)` clauses; express duration constraints via `LatencySpec` on the builder. |
+
+### F. Removed types (no replacement at the same surface)
+
+| Old form | New form | Classification | User-visible symptom | Migration |
+|----------|----------|----------------|----------------------|-----------|
+| `org.javai.punit.api.AdaptiveFactor` | None — adaptive factors are expressed via a custom `FactorsStepper<FT>` | breaking | `cannot find symbol class AdaptiveFactor`. | Implement a `FactorsStepper` that adapts based on the iteration history (`List<IterationResult<FT>>`). |
+| `org.javai.punit.api.UseCaseContext` | None — context concerns split between covariate metadata on `UseCase` and the `TokenTracker` parameter on `invoke` | breaking | `cannot find symbol class UseCaseContext`. | Move state previously held in `UseCaseContext` to either covariate values, `TokenTracker` calls, or the factor record. |
+| `org.javai.punit.api.ProbabilisticTestBudget` | Replaced by typed builder methods (`tokenBudget(...)`, `timeBudget(...)`, `onBudgetExhausted(...)`) on `PUnit.testing(...)` builders, plus `api/spec/BudgetExhaustionPolicy` | breaking | `cannot find symbol class ProbabilisticTestBudget`. | Configure budget on the spec builder. |
+| `org.javai.punit.api.ExploreExperiment`, `MeasureExperiment`, `OptimizeExperiment` | Single `@Experiment` marker + `PUnit.exploring/measuring/optimizing` factories | breaking | "annotation type ExploreExperiment is not visible". | See row A.2. |
+
+### G. The new typed pipeline (additive — additions to `api/`)
+
+| Type | Subpackage | Role |
+|------|------------|------|
+| `Contract<I, O>` | `api/` | Operational layer: `invoke(I, TokenTracker) → Outcome<O>` and `postconditions(ContractBuilder<O>)`. Base of `UseCase`. |
+| `ContractBuilder<O>` | `api/` | Builder consumed inside `postconditions`; records named clauses with `Outcome`-shaped checks. |
+| `UseCase<FT, I, O>` (now an interface) | `api/` | Metadata layer extending `Contract<I, O>`. |
+| `UseCaseOutcome` (record, relocated) | `api/` | Per-sample artefact. Carries `result`, `match`, `tokens`, `duration`, `postconditionResults`, `failureExemplars`. |
+| `Sampling<FT, I, O>` | `api/` | Builder for input/match strategy: `from(FT)`, `matching(InputSupplier<I>, ValueMatcher<I, O>)`. |
+| `NoFactors` | `api/` | Empty factor record; pairs with factor-less `PUnit.testing/measuring` overloads (replaces the `Void` + `null` workaround). |
+| `FactorBundle` / `FactorValue` (interface) + value records (`BooleanValue`, `DecimalValue`, `DurationValue`, `EnumValue`, `InstantValue`, `IntegralValue`, `StringValue`, `UriValue`) | `api/` | Canonical, content-addressable representation of a factor record for baseline filenames and YAML emission. |
+| `TokenTracker` | `api/` | Per-sample cost recorder, passed to `invoke`. Replaces the v0.6.0 `TokenChargeRecorder` usage pattern (the type still exists in `api/` but is now plumbing for the tracker). |
+| `Postcondition`, `PostconditionCheck`, `PostconditionEvaluator`, `PostconditionResult` | `api/` | Postcondition surface (relocated from `contract/`). |
+| `MatchResult`, `ValueMatcher<I, O>`, `Expectation`, `InputSupplier<I>` | `api/` | Matching surface for `Sampling.matching(...)`. |
+| `LatencyResult`, `LatencySpec` | `api/` | Typed latency constraints (replaces `@Latency` annotation attribute). |
+
+### H. The `api/spec` subpackage (additive — entirely new)
+
+`org.javai.punit.api.spec` did not exist at v0.6.0. It now hosts
+the spec types the typed builders construct and the engine
+consumes. All additive from a migration standpoint.
+
+Members: `Spec`, `TypedSpec`, `Experiment` (record — distinct
+from the `@Experiment` annotation in `api/`), `ExperimentResult`,
+`ProbabilisticTest` (record — distinct from the `@ProbabilisticTest`
+annotation in `api/`), `ProbabilisticTestResult`, `EngineResult`,
+`EngineRunSummary`, `Verdict`, `Trial`, `SampleClassification`,
+`SampleSummary`, `SampleObserver`, `SampleExecutor`,
+`FactorsStepper<FT>`, `NextFactor<FT>` (sealed `Continue` /
+`Stop`), `Scorer`, `ResourceControls`, `ResourceControlsBuilder`,
+`Criterion`, `CriterionResult`, `CriterionRole`,
+`EvaluatedCriterion`, `EvaluationContext`, `BaselineLookup`,
+`BaselineProvider`, `BaselineStatistics`, `BudgetExhaustionPolicy`,
+`Configuration`, `EmpiricalChecks`, `ExceptionPolicy`,
+`FailureCount`, `FailureExemplar`, `LatencyStatistics`,
+`PassRateStatistics`, `NoStatistics`, `PercentileKey`,
+`PercentileLatency`, `TerminationReason`, `DurationViolation`,
+`package-info`.
+
+The dual-package `ProbabilisticTest` and `Experiment` (annotation
+in `api/`, record in `api/spec/`) is intentional: the annotation
+marks the test method to JUnit; the record is the runtime spec
+the engine drives. They share a name because each *is* the
+named concept on its respective layer.
+
+### I. The `api/covariate` subpackage (additive — entirely new)
+
+Members: `Covariate` (sealed), `CovariateAlignment`,
+`CovariateProfile`, `CustomCovariate`, `DayOfWeekCovariate`,
+`RegionCovariate`, `TimeOfDayCovariate`, `TimezoneCovariate`.
+
+Replaces the v0.6.0 `@Covariate` / `@CovariateSource` annotation
+mechanism (see rows B.3 and D.4).
+
+### J. Feature additions on the typed pipeline
+
+| Addition | Classification | Notes |
+|----------|----------------|-------|
+| `OptimizeBuilder.disableEarlyTermination()` (PR #112) | additive | Lets an optimize run skip the statistical early-termination check; useful when the search must visit the full configured iteration count. |
+| `FactorsStepper.next` returns sealed `NextFactor<FT>` instead of `null`-as-stop (PR #113) | breaking *for in-progress 0.6.x→main migrators* who already wrote stepper implementations against an interim shape; **not breaking against v0.6.0** (no public stepper at v0.6.0) | Symptom: a custom stepper returning `null` no longer compiles. Migration: return `NextFactor.next(factors)` to continue, `NextFactor.stop()` to terminate. |
+| Postcondition failure histograms on `SampleSummary`, `ProbabilisticTestResult`, verdict text, and verdict XML (`<postcondition-failures>`) | additive | Surfaces which named postcondition clauses failed and how often, with bounded exemplars. |
+| `EngineRunSummary` on `ProbabilisticTestResult` | additive | Run-level scalars (sample counts, termination reason, total duration). |
+| `verdict-1.0.xsd` additive update — `<postcondition-failures>` block | additive (XSD-compatible) | Existing consumers continue to validate; new consumers can read the new block. |
+| Transparent stats (verbose stats rendering of failures by postcondition, contract id, etc.) wired into the typed pipeline | additive | Configured via builder-level `transparentStats(...)`. |
+| Covariate-aware best-match baseline selection | additive | A new baseline file naming + selection scheme keyed by covariate hash. Existing baseline files keep working until rewritten under the new scheme; the directive does not require existing baseline migration. |
+| Feasibility evaluation wired into the typed pipeline | additive | Surfaces "this test cannot reach its declared minimum detectable effect with this sample size" as an INCONCLUSIVE verdict instead of a misleading PASS/FAIL. |
+
+### K. Internal — listed for audit completeness
+
+| Change | Note |
+|--------|------|
+| `Punit` → `PUnit` rename | The v0.6.0 surface had no `PUnit`/`Punit` type; the rename happened mid-stream and ships as `PUnit` only. No user-visible rename to migrate. |
+| `BernoulliPassRate` → `PassRate` (and addition of `PassRateStatistics`) | At v0.6.0, no `*PassRate` type lived in `api/`; the rename is internal to non-api packages. The author surface meets only `PassRateStatistics` in `api/spec/`, which is additive. |
+| Module split punit-api / punit-runtime then re-merged into punit-core | Net zero: same module set at v0.6.0 and main. No coordinate change. |
+| `Phase B.2-4: delete legacy engine, JUnit extension stack, annotation package` (commit `c4efe68`) | Deletion of the v0.6.0 reflection-based engine and its annotation processor. User-visible *consequence* is captured in rows A–F; the deletion itself is internal. |
+| Sentinel module redesign (PRs #104, #105) | User-visible piece is row B.2 (`@Sentinel` annotation removed); the rest is internal. |
+| Verdict-1.0.xsd canonical sync (commit `85cdc96`) | Schema-additive; covered by row J.5. |
+
+## Methodology
+
+1. `git log v0.6.0..main --oneline` — 216 commits.
+2. `git diff v0.6.0..main` over the in-scope paths
+   (`punit-core/src/main/java/org/javai/punit/api/**`,
+   `punit-core/src/main/java/org/javai/punit/runtime/PUnit.java`).
+3. File-set delta computed from `git ls-tree`:
+   - 13 files removed from `api/` (all listed under rows B–F).
+   - ~80 files added under `api/`, `api/spec/`, `api/covariate/`
+     (covered by rows G–I as collections; not row-per-file).
+4. For each removed file the v0.6.0 source was inspected to
+   determine whether the type was an `@interface` or a
+   reference type; for each persisting type its v0.6.0 vs main
+   shape was inspected to surface attribute changes (this is
+   how the `@ProbabilisticTest` / `@Experiment` attribute
+   removals were caught — they are not file-level deletions).
+
+## Coverage assertion
+
+Every commit in `git log v0.6.0..main` is either:
+
+- captured by a row above (because it changes the in-scope
+  surface), or
+- internal to packages outside the in-scope paths (engine,
+  reporting, statistics, controls, model, util, verdict — all
+  framework internals or doc/build commits), or
+- listed in section K (internal but worth recording for the
+  audit trail).
+
+If a Phase 2 artefact references a change not present here, the
+audit is wrong; fix this file rather than duplicating the change
+into the artefact.


### PR DESCRIPTION
## Summary
- Catalogues the v0.6.0..main delta on the author-visible API surface (`api/**` plus `runtime/PUnit.java`) into `plan/release/0.7.0-breaking-changes.md`.
- Sections A–F enumerate breaking changes; G–J enumerate additive surface; K records internal-only changes for audit completeness.
- Seeds the 0.7.0 CHANGELOG, the migration doc, the README sign-post, and the GitHub release body — those derive from this audit, not the other way around.

## Test plan
- [ ] Spot-check a row against `git log v0.6.0..main` to confirm the cited mechanism (e.g. `@ProbabilisticTest` attribute drop, `@Sentinel` removal, sealed `Covariate` introduction).
- [ ] Confirm the in-scope path filter — nothing author-visible lives outside `api/**` + `runtime/PUnit.java`.
- [ ] Cross-check the "build coordinates unchanged" claim against `settings.gradle.kts` and any `publishing { … }` block in `punit-core/build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)