### PR TITLE
EX07 + EX10: per-sample resultProjection in baselines, contentFingerprint integrity

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Trial.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Trial.java
@@ -8,8 +8,9 @@ import org.javai.punit.api.UseCaseOutcome;
 /**
  * One per-sample observation: the input that drove the call, the
  * outcome the use case returned (or that the engine synthesised
- * under {@link ExceptionPolicy#FAIL_SAMPLE}), and the wall-clock
- * duration of the invocation.
+ * under {@link ExceptionPolicy#FAIL_SAMPLE}), the wall-clock
+ * duration of the invocation, and the position of the input in
+ * the spec's inputs list.
  *
  * <p>{@link SampleSummary#trials()} exposes the ordered sequence of
  * trials so history-sensitive criteria (collision rate, Shewhart
@@ -17,16 +18,45 @@ import org.javai.punit.api.UseCaseOutcome;
  * than only the aggregate counts a Bernoulli criterion is content
  * with.
  *
- * @param input    the per-sample input that drove this trial
- * @param outcome  the outcome the use case returned (success or fail)
- * @param duration wall-clock duration of the invocation
- * @param <IT>     the per-sample input type
- * @param <OT>     the per-sample outcome value type
+ * <p>{@link #inputIndex} is the zero-based position of {@link #input}
+ * in the spec's configured inputs list. The engine cycles inputs
+ * round-robin across samples, so for a run with N samples and M
+ * inputs the trial at sample index i has
+ * {@code inputIndex == (cycleStart + i) mod M}. Stored explicitly so
+ * downstream artefacts (per EX07) can correlate a sample to its
+ * driver without re-deriving the cycling formula.
+ *
+ * @param input      the per-sample input that drove this trial
+ * @param outcome    the outcome the use case returned (success or fail)
+ * @param duration   wall-clock duration of the invocation
+ * @param inputIndex zero-based position of {@code input} in the
+ *                   spec's inputs list
+ * @param <IT>       the per-sample input type
+ * @param <OT>       the per-sample outcome value type
  */
