### PR TITLE
Retire legacy statistics.percentile-latency YAML block

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
@@ -81,11 +81,55 @@ public final class BaselineReader {
             entries.put(e.getKey(), parseStatisticsEntry(e.getKey(), e.getValue()));
         }
 
+        // Canonical EX04 location for latency: the top-level
+        // `latency:` block. When present, it sources the
+        // PercentileLatency criterion's in-memory entry under
+        // "percentile-latency" and overrides any legacy entry that
+        // happened to be in the statistics map (old-shape baselines
+        // on disk continue to load via the existing loop above).
+        LatencyIndicator latencyIndicator = parseLatencyIndicator(root);
+        if (latencyIndicator.hasData()) {
+            entries.put("percentile-latency", new LatencyStatistics(
+                    latencyIndicator.passingPercentiles(),
+                    latencyIndicator.contributingSamples()));
+        }
+
         CovariateProfile profile = parseCovariates(root);
 
         return new BaselineRecord(
                 useCaseId, methodName, factorsFingerprint,
-                inputsIdentity, sampleCount, generatedAt, entries, profile);
+                inputsIdentity, sampleCount, generatedAt, entries, profile,
+                latencyIndicator);
+    }
+
+    /**
+     * Parse the top-level {@code latency:} block (the canonical EX04
+     * location post-LT01). Returns {@link LatencyIndicator#empty()}
+     * when the block is absent — legacy baselines that carry latency
+     * only under {@code statistics.percentile-latency} continue to
+     * load via the regular statistics-map path.
+     */
+    private LatencyIndicator parseLatencyIndicator(Map<String, Object> root) {
+        if (!root.containsKey("latency")) {
+            return LatencyIndicator.empty();
+        }
+        Map<String, Object> block = requireMap(root, "latency");
+        int contributing = requireInt(block, "contributingSamples");
+        int total = requireInt(block, "totalSamples");
+        Duration p50 = block.containsKey("p50Ms")
+                ? Duration.ofMillis(requireInt(block, "p50Ms"))
+                : Duration.ZERO;
+        Duration p90 = block.containsKey("p90Ms")
+                ? Duration.ofMillis(requireInt(block, "p90Ms"))
+                : Duration.ZERO;
+        Duration p95 = block.containsKey("p95Ms")
+                ? Duration.ofMillis(requireInt(block, "p95Ms"))
+                : Duration.ZERO;
+        Duration p99 = block.containsKey("p99Ms")
+                ? Duration.ofMillis(requireInt(block, "p99Ms"))
+                : Duration.ZERO;
+        LatencyResult result = new LatencyResult(p50, p90, p95, p99, contributing);
+        return new LatencyIndicator(result, contributing, total);
     }
 
     private CovariateProfile parseCovariates(Map<String, Object> root) {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
@@ -82,9 +82,19 @@ public final class BaselineWriter {
         root.put(FIELD_SAMPLE_COUNT, record.sampleCount());
         root.put(FIELD_GENERATED_AT, DateTimeFormatter.ISO_INSTANT.format(record.generatedAt()));
 
+        // The legacy criterion-named "percentile-latency" entry is
+        // no longer emitted to YAML — the canonical EX04 location
+        // for latency data is the top-level `latency:` block written
+        // below. The in-memory map keeps the entry for the
+        // PercentileLatency criterion's lookup; the reader
+        // re-synthesises it from the top-level block on load.
         Map<String, Object> stats = new LinkedHashMap<>();
-        record.statisticsByCriterionName().forEach((name, value) ->
-                stats.put(name, serialiseStatisticsEntry(name, value)));
+        record.statisticsByCriterionName().forEach((name, value) -> {
+            if (value instanceof LatencyStatistics) {
+                return; // suppressed; lives in the latency: block instead
+            }
+            stats.put(name, serialiseStatisticsEntry(name, value));
+        });
         root.put(FIELD_STATISTICS, stats);
 
         if (!record.covariateProfile().isEmpty()) {

--- a/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
@@ -141,9 +141,20 @@ final class BaselineEmitter {
         Map<String, BaselineStatistics> stats = new LinkedHashMap<>();
         stats.put("bernoulli-pass-rate",
                 new PassRateStatistics((double) summary.successes() / (double) total, total));
-        LatencyResult latency = summary.latencyResult();
-        if (latency.sampleCount() > 0) {
-            stats.put("percentile-latency", new LatencyStatistics(latency, total));
+        // LatencyStatistics retained on the in-memory record under
+        // the criterion-name "percentile-latency" so the
+        // PercentileLatency criterion's lookup path keeps working.
+        // Sourced from passingLatencyResult per LT01 — only samples
+        // whose contract evaluated to Outcome.ok contribute. The
+        // legacy YAML emission of this entry under
+        // statistics.percentile-latency is retired; the data lives
+        // canonically in the top-level latency: block, and the
+        // reader synthesises this map entry from that block at load
+        // time.
+        LatencyResult passingForCriterion = summary.passingLatencyResult();
+        if (passingForCriterion.sampleCount() > 0) {
+            stats.put("percentile-latency",
+                    new LatencyStatistics(passingForCriterion, summary.successes()));
         }
 
         // The resolved covariate profile is part of the baseline's

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
@@ -27,11 +27,18 @@ class BaselineReaderTest {
     private final BaselineWriter writer = new BaselineWriter();
 
     private BaselineRecord roundTrip(Map<String, BaselineStatistics> entries) {
+        return roundTrip(entries, LatencyIndicator.empty());
+    }
+
+    private BaselineRecord roundTrip(Map<String, BaselineStatistics> entries,
+                                     LatencyIndicator indicator) {
         BaselineRecord original = new BaselineRecord(
                 "ShoppingBasket", "measureBaseline", "a1b2c3d4",
                 "sha256:abc123", 1000,
                 Instant.parse("2026-04-26T15:30:00Z"),
-                entries);
+                entries,
+                org.javai.punit.api.covariate.CovariateProfile.empty(),
+                indicator);
         return reader.parse(writer.toYaml(original));
     }
 
@@ -56,7 +63,7 @@ class BaselineReaderTest {
     }
 
     @Test
-    @DisplayName("round-trips a LatencyStatistics record (all four percentiles)")
+    @DisplayName("round-trips latency through the top-level latency: block (ms-integer percentiles)")
     void roundTripLatency() {
         LatencyResult percentiles = new LatencyResult(
                 Duration.ofMillis(250),
@@ -64,10 +71,19 @@ class BaselineReaderTest {
                 Duration.ofMillis(800),
                 Duration.ofMillis(1200),
                 1000);
+        LatencyIndicator indicator = new LatencyIndicator(percentiles, 1000, 1000);
 
-        BaselineRecord parsed = roundTrip(Map.of(
-                "percentile-latency", new LatencyStatistics(percentiles, 1000)));
+        // Pass-rate is mandatory (statisticsByCriterionName must be
+        // non-empty per BaselineRecord's invariant); latency rides on
+        // the indicator.
+        BaselineRecord parsed = roundTrip(
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                indicator);
 
+        // Reader synthesises the LatencyStatistics map entry from
+        // the top-level latency: block, so the criterion-lookup
+        // pattern keeps working without requiring the legacy
+        // statistics.percentile-latency YAML emission.
         BaselineStatistics entry = parsed.statisticsByCriterionName().get("percentile-latency");
         assertThat(entry).isInstanceOf(LatencyStatistics.class);
         LatencyStatistics latency = (LatencyStatistics) entry;
@@ -76,16 +92,23 @@ class BaselineReaderTest {
         assertThat(latency.percentiles().p95()).isEqualTo(Duration.ofMillis(800));
         assertThat(latency.percentiles().p99()).isEqualTo(Duration.ofMillis(1200));
         assertThat(latency.sampleCount()).isEqualTo(1000);
+
+        // The typed indicator survives round-trip too.
+        assertThat(parsed.latencyIndicator().contributingSamples()).isEqualTo(1000);
+        assertThat(parsed.latencyIndicator().totalSamples()).isEqualTo(1000);
     }
 
     @Test
-    @DisplayName("round-trips multiple criterion entries side-by-side")
+    @DisplayName("round-trips both criteria — pass-rate via statistics:, latency via top-level block")
     void roundTripBothCriteria() {
         Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
         entries.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
-        entries.put("percentile-latency", new LatencyStatistics(LatencyResult.empty(), 1000));
+        LatencyIndicator indicator = new LatencyIndicator(
+                new LatencyResult(Duration.ofMillis(250), Duration.ofMillis(500),
+                        Duration.ofMillis(800), Duration.ofMillis(1200), 1000),
+                1000, 1000);
 
-        BaselineRecord parsed = roundTrip(entries);
+        BaselineRecord parsed = roundTrip(entries, indicator);
 
         assertThat(parsed.statisticsByCriterionName()).containsOnlyKeys(
                 "bernoulli-pass-rate", "percentile-latency");

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineResolverTest.java
@@ -25,10 +25,18 @@ class BaselineResolverTest {
 
     private void writeBaseline(Path dir, String useCaseId, String fingerprint,
                                 Map<String, BaselineStatistics> entries) throws IOException {
+        writeBaseline(dir, useCaseId, fingerprint, entries, LatencyIndicator.empty());
+    }
+
+    private void writeBaseline(Path dir, String useCaseId, String fingerprint,
+                                Map<String, BaselineStatistics> entries,
+                                LatencyIndicator indicator) throws IOException {
         BaselineRecord record = new BaselineRecord(
                 useCaseId, "measureBaseline", fingerprint,
                 "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
-                entries);
+                entries,
+                CovariateProfile.empty(),
+                indicator);
         writer.write(record, dir);
     }
 
@@ -122,9 +130,23 @@ class BaselineResolverTest {
     @Test
     @DisplayName("resolves multiple criterion entries from one baseline file")
     void resolvesMultipleEntries(@TempDir Path dir) throws IOException {
-        writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", new java.util.LinkedHashMap<>(Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000),
-                "percentile-latency", new LatencyStatistics(LatencyResult.empty(), 1000))));
+        // Pass-rate rides on the statistics: map; latency rides on
+        // the top-level latency: block (the indicator). The reader
+        // synthesises the "percentile-latency" map entry from the
+        // indicator at load time, so a resolver lookup keyed by the
+        // criterion name finds the entry as before.
+        LatencyIndicator indicator = new LatencyIndicator(
+                new LatencyResult(
+                        java.time.Duration.ofMillis(50),
+                        java.time.Duration.ofMillis(100),
+                        java.time.Duration.ofMillis(200),
+                        java.time.Duration.ofMillis(400),
+                        1000),
+                1000, 1000);
+        writeBaseline(dir, "ShoppingBasket", "a1b2c3d4",
+                new java.util.LinkedHashMap<>(Map.of(
+                        "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))),
+                indicator);
 
         var resolver = new BaselineResolver(dir);
 

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
@@ -71,7 +71,7 @@ class BaselineWriterTest {
     }
 
     @Test
-    @DisplayName("serialises a LatencyStatistics entry with all four percentiles in ISO-8601")
+    @DisplayName("serialises latency to the top-level latency: block with ms-integer percentiles")
     void serialisesLatency() {
         LatencyResult percentiles = new LatencyResult(
                 Duration.ofMillis(250),
@@ -79,36 +79,60 @@ class BaselineWriterTest {
                 Duration.ofMillis(800),
                 Duration.ofMillis(1200),
                 1000);
+        LatencyIndicator indicator = new LatencyIndicator(percentiles, 1000, 1000);
 
-        String yaml = writer.toYaml(recordWith(Map.of(
-                "percentile-latency", new LatencyStatistics(percentiles, 1000))));
+        String yaml = writer.toYaml(recordWithLatency(
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                indicator));
 
         Map<String, Object> root = new Yaml().load(yaml);
+        // Legacy statistics.percentile-latency block is retired —
+        // latency lives at the top level only.
         Map<String, Object> stats = (Map<String, Object>) root.get("statistics");
-        Map<String, Object> entry = (Map<String, Object>) stats.get("percentile-latency");
+        assertThat(stats).doesNotContainKey("percentile-latency");
 
-        assertThat(entry).containsEntry("sampleCount", 1000);
-
-        Map<String, Object> percentileMap = (Map<String, Object>) entry.get("percentiles");
-        assertThat(percentileMap)
-                .containsEntry("p50", "PT0.25S")
-                .containsEntry("p90", "PT0.5S")
-                .containsEntry("p95", "PT0.8S")
-                .containsEntry("p99", "PT1.2S");
+        Map<String, Object> latency = (Map<String, Object>) root.get("latency");
+        // snakeyaml round-trips small integers as Integer, not Long.
+        assertThat(latency)
+                .containsEntry("basis", "passing-samples")
+                .containsEntry("contributingSamples", 1000)
+                .containsEntry("totalSamples", 1000);
+        assertThat(((Number) latency.get("p50Ms")).longValue()).isEqualTo(250L);
+        assertThat(((Number) latency.get("p90Ms")).longValue()).isEqualTo(500L);
+        assertThat(((Number) latency.get("p95Ms")).longValue()).isEqualTo(800L);
+        assertThat(((Number) latency.get("p99Ms")).longValue()).isEqualTo(1200L);
     }
 
     @Test
-    @DisplayName("serialises multiple criterion entries side-by-side")
+    @DisplayName("serialises pass-rate under statistics: and latency at the top level alongside")
     void serialisesBothCriteria() {
         Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
         entries.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
-        entries.put("percentile-latency", new LatencyStatistics(LatencyResult.empty(), 1000));
+        LatencyIndicator indicator = new LatencyIndicator(
+                new LatencyResult(Duration.ofMillis(250), Duration.ofMillis(500),
+                        Duration.ofMillis(800), Duration.ofMillis(1200), 1000),
+                1000, 1000);
 
-        String yaml = writer.toYaml(recordWith(entries));
+        String yaml = writer.toYaml(recordWithLatency(entries, indicator));
         Map<String, Object> root = new Yaml().load(yaml);
         Map<String, Object> stats = (Map<String, Object>) root.get("statistics");
 
-        assertThat(stats).containsKeys("bernoulli-pass-rate", "percentile-latency");
+        assertThat(stats).containsOnlyKeys("bernoulli-pass-rate");
+        assertThat(root).containsKey("latency");
+    }
+
+    private BaselineRecord recordWithLatency(
+            Map<String, BaselineStatistics> stats, LatencyIndicator indicator) {
+        return new BaselineRecord(
+                "ShoppingBasketUseCase",
+                "measureBaseline",
+                "a1b2c3d4",
+                "sha256:7d3a8c1e9b2f",
+                1000,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                stats,
+                org.javai.punit.api.covariate.CovariateProfile.empty(),
+                indicator);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Baseline files were carrying latency data **twice** — once at the top-level `latency:` block (LT01-canonical, milliseconds, with the indicator triple) and once again under `statistics.percentile-latency.percentiles` in ISO-8601 Duration strings (`PT1.623285S`). Two formats for the same data, one of which was nearly unreadable to humans.

This change retires the legacy emission. The top-level `latency:` block becomes the **canonical EX04 location** for latency data on disk. The in-memory model is unchanged: `BaselineRecord` still carries a `LatencyStatistics` entry under `"percentile-latency"` in `statisticsByCriterionName` so the `PercentileLatency` criterion's lookup keeps working — but that entry is no longer serialised to YAML on write, and on read it is **synthesised from the top-level `latency:` block**.

## Before vs after

**Before** (excerpt from a measure baseline):

```yaml
statistics:
  bernoulli-pass-rate:
    observedPassRate: 0.94
    sampleCount: 1000
  percentile-latency:
    sampleCount: 1000
    percentiles:
      p50: PT1.623285S
      p90: PT2.498103209S
      p95: PT2.696651416S
      p99: PT3.376548083S

latency:
  basis: passing-samples
  contributingSamples: 1000
  totalSamples: 1000
  p50Ms: 1623
  p90Ms: 2498
  p95Ms: 2696
  p99Ms: 3376
```

**After**:

```yaml
statistics:
  bernoulli-pass-rate:
    observedPassRate: 0.94
    sampleCount: 1000

latency:
  basis: passing-samples
  contributingSamples: 1000
  totalSamples: 1000
  p50Ms: 1623
  p90Ms: 2498
  p95Ms: 2696
  p99Ms: 3376
```

## Behavioural specifics

- **`BaselineEmitter`** now sources the `LatencyStatistics` map entry from `passingLatencyResult` (per LT01) — the `PercentileLatency` criterion now enforces thresholds against the passing-only population, matching the descriptive emission instead of the all-samples enforcement that preceded LT01.
- **`BaselineWriter`** skips `LatencyStatistics`-typed entries when building the `statistics:` map. Only `PassRateStatistics` survives there. The top-level `latency:` block emission is unchanged.
- **`BaselineReader`** reads the top-level `latency:` block into a `LatencyIndicator` and synthesises the `"percentile-latency"` criterion entry from it. When the top-level block is **absent** (legacy baselines on disk), the existing parser inside `parseStatisticsEntry` still runs — old baselines continue to load via that backward-compatible fallback.

## Tests

`BaselineWriterTest` / `BaselineReaderTest` / `BaselineResolverTest` fixtures updated to construct `BaselineRecord` with a `LatencyIndicator` and assert the new top-level shape (ms-integer percentiles, indicator triple). The round-trip tests verify that the `LatencyStatistics` map entry the criterion looks up still survives a write→read cycle, sourced from the indicator on the load path.

`./gradlew test` (full suite, all modules) passes.

## Test plan
- [ ] Run a measure experiment in `punitexamples`; inspect the produced baseline YAML and confirm `statistics.percentile-latency` is absent and the only latency data is the readable top-level `latency:` block.
- [ ] Run a probabilistic test that uses `PercentileLatency.fromBaseline(...)` (LT04 path); confirm the criterion reads its thresholds correctly from the new YAML shape.
- [ ] Verify backward compat: load a pre-PR baseline file (one with `statistics.percentile-latency` and no top-level `latency:` block) — `BaselineReader.parse()` should still return a `LatencyStatistics` entry under `"percentile-latency"` via the legacy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)