### PR TITLE
DIR-INCONCLUSIVE-REASONS-punit: differentiate INCONCLUSIVE reasons in the verdict reason

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/EmpiricalChecks.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/EmpiricalChecks.java
@@ -71,6 +71,8 @@ public final class EmpiricalChecks {
         detail.putIfAbsent("origin", ThresholdOrigin.EMPIRICAL.name());
         detail.put("testSampleCount", testSampleCount);
         detail.put("baselineSampleCount", baselineSampleCount);
+        detail.put(InconclusiveReasons.DETAIL_KEY,
+                InconclusiveReasons.BASELINE_SAMPLE_SIZE_EXCEEDED);
         String reason = "test sample size (" + testSampleCount + ") exceeds baseline "
                 + "sample size (" + baselineSampleCount + "). The baseline must be "
                 + "at least as rigorous as the test it grounds. Re-run the baseline "
@@ -129,6 +131,8 @@ public final class EmpiricalChecks {
         detail.putIfAbsent("origin", ThresholdOrigin.EMPIRICAL.name());
         detail.put("testInputsIdentity", testIdentity);
         detail.put("baselineInputsIdentity", baselineIdentity);
+        detail.put(InconclusiveReasons.DETAIL_KEY,
+                InconclusiveReasons.BASELINE_INPUTS_MISMATCH);
         String reason = "test inputs identity (" + truncate(testIdentity)
                 + ") differs from the resolved baseline's recorded inputs "
                 + "identity (" + truncate(baselineIdentity) + "). An empirical "

--- a/punit-core/src/main/java/org/javai/punit/api/spec/InconclusiveReasons.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/InconclusiveReasons.java
@@ -1,0 +1,87 @@
+package org.javai.punit.api.spec;
+
+/**
+ * The RP01 vocabulary for the verdict-reason field on an
+ * INCONCLUSIVE verdict.
+ *
+ * <p>RP01 distinguishes six reasons. Two are detected at the run
+ * level (covariate alignment and budget exhaustion); the other four
+ * arise inside a criterion's {@link Criterion#evaluate} and are
+ * surfaced via the criterion's {@link CriterionResult#detail()}
+ * map under {@link #DETAIL_KEY}. The verdict builder reads the
+ * detail key when synthesising the verdict reason, falling back to
+ * {@link #INSUFFICIENT_EVIDENCE} when no discriminant is present.
+ *
+ * <p>Lives in the {@code api.spec} package because both the
+ * shared empirical-check helpers (here, alongside
+ * {@link EmpiricalChecks}) and the concrete criteria in
+ * {@code engine.criteria} stamp the discriminant — and the verdict
+ * builder reads it. {@code api.spec} is the lowest common ancestor
+ * package; placing the vocabulary anywhere else would force one
+ * direction of the dependency to go upward through the layering.
+ *
+ * <p>This class is the single point of change for any future
+ * RP01-vocabulary tweak — the catalog text and these constants
+ * must stay in lockstep.
+ *
+ * @see <a href="https://github.com/javai-org/javai-orchestrator/blob/main/inventory/catalog/reporting/RP01-verdict-record/README.md">RP01 — Verdict record</a>
+ */
+public final class InconclusiveReasons {
+
+    private InconclusiveReasons() { }
+
+    /**
+     * Detail-map key under which a criterion stamps its
+     * INCONCLUSIVE-reason discriminant. Value is one of the
+     * criterion-level constants below.
+     */
+    public static final String DETAIL_KEY = "inconclusiveReason";
+
+    // ── Criterion-level reasons (set on CriterionResult.detail) ──
+
+    /**
+     * Empirical mode but no baseline could be resolved for the use
+     * case + factors + covariates. Operator's next step: run a
+     * measure experiment to produce one.
+     */
+    public static final String NO_BASELINE_AVAILABLE = "no baseline available";
+
+    /**
+     * The test's inputs identity differs from the resolved
+     * baseline's recorded inputs identity. Operator's next step:
+     * re-baseline with the current inputs.
+     */
+    public static final String BASELINE_INPUTS_MISMATCH = "baseline inputs mismatch";
+
+    /**
+     * The test executed more samples than the resolved baseline
+     * supports. Operator's next step: re-baseline at a sample
+     * count ≥ the test's.
+     */
+    public static final String BASELINE_SAMPLE_SIZE_EXCEEDED = "baseline sample size exceeded";
+
+    /**
+     * Too few samples relative to the threshold for a statistical
+     * determination — the residual catch-all when no more specific
+     * cause was named on the criterion's detail map. Operator's
+     * next step: increase the sample count.
+     */
+    public static final String INSUFFICIENT_EVIDENCE = "insufficient evidence";
+
+    // ── Run-level reasons (set by the builder, not by criteria) ──
+
+    /**
+     * Test conditions do not match the baseline. Detected at the
+     * run level from {@link org.javai.punit.api.covariate.CovariateAlignment}.
+     * Operator's next step: re-baseline or check environment.
+     */
+    public static final String COVARIATE_MISALIGNMENT = "covariate misalignment";
+
+    /**
+     * Time or token budget expired before sufficient samples.
+     * Detected at the run level from the engine's termination
+     * reason. Operator's next step: raise the budget or accept
+     * the partial run.
+     */
+    public static final String BUDGET_EXHAUSTED = "budget exhausted";
+}

--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
@@ -12,6 +12,7 @@ import org.javai.punit.api.spec.CriterionResult;
 import org.javai.punit.api.spec.EmpiricalChecks;
 import org.javai.punit.api.spec.EvaluationContext;
 import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.InconclusiveReasons;
 import org.javai.punit.api.spec.PassRateStatistics;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.Verdict;
@@ -179,6 +180,8 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
                 Map<String, Object> detail = new LinkedHashMap<>();
                 detail.put("confidence", confidence);
                 detail.put("origin", ThresholdOrigin.EMPIRICAL.name());
+                detail.put(InconclusiveReasons.DETAIL_KEY,
+                        InconclusiveReasons.NO_BASELINE_AVAILABLE);
                 return inconclusive(
                         "no matching baseline was resolvable for empirical threshold; "
                                 + "see DG02 §'Baseline relationship' for the resolution mechanism",

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -9,7 +9,9 @@ import java.util.UUID;
 
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.spec.EvaluatedCriterion;
 import org.javai.punit.api.spec.FailureCount;
+import org.javai.punit.api.spec.InconclusiveReasons;
 import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.model.UseCaseAttributes;
 import org.javai.punit.controls.budget.CostBudgetMonitor.TokenMode;
@@ -106,6 +108,11 @@ public class ProbabilisticTestVerdictBuilder {
     // Verdict; tests that build a verdict directly without a criterion
     // run can override via criterionVerdict(...).
     private Verdict criterionVerdict = Verdict.FAIL;
+    // The criterion results carry the inconclusive-reason discriminant
+    // (per RP01 / InconclusiveReasons.DETAIL_KEY). When empty, the
+    // reason synthesis falls back to "insufficient evidence" — the
+    // RP01 catch-all.
+    private List<EvaluatedCriterion> criterionResults = List.of();
 
     // ── Postcondition failure histogram ───────────────────────────────────
     private Map<String, FailureCount> postconditionFailures = Map.of();
@@ -261,6 +268,25 @@ public class ProbabilisticTestVerdictBuilder {
      */
     public ProbabilisticTestVerdictBuilder criterionVerdict(Verdict verdict) {
         this.criterionVerdict = java.util.Objects.requireNonNull(verdict, "verdict");
+        return this;
+    }
+
+    /**
+     * Set the evaluated criterion results for this run. The verdict
+     * builder reads each result's {@link CriterionResult#detail() detail map}
+     * for the {@link InconclusiveReasons#DETAIL_KEY inconclusiveReason}
+     * discriminant when synthesising the verdict reason on an
+     * INCONCLUSIVE-aligned-non-budget verdict — the criterion is the
+     * only layer that knows which of the four non-covariate non-budget
+     * conditions fired (no baseline, inputs mismatch, sample-size
+     * violation, statistical insufficiency).
+     *
+     * <p>When unset, the verdict reason falls back to
+     * {@link InconclusiveReasons#INSUFFICIENT_EVIDENCE} — the RP01
+     * catch-all.
+     */
+    public ProbabilisticTestVerdictBuilder criterionResults(List<EvaluatedCriterion> results) {
+        this.criterionResults = results == null ? List.of() : List.copyOf(results);
         return this;
     }
 
@@ -551,21 +577,43 @@ public class ProbabilisticTestVerdictBuilder {
     private String deriveVerdictReason(PUnitVerdict punitVerdict, CovariateStatus covariates) {
         if (punitVerdict == PUnitVerdict.INCONCLUSIVE) {
             if (!covariates.aligned()) {
-                return "covariate misalignment";
+                return InconclusiveReasons.COVARIATE_MISALIGNMENT;
             }
             if (terminationReason.isBudgetExhaustion()) {
-                return "budget exhausted";
+                return InconclusiveReasons.BUDGET_EXHAUSTED;
             }
-            return "insufficient evidence";
+            return inconclusiveReasonFromCriteria()
+                    .orElse(InconclusiveReasons.INSUFFICIENT_EVIDENCE);
         }
         if (terminationReason.isBudgetExhaustion()) {
-            return "budget exhausted";
+            return InconclusiveReasons.BUDGET_EXHAUSTED;
         }
         String comparator = observedPassRate >= minPassRate ? ">=" : "<";
         return String.format("%s %s %s",
                 RateFormat.format(observedPassRate),
                 comparator,
                 RateFormat.format(minPassRate));
+    }
+
+    /**
+     * Scan the criterion results for the first INCONCLUSIVE-reason
+     * discriminant (per {@link InconclusiveReasons#DETAIL_KEY}). The
+     * "first" rule is fine: today's specs carry one criterion, and
+     * when multiple are added the first INCONCLUSIVE criterion is the
+     * one whose reason most narrowly describes the failure (subsequent
+     * criteria run only if earlier ones don't short-circuit).
+     */
+    private Optional<String> inconclusiveReasonFromCriteria() {
+        for (EvaluatedCriterion ec : criterionResults) {
+            if (ec.result().verdict() != Verdict.INCONCLUSIVE) {
+                continue;
+            }
+            Object marker = ec.result().detail().get(InconclusiveReasons.DETAIL_KEY);
+            if (marker instanceof String s && !s.isBlank()) {
+                return Optional.of(s);
+            }
+        }
+        return Optional.empty();
     }
 
     // ── Input records ─────────────────────────────────────────────────────

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
@@ -162,6 +162,10 @@ public final class VerdictAdapter {
 
         // Verdict
         b.criterionVerdict(result.verdict());
+        // Criterion results carry the inconclusive-reason discriminant
+        // per InconclusiveReasons.DETAIL_KEY; the builder reads them
+        // when synthesising the verdict reason.
+        b.criterionResults(result.criterionResults());
         // No JUnit-pass concept on the result; default true (the
         // field is only meaningful inside the JUnit context).
         b.junitPassed(true);

--- a/punit-core/src/test/java/org/javai/punit/api/spec/EmpiricalChecksTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/EmpiricalChecksTest.java
@@ -37,6 +37,11 @@ class EmpiricalChecksTest {
         assertThat(r.detail()).containsEntry("testSampleCount", 200);
         assertThat(r.detail()).containsEntry("baselineSampleCount", 100);
         assertThat(r.detail()).containsEntry("origin", "EMPIRICAL");
+        assertThat(r.detail())
+                .as("RP01 vocabulary discriminant for the verdict-builder")
+                .containsEntry(
+                        InconclusiveReasons.DETAIL_KEY,
+                        InconclusiveReasons.BASELINE_SAMPLE_SIZE_EXCEEDED);
     }
 
     @Test
@@ -99,6 +104,11 @@ class EmpiricalChecksTest {
         assertThat(r.detail()).containsEntry("testInputsIdentity", "sha256:test");
         assertThat(r.detail()).containsEntry("baselineInputsIdentity", "sha256:baseline");
         assertThat(r.detail()).containsEntry("origin", "EMPIRICAL");
+        assertThat(r.detail())
+                .as("RP01 vocabulary discriminant for the verdict-builder")
+                .containsEntry(
+                        InconclusiveReasons.DETAIL_KEY,
+                        InconclusiveReasons.BASELINE_INPUTS_MISMATCH);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/engine/criteria/PassRateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/criteria/PassRateTest.java
@@ -130,7 +130,8 @@ class PassRateTest {
     // ── empirical() — default resolution ────────────────────────────
 
     @Test
-    @DisplayName("empirical() with no baseline returns INCONCLUSIVE")
+    @DisplayName("empirical() with no baseline returns INCONCLUSIVE with the "
+            + "'no baseline available' RP01 discriminant on the detail map")
     void empiricalNoBaselineInconclusive() {
         PassRate<String> criterion = PassRate.empirical();
 
@@ -138,6 +139,11 @@ class PassRateTest {
 
         assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
         assertThat(result.explanation()).contains("baseline");
+        assertThat(result.detail())
+                .as("RP01 vocabulary discriminant for the verdict-builder")
+                .containsEntry(
+                        org.javai.punit.api.spec.InconclusiveReasons.DETAIL_KEY,
+                        org.javai.punit.api.spec.InconclusiveReasons.NO_BASELINE_AVAILABLE);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
@@ -19,6 +19,7 @@ import org.javai.punit.api.spec.EngineRunSummary;
 import org.javai.punit.api.spec.EvaluatedCriterion;
 import org.javai.punit.api.spec.FailureCount;
 import org.javai.punit.api.spec.FailureExemplar;
+import org.javai.punit.api.spec.InconclusiveReasons;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.model.TerminationReason;
@@ -138,6 +139,63 @@ class VerdictAdapterTest {
             ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.FAIL));
 
             assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.FAIL);
+        }
+
+        @Test
+        @DisplayName("INCONCLUSIVE with the 'no baseline available' criterion discriminant "
+                + "renders that reason on the verdict (RP01 vocabulary)")
+        void inconclusiveNoBaselineAvailable() {
+            ProbabilisticTestVerdict verdict = adapt(inconclusiveWithReason(
+                    InconclusiveReasons.NO_BASELINE_AVAILABLE));
+
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
+            assertThat(verdict.verdictReason()).isEqualTo("no baseline available");
+        }
+
+        @Test
+        @DisplayName("INCONCLUSIVE with the 'baseline inputs mismatch' discriminant renders "
+                + "that reason on the verdict")
+        void inconclusiveBaselineInputsMismatch() {
+            ProbabilisticTestVerdict verdict = adapt(inconclusiveWithReason(
+                    InconclusiveReasons.BASELINE_INPUTS_MISMATCH));
+
+            assertThat(verdict.verdictReason()).isEqualTo("baseline inputs mismatch");
+        }
+
+        @Test
+        @DisplayName("INCONCLUSIVE with the 'baseline sample size exceeded' discriminant "
+                + "renders that reason on the verdict")
+        void inconclusiveBaselineSampleSizeExceeded() {
+            ProbabilisticTestVerdict verdict = adapt(inconclusiveWithReason(
+                    InconclusiveReasons.BASELINE_SAMPLE_SIZE_EXCEEDED));
+
+            assertThat(verdict.verdictReason()).isEqualTo("baseline sample size exceeded");
+        }
+
+        @Test
+        @DisplayName("INCONCLUSIVE with the 'insufficient evidence' discriminant renders "
+                + "that reason on the verdict")
+        void inconclusiveInsufficientEvidenceExplicit() {
+            // Explicit discriminant — the criterion stamped INSUFFICIENT_EVIDENCE
+            // rather than leaving the detail map untouched. Same behaviour as
+            // the no-discriminant fallback, but exercised via the named path.
+            ProbabilisticTestVerdict verdict = adapt(inconclusiveWithReason(
+                    InconclusiveReasons.INSUFFICIENT_EVIDENCE));
+
+            assertThat(verdict.verdictReason()).isEqualTo("insufficient evidence");
+        }
+
+        @Test
+        @DisplayName("INCONCLUSIVE with no discriminant on the criterion-result detail "
+                + "map falls back to 'insufficient evidence' — RP01 catch-all "
+                + "(backward compat for criteria pre-dating the vocabulary expansion)")
+        void inconclusiveNoDiscriminantFallsBack() {
+            // No criterion result on the test result — the builder's
+            // criterionResults list is empty.
+            ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.INCONCLUSIVE));
+
+            assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
+            assertThat(verdict.verdictReason()).isEqualTo("insufficient evidence");
         }
 
         @Test
@@ -398,6 +456,27 @@ class VerdictAdapterTest {
         return new ProbabilisticTestResult(
                 v, FactorBundle.of(new Factors()),
                 List.of(), TestIntent.VERIFICATION, List.of(),
+                CovariateAlignment.none(), Optional.empty(), Map.of(),
+                EngineRunSummary.empty());
+    }
+
+    /**
+     * Build a {@link ProbabilisticTestResult} whose verdict is
+     * INCONCLUSIVE and whose single criterion result carries the
+     * given discriminant on its detail map under
+     * {@link InconclusiveReasons#DETAIL_KEY}. Aligned covariates —
+     * the case the bug masked.
+     */
+    private static ProbabilisticTestResult inconclusiveWithReason(String reasonValue) {
+        Map<String, Object> detail = new LinkedHashMap<>();
+        detail.put(InconclusiveReasons.DETAIL_KEY, reasonValue);
+        EvaluatedCriterion ec = new EvaluatedCriterion(
+                new CriterionResult("pass-rate", Verdict.INCONCLUSIVE,
+                        "synthetic — see test fixture", detail),
+                CriterionRole.REQUIRED);
+        return new ProbabilisticTestResult(
+                Verdict.INCONCLUSIVE, FactorBundle.of(new Factors()),
+                List.of(ec), TestIntent.VERIFICATION, List.of(),
                 CovariateAlignment.none(), Optional.empty(), Map.of(),
                 EngineRunSummary.empty());
     }


### PR DESCRIPTION
## Summary

Implements [DIR-INCONCLUSIVE-REASONS-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-INCONCLUSIVE-REASONS-punit.md) against the RP01 catalog amendment landed via orchestrator [PR #24](https://github.com/javai-org/javai-orchestrator/pull/24).

After [PR #125](https://github.com/javai-org/punit/pull/125) (DIR-RP01-VERDICT-FIDELITY) the verdict cell correctly surfaces INCONCLUSIVE for non-covariate causes — but the rendered reason text was the catch-all `"insufficient evidence"` for all three configuration-error conditions (no baseline resolved, inputs-identity mismatch, sample-size violation) plus the genuine statistical case. The first three are operator-actionable in distinct ways; lumping them together misled the operator about what was actually wrong.

## Implementation

- **`InconclusiveReasons`** (new, `api.spec`) — single source of truth for the RP01 vocabulary: `DETAIL_KEY` plus the six reason constants. Lives in `api.spec` because both the shared empirical-check helpers (also in `api.spec`) and the concrete criteria (`engine.criteria`) stamp the discriminant, and the verdict builder reads it. `api.spec` is the lowest common ancestor package.
- **Criterion-side discriminant population:**
  - `PassRate.java:178` (no-baseline branch) → `NO_BASELINE_AVAILABLE`
  - `EmpiricalChecks.sampleSizeConstraint` → `BASELINE_SAMPLE_SIZE_EXCEEDED`
  - `EmpiricalChecks.inputsIdentityMatch` → `BASELINE_INPUTS_MISMATCH`
  - `PassRate.java:166` (zero samples) and any future statistics-core feasibility-violation case stay unmarked — builder defaults to `INSUFFICIENT_EVIDENCE` when the discriminant is absent.
- **Builder plumbing:** `ProbabilisticTestVerdictBuilder` gains `criterionResults(List<EvaluatedCriterion>)`; `deriveVerdictReason` scans those results for the `DETAIL_KEY` discriminant on INCONCLUSIVE-aligned-non-budget verdicts, falling back to `INSUFFICIENT_EVIDENCE`. Hard-coded reason strings inside `deriveVerdictReason` now reference the `InconclusiveReasons` constants.
- **`VerdictAdapter`** passes `result.criterionResults()` to the builder alongside `result.verdict()`.

## Tests

- **`VerdictAdapterTest`** gains four new cases pinning each criterion-level reason via a synthetic `ProbabilisticTestResult` helper, plus a no-discriminant fallback test. The pre-existing `inconclusiveSurvivesAlignedCovariates` regression (from PR #125) is preserved unchanged — it still asserts `"insufficient evidence"` for the no-discriminant case, demonstrating the backward-compat path.
- **`PassRateTest`** asserts `NO_BASELINE_AVAILABLE` on the returned `CriterionResult.detail` for the empirical no-baseline branch.
- **`EmpiricalChecksTest`** asserts `BASELINE_SAMPLE_SIZE_EXCEEDED` for `sampleSizeConstraint` violations and `BASELINE_INPUTS_MISMATCH` for `inputsIdentityMatch` violations.

## Out of scope (per directive)

- Verdict-XML / RP07 schema unchanged.
- Long-form `CriterionResult.reason` strings unchanged — rich diagnostic prose at each site is independent of the short catalog string.
- No backwards-compat shim mapping legacy `"insufficient evidence"` XML to new vocabulary; verdict XML regenerated each run.
- feotest sync deferred to existing follow-up (`plan/followups/feotest-EX04-EX07-EX10-amendment-alignment.md` in the orchestrator).

## Test plan

- [x] `./gradlew test` — exit 0, all modules green
- [x] Existing INCONCLUSIVE regressions preserved
- [x] New tests pin each new reason at criterion-side and adapter-side
- [ ] Manual verification: `RegionalCoinTossExamples.shouldMatchBaseline` (without `-Dpunit.example.region`) renders verdict reason `"no baseline available"` (was `"insufficient evidence"` post-PR-#125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)