### PR TITLE
Restore EXPLORE/OPTIMIZE artefact emission

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -170,6 +170,20 @@ public final class Experiment implements Spec {
     }
 
     /**
+     * Diagnostic accessor returning the per-iteration
+     * {@link SampleSummary} parallel to {@link #history()}, in the
+     * same execution order. Empty for measure and explore. Consumed
+     * by the OPTIMIZE artefact emitter when it needs per-sample
+     * trial detail (the {@code resultProjection:} block of EX06).
+     */
+    public List<SampleSummary<?>> iterationSummaries() {
+        if (internal instanceof OptimizeInternal<?, ?, ?> o) {
+            return List.copyOf(o.iterationSummaries);
+        }
+        return List.of();
+    }
+
+    /**
      * Diagnostic accessor populated only after an explore experiment
      * has run. Yields one entry per {@code FT} in the grid, in
      * iteration order. Empty for measure and optimize, and for
@@ -512,6 +526,7 @@ public final class Experiment implements Spec {
         private final int noImprovementWindow;
 
         private final List<IterationResult<FT>> history = new ArrayList<>();
+        private final List<SampleSummary<OT>> iterationSummaries = new ArrayList<>();
         String terminationReason;
 
         private OptimizeInternal(OptimizeBuilder<FT, IT, OT> b) {
@@ -538,6 +553,7 @@ public final class Experiment implements Spec {
                     summary.successes(),
                     summary.failures(),
                     summary.total()));
+            iterationSummaries.add(summary);
         }
 
         private static List<FailureExemplar> flattenExemplars(

--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -169,6 +169,62 @@ public final class Experiment implements Spec {
         return List.of();
     }
 
+    /**
+     * Diagnostic accessor populated only after an explore experiment
+     * has run. Yields one entry per {@code FT} in the grid, in
+     * iteration order. Empty for measure and optimize, and for
+     * explores that have not yet been executed. Consumed by the
+     * EXPLORE artefact emitter.
+     */
+    public List<PerConfigSummary<?, ?>> perConfigSummaries() {
+        if (internal instanceof ExploreInternal<?, ?, ?> e) {
+            return List.copyOf(e.perConfigSummariesList());
+        }
+        return List.of();
+    }
+
+    /**
+     * Diagnostic accessor populated only after an optimize experiment
+     * has run. Returns the best-scoring iteration per the
+     * optimisation's declared direction (maximise / minimise).
+     * Empty for measure and explore, and for optimizes that have
+     * not yet been executed. Consumed by the OPTIMIZE artefact
+     * emitter.
+     */
+    public Optional<IterationResult<?>> bestOptimizeIteration() {
+        if (internal instanceof OptimizeInternal<?, ?, ?> o) {
+            return Optional.ofNullable(o.bestSoFar());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Diagnostic accessor populated for optimize experiments only.
+     * Returns the optimisation direction declared on the builder —
+     * {@code "MAXIMIZE"} or {@code "MINIMIZE"}. Empty for measure
+     * and explore.
+     */
+    public Optional<String> optimizeObjective() {
+        if (internal instanceof OptimizeInternal<?, ?, ?> o) {
+            return Optional.of(o.maximizing ? "MAXIMIZE" : "MINIMIZE");
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Diagnostic accessor populated for optimize experiments only,
+     * after the run has completed. Reports why the iteration loop
+     * stopped: {@code MAX_ITERATIONS}, {@code NO_IMPROVEMENT}, or
+     * {@code STEPPER_STOP}. Empty for measure and explore, and for
+     * optimizes that have not yet been executed.
+     */
+    public Optional<String> optimizeTerminationReason() {
+        if (internal instanceof OptimizeInternal<?, ?, ?> o) {
+            return Optional.ofNullable(o.terminationReason);
+        }
+        return Optional.empty();
+    }
+
     // ── Spec dispatch ────────────────────────────────────────────────
 
     @Override
@@ -321,6 +377,7 @@ public final class Experiment implements Spec {
 
         private final List<FT> grid;
         private final Map<FT, SampleSummary<OT>> perConfig = new LinkedHashMap<>();
+        private final Map<FT, Integer> perConfigSamplesPlanned = new LinkedHashMap<>();
 
         private ExploreInternal(ExploreBuilder<FT, IT, OT> b) {
             super(b.sampling, b.experimentId != null ? b.experimentId : defaultId("explore"));
@@ -337,6 +394,16 @@ public final class Experiment implements Spec {
 
         @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
             perConfig.put(config.factors(), summary);
+            perConfigSamplesPlanned.put(config.factors(), config.samples());
+        }
+
+        List<PerConfigSummary<FT, OT>> perConfigSummariesList() {
+            return perConfig.entrySet().stream()
+                    .map(entry -> new PerConfigSummary<>(
+                            entry.getKey(),
+                            entry.getValue(),
+                            perConfigSamplesPlanned.getOrDefault(entry.getKey(), 0)))
+                    .toList();
         }
 
         @Override public EngineResult conclude(BaselineProvider provider) {
@@ -445,6 +512,7 @@ public final class Experiment implements Spec {
         private final int noImprovementWindow;
 
         private final List<IterationResult<FT>> history = new ArrayList<>();
+        String terminationReason;
 
         private OptimizeInternal(OptimizeBuilder<FT, IT, OT> b) {
             super(b.sampling, b.experimentId != null ? b.experimentId : defaultId("optimize"));
@@ -466,7 +534,10 @@ public final class Experiment implements Spec {
                     config.factors(),
                     score,
                     summary.failuresByPostcondition(),
-                    flattenExemplars(summary.failuresByPostcondition())));
+                    flattenExemplars(summary.failuresByPostcondition()),
+                    summary.successes(),
+                    summary.failures(),
+                    summary.total()));
         }
 
         private static List<FailureExemplar> flattenExemplars(
@@ -529,6 +600,9 @@ public final class Experiment implements Spec {
                     return;
                 }
                 if (issued >= maxIterations) {
+                    if (terminationReason == null) {
+                        terminationReason = "MAX_ITERATIONS";
+                    }
                     return;
                 }
                 if (!history.isEmpty()) {
@@ -541,6 +615,9 @@ public final class Experiment implements Spec {
                         iterationsSinceImprovement++;
                     }
                     if (iterationsSinceImprovement >= noImprovementWindow) {
+                        if (terminationReason == null) {
+                            terminationReason = "NO_IMPROVEMENT";
+                        }
                         return;
                     }
                     FT current = last.factors();
@@ -548,7 +625,12 @@ public final class Experiment implements Spec {
                             Collections.unmodifiableList(history));
                     switch (candidate) {
                         case NextFactor.Continue<FT> c -> next = c.factor();
-                        case NextFactor.Stop<FT> s -> { /* leave next null; loop ends */ }
+                        case NextFactor.Stop<FT> s -> {
+                            if (terminationReason == null) {
+                                terminationReason = "STEPPER_STOP";
+                            }
+                            /* leave next null; loop ends */
+                        }
                     }
                 }
             }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/FactorsStepper.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/FactorsStepper.java
@@ -49,13 +49,24 @@ public interface FactorsStepper<FT> {
      *                                bounded exemplars
      * @param failureExemplars        flattened bounded view across
      *                                all clauses
+     * @param successes               raw count of samples whose
+     *                                outcome was {@code Ok}
+     * @param failures                raw count of samples whose
+     *                                outcome was {@code Fail}
+     * @param samplesExecuted         total samples executed in the
+     *                                iteration (successes + failures,
+     *                                matching the iteration's
+     *                                {@link SampleSummary#total()})
      * @param <FT> the factor record type
      */
     record IterationResult<FT>(
             FT factors,
             double score,
             Map<String, FailureCount> failuresByPostcondition,
-            List<FailureExemplar> failureExemplars) {
+            List<FailureExemplar> failureExemplars,
+            int successes,
+            int failures,
+            int samplesExecuted) {
 
         public IterationResult {
             Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
@@ -65,14 +76,31 @@ public interface FactorsStepper<FT> {
         }
 
         /**
-         * Backward-compatible constructor that defaults the histogram
-         * and exemplar list to empty. Used by call sites that haven't
-         * yet migrated to the canonical 4-field shape; the engine
-         * constructs results via the canonical constructor with
-         * populated histograms.
+         * Backward-compatible 4-field constructor. Defaults the raw
+         * count fields ({@code successes}, {@code failures},
+         * {@code samplesExecuted}) to {@code 0}; call sites that
+         * have access to the iteration's {@link SampleSummary}
+         * should use the canonical 7-field constructor so the
+         * counts reach the optimize artefact (EX06).
+         */
+        public IterationResult(
+                FT factors,
+                double score,
+                Map<String, FailureCount> failuresByPostcondition,
+                List<FailureExemplar> failureExemplars) {
+            this(factors, score, failuresByPostcondition, failureExemplars, 0, 0, 0);
+        }
+
+        /**
+         * Backward-compatible 2-field constructor. Defaults the
+         * histogram and exemplar list to empty and the raw counts
+         * to {@code 0}. Used by call sites that haven't yet migrated
+         * to the canonical 7-field shape; the engine constructs
+         * results via the canonical constructor with populated
+         * histograms and counts.
          */
         public IterationResult(FT factors, double score) {
-            this(factors, score, Map.of(), List.of());
+            this(factors, score, Map.of(), List.of(), 0, 0, 0);
         }
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerConfigSummary.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerConfigSummary.java
@@ -1,0 +1,39 @@
+package org.javai.punit.api.spec;
+
+import java.util.Objects;
+
+/**
+ * One configuration's outcome from an EXPLORE run — its factor
+ * record paired with the {@link SampleSummary} the engine produced
+ * for it, plus the configuration's planned sample count. Yielded in
+ * declaration-order from {@link Experiment#perConfigSummaries()}
+ * after an explore run completes.
+ *
+ * <p>Diagnostic surface, not an authoring surface. Consumed by the
+ * EXPLORE artefact emitter; user-side experiment code does not
+ * construct or read these values directly.
+ *
+ * @param factors the factor record for this configuration
+ * @param summary the engine's per-sample aggregate for this
+ *                configuration
+ * @param samplesPlanned the configuration's planned sample count —
+ *                       what the spec asked for, before any early
+ *                       termination. {@code summary.total()} reports
+ *                       what actually ran.
+ * @param <FT> factor record type
+ * @param <OT> use case output type
+ */
+public record PerConfigSummary<FT, OT>(
+        FT factors,
+        SampleSummary<OT> summary,
+        int samplesPlanned) {
+
+    public PerConfigSummary {
+        Objects.requireNonNull(factors, "factors");
+        Objects.requireNonNull(summary, "summary");
+        if (samplesPlanned < 0) {
+            throw new IllegalArgumentException(
+                    "samplesPlanned must be non-negative, got " + samplesPlanned);
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/explore/ExplorationsResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/explore/ExplorationsResolver.java
@@ -1,0 +1,46 @@
+package org.javai.punit.engine.explore;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Resolves the directory under which EXPLORE artefacts are written.
+ *
+ * <p>Precedence:
+ *
+ * <ol>
+ *   <li>System property {@value #EXPLORATIONS_DIR_PROPERTY} — explicit
+ *       per-run override (set by the punit Gradle plugin's
+ *       {@code exp} task, or by ad-hoc invocations).</li>
+ *   <li>Default {@value #DEFAULT_DIR} — the convention path
+ *       (gitignored by virtue of {@code build/} being ignored).</li>
+ * </ol>
+ *
+ * <p>The directory is not required to exist — the artefact emitter
+ * creates it on first write.
+ *
+ * <p>Mirror of {@link org.javai.punit.engine.baseline.BaselineResolver}
+ * for explore output. Optimize output has its own
+ * {@link org.javai.punit.engine.optimize.OptimizationsResolver}.
+ */
+public final class ExplorationsResolver {
+
+    /** System-property key for an explicit explorations directory. */
+    public static final String EXPLORATIONS_DIR_PROPERTY = "punit.explorations.outputDir";
+
+    /** Default explorations directory under the build output tree. */
+    public static final String DEFAULT_DIR = "build/punit/explorations";
+
+    private ExplorationsResolver() { }
+
+    /**
+     * @return the configured explorations directory.
+     */
+    public static Path resolveDir() {
+        String override = System.getProperty(EXPLORATIONS_DIR_PROPERTY);
+        if (override != null && !override.isBlank()) {
+            return Paths.get(override);
+        }
+        return Paths.get(DEFAULT_DIR);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
@@ -1,0 +1,190 @@
+package org.javai.punit.engine.explore;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.spec.FailureCount;
+import org.javai.punit.api.spec.PerConfigSummary;
+import org.javai.punit.api.spec.SampleSummary;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Serialises one EXPLORE configuration's outcome to the EX05 YAML
+ * schema and resolves its readable-stem filename.
+ *
+ * <p>Both methods are pure — the writer performs no I/O. The
+ * {@link org.javai.punit.runtime.ExploreEmitter EXPLORE emitter}
+ * orchestrates persistence (writing to disk or to an in-memory
+ * sink for tests).
+ *
+ * <p>Schema follows the canonical EX05 YAML shape: {@code factors:}
+ * block in {@code FT}-component declaration order, descriptive
+ * statistics only (no inferential statistics), small sample counts
+ * accepted without warning. Per-sample result projections (EX07)
+ * are not emitted here yet — when the trial path threads projection
+ * metadata through, a {@code resultProjection:} block can be
+ * appended additively.
+ */
+public final class ExploreOutputWriter {
+
+    /** Schema-version value carried in every emitted file. */
+    public static final String SCHEMA_VERSION = "punit-spec-1";
+
+    /** Maximum unsanitised canonical-value length before truncation kicks in. */
+    private static final int MAX_RAW_LENGTH = 32;
+
+    /** Truncated prefix length when the value exceeds {@link #MAX_RAW_LENGTH}. */
+    private static final int TRUNCATED_PREFIX_LENGTH = 24;
+
+    /** Stem used when the factor record is empty (no components). */
+    private static final String EMPTY_BUNDLE_STEM = "no-factors";
+
+    /**
+     * Build the EX05 YAML for one configuration. Pure — no I/O.
+     *
+     * @param useCaseId the use case identifier (becomes the
+     *                  {@code useCaseId:} field).
+     * @param factorBundle the configuration's factor bundle (becomes
+     *                     the {@code factors:} block).
+     * @param entry the per-config summary plus planned sample count.
+     * @return YAML matching the EX05 canonical schema.
+     */
+    public String writeYaml(String useCaseId, FactorBundle factorBundle, PerConfigSummary<?, ?> entry) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("schemaVersion", SCHEMA_VERSION);
+        root.put("useCaseId", useCaseId);
+        root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        root.put("factors", factorsBlock(factorBundle));
+        root.put("execution", executionBlock(entry));
+        root.put("statistics", statisticsBlock(entry.summary()));
+        root.put("cost", costBlock(entry.summary()));
+        return yaml().dump(root);
+    }
+
+    /**
+     * Compute the readable-stem filename (without extension) for a
+     * factor bundle, per the algorithm in EX05 §Configuration naming.
+     *
+     * <p>For each entry in declaration order: produce
+     * {@code {fieldName}-{canonicalValue}}, optionally truncated and
+     * suffixed with a 4-char SHA-256 hash if the value is long.
+     * Segments are joined with {@code _}; the whole result is
+     * sanitised (non-alphanumeric/{@code .-_} replaced with
+     * {@code _}, runs of {@code _} collapsed).
+     */
+    public String filenameFor(FactorBundle factorBundle) {
+        if (factorBundle.isEmpty()) {
+            return EMPTY_BUNDLE_STEM;
+        }
+        StringBuilder stem = new StringBuilder();
+        boolean first = true;
+        for (FactorBundle.Entry e : factorBundle.entries()) {
+            if (!first) {
+                stem.append('_');
+            }
+            first = false;
+            stem.append(e.name()).append('-').append(canonicalValueForFilename(e.value()));
+        }
+        return sanitise(stem.toString());
+    }
+
+    private static Map<String, Object> factorsBlock(FactorBundle bundle) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        for (FactorBundle.Entry e : bundle.entries()) {
+            block.put(e.name(), e.value().yamlValue());
+        }
+        return block;
+    }
+
+    private static Map<String, Object> executionBlock(PerConfigSummary<?, ?> entry) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        block.put("samplesPlanned", entry.samplesPlanned());
+        block.put("samplesExecuted", entry.summary().total());
+        block.put("terminationReason", entry.summary().terminationReason().name());
+        return block;
+    }
+
+    private static Map<String, Object> statisticsBlock(SampleSummary<?> summary) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        block.put("observed", summary.passRate());
+        block.put("successes", summary.successes());
+        block.put("failures", summary.failures());
+        Map<String, Object> failureDistribution = new LinkedHashMap<>();
+        for (Map.Entry<String, FailureCount> entry : summary.failuresByPostcondition().entrySet()) {
+            failureDistribution.put(entry.getKey(), entry.getValue().count());
+        }
+        block.put("failureDistribution", failureDistribution);
+        return block;
+    }
+
+    private static Map<String, Object> costBlock(SampleSummary<?> summary) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        Duration elapsed = summary.elapsed();
+        long totalMs = elapsed.toMillis();
+        block.put("totalTimeMs", totalMs);
+        int total = summary.total();
+        block.put("avgTimePerSampleMs", total == 0 ? 0L : totalMs / total);
+        return block;
+    }
+
+    static String canonicalValueForFilename(org.javai.punit.api.FactorValue value) {
+        Object yaml = value.yamlValue();
+        String raw = String.valueOf(yaml);
+        if (raw.length() > MAX_RAW_LENGTH) {
+            String prefix = sanitise(raw.substring(0, TRUNCATED_PREFIX_LENGTH));
+            return prefix + "-" + sha256HexPrefix(raw, 4);
+        }
+        return raw;
+    }
+
+    static String sanitise(String input) {
+        StringBuilder out = new StringBuilder(input.length());
+        char prev = 0;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            char emit = (Character.isLetterOrDigit(c) || c == '.' || c == '-' || c == '_') ? c : '_';
+            if (emit == '_' && prev == '_') {
+                continue;
+            }
+            out.append(emit);
+            prev = emit;
+        }
+        return out.toString();
+    }
+
+    static String sha256HexPrefix(String input, int hexChars) {
+        byte[] digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 must be supported by every JRE", e);
+        }
+        StringBuilder hex = new StringBuilder(hexChars);
+        for (int i = 0; i < (hexChars + 1) / 2 && i < digest.length; i++) {
+            int b = digest[i] & 0xff;
+            hex.append(HEX[b >>> 4]);
+            if (hex.length() < hexChars) {
+                hex.append(HEX[b & 0x0f]);
+            }
+        }
+        return hex.toString();
+    }
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private static Yaml yaml() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        return new Yaml(options);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
@@ -7,16 +7,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.javai.outcome.Outcome;
 import org.javai.punit.api.FactorBundle;
-import org.javai.punit.api.PostconditionResult;
 import org.javai.punit.api.spec.FailureCount;
 import org.javai.punit.api.spec.PerConfigSummary;
 import org.javai.punit.api.spec.SampleSummary;
-import org.javai.punit.api.spec.Trial;
+import org.javai.punit.engine.output.ResultProjections;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -70,8 +67,11 @@ public final class ExploreOutputWriter {
         root.put("execution", executionBlock(entry));
         root.put("statistics", statisticsBlock(entry.summary()));
         root.put("cost", costBlock(entry.summary()));
-        root.put("resultProjection", resultProjectionBlock(entry.summary()));
-        return yaml().dump(root);
+        root.put("resultProjection", ResultProjections.resultProjectionMap(entry.summary().trials()));
+
+        String dump = yaml().dump(root);
+        return ResultProjections.injectAnchorComments(
+                dump, ResultProjections.anchorsFor(entry.summary().trials()));
     }
 
     /**
@@ -140,47 +140,6 @@ public final class ExploreOutputWriter {
         return block;
     }
 
-    /**
-     * Per-sample projection block — one entry per trial, keyed by
-     * {@code sample[N]}. Always emitted for EXPLORE: a per-sample
-     * postcondition diff is the central DX of the explore artefact
-     * (compare two configs side-by-side via {@code diff}), so the
-     * block is unconditional rather than opt-in. Aggregate-only
-     * stats live in {@link #statisticsBlock}; this block carries the
-     * granular evaluation each developer wants to scrutinise.
-     */
-    private static Map<String, Object> resultProjectionBlock(SampleSummary<?> summary) {
-        Map<String, Object> block = new LinkedHashMap<>();
-        List<? extends Trial<?, ?>> trials = summary.trials();
-        for (int idx = 0; idx < trials.size(); idx++) {
-            block.put("sample[" + idx + "]", projectionFor(trials.get(idx)));
-        }
-        return block;
-    }
-
-    private static Map<String, Object> projectionFor(Trial<?, ?> trial) {
-        Map<String, Object> entry = new LinkedHashMap<>();
-        entry.put("input", String.valueOf(trial.input()));
-        Map<String, Object> postconds = new LinkedHashMap<>();
-        for (PostconditionResult pr : trial.outcome().postconditionResults()) {
-            postconds.put(pr.description(), pr.passed() ? "passed" : "failed");
-        }
-        entry.put("postconditions", postconds);
-        entry.put("executionTimeMs", trial.duration().toMillis());
-
-        Outcome<?> result = trial.outcome().result();
-        switch (result) {
-            case Outcome.Ok<?> ok -> entry.put("content", String.valueOf(ok.value()));
-            case Outcome.Fail<?> fail -> entry.put("failureDetail",
-                    fail.failure().id().name() + ": " + fail.failure().message());
-        }
-
-        long tokens = trial.outcome().tokens();
-        if (tokens > 0L) {
-            entry.put("tokensUsed", tokens);
-        }
-        return entry;
-    }
 
     static String canonicalValueForFilename(org.javai.punit.api.FactorValue value) {
         Object yaml = value.yamlValue();

--- a/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
@@ -7,12 +7,16 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.PostconditionResult;
 import org.javai.punit.api.spec.FailureCount;
 import org.javai.punit.api.spec.PerConfigSummary;
 import org.javai.punit.api.spec.SampleSummary;
+import org.javai.punit.api.spec.Trial;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -66,6 +70,7 @@ public final class ExploreOutputWriter {
         root.put("execution", executionBlock(entry));
         root.put("statistics", statisticsBlock(entry.summary()));
         root.put("cost", costBlock(entry.summary()));
+        root.put("resultProjection", resultProjectionBlock(entry.summary()));
         return yaml().dump(root);
     }
 
@@ -133,6 +138,48 @@ public final class ExploreOutputWriter {
         int total = summary.total();
         block.put("avgTimePerSampleMs", total == 0 ? 0L : totalMs / total);
         return block;
+    }
+
+    /**
+     * Per-sample projection block — one entry per trial, keyed by
+     * {@code sample[N]}. Always emitted for EXPLORE: a per-sample
+     * postcondition diff is the central DX of the explore artefact
+     * (compare two configs side-by-side via {@code diff}), so the
+     * block is unconditional rather than opt-in. Aggregate-only
+     * stats live in {@link #statisticsBlock}; this block carries the
+     * granular evaluation each developer wants to scrutinise.
+     */
+    private static Map<String, Object> resultProjectionBlock(SampleSummary<?> summary) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        List<? extends Trial<?, ?>> trials = summary.trials();
+        for (int idx = 0; idx < trials.size(); idx++) {
+            block.put("sample[" + idx + "]", projectionFor(trials.get(idx)));
+        }
+        return block;
+    }
+
+    private static Map<String, Object> projectionFor(Trial<?, ?> trial) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("input", String.valueOf(trial.input()));
+        Map<String, Object> postconds = new LinkedHashMap<>();
+        for (PostconditionResult pr : trial.outcome().postconditionResults()) {
+            postconds.put(pr.description(), pr.passed() ? "passed" : "failed");
+        }
+        entry.put("postconditions", postconds);
+        entry.put("executionTimeMs", trial.duration().toMillis());
+
+        Outcome<?> result = trial.outcome().result();
+        switch (result) {
+            case Outcome.Ok<?> ok -> entry.put("content", String.valueOf(ok.value()));
+            case Outcome.Fail<?> fail -> entry.put("failureDetail",
+                    fail.failure().id().name() + ": " + fail.failure().message());
+        }
+
+        long tokens = trial.outcome().tokens();
+        if (tokens > 0L) {
+            entry.put("tokensUsed", tokens);
+        }
+        return entry;
     }
 
     static String canonicalValueForFilename(org.javai.punit.api.FactorValue value) {

--- a/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizationsResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizationsResolver.java
@@ -1,0 +1,46 @@
+package org.javai.punit.engine.optimize;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Resolves the directory under which OPTIMIZE artefacts are written.
+ *
+ * <p>Precedence:
+ *
+ * <ol>
+ *   <li>System property {@value #OPTIMIZATIONS_DIR_PROPERTY} — explicit
+ *       per-run override (set by the punit Gradle plugin's
+ *       {@code exp} task, or by ad-hoc invocations).</li>
+ *   <li>Default {@value #DEFAULT_DIR} — the convention path
+ *       (gitignored by virtue of {@code build/} being ignored).</li>
+ * </ol>
+ *
+ * <p>The directory is not required to exist — the artefact emitter
+ * creates it on first write.
+ *
+ * <p>Mirror of {@link org.javai.punit.engine.baseline.BaselineResolver}
+ * for optimize output. Explore output has its own
+ * {@link org.javai.punit.engine.explore.ExplorationsResolver}.
+ */
+public final class OptimizationsResolver {
+
+    /** System-property key for an explicit optimizations directory. */
+    public static final String OPTIMIZATIONS_DIR_PROPERTY = "punit.optimizations.outputDir";
+
+    /** Default optimizations directory under the build output tree. */
+    public static final String DEFAULT_DIR = "build/punit/optimizations";
+
+    private OptimizationsResolver() { }
+
+    /**
+     * @return the configured optimizations directory.
+     */
+    public static Path resolveDir() {
+        String override = System.getProperty(OPTIMIZATIONS_DIR_PROPERTY);
+        if (override != null && !override.isBlank()) {
+            return Paths.get(override);
+        }
+        return Paths.get(DEFAULT_DIR);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizeOutputWriter.java
@@ -9,6 +9,9 @@ import java.util.Map;
 
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.spec.FactorsStepper.IterationResult;
+import org.javai.punit.api.spec.SampleSummary;
+import org.javai.punit.api.spec.Trial;
+import org.javai.punit.engine.output.ResultProjections;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -54,6 +57,7 @@ public final class OptimizeOutputWriter {
             String experimentId,
             String objective,
             List<? extends IterationResult<?>> history,
+            List<? extends SampleSummary<?>> iterationSummaries,
             IterationResult<?> bestIteration,
             String terminationReason) {
 
@@ -63,15 +67,34 @@ public final class OptimizeOutputWriter {
         root.put("experimentId", experimentId);
         root.put("objective", objective);
         root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
-        root.put("iterations", iterationsBlock(history));
+        root.put("iterations", iterationsBlock(history, iterationSummaries));
         root.put("convergence", convergenceBlock(history, bestIteration, terminationReason));
-        return yaml().dump(root);
+
+        String dump = yaml().dump(root);
+        return ResultProjections.injectAnchorComments(dump, allAnchors(iterationSummaries));
     }
 
-    private static List<Map<String, Object>> iterationsBlock(List<? extends IterationResult<?>> history) {
+    /**
+     * Concatenate every iteration's per-trial anchors in iteration
+     * order. The post-processor consumes them in document order as
+     * it walks the dumped YAML's {@code sample[N]:} lines, so the
+     * concatenated list must mirror that traversal: iteration[0]'s
+     * trials, then iteration[1]'s trials, and so on.
+     */
+    private static List<String> allAnchors(List<? extends SampleSummary<?>> iterationSummaries) {
+        List<String> all = new ArrayList<>();
+        for (SampleSummary<?> summary : iterationSummaries) {
+            all.addAll(ResultProjections.anchorsFor(summary.trials()));
+        }
+        return all;
+    }
+
+    private static List<Map<String, Object>> iterationsBlock(
+            List<? extends IterationResult<?>> history,
+            List<? extends SampleSummary<?>> iterationSummaries) {
         List<Map<String, Object>> out = new ArrayList<>(history.size());
-        int idx = 0;
-        for (IterationResult<?> ir : history) {
+        for (int idx = 0; idx < history.size(); idx++) {
+            IterationResult<?> ir = history.get(idx);
             Map<String, Object> entry = new LinkedHashMap<>();
             entry.put("iteration", idx);
             entry.put("factors", factorsBlock(FactorBundle.of(ir.factors())));
@@ -79,8 +102,15 @@ public final class OptimizeOutputWriter {
             entry.put("successes", ir.successes());
             entry.put("failures", ir.failures());
             entry.put("samplesExecuted", ir.samplesExecuted());
+            // Per-iteration result projection: one sample[N]: block
+            // per trial, carrying input / postconditions / etc. The
+            // writer leaves anchor-comment injection to the
+            // top-level injectAnchorComments pass.
+            if (idx < iterationSummaries.size()) {
+                List<? extends Trial<?, ?>> trials = iterationSummaries.get(idx).trials();
+                entry.put("resultProjection", ResultProjections.resultProjectionMap(trials));
+            }
             out.add(entry);
-            idx++;
         }
         return out;
     }

--- a/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizeOutputWriter.java
@@ -1,0 +1,124 @@
+package org.javai.punit.engine.optimize;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.spec.FactorsStepper.IterationResult;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Serialises a completed OPTIMIZE run's history to the EX06 YAML
+ * schema. Pure — performs no I/O. The
+ * {@link org.javai.punit.runtime.OptimizeEmitter OPTIMIZE emitter}
+ * orchestrates persistence (writing to disk or to an in-memory sink
+ * for tests).
+ *
+ * <p>One file per optimize run, carrying the full iteration history
+ * and a {@code convergence:} block. Filename is
+ * {@code {useCaseId}/{experimentId}.yaml} — assembled by the
+ * emitter, not the writer.
+ */
+public final class OptimizeOutputWriter {
+
+    /** Schema-version value carried in every emitted file. */
+    public static final String SCHEMA_VERSION = "punit-spec-1";
+
+    /**
+     * Build the EX06 YAML for one optimize run. Pure — no I/O.
+     *
+     * @param useCaseId the use case identifier
+     * @param experimentId the experiment identifier (becomes the
+     *                     filename stem)
+     * @param objective {@code "MAXIMIZE"} or {@code "MINIMIZE"}
+     * @param history the full iteration history in execution order;
+     *                each {@link IterationResult} carries its
+     *                factors, score, raw counts, and per-clause
+     *                failure histogram.
+     * @param bestIteration the iteration the optimisation chose as
+     *                      best per the declared direction
+     * @param terminationReason why the iteration loop stopped
+     *                          ({@code MAX_ITERATIONS},
+     *                          {@code NO_IMPROVEMENT},
+     *                          {@code STEPPER_STOP}, or another
+     *                          framework-recognised value)
+     * @return YAML matching the EX06 canonical schema
+     */
+    public String writeYaml(
+            String useCaseId,
+            String experimentId,
+            String objective,
+            List<? extends IterationResult<?>> history,
+            IterationResult<?> bestIteration,
+            String terminationReason) {
+
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("schemaVersion", SCHEMA_VERSION);
+        root.put("useCaseId", useCaseId);
+        root.put("experimentId", experimentId);
+        root.put("objective", objective);
+        root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        root.put("iterations", iterationsBlock(history));
+        root.put("convergence", convergenceBlock(history, bestIteration, terminationReason));
+        return yaml().dump(root);
+    }
+
+    private static List<Map<String, Object>> iterationsBlock(List<? extends IterationResult<?>> history) {
+        List<Map<String, Object>> out = new ArrayList<>(history.size());
+        int idx = 0;
+        for (IterationResult<?> ir : history) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("iteration", idx);
+            entry.put("factors", factorsBlock(FactorBundle.of(ir.factors())));
+            entry.put("score", ir.score());
+            entry.put("successes", ir.successes());
+            entry.put("failures", ir.failures());
+            entry.put("samplesExecuted", ir.samplesExecuted());
+            out.add(entry);
+            idx++;
+        }
+        return out;
+    }
+
+    private static Map<String, Object> convergenceBlock(
+            List<? extends IterationResult<?>> history,
+            IterationResult<?> best,
+            String terminationReason) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        block.put("totalIterations", history.size());
+        int bestIndex = -1;
+        if (best != null) {
+            for (int i = 0; i < history.size(); i++) {
+                if (history.get(i) == best) {
+                    bestIndex = i;
+                    break;
+                }
+            }
+            block.put("bestIteration", bestIndex);
+            block.put("bestScore", best.score());
+            block.put("bestFactors", factorsBlock(FactorBundle.of(best.factors())));
+        }
+        block.put("terminationReason", terminationReason);
+        return block;
+    }
+
+    private static Map<String, Object> factorsBlock(FactorBundle bundle) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        for (FactorBundle.Entry e : bundle.entries()) {
+            block.put(e.name(), e.value().yamlValue());
+        }
+        return block;
+    }
+
+    private static Yaml yaml() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        return new Yaml(options);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/output/ResultProjections.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/output/ResultProjections.java
@@ -1,0 +1,170 @@
+package org.javai.punit.engine.output;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionResult;
+import org.javai.punit.api.spec.Trial;
+
+/**
+ * Shared helpers for the per-sample {@code resultProjection:} block
+ * emitted by EXPLORE and OPTIMIZE artefacts (per the EX07 catalog
+ * shape). Used by both
+ * {@link org.javai.punit.engine.explore.ExploreOutputWriter} and
+ * {@link org.javai.punit.engine.optimize.OptimizeOutputWriter}.
+ *
+ * <p>Two responsibilities:
+ *
+ * <ol>
+ *   <li>{@link #projectionFor(Trial)} renders one trial as the EX07
+ *       per-sample map (input / postconditions / executionTimeMs /
+ *       content-or-failureDetail / optional tokensUsed).</li>
+ *   <li>{@link #injectAnchorComments(String, List)} post-processes
+ *       a snakeyaml-emitted YAML string to inject a deterministic
+ *       diff anchor comment before every {@code sample[N]:} line —
+ *       so a {@code diff} between two artefact files of the same
+ *       configuration aligns at sample boundaries rather than
+ *       merging adjacent samples' content.</li>
+ * </ol>
+ *
+ * <p>Anchors are content-deterministic — two runs of the same
+ * configuration produce the same anchor at the same sample position,
+ * so the anchor line matches across the two files and acts as a
+ * synchronisation point for the diff tool.
+ */
+public final class ResultProjections {
+
+    private ResultProjections() { }
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    /**
+     * Render one trial as the EX07 per-sample projection map.
+     *
+     * @param trial one per-sample observation
+     * @return ordered map carrying {@code input},
+     *         {@code postconditions}, {@code executionTimeMs},
+     *         {@code content} (on success) or {@code failureDetail}
+     *         (on failure), and {@code tokensUsed} when token
+     *         bookkeeping is active.
+     */
+    public static Map<String, Object> projectionFor(Trial<?, ?> trial) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("input", String.valueOf(trial.input()));
+        Map<String, Object> postconds = new LinkedHashMap<>();
+        for (PostconditionResult pr : trial.outcome().postconditionResults()) {
+            postconds.put(pr.description(), pr.passed() ? "passed" : "failed");
+        }
+        entry.put("postconditions", postconds);
+        entry.put("executionTimeMs", trial.duration().toMillis());
+
+        Outcome<?> result = trial.outcome().result();
+        switch (result) {
+            case Outcome.Ok<?> ok -> entry.put("content", String.valueOf(ok.value()));
+            case Outcome.Fail<?> fail -> entry.put("failureDetail",
+                    fail.failure().id().name() + ": " + fail.failure().message());
+        }
+
+        long tokens = trial.outcome().tokens();
+        if (tokens > 0L) {
+            entry.put("tokensUsed", tokens);
+        }
+        return entry;
+    }
+
+    /**
+     * Build the {@code resultProjection:} block — a map keyed by
+     * {@code sample[N]} carrying one {@link #projectionFor projection}
+     * per trial in iteration order.
+     */
+    public static Map<String, Object> resultProjectionMap(List<? extends Trial<?, ?>> trials) {
+        Map<String, Object> block = new LinkedHashMap<>();
+        for (int idx = 0; idx < trials.size(); idx++) {
+            block.put("sample[" + idx + "]", projectionFor(trials.get(idx)));
+        }
+        return block;
+    }
+
+    /**
+     * Compute the per-trial diff anchors to interleave with a
+     * {@code resultProjection:} block. Anchor for trial at index
+     * {@code i} = first 8 hex chars of
+     * {@code SHA-256(i + ":" + canonical(input))}. Same trial →
+     * same anchor → diff aligns.
+     */
+    public static List<String> anchorsFor(List<? extends Trial<?, ?>> trials) {
+        List<String> anchors = new ArrayList<>(trials.size());
+        for (int i = 0; i < trials.size(); i++) {
+            anchors.add(anchorOf(i, trials.get(i).input()));
+        }
+        return anchors;
+    }
+
+    /** Anchor for one (index, input) pair. */
+    public static String anchorOf(int sampleIndex, Object input) {
+        String content = sampleIndex + ":" + String.valueOf(input);
+        return sha256HexPrefix(content, 8);
+    }
+
+    /**
+     * Inject anchor comments before every {@code sample[N]:} line in
+     * {@code yaml}, consuming anchors from {@code anchors} in the
+     * order the sample lines appear. The comment indent matches the
+     * indent of the {@code sample[N]:} line it annotates so the
+     * resulting YAML stays well-formed.
+     *
+     * <p>If the YAML has more {@code sample[N]:} lines than the
+     * caller supplied anchors, any surplus lines are left
+     * un-annotated rather than annotated with placeholder strings —
+     * a missing anchor is preferable to a misleading one.
+     */
+    public static String injectAnchorComments(String yaml, List<String> anchors) {
+        Pattern p = Pattern.compile("^(\\s*)sample\\[(\\d+)\\]:", Pattern.MULTILINE);
+        Matcher m = p.matcher(yaml);
+        StringBuilder out = new StringBuilder(yaml.length() + anchors.size() * 40);
+        int last = 0;
+        int anchorIdx = 0;
+        while (m.find()) {
+            out.append(yaml, last, m.start());
+            if (anchorIdx < anchors.size()) {
+                String indent = m.group(1);
+                out.append(indent)
+                        .append("# ────── anchor:")
+                        .append(anchors.get(anchorIdx))
+                        .append(" ──────\n");
+            }
+            anchorIdx++;
+            out.append(yaml, m.start(), m.end());
+            last = m.end();
+        }
+        out.append(yaml, last, yaml.length());
+        return out.toString();
+    }
+
+    private static String sha256HexPrefix(String input, int hexChars) {
+        byte[] digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 must be supported by every JRE", e);
+        }
+        StringBuilder hex = new StringBuilder(hexChars);
+        for (int i = 0; hex.length() < hexChars && i < digest.length; i++) {
+            int b = digest[i] & 0xff;
+            hex.append(HEX[b >>> 4]);
+            if (hex.length() < hexChars) {
+                hex.append(HEX[b & 0x0f]);
+            }
+        }
+        return hex.toString();
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
@@ -2,12 +2,16 @@ package org.javai.punit.runtime;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
 
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.InputSupplier;
@@ -62,6 +66,28 @@ final class BaselineEmitter {
     private BaselineEmitter() { }
 
     static void emit(Experiment experiment, Path baselineDir) {
+        Objects.requireNonNull(baselineDir, "baselineDir");
+        emit(experiment, (relativePath, content) -> {
+            try {
+                Files.createDirectories(baselineDir);
+                Path target = baselineDir.resolve(relativePath);
+                Files.writeString(target, content, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to write baseline " + relativePath + " under " + baselineDir, e);
+            }
+        });
+    }
+
+    /**
+     * Test seam — emit the baseline artefact via a sink so tests can
+     * scrutinise the YAML without touching disk. The sink receives a
+     * single {@code (relativePath, yamlContent)} pair where
+     * {@code relativePath} is the canonical baseline filename.
+     */
+    static void emit(Experiment experiment, BiConsumer<String, String> sink) {
+        Objects.requireNonNull(experiment, "experiment");
+        Objects.requireNonNull(sink, "sink");
         if (experiment.kind() != Experiment.Kind.MEASURE) {
             // Only MEASURE produces a baseline. The only caller is
             // PUnit.MeasureBuilder.run(), which by construction passes a
@@ -89,7 +115,7 @@ final class BaselineEmitter {
                 return composeRecord(typed, summary, experiment.experimentId());
             }
         });
-        writeRecord(record, baselineDir);
+        sink.accept(record.filename(), new BaselineWriter().toYaml(record));
     }
 
     @SuppressWarnings("unchecked")
@@ -141,12 +167,4 @@ final class BaselineEmitter {
                 profile);
     }
 
-    private static void writeRecord(BaselineRecord record, Path baselineDir) {
-        try {
-            new BaselineWriter().write(record, baselineDir);
-        } catch (IOException e) {
-            throw new UncheckedIOException(
-                    "Failed to write baseline " + record.filename() + " under " + baselineDir, e);
-        }
-    }
 }

--- a/punit-core/src/main/java/org/javai/punit/runtime/ExploreEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/ExploreEmitter.java
@@ -1,0 +1,114 @@
+package org.javai.punit.runtime;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.PerConfigSummary;
+import org.javai.punit.api.spec.SampleSummary;
+import org.javai.punit.api.spec.Spec;
+import org.javai.punit.api.spec.TypedSpec;
+import org.javai.punit.engine.explore.ExploreOutputWriter;
+
+/**
+ * Translates a completed EXPLORE {@link Experiment} into one EX05
+ * YAML file per configuration. Called from
+ * {@link PUnit.ExploreBuilder#run} after the engine finishes the
+ * sampling loop across the grid.
+ *
+ * <p>Two overloads:
+ *
+ * <ul>
+ *   <li>{@link #emit(Experiment, Path)} — production: writes one
+ *       file per configuration under
+ *       {@code {baseDir}/{useCaseId}/{readableStem}.yaml}.</li>
+ *   <li>{@link #emit(Experiment, BiConsumer)} — test seam: yields
+ *       {@code (relativePath, content)} pairs to the supplied sink so
+ *       tests can scrutinise the output without touching disk.</li>
+ * </ul>
+ *
+ * <p>The Path overload is a thin wrapper around the BiConsumer
+ * overload; both share the same per-configuration logic so tests
+ * exercise the same path production code drives.
+ */
+public final class ExploreEmitter {
+
+    private ExploreEmitter() { }
+
+    /**
+     * Persist EXPLORE artefacts under {@code baseDir}.
+     *
+     * @param experiment a completed {@link Experiment.Kind#EXPLORE EXPLORE} experiment
+     * @param baseDir directory under which {@code {useCaseId}/...yaml} files
+     *                land. Created if missing.
+     */
+    public static void emit(Experiment experiment, Path baseDir) {
+        Objects.requireNonNull(baseDir, "baseDir");
+        emit(experiment, (relativePath, content) -> {
+            Path target = baseDir.resolve(relativePath);
+            try {
+                Path parent = target.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                Files.writeString(target, content, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to write EXPLORE artefact " + relativePath
+                                + " under " + baseDir, e);
+            }
+        });
+    }
+
+    /**
+     * Emit EXPLORE artefacts to a sink. The sink receives one
+     * {@code (relativePath, yamlContent)} pair per configuration —
+     * {@code relativePath} is {@code {useCaseId}/{readableStem}.yaml}.
+     *
+     * <p>This is the test-seam overload: a test passes a
+     * {@code BiConsumer} that captures into a {@code Map<String, String>}
+     * and asserts on the captured YAML strings, without ever
+     * touching disk.
+     *
+     * @param experiment a completed {@link Experiment.Kind#EXPLORE EXPLORE} experiment
+     * @param sink receives {@code (relativePath, yamlContent)}
+     */
+    public static void emit(Experiment experiment, BiConsumer<String, String> sink) {
+        Objects.requireNonNull(experiment, "experiment");
+        Objects.requireNonNull(sink, "sink");
+        if (experiment.kind() != Experiment.Kind.EXPLORE) {
+            throw new IllegalArgumentException(
+                    "ExploreEmitter.emit only accepts EXPLORE-flavour Experiments; got "
+                            + experiment.kind() + ".");
+        }
+        ExploreOutputWriter writer = new ExploreOutputWriter();
+        List<PerConfigSummary<?, ?>> entries = experiment.perConfigSummaries();
+        if (entries.isEmpty()) {
+            // The grid had no configurations or the engine hadn't
+            // executed any. Nothing to emit; not an error.
+            return;
+        }
+        experiment.dispatch(new Spec.Dispatcher<Void>() {
+            @Override
+            public <FT, IT, OT> Void apply(TypedSpec<FT, IT, OT> typed) {
+                for (PerConfigSummary<?, ?> entry : entries) {
+                    @SuppressWarnings("unchecked")
+                    FT factors = (FT) entry.factors();
+                    String useCaseId = typed.useCaseFactory().apply(factors).id();
+                    FactorBundle bundle = FactorBundle.of(factors);
+                    String stem = writer.filenameFor(bundle);
+                    String yaml = writer.writeYaml(useCaseId, bundle, entry);
+                    sink.accept(useCaseId + "/" + stem + ".yaml", yaml);
+                }
+                return null;
+            }
+        });
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/runtime/OptimizeEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/OptimizeEmitter.java
@@ -12,6 +12,7 @@ import java.util.function.BiConsumer;
 
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.FactorsStepper.IterationResult;
+import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.Spec;
 import org.javai.punit.api.spec.TypedSpec;
 import org.javai.punit.engine.optimize.OptimizeOutputWriter;
@@ -96,6 +97,7 @@ public final class OptimizeEmitter {
             // No iterations completed — nothing to emit.
             return;
         }
+        List<SampleSummary<?>> iterationSummaries = experiment.iterationSummaries();
         Optional<IterationResult<?>> best = experiment.bestOptimizeIteration();
         String objective = experiment.optimizeObjective().orElse("MAXIMIZE");
         String terminationReason = experiment.optimizeTerminationReason().orElse("UNKNOWN");
@@ -108,6 +110,7 @@ public final class OptimizeEmitter {
                 experimentId,
                 objective,
                 history,
+                iterationSummaries,
                 best.orElse(null),
                 terminationReason);
         sink.accept(useCaseId + "/" + experimentId + ".yaml", yaml);

--- a/punit-core/src/main/java/org/javai/punit/runtime/OptimizeEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/OptimizeEmitter.java
@@ -1,0 +1,125 @@
+package org.javai.punit.runtime;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.FactorsStepper.IterationResult;
+import org.javai.punit.api.spec.Spec;
+import org.javai.punit.api.spec.TypedSpec;
+import org.javai.punit.engine.optimize.OptimizeOutputWriter;
+
+/**
+ * Translates a completed OPTIMIZE {@link Experiment} into the EX06
+ * YAML artefact. Called from {@link PUnit.OptimizeBuilder#run} after
+ * the engine finishes the iteration loop.
+ *
+ * <p>One file per optimize run at
+ * {@code {baseDir}/{useCaseId}/{experimentId}.yaml}. The file
+ * carries the full iteration history (one block per iteration with
+ * factors / score / counts) plus a {@code convergence:} block
+ * (best iteration, best score, best factors, termination reason).
+ *
+ * <p>Two overloads:
+ *
+ * <ul>
+ *   <li>{@link #emit(Experiment, Path)} — production: writes to
+ *       disk under the supplied directory.</li>
+ *   <li>{@link #emit(Experiment, BiConsumer)} — test seam: yields a
+ *       single {@code (relativePath, content)} pair to the supplied
+ *       sink so tests can scrutinise the output without touching
+ *       disk.</li>
+ * </ul>
+ *
+ * <p>The Path overload is a thin wrapper around the BiConsumer
+ * overload; both share the same artefact-assembly logic.
+ */
+public final class OptimizeEmitter {
+
+    private OptimizeEmitter() { }
+
+    /**
+     * Persist the OPTIMIZE artefact under {@code baseDir}.
+     *
+     * @param experiment a completed {@link Experiment.Kind#OPTIMIZE OPTIMIZE} experiment
+     * @param baseDir directory under which the file
+     *                {@code {useCaseId}/{experimentId}.yaml} is
+     *                written. Created if missing.
+     */
+    public static void emit(Experiment experiment, Path baseDir) {
+        Objects.requireNonNull(baseDir, "baseDir");
+        emit(experiment, (relativePath, content) -> {
+            Path target = baseDir.resolve(relativePath);
+            try {
+                Path parent = target.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                Files.writeString(target, content, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to write OPTIMIZE artefact " + relativePath
+                                + " under " + baseDir, e);
+            }
+        });
+    }
+
+    /**
+     * Emit the OPTIMIZE artefact to a sink. The sink receives one
+     * {@code (relativePath, yamlContent)} pair —
+     * {@code relativePath} is {@code {useCaseId}/{experimentId}.yaml}.
+     *
+     * <p>This is the test-seam overload: a test passes a
+     * {@code BiConsumer} that captures into a {@code Map<String, String>}
+     * and asserts on the captured YAML, without ever touching disk.
+     *
+     * @param experiment a completed {@link Experiment.Kind#OPTIMIZE OPTIMIZE} experiment
+     * @param sink receives {@code (relativePath, yamlContent)}
+     */
+    public static void emit(Experiment experiment, BiConsumer<String, String> sink) {
+        Objects.requireNonNull(experiment, "experiment");
+        Objects.requireNonNull(sink, "sink");
+        if (experiment.kind() != Experiment.Kind.OPTIMIZE) {
+            throw new IllegalArgumentException(
+                    "OptimizeEmitter.emit only accepts OPTIMIZE-flavour Experiments; got "
+                            + experiment.kind() + ".");
+        }
+        List<IterationResult<?>> history = experiment.history();
+        if (history.isEmpty()) {
+            // No iterations completed — nothing to emit.
+            return;
+        }
+        Optional<IterationResult<?>> best = experiment.bestOptimizeIteration();
+        String objective = experiment.optimizeObjective().orElse("MAXIMIZE");
+        String terminationReason = experiment.optimizeTerminationReason().orElse("UNKNOWN");
+        String experimentId = experiment.experimentId();
+
+        OptimizeOutputWriter writer = new OptimizeOutputWriter();
+        String useCaseId = useCaseIdFor(experiment, history.get(0).factors());
+        String yaml = writer.writeYaml(
+                useCaseId,
+                experimentId,
+                objective,
+                history,
+                best.orElse(null),
+                terminationReason);
+        sink.accept(useCaseId + "/" + experimentId + ".yaml", yaml);
+    }
+
+    private static String useCaseIdFor(Experiment experiment, Object factors) {
+        return experiment.dispatch(new Spec.Dispatcher<String>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <FT, IT, OT> String apply(TypedSpec<FT, IT, OT> typed) {
+                return typed.useCaseFactory().apply((FT) factors).id();
+            }
+        });
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -160,6 +160,18 @@ public final class PUnit {
         BaselineEmitter.emit(experiment, BaselineProviderResolver.resolveDir());
     }
 
+    private static void driveAndEmitExplore(Experiment experiment) {
+        drive(experiment);
+        ExploreEmitter.emit(experiment,
+                org.javai.punit.engine.explore.ExplorationsResolver.resolveDir());
+    }
+
+    private static void driveAndEmitOptimize(Experiment experiment) {
+        drive(experiment);
+        OptimizeEmitter.emit(experiment,
+                org.javai.punit.engine.optimize.OptimizationsResolver.resolveDir());
+    }
+
     /**
      * Resolves the use case's covariate profile from {@code spec}'s
      * first configuration. Returns {@link CovariateProfile#empty()}
@@ -477,7 +489,7 @@ public final class PUnit {
         }
 
         public void run() {
-            drive(build());
+            driveAndEmitExplore(build());
         }
     }
 
@@ -535,7 +547,7 @@ public final class PUnit {
         }
 
         public void run() {
-            drive(build());
+            driveAndEmitOptimize(build());
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
@@ -1,0 +1,176 @@
+package org.javai.punit.engine.explore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.PerConfigSummary;
+import org.javai.punit.engine.Engine;
+import org.javai.punit.runtime.ExploreEmitter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Pure / in-memory tests for the EX05 explore output writer.
+ *
+ * <p>The writer is exercised both directly ({@link #writeYamlAndFilenameForOneConfig})
+ * and through {@link ExploreEmitter}'s in-memory sink overload
+ * ({@link #emitterCapturesOnePerConfig}) — neither test touches
+ * disk.
+ */
+@DisplayName("ExploreOutputWriter — EX05 schema, filename, end-to-end via in-memory sink")
+class ExploreOutputWriterTest {
+
+    record LlmFactors(String model, double temperature) {}
+
+    /** Always-passing use case. Output type is the input length, for trivial sampling. */
+    private static class LengthUseCase implements UseCase<LlmFactors, String, Integer> {
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+    }
+
+    @Test
+    @DisplayName("writeYaml emits the EX05 schema with factors / execution / statistics / cost blocks")
+    void writeYamlAndFilenameForOneConfig() {
+        // Drive a 1-config explore through the engine to produce a
+        // real PerConfigSummary, then feed the writer directly.
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> new LengthUseCase())
+                .inputs("a", "bb")
+                .samples(2)
+                .build();
+        Experiment experiment = Experiment.exploring(sampling)
+                .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
+                .build();
+        new Engine().run(experiment);
+
+        PerConfigSummary<?, ?> entry = experiment.perConfigSummaries().get(0);
+        FactorBundle bundle = FactorBundle.of(entry.factors());
+
+        ExploreOutputWriter writer = new ExploreOutputWriter();
+        String yaml = writer.writeYaml("LengthUseCase", bundle, entry);
+
+        Map<String, Object> parsed = new Yaml().load(yaml);
+        assertThat(parsed).containsKeys(
+                "schemaVersion", "useCaseId", "generatedAt",
+                "factors", "execution", "statistics", "cost");
+        assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");
+        assertThat(parsed).containsEntry("useCaseId", "LengthUseCase");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> factors = (Map<String, Object>) parsed.get("factors");
+        assertThat(factors).containsEntry("model", "gpt-4o");
+        assertThat(factors).containsEntry("temperature", 0.3);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> execution = (Map<String, Object>) parsed.get("execution");
+        assertThat(execution).containsKey("samplesPlanned");
+        assertThat(execution).containsKey("samplesExecuted");
+        assertThat(execution).containsKey("terminationReason");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> statistics = (Map<String, Object>) parsed.get("statistics");
+        assertThat(statistics).containsKeys("observed", "successes", "failures", "failureDistribution");
+    }
+
+    @Test
+    @DisplayName("filenameFor produces a readable stem from {field}-{value} pairs joined by _")
+    void filenameForReadableStem() {
+        ExploreOutputWriter writer = new ExploreOutputWriter();
+        FactorBundle bundle = FactorBundle.of(new LlmFactors("gpt-4o", 0.3));
+        String stem = writer.filenameFor(bundle);
+        assertThat(stem).isEqualTo("model-gpt-4o_temperature-0.3");
+    }
+
+    @Test
+    @DisplayName("filenameFor truncates long values and appends a 4-char SHA-256 hash")
+    void filenameForTruncatesLongValues() {
+        record PromptFactors(String systemPrompt) {}
+        ExploreOutputWriter writer = new ExploreOutputWriter();
+        FactorBundle bundle = FactorBundle.of(new PromptFactors(
+                "You are a helpful shopping assistant answering customer queries"));
+        String stem = writer.filenameFor(bundle);
+        // First 24 chars of the value, sanitised, then "-" + 4 hex.
+        // Chars 0..23 of the prompt (counting from 0): "You are a helpful shoppi".
+        assertThat(stem).startsWith("systemPrompt-You_are_a_helpful_shoppi-");
+        assertThat(stem).matches("systemPrompt-.{24}-[0-9a-f]{4}");
+    }
+
+    @Test
+    @DisplayName("ExploreEmitter writes one entry per FT to the in-memory sink, keyed by useCaseId/{stem}.yaml")
+    void emitterCapturesOnePerConfig() {
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> new IdUseCase("explore-test"))
+                .inputs("x", "y")
+                .samples(2)
+                .build();
+        Experiment experiment = Experiment.exploring(sampling)
+                .grid(List.of(
+                        new LlmFactors("gpt-4o", 0.3),
+                        new LlmFactors("gpt-4o", 0.7)))
+                .build();
+        new Engine().run(experiment);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        BiConsumer<String, String> capture = sink::put;
+        ExploreEmitter.emit(experiment, capture);
+
+        assertThat(sink).hasSize(2);
+        assertThat(sink).containsKeys(
+                "explore-test/model-gpt-4o_temperature-0.3.yaml",
+                "explore-test/model-gpt-4o_temperature-0.7.yaml");
+        // Each captured value parses as YAML carrying the EX05 schema header.
+        for (String yaml : sink.values()) {
+            Map<String, Object> parsed = new Yaml().load(yaml);
+            assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");
+            assertThat(parsed).containsEntry("useCaseId", "explore-test");
+        }
+    }
+
+    @Test
+    @DisplayName("ExploreEmitter rejects non-EXPLORE experiments")
+    void emitterRejectsWrongKind() {
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> new LengthUseCase())
+                .inputs("a")
+                .samples(1)
+                .build();
+        Experiment measure = Experiment.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
+
+        try {
+            ExploreEmitter.emit(measure, new HashMap<String, String>()::put);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("EXPLORE");
+            return;
+        }
+        throw new AssertionError("expected IllegalArgumentException for non-EXPLORE experiment");
+    }
+
+    /** Use case with a configured id, useful for asserting on the emitted relative path. */
+    private static final class IdUseCase implements UseCase<LlmFactors, String, Integer> {
+        private final String id;
+        IdUseCase(String id) { this.id = id; }
+        @Override public String id() { return id; }
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
@@ -44,7 +44,7 @@ class ExploreOutputWriterTest {
     }
 
     @Test
-    @DisplayName("writeYaml emits the EX05 schema with factors / execution / statistics / cost blocks")
+    @DisplayName("writeYaml emits the EX05 schema with factors / execution / statistics / cost / resultProjection blocks")
     void writeYamlAndFilenameForOneConfig() {
         // Drive a 1-config explore through the engine to produce a
         // real PerConfigSummary, then feed the writer directly.
@@ -68,7 +68,7 @@ class ExploreOutputWriterTest {
         Map<String, Object> parsed = new Yaml().load(yaml);
         assertThat(parsed).containsKeys(
                 "schemaVersion", "useCaseId", "generatedAt",
-                "factors", "execution", "statistics", "cost");
+                "factors", "execution", "statistics", "cost", "resultProjection");
         assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");
         assertThat(parsed).containsEntry("useCaseId", "LengthUseCase");
 
@@ -86,6 +86,17 @@ class ExploreOutputWriterTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> statistics = (Map<String, Object>) parsed.get("statistics");
         assertThat(statistics).containsKeys("observed", "successes", "failures", "failureDistribution");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> projection = (Map<String, Object>) parsed.get("resultProjection");
+        // 2 samples — one entry per sample, keyed by sample[N].
+        assertThat(projection).containsKeys("sample[0]", "sample[1]");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> sample0 = (Map<String, Object>) projection.get("sample[0]");
+        // EX07 per-sample fields: input, postconditions, executionTimeMs;
+        // content present on success, failureDetail on failure (LengthUseCase
+        // never fails so content is the expected key here).
+        assertThat(sample0).containsKeys("input", "postconditions", "executionTimeMs", "content");
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
@@ -97,6 +97,58 @@ class ExploreOutputWriterTest {
         // content present on success, failureDetail on failure (LengthUseCase
         // never fails so content is the expected key here).
         assertThat(sample0).containsKeys("input", "postconditions", "executionTimeMs", "content");
+
+        // Diff anchor comments must be injected before each sample[N]: line.
+        // Two samples → two anchor comments. snakeyaml strips comments on
+        // re-parse, so we assert against the raw YAML string, not the parsed
+        // map.
+        long anchorCount = yaml.lines()
+                .filter(line -> line.contains("anchor:"))
+                .count();
+        assertThat(anchorCount).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("Two runs of the same explore produce identical anchor comments — diff aligns")
+    void anchorsAreContentDeterministic() {
+        Sampling<LlmFactors, String, Integer> sampling1 = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> new LengthUseCase())
+                .inputs("a", "bb")
+                .samples(2)
+                .build();
+        Experiment run1 = Experiment.exploring(sampling1)
+                .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
+                .build();
+        new Engine().run(run1);
+
+        Sampling<LlmFactors, String, Integer> sampling2 = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> new LengthUseCase())
+                .inputs("a", "bb")
+                .samples(2)
+                .build();
+        Experiment run2 = Experiment.exploring(sampling2)
+                .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
+                .build();
+        new Engine().run(run2);
+
+        ExploreOutputWriter writer = new ExploreOutputWriter();
+        String yaml1 = writer.writeYaml("LengthUseCase",
+                FactorBundle.of(run1.perConfigSummaries().get(0).factors()),
+                run1.perConfigSummaries().get(0));
+        String yaml2 = writer.writeYaml("LengthUseCase",
+                FactorBundle.of(run2.perConfigSummaries().get(0).factors()),
+                run2.perConfigSummaries().get(0));
+
+        // Strip generatedAt timestamps (run-specific) and compare anchor lines.
+        List<String> anchors1 = yaml1.lines()
+                .filter(line -> line.contains("anchor:"))
+                .toList();
+        List<String> anchors2 = yaml2.lines()
+                .filter(line -> line.contains("anchor:"))
+                .toList();
+        assertThat(anchors1).isEqualTo(anchors2);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
@@ -1,0 +1,112 @@
+package org.javai.punit.engine.optimize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.NextFactor;
+import org.javai.punit.engine.Engine;
+import org.javai.punit.runtime.OptimizeEmitter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Pure / in-memory tests for the EX06 optimize output writer.
+ *
+ * <p>The writer is exercised through {@link OptimizeEmitter}'s
+ * in-memory sink overload — neither test touches disk.
+ */
+@DisplayName("OptimizeOutputWriter — EX06 schema, end-to-end via in-memory sink")
+class OptimizeOutputWriterTest {
+
+    record LlmFactors(String model, double temperature) {}
+
+    private static class IdUseCase implements UseCase<LlmFactors, String, Integer> {
+        private final String id;
+        IdUseCase(String id) { this.id = id; }
+        @Override public String id() { return id; }
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+    }
+
+    @Test
+    @DisplayName("OptimizeEmitter writes one YAML carrying iterations + convergence to the sink")
+    void emitterCapturesOneFilePerRun() {
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> new IdUseCase("optimize-test"))
+                .inputs("a", "bb")
+                .samples(2)
+                .build();
+        Experiment experiment = Experiment.optimizing(sampling)
+                .initialFactors(new LlmFactors("gpt-4o", 0.0))
+                .stepper((cur, hist) -> hist.size() < 2
+                        ? NextFactor.next(new LlmFactors("gpt-4o", cur.temperature() + 0.3))
+                        : NextFactor.stop())
+                .maximize(s -> 1.0 * s.successes() / Math.max(1, s.total()))
+                .maxIterations(5)
+                .experimentId("opt-run-1")
+                .build();
+        new Engine().run(experiment);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        BiConsumer<String, String> capture = sink::put;
+        OptimizeEmitter.emit(experiment, capture);
+
+        assertThat(sink).hasSize(1);
+        assertThat(sink).containsKey("optimize-test/opt-run-1.yaml");
+
+        String yaml = sink.values().iterator().next();
+        Map<String, Object> parsed = new Yaml().load(yaml);
+        assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");
+        assertThat(parsed).containsEntry("useCaseId", "optimize-test");
+        assertThat(parsed).containsEntry("experimentId", "opt-run-1");
+        assertThat(parsed).containsEntry("objective", "MAXIMIZE");
+        assertThat(parsed).containsKeys("iterations", "convergence", "generatedAt");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> iterations = (List<Map<String, Object>>) parsed.get("iterations");
+        assertThat(iterations).isNotEmpty();
+        Map<String, Object> first = iterations.get(0);
+        assertThat(first).containsKeys("iteration", "factors", "score",
+                "successes", "failures", "samplesExecuted");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> convergence = (Map<String, Object>) parsed.get("convergence");
+        assertThat(convergence).containsKeys("totalIterations", "bestIteration",
+                "bestScore", "bestFactors", "terminationReason");
+    }
+
+    @Test
+    @DisplayName("OptimizeEmitter rejects non-OPTIMIZE experiments")
+    void emitterRejectsWrongKind() {
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .useCaseFactory(f -> new IdUseCase("x"))
+                .inputs("a")
+                .samples(1)
+                .build();
+        Experiment measure = Experiment.measuring(sampling, new LlmFactors("gpt-4o", 0.3)).build();
+
+        try {
+            OptimizeEmitter.emit(measure, new HashMap<String, String>()::put);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("OPTIMIZE");
+            return;
+        }
+        throw new AssertionError("expected IllegalArgumentException for non-OPTIMIZE experiment");
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
@@ -82,12 +82,30 @@ class OptimizeOutputWriterTest {
         assertThat(iterations).isNotEmpty();
         Map<String, Object> first = iterations.get(0);
         assertThat(first).containsKeys("iteration", "factors", "score",
-                "successes", "failures", "samplesExecuted");
+                "successes", "failures", "samplesExecuted", "resultProjection");
+
+        // Each iteration's resultProjection must carry one sample[N] entry per trial.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> projection = (Map<String, Object>) first.get("resultProjection");
+        assertThat(projection).containsKeys("sample[0]", "sample[1]");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> sample0 = (Map<String, Object>) projection.get("sample[0]");
+        assertThat(sample0).containsKeys("input", "postconditions", "executionTimeMs", "content");
 
         @SuppressWarnings("unchecked")
         Map<String, Object> convergence = (Map<String, Object>) parsed.get("convergence");
         assertThat(convergence).containsKeys("totalIterations", "bestIteration",
                 "bestScore", "bestFactors", "terminationReason");
+
+        // Diff anchor comments must appear before every sample[N]: line.
+        // History size × samples-per-iteration = total anchor count.
+        int totalSamples = iterations.stream()
+                .mapToInt(it -> ((Number) it.get("samplesExecuted")).intValue())
+                .sum();
+        long anchorCount = yaml.lines()
+                .filter(line -> line.contains("anchor:"))
+                .count();
+        assertThat(anchorCount).isEqualTo((long) totalSamples);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/runtime/ArtefactEmissionRegressionTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/ArtefactEmissionRegressionTest.java
@@ -1,0 +1,113 @@
+package org.javai.punit.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.NextFactor;
+import org.javai.punit.engine.Engine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Regression-guard meta-test: every {@link Experiment.Kind} must
+ * produce at least one artefact when its {@code .run()} succeeds.
+ *
+ * <p>This is the test that <em>should</em> have caught the silent
+ * EXPLORE / OPTIMIZE emission gap that this work restores. The
+ * structure is deliberate: a switch expression over
+ * {@link Experiment.Kind} forces the compiler to flag any new
+ * kind added without a matching emitter dispatch — adding a new
+ * kind without wiring an emitter fails at compile time, not
+ * silently at runtime.
+ *
+ * <p>All emitters are exercised through their
+ * {@code BiConsumer<String, String>} sink overload — no temp
+ * directories, no disk I/O. The test verifies "the emit step
+ * yields at least one artefact"; the per-kind writer tests
+ * verify schema details.
+ */
+@DisplayName("Every Experiment.Kind must emit at least one artefact")
+class ArtefactEmissionRegressionTest {
+
+    record F(String label, double weight) {}
+
+    private static class TrivialUseCase implements UseCase<F, String, Integer> {
+        @Override public String id() { return "regression-guard"; }
+        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(Experiment.Kind.class)
+    @DisplayName("Each Kind yields ≥ 1 artefact when run end-to-end")
+    void everyKindEmitsAtLeastOneArtefact(Experiment.Kind kind) {
+        Experiment experiment = buildMinimalFor(kind);
+        new Engine().run(experiment);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        BiConsumer<String, String> capture = sink::put;
+
+        // Switch expression — exhaustive over Experiment.Kind.
+        // Adding a new kind without wiring an emitter here is a
+        // compile-time fail, not a runtime fail.
+        String dispatched = switch (kind) {
+            case MEASURE -> {
+                BaselineEmitter.emit(experiment, capture);
+                yield "MEASURE";
+            }
+            case EXPLORE -> {
+                ExploreEmitter.emit(experiment, capture);
+                yield "EXPLORE";
+            }
+            case OPTIMIZE -> {
+                OptimizeEmitter.emit(experiment, capture);
+                yield "OPTIMIZE";
+            }
+        };
+
+        assertThat(sink)
+                .as("kind %s (%s) must produce at least one artefact", kind, dispatched)
+                .isNotEmpty();
+        // Each entry must carry a relativePath and non-empty content.
+        sink.forEach((relativePath, content) -> {
+            assertThat(relativePath).isNotBlank();
+            assertThat(content).isNotBlank();
+        });
+    }
+
+    private static Experiment buildMinimalFor(Experiment.Kind kind) {
+        Sampling<F, String, Integer> sampling = Sampling
+                .<F, String, Integer>builder()
+                .useCaseFactory(f -> new TrivialUseCase())
+                .inputs("a", "bb")
+                .samples(2)
+                .build();
+        return switch (kind) {
+            case MEASURE -> Experiment.measuring(sampling, new F("only", 0.0)).build();
+            case EXPLORE -> Experiment.exploring(sampling)
+                    .grid(List.of(new F("low", 0.0), new F("high", 0.5)))
+                    .build();
+            case OPTIMIZE -> Experiment.optimizing(sampling)
+                    .initialFactors(new F("init", 0.0))
+                    .stepper((cur, hist) -> hist.size() < 1
+                            ? NextFactor.next(new F("step", 0.5))
+                            : NextFactor.stop())
+                    .maximize(s -> 1.0 * s.successes() / Math.max(1, s.total()))
+                    .maxIterations(3)
+                    .build();
+        };
+    }
+}


### PR DESCRIPTION
## Summary

The Phase C package-rename sweep retired the previous `experiment.explore.*` and `experiment.optimize.*` writers and never restored them under the post-Phase-C layout. As a result, `PUnit.exploring(...).run()` and `PUnit.optimizing(...).run()` drove the engine but emitted no artefact — JUnit reported `PASSED`, the Gradle plugin reported "No output files were written.", and the inventory's "done" status for EX05 / EX06 was inaccurate. This PR restores per-configuration emission for both kinds.

- **EXPLORE** — one YAML file per `FT` in the grid at `{output_dir}/{useCaseId}/{readableStem}.yaml`, default `build/punit/explorations/`, override `punit.explorations.outputDir`. Filename derived from the factor record per the EX05 readable-stem algorithm (long values truncated to 24 chars + 4-hex SHA-256 suffix).
- **OPTIMIZE** — one YAML per run at `{output_dir}/{useCaseId}/{experimentId}.yaml`, default `build/punit/optimizations/`, override `punit.optimizations.outputDir`. File carries the full iteration history (factors, score, raw counts, postcondition failures) plus a `convergence:` block with best-iteration / best-score / best-factors / termination reason.

### Restored / new types

- `engine.explore.{ExplorationsResolver, ExploreOutputWriter}`
- `engine.optimize.{OptimizationsResolver, OptimizeOutputWriter}`
- `runtime.{ExploreEmitter, OptimizeEmitter}` — orchestrators alongside `BaselineEmitter`.

### API additions in `api/spec` (additive, no breaking changes)

- `IterationResult` now also carries `successes` / `failures` / `samplesExecuted` (existing 4-arg and 2-arg constructors retained as backward-compat).
- New record `PerConfigSummary<FT, OT>` bundling factors + summary + samplesPlanned per explore configuration.
- New `Experiment` accessors mirroring `lastSummary()` / `history()`: `perConfigSummaries()`, `bestOptimizeIteration()`, `optimizeObjective()`, `optimizeTerminationReason()`.
- `OptimizeInternal` now records its termination reason (`MAX_ITERATIONS` / `NO_IMPROVEMENT` / `STEPPER_STOP`) so the OPTIMIZE artefact's `convergence.terminationReason` can carry it.

### Testability

Writers produce YAML as Strings (no I/O). Emitters expose a `BiConsumer<String, String>` sink overload alongside the disk-writing `Path` overload, so unit tests scrutinise output entirely in memory. `BaselineEmitter` was refactored to the same shape for symmetry across the three emitters.

### Tests

- `ExploreOutputWriterTest` — schema, readable-stem filename (including long-value truncation + hash suffix), end-to-end EXPLORE emission via in-memory sink.
- `OptimizeOutputWriterTest` — EX06 schema, end-to-end OPTIMIZE emission via in-memory sink.
- `ArtefactEmissionRegressionTest` — meta-test parameterised over `Experiment.Kind`. For each kind, builds a minimal experiment, runs it via `Engine`, dispatches to the matching emitter via an **exhaustive switch expression**, and asserts that the emitter yields ≥ 1 non-empty `(relativePath, content)` pair. A new kind added without a wired emitter fails the build at *compile time*. **This is the test that would have caught the original Phase C silent regression.**

`./gradlew test` (full suite, all modules) passes.

## Test plan
- [ ] Re-run a worked optimize / explore example in `punitexamples` (e.g. `./ex-1.sh`) and confirm the Gradle plugin's post-task scan now reports `EXPLORE results written to: build/punit/explorations/` (and the same for optimize).
- [ ] Inspect a generated EXPLORE YAML and confirm it carries `factors:`, `execution:`, `statistics:`, `cost:` blocks per the EX05 schema.
- [ ] Inspect a generated OPTIMIZE YAML and confirm it carries `iterations: [...]` and `convergence:` per the EX06 schema.
- [ ] Verify the regression-guard meta-test fires on intent: temporarily comment out one `case` arm of the switch in `ArtefactEmissionRegressionTest` and confirm the build fails with a `switch expression does not cover all possible input values` error rather than a runtime test failure.

## Follow-ups (not in this PR)
- The EX05 catalog README example shows `systemPrompt-You_are_a_helpful_shoppin-e5f6` (25 chars) but the rule says "first 24 characters"; the example is one char off. Same one-char example reused in `docs/MIGRATION-0.6-to-0.7.md`. Doc-only fix.
- Punitexamples-side verification per the EX05/EX06 directive's step 6 — runs once this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)