### PR TITLE
DIR-RP01-VERDICT-FIDELITY: preserve INCONCLUSIVE through the adapter/builder boundary

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.spec.FailureCount;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
 import org.javai.punit.controls.budget.SharedBudgetMonitor;
@@ -100,7 +101,11 @@ public class ProbabilisticTestVerdictBuilder {
 
     // ── Verdicts ──────────────────────────────────────────────────────────
     private boolean junitPassed;
-    private boolean passedStatistically;
+    // Default to FAIL — the criterion-side default for "no information
+    // recorded yet." The adapter sets this from the criterion's actual
+    // Verdict; tests that build a verdict directly without a criterion
+    // run can override via criterionVerdict(...).
+    private Verdict criterionVerdict = Verdict.FAIL;
 
     // ── Postcondition failure histogram ───────────────────────────────────
     private Map<String, FailureCount> postconditionFailures = Map.of();
@@ -246,8 +251,16 @@ public class ProbabilisticTestVerdictBuilder {
         return this;
     }
 
-    public ProbabilisticTestVerdictBuilder passedStatistically(boolean passed) {
-        this.passedStatistically = passed;
+    /**
+     * Set the criterion-side verdict for this run. The three-state
+     * value is preserved through to {@link #derivePUnitVerdict} so an
+     * INCONCLUSIVE result from the criterion (no baseline, sample-size
+     * violation, identity mismatch) does not silently collapse to FAIL
+     * just because the run's covariates happen to be aligned (per
+     * RP01's verdict-consistent-with-statistical-analysis invariant).
+     */
+    public ProbabilisticTestVerdictBuilder criterionVerdict(Verdict verdict) {
+        this.criterionVerdict = java.util.Objects.requireNonNull(verdict, "verdict");
         return this;
     }
 
@@ -524,7 +537,15 @@ public class ProbabilisticTestVerdictBuilder {
         if (!covariates.aligned()) {
             return PUnitVerdict.INCONCLUSIVE;
         }
-        return passedStatistically ? PUnitVerdict.PASS : PUnitVerdict.FAIL;
+        if (terminationReason.isBudgetExhaustion()) {
+            return PUnitVerdict.INCONCLUSIVE;
+        }
+        if (criterionVerdict == Verdict.INCONCLUSIVE) {
+            return PUnitVerdict.INCONCLUSIVE;
+        }
+        return criterionVerdict == Verdict.PASS
+                ? PUnitVerdict.PASS
+                : PUnitVerdict.FAIL;
     }
 
     private String deriveVerdictReason(PUnitVerdict punitVerdict, CovariateStatus covariates) {

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
@@ -58,10 +58,17 @@ import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder.MisalignmentInput
  *       to the richer core enum; details kept null.</li>
  *   <li><b>Postcondition failures</b> — pass-through from
  *       {@link ProbabilisticTestResult#failuresByPostcondition()}.</li>
- *   <li><b>Verdict</b> — {@link Verdict#PASS} maps to
- *       {@code passedStatistically=true}; {@link Verdict#FAIL} and
- *       {@link Verdict#INCONCLUSIVE} both map to false (the builder's
- *       covariate-alignment logic decides FAIL vs INCONCLUSIVE).</li>
+ *   <li><b>Verdict</b> — the criterion's three-state
+ *       {@link Verdict} flows straight through to the builder via
+ *       {@link ProbabilisticTestVerdictBuilder#criterionVerdict}. The
+ *       builder then derives the {@link PUnitVerdict} consulting both
+ *       the criterion verdict and the run-level overrides
+ *       (covariate misalignment and budget exhaustion both force
+ *       INCONCLUSIVE regardless of what the criterion concluded).
+ *       This preserves a non-covariate INCONCLUSIVE — no baseline,
+ *       sample-size violation, identity mismatch — through to the
+ *       rendered verdict, per the RP01 invariant that "the verdict
+ *       is consistent with the statistical analysis."</li>
  * </ul>
  *
  * <h2>What the adapter cannot fill</h2>
@@ -153,7 +160,7 @@ public final class VerdictAdapter {
         b.postconditionFailures(result.failuresByPostcondition());
 
         // Verdict
-        b.passedStatistically(result.verdict() == Verdict.PASS);
+        b.criterionVerdict(result.verdict());
         // No JUnit-pass concept on the result; default true (the
         // field is only meaningful inside the JUnit context).
         b.junitPassed(true);

--- a/punit-core/src/test/java/org/javai/punit/reporting/CompositeVerdictSinkTest.java
+++ b/punit-core/src/test/java/org/javai/punit/reporting/CompositeVerdictSinkTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.List;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder;
 import org.javai.punit.verdict.VerdictSink;
@@ -18,7 +19,7 @@ class CompositeVerdictSinkTest {
                 .identity("TestClass", "testMethod", "useCase1")
                 .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
                 .junitPassed(true)
-                .passedStatistically(true)
+                .criterionVerdict(Verdict.PASS)
                 .build();
     }
 

--- a/punit-core/src/test/java/org/javai/punit/reporting/ConsoleVerdictSinkTest.java
+++ b/punit-core/src/test/java/org/javai/punit/reporting/ConsoleVerdictSinkTest.java
@@ -7,6 +7,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.model.TerminationReason;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder;
@@ -70,7 +71,7 @@ class ConsoleVerdictSinkTest {
                     .execution(100, 42, 30, 12, 0.9, 0.7143, 200)
                     .termination(TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED, "Time budget exceeded")
                     .junitPassed(false)
-                    .passedStatistically(false)
+                    .criterionVerdict(Verdict.FAIL)
                     .build();
 
             String output = renderVerdict(verdict);
@@ -96,7 +97,7 @@ class ConsoleVerdictSinkTest {
                             10, 20, 30, 50, 100,
                             List.of(), List.of(), 90, 10))
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
 
             String output = renderVerdict(verdict);
@@ -115,7 +116,7 @@ class ConsoleVerdictSinkTest {
                     .execution(100, 100, 95, 5, 0.9, 0.95, 150)
                     .functionalDimension(95, 5)
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
 
             String output = renderVerdict(verdict);
@@ -147,7 +148,7 @@ class ConsoleVerdictSinkTest {
                 .identity("MySpec", "shouldPass", null)
                 .execution(100, 100, 95, 5, 0.9, 0.95, 150)
                 .junitPassed(true)
-                .passedStatistically(true)
+                .criterionVerdict(Verdict.PASS)
                 .build();
     }
 
@@ -156,7 +157,7 @@ class ConsoleVerdictSinkTest {
                 .identity("MySpec", "shouldPass", null)
                 .execution(100, 100, 80, 20, 0.9, 0.80, 200)
                 .junitPassed(false)
-                .passedStatistically(false)
+                .criterionVerdict(Verdict.FAIL)
                 .build();
     }
 

--- a/punit-core/src/test/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
 import org.javai.punit.controls.budget.SharedBudgetMonitor;
 import org.javai.punit.controls.budget.SharedBudgetMonitor.Scope;
@@ -272,7 +273,7 @@ class ProbabilisticTestVerdictBuilderTest {
         @Test
         void alignedCovariatesWithPassYieldsPass() {
             ProbabilisticTestVerdict verdict = minimalBuilder()
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
 
             assertThat(verdict.covariates().aligned()).isTrue();
@@ -283,7 +284,7 @@ class ProbabilisticTestVerdictBuilderTest {
         @Test
         void alignedCovariatesWithFailYieldsFail() {
             ProbabilisticTestVerdict verdict = minimalBuilder()
-                    .passedStatistically(false)
+                    .criterionVerdict(Verdict.FAIL)
                     .build();
 
             assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.FAIL);
@@ -294,7 +295,7 @@ class ProbabilisticTestVerdictBuilderTest {
             ProbabilisticTestVerdict verdict = minimalBuilder()
                     .misalignments(List.of(
                             new MisalignmentInput("model", "gpt-4", "gpt-3.5")))
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
 
             assertThat(verdict.covariates().aligned()).isFalse();
@@ -308,7 +309,7 @@ class ProbabilisticTestVerdictBuilderTest {
             ProbabilisticTestVerdict verdict = minimalBuilder()
                     .misalignments(List.of(
                             new MisalignmentInput("model", "gpt-4", "gpt-3.5")))
-                    .passedStatistically(false)
+                    .criterionVerdict(Verdict.FAIL)
                     .build();
 
             assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
@@ -332,7 +333,7 @@ class ProbabilisticTestVerdictBuilderTest {
         void junitFailWithPUnitPassIsLegitimate() {
             ProbabilisticTestVerdict verdict = minimalBuilder()
                     .junitPassed(false)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
 
             assertThat(verdict.junitPassed()).isFalse();
@@ -511,7 +512,7 @@ class ProbabilisticTestVerdictBuilderTest {
                     .identity("Test", "method", null)
                     .execution(100, 100, 96, 4, 0.9374, 0.96, 150)
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
 
             double se = verdict.statistics().standardError();
@@ -531,7 +532,7 @@ class ProbabilisticTestVerdictBuilderTest {
                     .identity("Test", "method", null)
                     .execution(100, 100, 96, 4, 0.9374, 0.96, 150)
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
 
             double z = verdict.statistics().testStatistic().orElseThrow();
@@ -621,6 +622,6 @@ class ProbabilisticTestVerdictBuilderTest {
                 .identity("TestClass", "testMethod", null)
                 .execution(100, 100, 95, 5, 0.90, 0.95, 1000)
                 .junitPassed(true)
-                .passedStatistically(true);
+                .criterionVerdict(Verdict.PASS);
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
@@ -125,7 +125,7 @@ class VerdictAdapterTest {
     class VerdictMapping {
 
         @Test
-        @DisplayName("PASS verdict produces passedStatistically=true and PUnitVerdict.PASS")
+        @DisplayName("PASS verdict with aligned covariates produces PUnitVerdict.PASS")
         void passVerdict() {
             ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.PASS));
 
@@ -138,6 +138,28 @@ class VerdictAdapterTest {
             ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.FAIL));
 
             assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.FAIL);
+        }
+
+        @Test
+        @DisplayName("INCONCLUSIVE with aligned covariates produces PUnitVerdict.INCONCLUSIVE "
+                + "with reason 'insufficient evidence' (RP01 verdict-fidelity regression)")
+        void inconclusiveSurvivesAlignedCovariates() {
+            // The reproducer: a criterion that returns Verdict.INCONCLUSIVE
+            // for a non-covariate reason (no baseline, sample-size violation,
+            // identity mismatch) must not silently collapse to FAIL just
+            // because the run's covariates happen to be aligned. RP01
+            // requires the punit verdict to be consistent with the
+            // statistical analysis and the verdict reason to be consistent
+            // with the verdict enum.
+            ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.INCONCLUSIVE));
+
+            assertThat(verdict.covariates().aligned())
+                    .as("covariate alignment is the *common* case the bug masked")
+                    .isTrue();
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
+            assertThat(verdict.verdictReason())
+                    .as("RP01: verdict reason consistent with verdict enum value")
+                    .isEqualTo("insufficient evidence");
         }
 
         @Test

--- a/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelResultTest.java
+++ b/punit-sentinel/src/test/java/org/javai/punit/sentinel/SentinelResultTest.java
@@ -3,6 +3,7 @@ package org.javai.punit.sentinel;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.List;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder;
 import org.junit.jupiter.api.DisplayName;
@@ -68,7 +69,7 @@ class SentinelResultTest {
                     .identity("TestClass", "testMethod", "useCase1")
                     .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
             var verdicts = List.of(verdict);
             var duration = Duration.ofMillis(1500);

--- a/punit-sentinel/src/test/java/org/javai/punit/sentinel/verdict/WebhookVerdictSinkTest.java
+++ b/punit-sentinel/src/test/java/org/javai/punit/sentinel/verdict/WebhookVerdictSinkTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,7 @@ class WebhookVerdictSinkTest {
                 .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
                 .environmentMetadata(Map.of("environment", "staging"))
                 .junitPassed(true)
-                .passedStatistically(true)
+                .criterionVerdict(Verdict.PASS)
                 .build();
     }
 
@@ -92,7 +93,7 @@ class WebhookVerdictSinkTest {
                     .identity("TestClass", "failingTest", "uc2")
                     .execution(100, 100, 80, 20, 0.9, 0.8, 1000)
                     .junitPassed(false)
-                    .passedStatistically(false)
+                    .criterionVerdict(Verdict.FAIL)
                     .build();
             String json = WebhookVerdictSink.toJson(verdict);
 
@@ -107,7 +108,7 @@ class WebhookVerdictSinkTest {
                     .identity("test\"Class", "test\"Method", "use\"Case")
                     .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
             String json = WebhookVerdictSink.toJson(verdict);
 
@@ -123,7 +124,7 @@ class WebhookVerdictSinkTest {
                     .identity("test\\Class", "testMethod", "useCase")
                     .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
             String json = WebhookVerdictSink.toJson(verdict);
 
@@ -138,7 +139,7 @@ class WebhookVerdictSinkTest {
                     .identity("TestClass", "test", "uc")
                     .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
                     .junitPassed(true)
-                    .passedStatistically(true)
+                    .criterionVerdict(Verdict.PASS)
                     .build();
             String json = WebhookVerdictSink.toJson(verdict);
 


### PR DESCRIPTION
## Summary

Implements [DIR-RP01-VERDICT-FIDELITY-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-RP01-VERDICT-FIDELITY-punit.md). Pre-fix, a criterion that returned `Verdict.INCONCLUSIVE` for any non-covariate reason — no baseline, sample-size violation, inputs-identity mismatch — silently became `PUnitVerdict.FAIL` with a PASS-shaped reason like `"1.0000 >= 0.0000"`. The collapse violated both RP01 invariants:

> *"The verdict is consistent with the statistical analysis: if pass rate exceeds the threshold at the stated confidence, verdict must be Pass."*
>
> *"The verdict reason is always populated and is consistent with the verdict enum value."*

The cause was a two-stage information loss:

1. `VerdictAdapter` mapped the criterion's three-state `Verdict` to a boolean — both `FAIL` and `INCONCLUSIVE` became `false`.
2. `ProbabilisticTestVerdictBuilder.derivePUnitVerdict` only restored `INCONCLUSIVE` on covariate misalignment. With covariates aligned (the common case), `INCONCLUSIVE` collapsed to `FAIL`.

## Implementation

- **`ProbabilisticTestVerdictBuilder`**: replaced boolean `passedStatistically` field with three-state `criterionVerdict` (type `Verdict` from `org.javai.punit.api.spec`). New setter `criterionVerdict(Verdict)` accepts the criterion's verdict verbatim.
- **`derivePUnitVerdict`**: order is now (1) covariates misaligned → INCONCLUSIVE; (2) budget exhaustion → INCONCLUSIVE; (3) `criterionVerdict == INCONCLUSIVE` → INCONCLUSIVE; (4) else PASS/FAIL by `criterionVerdict`. Run-level overrides preserved; non-covariate INCONCLUSIVE now survives.
- **`VerdictAdapter:156`**: `b.passedStatistically(result.verdict() == Verdict.PASS)` → `b.criterionVerdict(result.verdict())`. Class-level Field-provenance docstring rewritten to describe the three-state pass-through.
- **Test fixture migration** (per directive option (a) — "Pick (a) unless touching the callers is disproportionate"): 20 `.passedStatistically(true|false)` call sites across 5 test files migrated to `.criterionVerdict(Verdict.PASS|FAIL)`. The boolean field/setter is gone.
- **Regression test**: `VerdictAdapterTest.inconclusiveSurvivesAlignedCovariates` pins the reproducer at unit-test level: INCONCLUSIVE result + aligned covariates → `punitVerdict()==INCONCLUSIVE` and `verdictReason()=="insufficient evidence"`.

## Out of scope

Per directive §"What NOT to implement":

- **RP01 catalog unchanged** — the spec is correct; this is purely implementation alignment.
- **Verdict XML schema unchanged** — only the values written into the existing element shape are corrected.
- **Criterion-side logic unchanged** — `PassRate.evaluate` and `EmpiricalChecks` already produce the right three-state verdict.

The "insufficient evidence" catch-all reason for non-covariate INCONCLUSIVE — visible in the rendered reproducer screenshot — is the directive's §After completion follow-up: "treating the missing-baseline diagnostic as a first-class report element rather than burying it in the verdict reason." Will be addressed in a separate small directive that plumbs a richer reason vocabulary through the criterion's detail map and amends RP01 accordingly.

## Test plan

- [x] `./gradlew test` — exit 0, all modules green
- [x] New regression test `VerdictAdapterTest.inconclusiveSurvivesAlignedCovariates` passes
- [x] All migrated test fixtures still pass
- [x] Manual verification: `RegionalCoinTossExamples.shouldMatchBaseline` (run without `-Dpunit.example.region`) renders **INCONCLUSIVE** in the punit-report HTML verdict cell (was FAIL pre-fix). Reason text reads `Inconclusive — insufficient evidence` — correct verdict, expected catch-all reason; the catch-all granularity is the §After completion follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)