### PR TITLE
HTML report: drop JUnit column, rename PUnit column to Verdict

### DIFF
--- a/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
@@ -92,8 +92,7 @@ final class HtmlReportWriter {
             html.append("<table>\n");
             html.append("<thead>\n<tr>\n");
             html.append("<th>Test Name</th>");
-            html.append("<th>JUnit</th>");
-            html.append("<th>PUnit</th>");
+            html.append("<th>Verdict</th>");
             html.append("<th>Functional</th>");
             html.append("<th>p50</th>");
             html.append("<th>p95</th>");
@@ -149,7 +148,6 @@ final class HtmlReportWriter {
     private static void appendVerdictRow(StringBuilder html, ProbabilisticTestVerdict verdict) {
         ExecutionSummary exec = verdict.execution();
         String methodName = verdict.identity().methodName();
-        String junitClass = verdict.junitPassed() ? "junit-pass" : "junit-fail";
         String punitClass = punitCssClass(verdict.punitVerdict());
 
         html.append("<tr>\n");
@@ -177,11 +175,10 @@ final class HtmlReportWriter {
         html.append("</details>\n");
         html.append("</td>\n");
 
-        // JUnit verdict
-        html.append("<td class=\"").append(junitClass).append("\">")
-                .append(verdict.junitPassed() ? "PASS" : "FAIL").append("</td>\n");
-
-        // PUnit verdict
+        // Verdict (single column; in 0.7.0 the test body always represents
+        // one statistical test, so a JUnit pass/fail cannot diverge from
+        // the punit verdict — the JUnit column would carry no extra
+        // signal).
         html.append("<td class=\"").append(punitClass).append("\">")
                 .append(verdict.punitVerdict().name()).append("</td>\n");
 
@@ -412,8 +409,8 @@ final class HtmlReportWriter {
                     z-index: 10;
                     pointer-events: none;
                 }
-                .junit-pass, .punit-pass { color: var(--pass-color); font-weight: 600; }
-                .junit-fail, .punit-fail { color: var(--fail-color); font-weight: 600; }
+                .punit-pass { color: var(--pass-color); font-weight: 600; }
+                .punit-fail { color: var(--fail-color); font-weight: 600; }
                 .punit-inconclusive { color: var(--inconclusive-color); font-weight: 600; }
                 .latency-observed { color: #adb5bd; }
                 .latency-pass { color: var(--pass-color); font-weight: 600; }

--- a/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
@@ -81,6 +81,18 @@ class HtmlReportWriterTest {
     class TableRows {
 
         @Test
+        @DisplayName("the verdict table carries a single Verdict column — the JUnit "
+                + "column was retired in 0.7.0")
+        void tableHeaderShape() {
+            String html = HtmlReportWriter.generate(List.of(passingVerdict()));
+
+            assertThat(html).contains("<th>Verdict</th>");
+            assertThat(html)
+                    .doesNotContain("<th>JUnit</th>")
+                    .doesNotContain("<th>PUnit</th>");
+        }
+
+        @Test
         @DisplayName("renders test method name as expandable summary")
         void rendersMethodName() {
             String html = HtmlReportWriter.generate(List.of(passingVerdict()));
@@ -89,32 +101,27 @@ class HtmlReportWriterTest {
         }
 
         @Test
-        @DisplayName("applies correct CSS classes for passing verdict")
+        @DisplayName("applies the punit-pass CSS class on the verdict cell for a passing verdict")
         void appliesPassCssClasses() {
             String html = HtmlReportWriter.generate(List.of(passingVerdict()));
 
-            assertThat(html).contains("class=\"junit-pass\"");
             assertThat(html).contains("class=\"punit-pass\"");
+            assertThat(html)
+                    .as("the JUnit column was retired in 0.7.0 — the verdict cell "
+                            + "carries the punit verdict only")
+                    .doesNotContain("junit-pass")
+                    .doesNotContain("junit-fail");
         }
 
         @Test
-        @DisplayName("applies correct CSS classes for failing verdict")
+        @DisplayName("applies the punit-fail CSS class on the verdict cell for a failing verdict")
         void appliesFailCssClasses() {
             String html = HtmlReportWriter.generate(List.of(failingVerdict()));
 
-            assertThat(html).contains("class=\"junit-fail\"");
             assertThat(html).contains("class=\"punit-fail\"");
-        }
-
-        @Test
-        @DisplayName("JUnit FAIL with PUnit PASS renders divergent CSS classes")
-        void junitFailWithPUnitPassRendersDivergentClasses() {
-            ProbabilisticTestVerdict verdict = divergentVerdict();
-
-            String html = HtmlReportWriter.generate(List.of(verdict));
-
-            assertThat(html).contains("class=\"junit-fail\"");
-            assertThat(html).contains("class=\"punit-pass\"");
+            assertThat(html)
+                    .doesNotContain("junit-pass")
+                    .doesNotContain("junit-fail");
         }
 
         @Test
@@ -549,26 +556,6 @@ class HtmlReportWriterTest {
 
     private ProbabilisticTestVerdict inconclusiveVerdict() {
         return minimalVerdict("shouldBeInconclusive", false, PUnitVerdict.INCONCLUSIVE);
-    }
-
-    private ProbabilisticTestVerdict divergentVerdict() {
-        return new ProbabilisticTestVerdict(
-                "v:test01",
-                Instant.parse("2026-03-11T14:30:00Z"),
-                new TestIdentity("com.example.MyTest", "shouldDiverge", Optional.empty()),
-                new ExecutionSummary(100, 100, 80, 20, 0.7, 0.80, 150,
-                        Optional.empty(), TestIntent.VERIFICATION, 0.95, UseCaseAttributes.DEFAULT),
-                Optional.empty(), Optional.empty(),
-                new StatisticalAnalysis(0.95, 0.04, 0.72, 0.88,
-                        Optional.of(2.50), Optional.of(0.006),
-                        Optional.empty(), Optional.empty(), List.of()),
-                CovariateStatus.allAligned(),
-                new CostSummary(0, 0, 0, TokenMode.NONE, Optional.empty(), Optional.empty()),
-                Optional.empty(), Optional.empty(),
-                new Termination(TerminationReason.COMPLETED, Optional.empty()),
-                Map.of(), false, PUnitVerdict.PASS,
-                "0.8000 >= 0.7000"
-        );
     }
 
     private ProbabilisticTestVerdict minimalVerdict(String methodName, boolean passed, PUnitVerdict punitVerdict) {


### PR DESCRIPTION
## Summary

Pre-0.7.0, the HTML report carried two side-by-side outcome columns: a JUnit column showing whether any individual sample threw, and a PUnit column showing the statistical verdict. The two could diverge — JUnit FAIL with PUnit PASS happened whenever a sample threw but the overall pass rate met its threshold — and the side-by-side rendering made that divergence visible.

In 0.7.0 the divergence cannot occur. The test body represents one test, comprising N >= 1 samples, and JUnit's pass/fail is now strictly the punit verdict surfaced through the JUnit machinery. The two columns therefore carry the same signal, and showing both just dilutes the verdict cell with a redundant column.

**Catalog alignment.** RP04 §"Verdict table" already specifies a single 'verdict' column ("name, verdict (colour-coded), pass rate, threshold, confidence level, p-value"). RP07 verdict XML doesn't carry `junitPassed` at all — `CLAUDE.md` notes the field is "the only punit-specific field not serialised to XML, meaningless outside the JUnit context." So this change brings the report into line with the catalog rather than departing from it.

**Implementation.**

- `HtmlReportWriter`: drop `<th>JUnit</th>`, rename `<th>PUnit</th>` → `<th>Verdict</th>`, drop the JUnit row cell, retire the now-unused `junitClass` local. The `.junit-pass` / `.junit-fail` CSS selectors are removed; `.punit-pass` / `.punit-fail` survive (the summary "Pass: N / Fail: N" stat spans use them).
- The `verdict.junitPassed()` field on `ProbabilisticTestVerdict` is **not** removed here. It is still produced by the JUnit extension's verdict-record construction path; retiring the field is a wider blast radius than this report-only fix justifies.

**Tests.**

- Drop the `junit-pass` / `junit-fail` CSS assertions, add explicit `doesNotContain` guards so a future re-introduction of the JUnit column would fail the test.
- Add a new `tableHeaderShape` test asserting `<th>Verdict</th>` and the absence of `<th>JUnit</th>` / `<th>PUnit</th>`.
- Delete `junitFailWithPUnitPassRendersDivergentClasses` and its now-orphaned `divergentVerdict()` fixture — the state that test exercised cannot occur in 0.7.0.

**Out of scope (flagged for follow-up):** RP04 §"Rendering mechanism" mandates XSLT-driven rendering of RP07 XML; punit's `HtmlReportWriter` is a Java string-builder. Different topic — not addressed here.

## Test plan

- [x] `./gradlew :punit-report:test` — green
- [x] `./gradlew test` — full suite green across all modules
- [ ] Regenerate `punitexamples/build/reports/punit/html/index.html` and confirm the verdict column header reads "Verdict" with no preceding JUnit column

🤖 Generated with [Claude Code](https://claude.com/claude-code)