-public record Trial<IT, OT>(IT input, UseCaseOutcome<IT, OT> outcome, Duration duration) {
+public record Trial<IT, OT>(
+        IT input,
+        UseCaseOutcome<IT, OT> outcome,
+        Duration duration,
+        int inputIndex) {
 
     public Trial {
         Objects.requireNonNull(outcome, "outcome");
         Objects.requireNonNull(duration, "duration");
+        if (inputIndex < 0) {
+            throw new IllegalArgumentException(
+                    "inputIndex must be non-negative, got " + inputIndex);
+        }
+    }
+
+    /**
+     * Backward-compatible 3-arg constructor that defaults
+     * {@link #inputIndex} to {@code 0}. Used by test fixtures and
+     * call sites that haven't yet migrated to the canonical 4-field
+     * shape; the engine constructs trials via the canonical
+     * constructor with the correct cycled input position.
+     */
+    public Trial(IT input, UseCaseOutcome<IT, OT> outcome, Duration duration) {
+        this(input, outcome, duration, 0);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/Engine.java
@@ -268,12 +268,16 @@ public final class Engine {
             // ever supplies UseCaseOutcome<IT, OT> so this is safe.
             @SuppressWarnings("unchecked")
             UseCaseOutcome<IT, OT> typed = (UseCaseOutcome<IT, OT>) stamped;
-            return new Trial<>(inputForIndex(index), typed, stamped.duration());
+            int inputIndex = cycleIndexFor(index);
+            return new Trial<>(inputs.get(inputIndex), typed, stamped.duration(), inputIndex);
         }
 
         private IT inputForIndex(int index) {
-            int cycleIndex = (cycleStart + index) % inputs.size();
-            return inputs.get(cycleIndex);
+            return inputs.get(cycleIndexFor(index));
+        }
+
+        private int cycleIndexFor(int index) {
+            return (cycleStart + index) % inputs.size();
         }
 
         SampleSummary<OT> toSummary(Duration elapsed) {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineIntegrity.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineIntegrity.java
@@ -1,0 +1,105 @@
+package org.javai.punit.engine.baseline;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.javai.punit.util.HashUtils;
+
+/**
+ * EX10 baseline-integrity helper. Computes and verifies the
+ * {@code contentFingerprint:} field appended as the last line of
+ * every measure baseline.
+ *
+ * <p>The fingerprint is the lowercase-hex SHA-256 digest of the YAML
+ * content preceding the {@code contentFingerprint:} line. On read,
+ * the framework recomputes the digest over the same prefix and
+ * compares; a mismatch indicates the spec has been edited since the
+ * measure produced it. The check is a soft warning on the verdict —
+ * not a hard abort. The live test data is independently informative;
+ * a verdict warning is loud, durable, and routes through the same
+ * observability channel as every other test signal (per the EX10
+ * "consequence of failure" prose).
+ *
+ * <p>Three states:
+ *
+ * <ol>
+ *   <li><b>OK</b> — line present, computed digest matches stored
+ *       value. {@link #verify} returns {@link Optional#empty()}.</li>
+ *   <li><b>MISSING</b> — line absent (typically a pre-EX10 baseline
+ *       on disk). Returns the softer "predates integrity verification"
+ *       wording.</li>
+ *   <li><b>MISMATCH</b> — line present, computed digest disagrees.
+ *       Returns the louder "modified since generation" wording with
+ *       expected and computed digests in the diagnostic.</li>
+ * </ol>
+ *
+ * <p>Match rule for finding the fingerprint line: the regex is
+ * anchored at the start of a line (column 0) so a {@code contentFingerprint:}
+ * embedded inside a quoted value or as a child key cannot be confused
+ * with the integrity field. The body for hashing is the substring up
+ * to (but excluding) the matched line — which is what the writer
+ * hashes when it builds the file.
+ */
+final class BaselineIntegrity {
+
+    private BaselineIntegrity() { }
+
+    static final String FINGERPRINT_KEY = "contentFingerprint";
+
+    private static final Pattern LINE = Pattern.compile(
+            "(?m)^" + FINGERPRINT_KEY + ":\\s*([0-9a-fA-F]+)\\s*$");
+
+    /**
+     * Append a {@code contentFingerprint:} line to {@code body},
+     * computing the SHA-256 over {@code body} as-is. The body is
+     * normalised to end with a newline so the appended line stays
+     * on its own line regardless of whether the dumper produced a
+     * trailing newline.
+     */
+    static String appendFingerprint(String body) {
+        String normalised = body.endsWith("\n") ? body : body + "\n";
+        String digest = HashUtils.sha256(normalised);
+        return normalised + FINGERPRINT_KEY + ": " + digest + "\n";
+    }
+
+    /**
+     * Verify the integrity of a loaded baseline.
+     *
+     * @param yaml the full file contents (including any trailing
+     *             {@code contentFingerprint:} line)
+     * @param file the file path — included in the warning message
+     *             so the operator can locate the offending baseline
+     * @return {@link Optional#empty()} when the fingerprint matches;
+     *         otherwise a one-line warning describing the integrity
+     *         failure (mismatch or missing) for inclusion in the
+     *         verdict's warnings list
+     */
+    static Optional<String> verify(String yaml, Path file) {
+        Matcher m = LINE.matcher(yaml);
+        if (!m.find()) {
+            return Optional.of(missingWarning(file));
+        }
+        String stored = m.group(1).toLowerCase();
+        String body = yaml.substring(0, m.start());
+        String computed = HashUtils.sha256(body);
+        if (computed.equals(stored)) {
+            return Optional.empty();
+        }
+        return Optional.of(mismatchWarning(file, stored, computed));
+    }
+
+    private static String missingWarning(Path file) {
+        return "baseline predates integrity verification; spec was not produced "
+                + "with a content fingerprint, so post-generation modifications "
+                + "cannot be detected (file: " + file + ").";
+    }
+
+    private static String mismatchWarning(Path file, String expected, String computed) {
+        return "baseline integrity check failed — the spec file has been modified "
+                + "since generation; verdict may not reflect a valid empirical "
+                + "comparison (file: " + file + ", expected: " + expected
+                + ", got: " + computed + ").";
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.covariate.CovariateProfile;
@@ -46,13 +47,47 @@ public final class BaselineReader {
 
     /** Reads and parses the file at {@code baselineFile}. */
     public BaselineRecord read(Path baselineFile) throws IOException {
+        return load(baselineFile).record();
+    }
+
+    /**
+     * Reads, parses, and integrity-verifies the file at
+     * {@code baselineFile}. Returns the parsed {@link BaselineRecord}
+     * paired with an optional integrity warning per EX10 — empty
+     * when the {@code contentFingerprint:} field's stored digest
+     * matches the recomputed body digest, populated otherwise.
+     *
+     * <p>Integrity failure does <em>not</em> propagate as an
+     * exception; the warning is reported through the verdict's
+     * warnings list, not the test outcome. Parse failures still
+     * throw — a malformed file is a different category from a
+     * modified-but-well-formed file.
+     */
+    public LoadedBaseline load(Path baselineFile) throws IOException {
         Objects.requireNonNull(baselineFile, "baselineFile");
         String content = Files.readString(baselineFile, StandardCharsets.UTF_8);
+        BaselineRecord record;
         try {
-            return parse(content);
+            record = parse(content);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
                     "Failed to parse baseline file " + baselineFile + ": " + e.getMessage(), e);
+        }
+        Optional<String> integrityWarning = BaselineIntegrity.verify(content, baselineFile);
+        return new LoadedBaseline(record, integrityWarning);
+    }
+
+    /**
+     * Bundles a parsed {@link BaselineRecord} with an optional
+     * integrity warning surfaced by {@link BaselineIntegrity#verify}.
+     * The resolver propagates the warning into the
+     * {@link org.javai.punit.api.spec.BaselineLookup}'s notes when
+     * this record is the selected candidate.
+     */
+    public record LoadedBaseline(BaselineRecord record, Optional<String> integrityWarning) {
+        public LoadedBaseline {
+            Objects.requireNonNull(record, "record");
+            Objects.requireNonNull(integrityWarning, "integrityWarning");
         }
     }
 

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -6,7 +6,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -142,8 +144,11 @@ public final class BaselineResolver {
         Objects.requireNonNull(currentProfile, "currentProfile");
         Objects.requireNonNull(declarations, "declarations");
 
-        BaselineSelector.SelectionReport report = findAndSelectWithReport(
-                useCaseId, factorsFingerprint, currentProfile, declarations);
+        EnumeratedBaselines enumerated = enumerateCandidates(useCaseId, factorsFingerprint);
+        BaselineSelector.SelectionReport report = enumerated.records().isEmpty()
+                ? BaselineSelector.SelectionReport.NONE
+                : BaselineSelector.selectWithReport(
+                        enumerated.records(), currentProfile, declarations);
         Optional<BaselineRecord> selected = report.selected();
         if (selected.isEmpty()) {
             return new BaselineLookup<>(
@@ -151,11 +156,16 @@ public final class BaselineResolver {
                     Optional.empty());
         }
         Optional<String> sourceFile = Optional.of(selected.get().filename());
+        // EX10: surface the integrity warning (if any) for the
+        // *selected* candidate only — warnings about candidates that
+        // didn't influence the verdict would be noise.
+        List<String> notes = withIntegrityWarning(
+                report.notes(), enumerated, selected.get());
         CovariateProfile baselineProfile = selected.get().covariateProfile();
         BaselineStatistics entry = selected.get().statisticsByCriterionName().get(criterionName);
         if (entry == null) {
             return new BaselineLookup<>(
-                    Optional.empty(), baselineProfile, report.notes(), sourceFile);
+                    Optional.empty(), baselineProfile, notes, sourceFile);
         }
         if (!statisticsType.isInstance(entry)) {
             throw new IllegalStateException(
@@ -166,8 +176,21 @@ public final class BaselineResolver {
                             + " — write-side and read-side criterion kinds disagree");
         }
         return new BaselineLookup<>(
-                Optional.of(statisticsType.cast(entry)), baselineProfile, report.notes(),
-                sourceFile);
+                Optional.of(statisticsType.cast(entry)), baselineProfile, notes, sourceFile);
+    }
+
+    private static List<String> withIntegrityWarning(
+            List<String> selectionNotes,
+            EnumeratedBaselines enumerated,
+            BaselineRecord selected) {
+        Optional<String> integrity = enumerated.integrityWarningFor(selected.filename());
+        if (integrity.isEmpty()) {
+            return selectionNotes;
+        }
+        List<String> combined = new ArrayList<>(selectionNotes.size() + 1);
+        combined.addAll(selectionNotes);
+        combined.add(integrity.get());
+        return combined;
     }
 
     /**
@@ -203,37 +226,34 @@ public final class BaselineResolver {
             String factorsFingerprint,
             CovariateProfile currentProfile,
             List<Covariate> declarations) {
-        return findAndSelectWithReport(useCaseId, factorsFingerprint,
-                currentProfile, declarations).selected();
-    }
-
-    private BaselineSelector.SelectionReport findAndSelectWithReport(
-            String useCaseId,
-            String factorsFingerprint,
-            CovariateProfile currentProfile,
-            List<Covariate> declarations) {
-        List<BaselineRecord> candidates = findRecords(useCaseId, factorsFingerprint);
-        if (candidates.isEmpty()) {
-            return BaselineSelector.SelectionReport.NONE;
+        EnumeratedBaselines enumerated = enumerateCandidates(useCaseId, factorsFingerprint);
+        if (enumerated.records().isEmpty()) {
+            return Optional.empty();
         }
         return BaselineSelector.selectWithReport(
-                candidates, currentProfile, declarations);
+                enumerated.records(), currentProfile, declarations).selected();
     }
 
-    private List<BaselineRecord> findRecords(String useCaseId, String factorsFingerprint) {
+    private EnumeratedBaselines enumerateCandidates(
+            String useCaseId, String factorsFingerprint) {
         if (!Files.isDirectory(baselineDir)) {
-            return List.of();
+            return EnumeratedBaselines.empty();
         }
         String prefix = useCaseId + ".";
         String factorsSegment = "-" + factorsFingerprint;
         String yamlExt = ".yaml";
         try (var stream = Files.list(baselineDir)) {
-            List<BaselineRecord> out = new ArrayList<>();
+            List<BaselineRecord> records = new ArrayList<>();
+            Map<String, Optional<String>> warnings = new LinkedHashMap<>();
             stream
                     .filter(p -> matchesFactorsFingerprint(
                             p.getFileName().toString(), prefix, factorsSegment, yamlExt))
-                    .forEach(p -> out.add(readUnchecked(p)));
-            return out;
+                    .forEach(p -> {
+                        BaselineReader.LoadedBaseline loaded = loadUnchecked(p);
+                        records.add(loaded.record());
+                        warnings.put(loaded.record().filename(), loaded.integrityWarning());
+                    });
+            return new EnumeratedBaselines(records, warnings);
         } catch (IOException e) {
             throw new UncheckedIOException(
                     "Failed to enumerate baselines in " + baselineDir, e);
@@ -271,12 +291,34 @@ public final class BaselineResolver {
                 || name.charAt(afterSegment) == '-';
     }
 
-    private BaselineRecord readUnchecked(Path file) {
+    private BaselineReader.LoadedBaseline loadUnchecked(Path file) {
         try {
-            return reader.read(file);
+            return reader.load(file);
         } catch (IOException e) {
             throw new UncheckedIOException(
                     "Failed to read baseline file " + file, e);
+        }
+    }
+
+    /**
+     * Per-enumeration scratch carrying the candidate records the
+     * selector chooses among, plus a side-table of integrity
+     * warnings keyed by canonical filename. After selection, only
+     * the warning matching the chosen record's filename is folded
+     * into the lookup notes; non-selected candidates' warnings are
+     * dropped (they would be noise — the verdict only depends on
+     * the selected baseline).
+     */
+    private record EnumeratedBaselines(
+            List<BaselineRecord> records,
+            Map<String, Optional<String>> integrityWarningsByFilename) {
+
+        Optional<String> integrityWarningFor(String filename) {
+            return integrityWarningsByFilename.getOrDefault(filename, Optional.empty());
+        }
+
+        static EnumeratedBaselines empty() {
+            return new EnumeratedBaselines(List.of(), Map.of());
         }
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,6 +34,8 @@ import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.Trial;
+import org.javai.punit.engine.output.ResultProjections;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -58,18 +61,57 @@ public final class BaselineWriter {
      * filename. Returns the path the file was written to.
      */
     public Path write(BaselineRecord record, Path baselineDir) throws IOException {
+        return write(record, List.of(), baselineDir);
+    }
+
+    /**
+     * Writes {@code record} plus a per-sample {@code resultProjection:}
+     * block built from {@code trials} to {@code baselineDir}. Returns
+     * the path the file was written to.
+     */
+    public Path write(BaselineRecord record, List<? extends Trial<?, ?>> trials, Path baselineDir)
+            throws IOException {
         Objects.requireNonNull(record, "record");
+        Objects.requireNonNull(trials, "trials");
         Objects.requireNonNull(baselineDir, "baselineDir");
         Files.createDirectories(baselineDir);
         Path file = baselineDir.resolve(record.filename());
-        Files.writeString(file, toYaml(record), StandardCharsets.UTF_8);
+        Files.writeString(file, toYaml(record, trials), StandardCharsets.UTF_8);
         return file;
     }
 
     /** Serialises {@code record} to the YAML schema as a string. */
     public String toYaml(BaselineRecord record) {
+        return toYaml(record, List.of());
+    }
+
+    /**
+     * Serialises {@code record} to the YAML schema, appending a per-sample
+     * {@code resultProjection:} block sourced from {@code trials} when
+     * non-empty. Per EX07 the block carries one {@code sample[N]} entry
+     * per trial in iteration order — inputIndex, postconditions,
+     * executionTimeMs, content-or-failureDetail, optional tokensUsed —
+     * with diff-anchor comments injected before each entry to keep
+     * {@code diff} aligned across runs.
+     *
+     * <p>Per the user's "bulk argument holds, but the information is
+     * valuable" guidance: every trial is emitted (no failure cap), so a
+     * baseline file preserves every per-sample observation that drove
+     * the recorded statistics.
+     */
+    public String toYaml(BaselineRecord record, List<? extends Trial<?, ?>> trials) {
         Objects.requireNonNull(record, "record");
-        return yaml().dump(toYamlMap(record));
+        Objects.requireNonNull(trials, "trials");
+        Map<String, Object> root = toYamlMap(record);
+        if (!trials.isEmpty()) {
+            root.put("resultProjection", ResultProjections.resultProjectionMap(trials));
+        }
+        String dump = yaml().dump(root);
+        if (trials.isEmpty()) {
+            return dump;
+        }
+        return ResultProjections.injectAnchorComments(
+                dump, ResultProjections.anchorsFor(trials));
     }
 
     private Map<String, Object> toYamlMap(BaselineRecord record) {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
@@ -107,11 +107,15 @@ public final class BaselineWriter {
             root.put("resultProjection", ResultProjections.resultProjectionMap(trials));
         }
         String dump = yaml().dump(root);
-        if (trials.isEmpty()) {
-            return dump;
-        }
-        return ResultProjections.injectAnchorComments(
-                dump, ResultProjections.anchorsFor(trials));
+        String body = trials.isEmpty()
+                ? dump
+                : ResultProjections.injectAnchorComments(
+                        dump, ResultProjections.anchorsFor(trials));
+        // EX10: append the SHA-256 of the body as the last field. The
+        // reader recomputes the digest over the same prefix at load
+        // time and surfaces a verdict warning when the file has been
+        // modified since the measure produced it.
+        return BaselineIntegrity.appendFingerprint(body);
     }
 
     private Map<String, Object> toYamlMap(BaselineRecord record) {

--- a/punit-core/src/main/java/org/javai/punit/engine/output/ResultProjections.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/output/ResultProjections.java
@@ -58,7 +58,13 @@ public final class ResultProjections {
      */
     public static Map<String, Object> projectionFor(Trial<?, ?> trial) {
         Map<String, Object> entry = new LinkedHashMap<>();
-        entry.put("input", String.valueOf(trial.input()));
+        // EX07: emit the input's position in the inputs list, not
+        // the input's value. Punit's deterministic-inputs-list model
+        // means the developer has the inputs in hand; rendering
+        // arbitrary IT types as canonical strings is fragile
+        // (Object.toString → "com.example.Foo@1a2b3c4d") and bulks
+        // up artefacts without proportionate value.
+        entry.put("inputIndex", trial.inputIndex());
         Map<String, Object> postconds = new LinkedHashMap<>();
         for (PostconditionResult pr : trial.outcome().postconditionResults()) {
             postconds.put(pr.description(), pr.passed() ? "passed" : "failed");
@@ -97,20 +103,25 @@ public final class ResultProjections {
      * Compute the per-trial diff anchors to interleave with a
      * {@code resultProjection:} block. Anchor for trial at index
      * {@code i} = first 8 hex chars of
-     * {@code SHA-256(i + ":" + canonical(input))}. Same trial →
-     * same anchor → diff aligns.
+     * {@code SHA-256(i + ":" + inputIndex)}. Same trial position +
+     * same inputIndex → same anchor → diff aligns. The hash uses
+     * the inputIndex rather than a canonical-string rendering of
+     * the input value (per EX07): the input value itself isn't
+     * persisted to the artefact, and two runs of the same spec
+     * produce identical inputIndex sequences by virtue of
+     * deterministic cycling.
      */
     public static List<String> anchorsFor(List<? extends Trial<?, ?>> trials) {
         List<String> anchors = new ArrayList<>(trials.size());
         for (int i = 0; i < trials.size(); i++) {
-            anchors.add(anchorOf(i, trials.get(i).input()));
+            anchors.add(anchorOf(i, trials.get(i).inputIndex()));
         }
         return anchors;
     }
 
-    /** Anchor for one (index, input) pair. */
-    public static String anchorOf(int sampleIndex, Object input) {
-        String content = sampleIndex + ":" + String.valueOf(input);
+    /** Anchor for one (sampleIndex, inputIndex) pair. */
+    public static String anchorOf(int sampleIndex, int inputIndex) {
+        String content = sampleIndex + ":" + inputIndex;
         return sha256HexPrefix(content, 8);
     }
 

--- a/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
@@ -26,6 +26,7 @@ import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.Spec;
+import org.javai.punit.api.spec.Trial;
 import org.javai.punit.api.spec.TypedSpec;
 import org.javai.punit.engine.baseline.BaselineRecord;
 import org.javai.punit.engine.baseline.BaselineWriter;
@@ -116,7 +117,8 @@ final class BaselineEmitter {
                 return composeRecord(typed, summary, experiment.experimentId());
             }
         });
-        sink.accept(record.filename(), new BaselineWriter().toYaml(record));
+        List<? extends Trial<?, ?>> trials = summary.trials();
+        sink.accept(record.filename(), new BaselineWriter().toYaml(record, trials));
     }
 
     @SuppressWarnings("unchecked")

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineIntegrityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineIntegrityTest.java
@@ -1,0 +1,92 @@
+package org.javai.punit.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.javai.punit.util.HashUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("BaselineIntegrity — EX10 fingerprint emission and verification")
+class BaselineIntegrityTest {
+
+    private static final Path FAKE_FILE = Path.of("/baselines/ShoppingBasket.measure-a1b2c3d4.yaml");
+
+    @Test
+    @DisplayName("appendFingerprint adds a final contentFingerprint: line whose digest is "
+            + "SHA-256 of the body that precedes it")
+    void appendsFingerprintMatchingBodyDigest() {
+        String body = "schemaVersion: punit-baseline-2\nuseCaseId: X\n";
+        String fingerprinted = BaselineIntegrity.appendFingerprint(body);
+
+        assertThat(fingerprinted)
+                .startsWith(body)
+                .contains("\ncontentFingerprint: ")
+                .endsWith("\n");
+
+        String expectedDigest = HashUtils.sha256(body);
+        assertThat(fingerprinted).contains("contentFingerprint: " + expectedDigest);
+    }
+
+    @Test
+    @DisplayName("appendFingerprint normalises a body without trailing newline so the "
+            + "fingerprint line stays on its own line")
+    void appendsTrailingNewlineWhenAbsent() {
+        String body = "schemaVersion: punit-baseline-2"; // no trailing newline
+        String fingerprinted = BaselineIntegrity.appendFingerprint(body);
+
+        assertThat(fingerprinted.lines().toList())
+                .containsExactly(
+                        "schemaVersion: punit-baseline-2",
+                        "contentFingerprint: " + HashUtils.sha256(body + "\n"));
+    }
+
+    @Test
+    @DisplayName("verify returns empty when stored digest matches recomputed body digest")
+    void verifyOkOnMatchingDigest() {
+        String body = "schemaVersion: punit-baseline-2\n";
+        String yaml = BaselineIntegrity.appendFingerprint(body);
+
+        Optional<String> warning = BaselineIntegrity.verify(yaml, FAKE_FILE);
+
+        assertThat(warning).as("a freshly-fingerprinted body must verify cleanly").isEmpty();
+    }
+
+    @Test
+    @DisplayName("verify returns the louder mismatch warning — naming the expected and "
+            + "computed digests — when the body has been edited after the fingerprint "
+            + "was appended")
+    void verifyMismatchOnEditedBody() {
+        String body = "schemaVersion: punit-baseline-2\nminPassRate: 0.95\n";
+        String yaml = BaselineIntegrity.appendFingerprint(body);
+        // Tamper: lower the threshold without re-fingerprinting.
+        String tampered = yaml.replace("minPassRate: 0.95", "minPassRate: 0.50");
+
+        Optional<String> warning = BaselineIntegrity.verify(tampered, FAKE_FILE);
+
+        assertThat(warning).isPresent();
+        assertThat(warning.get())
+                .contains("integrity check failed")
+                .contains("modified since generation")
+                .contains(FAKE_FILE.toString())
+                .contains("expected:")
+                .contains("got:");
+    }
+
+    @Test
+    @DisplayName("verify returns the softer missing warning when no contentFingerprint: "
+            + "field is present (legacy pre-EX10 baseline)")
+    void verifyMissingOnLegacyBaseline() {
+        String legacy = "schemaVersion: punit-baseline-2\nuseCaseId: X\n";
+
+        Optional<String> warning = BaselineIntegrity.verify(legacy, FAKE_FILE);
+
+        assertThat(warning).isPresent();
+        assertThat(warning.get())
+                .contains("predates integrity verification")
+                .contains("post-generation modifications cannot be detected")
+                .contains(FAKE_FILE.toString());
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineReaderTest.java
@@ -127,6 +127,78 @@ class BaselineReaderTest {
     }
 
     @Test
+    @DisplayName("load(Path) returns the parsed record with no integrity warning when the "
+            + "file's contentFingerprint matches its body")
+    void loadOkOnFreshlyWrittenFile(@TempDir Path tempDir) throws IOException {
+        BaselineRecord original = new BaselineRecord(
+                "ShoppingBasket", "measureBaseline", "a1b2c3d4",
+                "sha256:abc", 100,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.9, 100)),
+                CovariateProfile.empty(),
+                LatencyIndicator.empty());
+        Path file = writer.write(original, tempDir);
+
+        BaselineReader.LoadedBaseline loaded = reader.load(file);
+
+        assertThat(loaded.record().useCaseId()).isEqualTo("ShoppingBasket");
+        assertThat(loaded.integrityWarning())
+                .as("a freshly-written baseline must verify cleanly")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("load(Path) surfaces the mismatch warning when the file body has been "
+            + "edited after the contentFingerprint was written")
+    void loadMismatchOnTamperedFile(@TempDir Path tempDir) throws IOException {
+        BaselineRecord original = new BaselineRecord(
+                "ShoppingBasket", "measureBaseline", "a1b2c3d4",
+                "sha256:abc", 100,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.95, 100)),
+                CovariateProfile.empty(),
+                LatencyIndicator.empty());
+        Path file = writer.write(original, tempDir);
+        // Tamper: lower the observed pass rate without re-fingerprinting.
+        String tampered = Files.readString(file).replace(
+                "observedPassRate: 0.95", "observedPassRate: 0.5");
+        Files.writeString(file, tampered);
+
+        BaselineReader.LoadedBaseline loaded = reader.load(file);
+
+        assertThat(loaded.integrityWarning()).isPresent();
+        assertThat(loaded.integrityWarning().get())
+                .contains("integrity check failed")
+                .contains(file.toString());
+    }
+
+    @Test
+    @DisplayName("load(Path) surfaces the softer missing warning when the file predates "
+            + "the contentFingerprint convention")
+    void loadMissingOnLegacyFile(@TempDir Path tempDir) throws IOException {
+        // Synthesise a legacy baseline by writing a valid record and then
+        // stripping the trailing contentFingerprint: line.
+        BaselineRecord original = new BaselineRecord(
+                "Legacy", "measureBaseline", "a1b2c3d4",
+                "sha256:abc", 50,
+                Instant.parse("2026-04-26T15:30:00Z"),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.8, 50)),
+                CovariateProfile.empty(),
+                LatencyIndicator.empty());
+        Path file = writer.write(original, tempDir);
+        String stripped = Files.readString(file)
+                .replaceAll("(?m)^contentFingerprint:.*\\R?", "");
+        Files.writeString(file, stripped);
+
+        BaselineReader.LoadedBaseline loaded = reader.load(file);
+
+        assertThat(loaded.integrityWarning()).isPresent();
+        assertThat(loaded.integrityWarning().get())
+                .contains("predates integrity verification")
+                .contains(file.toString());
+    }
+
+    @Test
     @DisplayName("rejects unknown schemaVersion")
     void rejectsUnknownSchemaVersion() {
         String yaml = "schemaVersion: punit-baseline-99\n"

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
@@ -155,6 +155,27 @@ class BaselineWriterTest {
     }
 
     @Test
+    @DisplayName("emits a contentFingerprint: line as the last field — SHA-256 of the body "
+            + "preceding it (EX10 integrity)")
+    void emitsContentFingerprintAsLastField() {
+        String yaml = writer.toYaml(recordWith(Map.of(
+                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+
+        // Last non-empty line carries the fingerprint key.
+        java.util.List<String> nonEmpty = yaml.lines()
+                .filter(l -> !l.isBlank())
+                .toList();
+        assertThat(nonEmpty.get(nonEmpty.size() - 1))
+                .startsWith("contentFingerprint: ")
+                .matches("contentFingerprint: [0-9a-f]{64}");
+
+        // The reader must accept its own writer's output without surfacing
+        // an integrity warning.
+        Map<String, Object> root = new Yaml().load(yaml);
+        assertThat(root).containsKey("contentFingerprint");
+    }
+
+    @Test
     @DisplayName("rejects an unsupported BaselineStatistics flavour with a diagnostic")
     void rejectsUnknownStatisticsKind() {
         BaselineStatistics unknown = () -> 1;

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/YamlBaselineProviderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/YamlBaselineProviderTest.java
@@ -3,11 +3,13 @@ package org.javai.punit.engine.baseline;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
 
 import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.spec.BaselineLookup;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
@@ -67,6 +69,72 @@ class YamlBaselineProviderTest {
                 PassRateStatistics.class);
 
         assertThat(resolved).isEmpty();
+    }
+
+    @Test
+    @DisplayName("baselineLookup returns no integrity warning for a freshly-written, "
+            + "fingerprint-matching baseline")
+    void lookupCleanWhenFingerprintMatches(@TempDir Path dir) throws IOException {
+        FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
+        BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+        writer.write(record, dir);
+
+        var provider = new YamlBaselineProvider(dir);
+        BaselineLookup<PassRateStatistics> lookup = provider.baselineLookup(
+                "ShoppingBasket", bundle, "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(lookup.selected()).isPresent();
+        assertThat(lookup.notes())
+                .as("clean integrity check produces no notes")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("baselineLookup propagates the integrity-mismatch warning into notes "
+            + "when the selected baseline's body has been edited after fingerprint emission")
+    void lookupSurfacesMismatchWarning(@TempDir Path dir) throws IOException {
+        FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
+        BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+        Path file = writer.write(record, dir);
+        // Tamper: lower observedPassRate without re-fingerprinting.
+        String tampered = Files.readString(file).replace(
+                "observedPassRate: 0.92", "observedPassRate: 0.50");
+        Files.writeString(file, tampered);
+
+        var provider = new YamlBaselineProvider(dir);
+        BaselineLookup<PassRateStatistics> lookup = provider.baselineLookup(
+                "ShoppingBasket", bundle, "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(lookup.selected())
+                .as("test runs to completion — verdict is not dismissed out of hand (EX10)")
+                .isPresent();
+        assertThat(lookup.notes())
+                .as("integrity warning lands in notes → ProbabilisticTestResult.warnings()")
+                .anyMatch(n -> n.contains("integrity check failed"));
+    }
+
+    @Test
+    @DisplayName("baselineLookup propagates the softer missing-fingerprint warning when "
+            + "the selected baseline predates EX10")
+    void lookupSurfacesMissingWarning(@TempDir Path dir) throws IOException {
+        FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
+        BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
+                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.88, 500)));
+        Path file = writer.write(record, dir);
+        // Strip the trailing fingerprint line — synthesises a pre-EX10 baseline.
+        String stripped = Files.readString(file)
+                .replaceAll("(?m)^contentFingerprint:.*\\R?", "");
+        Files.writeString(file, stripped);
+
+        var provider = new YamlBaselineProvider(dir);
+        BaselineLookup<PassRateStatistics> lookup = provider.baselineLookup(
+                "ShoppingBasket", bundle, "bernoulli-pass-rate", PassRateStatistics.class);
+
+        assertThat(lookup.selected()).isPresent();
+        assertThat(lookup.notes())
+                .anyMatch(n -> n.contains("predates integrity verification"));
     }
 
     private BaselineRecord baseline(String useCaseId, String fingerprint,

--- a/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
@@ -96,7 +96,8 @@ class ExploreOutputWriterTest {
         // EX07 per-sample fields: input, postconditions, executionTimeMs;
         // content present on success, failureDetail on failure (LengthUseCase
         // never fails so content is the expected key here).
-        assertThat(sample0).containsKeys("input", "postconditions", "executionTimeMs", "content");
+        assertThat(sample0).containsKeys("inputIndex", "postconditions", "executionTimeMs", "content");
+        assertThat(sample0).doesNotContainKey("input");
 
         // Diff anchor comments must be injected before each sample[N]: line.
         // Two samples → two anchor comments. snakeyaml strips comments on

--- a/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
@@ -90,7 +90,8 @@ class OptimizeOutputWriterTest {
         assertThat(projection).containsKeys("sample[0]", "sample[1]");
         @SuppressWarnings("unchecked")
         Map<String, Object> sample0 = (Map<String, Object>) projection.get("sample[0]");
-        assertThat(sample0).containsKeys("input", "postconditions", "executionTimeMs", "content");
+        assertThat(sample0).containsKeys("inputIndex", "postconditions", "executionTimeMs", "content");
+        assertThat(sample0).doesNotContainKey("input");
 
         @SuppressWarnings("unchecked")
         Map<String, Object> convergence = (Map<String, Object>) parsed.get("convergence");

--- a/punit-core/src/test/java/org/javai/punit/runtime/BaselineEmitterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/BaselineEmitterTest.java
@@ -1,8 +1,13 @@
 package org.javai.punit.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ContractBuilder;
@@ -12,14 +17,17 @@ import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.UseCase;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.NextFactor;
+import org.javai.punit.engine.Engine;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
 
-@DisplayName("BaselineEmitter — defect-on-misuse contract")
+@DisplayName("BaselineEmitter — misuse contract and per-sample emission")
 class BaselineEmitterTest {
 
     private static final UseCase<NoFactors, Integer, Boolean> ALWAYS_PASSES = new UseCase<>() {
+        @Override public String id() { return "AlwaysPassesUseCase"; }
         @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(true);
@@ -71,5 +79,108 @@ class BaselineEmitterTest {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> BaselineEmitter.emit(measure, dir))
                 .withMessageContaining("no recorded summary");
+    }
+
+    private static final UseCase<NoFactors, Integer, String> EVENS_PASS = new UseCase<>() {
+        @Override public String id() { return "EvensPassUseCase"; }
+        @Override public void postconditions(ContractBuilder<String> b) {
+            b.ensure("non-blank", s -> s.isBlank()
+                    ? Outcome.fail("blank", "value was blank")
+                    : Outcome.ok(null));
+        }
+        @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+            return input % 2 == 0 ? Outcome.ok("even-" + input) : Outcome.fail("odd", "got " + input);
+        }
+    };
+
+    @Test
+    @DisplayName("emits a per-sample resultProjection: block carrying every trial — "
+            + "inputIndex, postconditions, executionTimeMs, content-or-failureDetail")
+    void emitsResultProjection() {
+        Sampling<NoFactors, Integer, String> sampling = Sampling
+                .<NoFactors, Integer, String>builder()
+                .useCaseFactory(f -> EVENS_PASS)
+                .inputs(2, 3) // alternating pass / fail by parity
+                .samples(4)   // 4 samples cycle the 2-input list twice
+                .build();
+        Experiment measure = Experiment.measuring(sampling, new NoFactors()).build();
+        new Engine().run(measure);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        BiConsumer<String, String> capture = sink::put;
+        BaselineEmitter.emit(measure, capture);
+
+        assertThat(sink).hasSize(1);
+        String yaml = sink.values().iterator().next();
+        Map<String, Object> root = new Yaml().load(yaml);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> projection = (Map<String, Object>) root.get("resultProjection");
+        assertThat(projection)
+                .as("MEASURE baselines must carry a resultProjection: block — "
+                        + "per-sample observations are not lost to bulk")
+                .isNotNull();
+        // 4 samples → 4 sample[N] entries in iteration order.
+        assertThat(projection).containsKeys("sample[0]", "sample[1]", "sample[2]", "sample[3]");
+
+        // Cycling: sample[0] → input 2 (index 0, passes), sample[1] → input 3 (index 1, fails),
+        // sample[2] → input 2 (index 0, passes), sample[3] → input 3 (index 1, fails).
+        @SuppressWarnings("unchecked")
+        Map<String, Object> s0 = (Map<String, Object>) projection.get("sample[0]");
+        assertThat(s0).containsKeys("inputIndex", "postconditions", "executionTimeMs", "content");
+        assertThat(s0).doesNotContainKey("input");
+        assertThat(s0).containsEntry("inputIndex", 0);
+        assertThat(s0.get("content")).isEqualTo("even-2");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> s1 = (Map<String, Object>) projection.get("sample[1]");
+        assertThat(s1).containsKeys("inputIndex", "postconditions", "executionTimeMs", "failureDetail");
+        assertThat(s1).containsEntry("inputIndex", 1);
+        assertThat(((String) s1.get("failureDetail"))).startsWith("odd: got 3");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> s2 = (Map<String, Object>) projection.get("sample[2]");
+        assertThat(s2).containsEntry("inputIndex", 0);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> s3 = (Map<String, Object>) projection.get("sample[3]");
+        assertThat(s3).containsEntry("inputIndex", 1);
+
+        // Diff-anchor comments: one per sample[N] line, snakeyaml-stripped on
+        // re-parse so we assert against the raw YAML string.
+        long anchorCount = yaml.lines()
+                .filter(line -> line.contains("anchor:"))
+                .count();
+        assertThat(anchorCount).isEqualTo(4L);
+    }
+
+    @Test
+    @DisplayName("two runs of the same MEASURE produce identical anchor lines — diff aligns")
+    void anchorsContentDeterministic() {
+        Sampling<NoFactors, Integer, Boolean> sampling1 = Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> ALWAYS_PASSES)
+                .inputs(1, 2, 3)
+                .samples(3)
+                .build();
+        Experiment run1 = Experiment.measuring(sampling1, new NoFactors()).build();
+        new Engine().run(run1);
+
+        Sampling<NoFactors, Integer, Boolean> sampling2 = Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> ALWAYS_PASSES)
+                .inputs(1, 2, 3)
+                .samples(3)
+                .build();
+        Experiment run2 = Experiment.measuring(sampling2, new NoFactors()).build();
+        new Engine().run(run2);
+
+        Map<String, String> sink1 = new LinkedHashMap<>();
+        Map<String, String> sink2 = new LinkedHashMap<>();
+        BaselineEmitter.emit(run1, (BiConsumer<String, String>) sink1::put);
+        BaselineEmitter.emit(run2, (BiConsumer<String, String>) sink2::put);
+
+        List<String> anchors1 = sink1.values().iterator().next().lines()
+                .filter(l -> l.contains("anchor:")).toList();
+        List<String> anchors2 = sink2.values().iterator().next().lines()
+                .filter(l -> l.contains("anchor:")).toList();
+        assertThat(anchors1).hasSize(3).isEqualTo(anchors2);
     }
 }


### PR DESCRIPTION
## Summary

Three-step rollup addressing concerns the user surfaced after inspecting actual punitexamples baseline output (orchestrator catalog amendments landed earlier via PR #23):

- **EX07 input → inputIndex** — replace the per-sample `input` field in `resultProjection:` with one integer, the input's position in the spec's inputs list. Punit's deterministic-inputs-list model means the developer has the inputs in hand; rendering arbitrary `IT` types as canonical strings is fragile (`Object.toString` → `com.example.Foo@1a2b3c4d`) and the field was the second-heaviest contributor to projection bulk after `content`. Anchors switch from hashing `(sampleIndex + canonical(input))` to `(sampleIndex + inputIndex)` — same diff-alignment property, no input value leaked into the artefact.
- **EX07 per-sample resultProjection in MEASURE baselines** — `EXPLORE` and `OPTIMIZE` already emit a `resultProjection:` block per the catalog; `MEASURE` previously summarised every per-sample observation into the bernoulli-pass-rate / passing-latency aggregates and threw the per-trial detail away, even though the engine retains it on `SampleSummary.trials()`. Per the user's bulk-vs-information call: "It's valuable information because otherwise information concerning individual sample failures is lost completely." Every trial is emitted in iteration order — no failure cap on the projection.
- **EX10 contentFingerprint** — every measure baseline now closes with a `contentFingerprint:` line: lowercase-hex SHA-256 of the YAML body that precedes it. On load, the framework recomputes the digest, and on disagreement surfaces a soft warning on the verdict (not a hard abort). `MISSING` (legacy pre-EX10 file) and `MISMATCH` (file edited since generation) are distinct wordings. Warnings flow through the existing `BaselineLookup.notes` → `ProbabilisticTestResult.warnings()` → verdict-record channel — no plumbing changes downstream of the resolver.

## Test plan

- [x] `./gradlew test` — all modules green
- [x] `BaselineIntegrityTest` — helper-level OK/mismatch/missing
- [x] `BaselineWriterTest` — last non-empty line matches `contentFingerprint: [0-9a-f]{64}`
- [x] `BaselineReaderTest` — `load(Path)` returns clean / mismatch / missing warnings on freshly-written, tampered, and stripped fixtures
- [x] `YamlBaselineProviderTest` — full plumbing: clean lookup → no notes; tampered file → "integrity check failed" note in `BaselineLookup.notes` AND the lookup still selects (test runs to completion); stripped legacy file → "predates integrity verification" note
- [x] `BaselineEmitterTest` — end-to-end MEASURE through `Engine.run` then in-memory sink: `resultProjection:` carries `sample[N]` entries with `inputIndex` cycling (0,1,0,1), `content`/`failureDetail` discriminator, and per-sample anchor count matching the trial count. A second test asserts anchors are content-deterministic across two runs.
- [x] `ExploreOutputWriterTest` / `OptimizeOutputWriterTest` — assertions updated to expect `inputIndex` and `doesNotContainKey("input")` on every `sample[N]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)