### PR TITLE
DIR-SAMPLE-PROGRESS: cross-module bridge for in-place per-sample counter

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1433,10 +1433,33 @@ PUnit resolves configuration in this order (highest priority first):
 | Confidence level        | `punit.confidence`           | `PUNIT_CONFIDENCE`          | `0.95`                                             |
 | Latency enforcement     | `punit.latency.enforcement`  | `PUNIT_LATENCY_ENFORCEMENT` | `advisory`                                         |
 | Default samples         | `punit.samples`              | `PUNIT_SAMPLES`             | builder-supplied; no global default                |
+| Progress glyph colour   | `punit.progress.color`       | —                           | `true`                                             |
 
 Gradle plugin configuration in the `punit { }` extension block
 mirrors the same settings. See the plugin module's README for the
 extension surface.
+
+### Per-sample progress glyphs
+
+PUnit emits a single non-newline character to standard output after
+each sample completes — `.` for a passing sample, `x` for a failing
+one. The glyphs are flushed immediately so a long-running MEASURE
+or probabilistic test gives live feedback that the JVM is busy
+rather than blocked. With the default `punit.progress.color=true`,
+each glyph is wrapped in ANSI green / red so a colour-aware
+terminal reinforces the pass/fail signal — but the differentiation
+is doubly encoded (period vs ex, green vs red), so a colour-blind
+reader or a non-ANSI terminal still sees the distinction.
+
+Set `-Dpunit.progress.color=false` to disable the ANSI wrapper.
+The glyphs continue to be emitted.
+
+The feature is deliberately lean: one glyph per sample, no spinner,
+no percentage, no ETA, no end-of-run summary. Verdict-rendering
+machinery remains the sole producer of structured run output. If
+the Gradle rich console garbles the glyph stream, run with
+`./gradlew exp --console=plain` — Gradle's plain console preserves
+the per-sample emission order exactly.
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1433,33 +1433,45 @@ PUnit resolves configuration in this order (highest priority first):
 | Confidence level        | `punit.confidence`           | `PUNIT_CONFIDENCE`          | `0.95`                                             |
 | Latency enforcement     | `punit.latency.enforcement`  | `PUNIT_LATENCY_ENFORCEMENT` | `advisory`                                         |
 | Default samples         | `punit.samples`              | `PUNIT_SAMPLES`             | builder-supplied; no global default                |
-| Progress glyph colour   | `punit.progress.color`       | —                           | `true`                                             |
 
 Gradle plugin configuration in the `punit { }` extension block
 mirrors the same settings. See the plugin module's README for the
 extension surface.
 
-### Per-sample progress glyphs
+### Per-sample progress counter
 
-PUnit emits a single non-newline character to standard output after
-each sample completes — `.` for a passing sample, `x` for a failing
-one. The glyphs are flushed immediately so a long-running MEASURE
-or probabilistic test gives live feedback that the JVM is busy
-rather than blocked. With the default `punit.progress.color=true`,
-each glyph is wrapped in ANSI green / red so a colour-aware
-terminal reinforces the pass/fail signal — but the differentiation
-is doubly encoded (period vs ex, green vs red), so a colour-blind
-reader or a non-ANSI terminal still sees the distinction.
+PUnit emits a `completed/total` counter to standard output after
+each sample completes — for a 100-sample MEASURE you'll see
+`  1/100`, `  2/100`, `  3/100`, …, `100/100`. The counter is
+prefixed with a carriage return (`\r`) and width-padded so a real
+terminal updates the counter in place rather than scrolling — a
+single line that ticks upward as the run progresses. The counter
+flushes after every sample, so a long-running test gives live
+feedback that the JVM is busy rather than blocked.
 
-Set `-Dpunit.progress.color=false` to disable the ANSI wrapper.
-The glyphs continue to be emitted.
+Display under Gradle is the one rough edge. Gradle's
+`testLogging.showStandardStreams` infrastructure fires a
+`TestOutputEvent` per flush from the test JVM and renders each
+event on its own indented `STANDARD_OUT` line — regardless of
+console mode. The carriage return survives in the byte stream but
+is rendered after the per-event indent, so the in-place update is
+not honoured. Under Gradle the counter appears as a vertical
+scroll of `1/100`, `2/100`, … lines rather than a single updating
+line. Verbose, but still informative — each line carries the
+running count and the operator gets a live signal that the run is
+making progress.
 
-The feature is deliberately lean: one glyph per sample, no spinner,
-no percentage, no ETA, no end-of-run summary. Verdict-rendering
-machinery remains the sole producer of structured run output. If
-the Gradle rich console garbles the glyph stream, run with
-`./gradlew exp --console=plain` — Gradle's plain console preserves
-the per-sample emission order exactly.
+Outside Gradle (IntelliJ direct-JVM, Maven Surefire, plain
+`java` invocation) the carriage-return semantics are honoured by
+the terminal natively and the counter updates in place as
+intended.
+
+The feature is deliberately lean: one counter emission per sample,
+no spinner, no ETA, no rate, no end-of-run summary, and no
+pass/fail glyph (the verdict record covers post-run pass/fail in
+full; threshold-aware live colouring would require statistics-core
+plumbing into the executor that breaches the package-isolation
+rule, so it is out of scope for this surface).
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1441,37 +1441,37 @@ extension surface.
 ### Per-sample progress counter
 
 PUnit emits a `completed/total` counter to standard output after
-each sample completes — for a 100-sample MEASURE you'll see
-`  1/100`, `  2/100`, `  3/100`, …, `100/100`. The counter is
-prefixed with a carriage return (`\r`) and width-padded so a real
-terminal updates the counter in place rather than scrolling — a
-single line that ticks upward as the run progresses. The counter
-flushes after every sample, so a long-running test gives live
-feedback that the JVM is busy rather than blocked.
+each sample completes. For a 100-sample MEASURE the counter ticks
+through `  1/100`, `  2/100`, `  3/100`, ..., `100/100` — width-
+padded so the rendered length stays constant — giving live
+feedback that the JVM is making progress rather than blocked.
 
-Display under Gradle is the one rough edge. Gradle's
-`testLogging.showStandardStreams` infrastructure fires a
-`TestOutputEvent` per flush from the test JVM and renders each
-event on its own indented `STANDARD_OUT` line — regardless of
-console mode. The carriage return survives in the byte stream but
-is rendered after the per-event indent, so the in-place update is
-not honoured. Under Gradle the counter appears as a vertical
-scroll of `1/100`, `2/100`, … lines rather than a single updating
-line. Verbose, but still informative — each line carries the
-running count and the operator gets a live signal that the run is
-making progress.
+The display rendering depends on whether you run via Gradle or via
+another launcher:
 
-Outside Gradle (IntelliJ direct-JVM, Maven Surefire, plain
-`java` invocation) the carriage-return semantics are honoured by
-the terminal natively and the counter updates in place as
-intended.
+**Under Gradle (`./gradlew test`, `./gradlew exp`)** — the
+punit-gradle-plugin installs a test-output bridge that intercepts
+the per-sample emissions, strips an internal protocol marker, and
+relays the counter to the build's terminal as a single
+`\r`-prefixed line that updates in place. So you see one ticking
+counter, not a vertical scroll of every count. Real test stdout
+that *isn't* progress is passed through unmodified — the bridge
+restores the visibility the dropped `STANDARD_OUT` decoration
+would have provided.
+
+**Outside Gradle** — IntelliJ's direct-JVM test runner, Maven
+Surefire, plain `java` invocation — the marker prefix is visible
+in the raw output (`[PUNIT-PROGRESS]  1/100`, one line per
+sample), and the counter scrolls. The bridge that strips the
+marker is plugin-side, so other launchers don't get the in-place
+nicety; they do still get a live progress signal.
 
 The feature is deliberately lean: one counter emission per sample,
 no spinner, no ETA, no rate, no end-of-run summary, and no
-pass/fail glyph (the verdict record covers post-run pass/fail in
+pass/fail glyph. The verdict record covers post-run pass/fail in
 full; threshold-aware live colouring would require statistics-core
 plumbing into the executor that breaches the package-isolation
-rule, so it is out of scope for this surface).
+rule, so it is out of scope for this surface.
 
 ---
 

--- a/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
@@ -124,33 +124,49 @@ public final class SerialSampleExecutor implements SampleExecutor {
     }
 
     /**
+     * Token prefixed to every progress emission so the
+     * punit-gradle-plugin can pattern-match the chunks on the
+     * receiving side of Gradle's test-stdout pipe and reformat
+     * them into clean in-place updates on the build's terminal.
+     *
+     * <p><b>Cross-module invariant:</b> this string must stay
+     * byte-identical with the matcher in
+     * {@code punit-gradle-plugin/.../PUnitPlugin.kt} (constant
+     * {@code SAMPLE_PROGRESS_MARKER}). The two live in different
+     * Gradle projects with separate classpaths — the plugin runs
+     * in the Gradle build process, this code runs in the test
+     * JVM — so a shared Java/Kotlin import is impractical. A
+     * change here requires a matching change there.
+     *
+     * <p>The token is written verbatim and contains no characters
+     * that need shell escaping, so a stray emission visible in a
+     * raw log is human-readable rather than mojibake.
+     */
+    public static final String SAMPLE_PROGRESS_MARKER = "[PUNIT-PROGRESS]";
+
+    /**
      * Emit a per-sample progress counter to {@code System.out} and
-     * flush. The format is a leading carriage return followed by
-     * width-padded {@code "completed/total"} (e.g. {@code "  12/100"}
-     * for total = 100). The carriage return returns the cursor to
-     * column 0 so a real terminal updates the counter in place; the
-     * width-padding keeps the rendered length stable across the
-     * run so an in-place update fully overwrites the previous
-     * counter.
+     * flush. The format is the {@link #SAMPLE_PROGRESS_MARKER}
+     * token followed by width-padded {@code "completed/total"} and
+     * a trailing newline (e.g. {@code "[PUNIT-PROGRESS]  12/100\n"}
+     * for total = 100). The newline ensures Gradle's test-stdout
+     * pipe delivers the line as one event; the marker lets the
+     * punit-gradle-plugin's {@link
+     * org.gradle.api.tasks.testing.TestOutputListener} recognise
+     * the chunk, strip the decoration, and replay the counter as
+     * an in-place {@code \r}-prefixed update on the build's
+     * terminal.
      *
-     * <h3>Display under Gradle's test task</h3>
-     *
-     * <p>Gradle's {@code testLogging.showStandardStreams} fires a
-     * {@code TestOutputEvent} per flush from the test JVM and
-     * renders each event on its own indented {@code STANDARD_OUT}
-     * line, regardless of console mode. So under Gradle the
-     * counter appears as a vertical scroll of {@code 1/100},
-     * {@code 2/100}, {@code 3/100}, ... lines rather than a single
-     * updating line. This is verbose but informative — each line
-     * carries the running count, and the operator gets a live
-     * signal that the JVM is busy. Outside Gradle (IntelliJ
-     * direct-JVM, Maven Surefire, plain {@code java} invocation)
-     * the carriage-return semantics are honoured by the terminal
-     * and the counter updates in place.
+     * <p>Outside Gradle's test task — IntelliJ direct-JVM, Maven
+     * Surefire, plain {@code java} invocation — the marker is
+     * harmless visual noise, and the counter still scrolls
+     * line-by-line as a live progress signal. The in-place update
+     * is a Gradle-only nicety that the plugin layer provides.
      */
     private static void emitProgress(int completed, int total) {
         int width = String.valueOf(total).length();
-        System.out.print('\r' + String.format("%" + width + "d/%d", completed, total));
+        System.out.println(SAMPLE_PROGRESS_MARKER
+                + String.format("%" + width + "d/%d", completed, total));
         System.out.flush();
     }
 

--- a/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
-import org.javai.outcome.Outcome;
 import org.javai.punit.api.spec.ExceptionPolicy;
 import org.javai.punit.api.Pacing;
 import org.javai.punit.api.TokenTracker;
@@ -106,12 +105,12 @@ public final class SerialSampleExecutor implements SampleExecutor {
             } catch (Throwable t) {
                 Duration elapsed = Duration.ofNanos(System.nanoTime() - t0);
                 observer.onDefect(i, t, elapsed);
-                emitProgress(false);
+                emitProgress(i + 1, sampleCount);
                 continue;
             }
             Duration elapsed = Duration.ofNanos(System.nanoTime() - t0);
             observer.onSample(i, outcome, elapsed);
-            emitProgress(outcome.value() instanceof Outcome.Ok);
+            emitProgress(i + 1, sampleCount);
         }
     }
 
@@ -125,39 +124,34 @@ public final class SerialSampleExecutor implements SampleExecutor {
     }
 
     /**
-     * Emit a single per-sample progress glyph to {@code System.out}
-     * and flush. {@code '.'} for a passing sample, {@code 'x'} for
-     * a failing one. When the {@code punit.progress.color} system
-     * property is unset or {@code true} (the default), the glyph
-     * is wrapped in ANSI green / red so a colour-aware terminal
-     * reinforces the pass/fail signal. The glyph itself remains
-     * visible without colour — the differentiation is doubly
-     * encoded so neither encoding alone carries the distinction.
+     * Emit a per-sample progress counter to {@code System.out} and
+     * flush. The format is a leading carriage return followed by
+     * width-padded {@code "completed/total"} (e.g. {@code "  12/100"}
+     * for total = 100). The carriage return returns the cursor to
+     * column 0 so a real terminal updates the counter in place; the
+     * width-padding keeps the rendered length stable across the
+     * run so an in-place update fully overwrites the previous
+     * counter.
      *
-     * <p>The property is read on every call rather than cached in
-     * a {@code static final} so test fixtures can flip it via
-     * {@code System.setProperty} without forking the JVM. The
-     * per-sample cost of one {@link System#getProperty(String, String)}
-     * is negligible against the stdout I/O the method already
-     * performs.
+     * <h3>Display under Gradle's test task</h3>
+     *
+     * <p>Gradle's {@code testLogging.showStandardStreams} fires a
+     * {@code TestOutputEvent} per flush from the test JVM and
+     * renders each event on its own indented {@code STANDARD_OUT}
+     * line, regardless of console mode. So under Gradle the
+     * counter appears as a vertical scroll of {@code 1/100},
+     * {@code 2/100}, {@code 3/100}, ... lines rather than a single
+     * updating line. This is verbose but informative — each line
+     * carries the running count, and the operator gets a live
+     * signal that the JVM is busy. Outside Gradle (IntelliJ
+     * direct-JVM, Maven Surefire, plain {@code java} invocation)
+     * the carriage-return semantics are honoured by the terminal
+     * and the counter updates in place.
      */
-    private static void emitProgress(boolean ok) {
-        boolean color = Boolean.parseBoolean(
-                System.getProperty(PROGRESS_COLOR_PROPERTY, "true"));
-        String glyph;
-        if (ok) {
-            glyph = color ? GREEN + '.' + RESET : ".";
-        } else {
-            glyph = color ? RED + 'x' + RESET : "x";
-        }
-        System.out.print(glyph);
+    private static void emitProgress(int completed, int total) {
+        int width = String.valueOf(total).length();
+        System.out.print('\r' + String.format("%" + width + "d/%d", completed, total));
         System.out.flush();
     }
 
-    /** System property toggling ANSI colour on the per-sample progress glyphs. */
-    static final String PROGRESS_COLOR_PROPERTY = "punit.progress.color";
-
-    private static final String GREEN = "[32m";
-    private static final String RED = "[31m";
-    private static final String RESET = "[0m";
 }

--- a/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/SerialSampleExecutor.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
+import org.javai.outcome.Outcome;
 import org.javai.punit.api.spec.ExceptionPolicy;
 import org.javai.punit.api.Pacing;
 import org.javai.punit.api.TokenTracker;
@@ -105,10 +106,12 @@ public final class SerialSampleExecutor implements SampleExecutor {
             } catch (Throwable t) {
                 Duration elapsed = Duration.ofNanos(System.nanoTime() - t0);
                 observer.onDefect(i, t, elapsed);
+                emitProgress(false);
                 continue;
             }
             Duration elapsed = Duration.ofNanos(System.nanoTime() - t0);
             observer.onSample(i, outcome, elapsed);
+            emitProgress(outcome.value() instanceof Outcome.Ok);
         }
     }
 
@@ -120,4 +123,41 @@ public final class SerialSampleExecutor implements SampleExecutor {
             throw new RuntimeException("pacing sleep interrupted", ie);
         }
     }
+
+    /**
+     * Emit a single per-sample progress glyph to {@code System.out}
+     * and flush. {@code '.'} for a passing sample, {@code 'x'} for
+     * a failing one. When the {@code punit.progress.color} system
+     * property is unset or {@code true} (the default), the glyph
+     * is wrapped in ANSI green / red so a colour-aware terminal
+     * reinforces the pass/fail signal. The glyph itself remains
+     * visible without colour — the differentiation is doubly
+     * encoded so neither encoding alone carries the distinction.
+     *
+     * <p>The property is read on every call rather than cached in
+     * a {@code static final} so test fixtures can flip it via
+     * {@code System.setProperty} without forking the JVM. The
+     * per-sample cost of one {@link System#getProperty(String, String)}
+     * is negligible against the stdout I/O the method already
+     * performs.
+     */
+    private static void emitProgress(boolean ok) {
+        boolean color = Boolean.parseBoolean(
+                System.getProperty(PROGRESS_COLOR_PROPERTY, "true"));
+        String glyph;
+        if (ok) {
+            glyph = color ? GREEN + '.' + RESET : ".";
+        } else {
+            glyph = color ? RED + 'x' + RESET : "x";
+        }
+        System.out.print(glyph);
+        System.out.flush();
+    }
+
+    /** System property toggling ANSI colour on the per-sample progress glyphs. */
+    static final String PROGRESS_COLOR_PROPERTY = "punit.progress.color";
+
+    private static final String GREEN = "[32m";
+    private static final String RED = "[31m";
+    private static final String RESET = "[0m";
 }

--- a/punit-core/src/test/java/org/javai/punit/engine/SerialSampleExecutorProgressTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/SerialSampleExecutorProgressTest.java
@@ -24,9 +24,12 @@ import org.junit.jupiter.api.Test;
  * Progress-counter behavioural contract for {@link SerialSampleExecutor}.
  *
  * <p>Captures {@code System.out} during a controlled sample-loop run
- * and asserts the executor emits a per-sample {@code "\r m/n"}
- * counter — one event per sample, immediately flushed, width-padded
- * for stable in-place updates outside Gradle.
+ * and asserts the executor emits one {@code [PUNIT-PROGRESS] m/n\n}
+ * line per sample, immediately flushed. The marker lets the
+ * punit-gradle-plugin's {@code TestOutputListener} recognise
+ * progress chunks on the receiving side of Gradle's test-stdout
+ * pipe and reformat them as clean in-place updates on the build's
+ * terminal.
  */
 @DisplayName("SerialSampleExecutor — per-sample progress counter")
 class SerialSampleExecutorProgressTest {
@@ -57,26 +60,37 @@ class SerialSampleExecutorProgressTest {
         }
     }
 
+    private static final String MARKER = SerialSampleExecutor.SAMPLE_PROGRESS_MARKER;
+
     @Test
-    @DisplayName("emits a \\r-prefixed m/n counter after every sample, regardless of pass/fail")
+    @DisplayName("emits one [PUNIT-PROGRESS] m/n line after every sample, regardless of pass/fail")
     void emitsCounterPerSample() {
         runWith(new AlternatingUseCase(), List.of(0, 1, 2, 3));
 
-        assertThat(captured.toString(StandardCharsets.UTF_8))
-                .as("4 samples → 4 counter emissions: 1/4, 2/4, 3/4, 4/4")
-                .isEqualTo("\r1/4\r2/4\r3/4\r4/4");
+        // 4 samples → 4 newline-terminated lines, each prefixed with the marker.
+        // System.out.println uses the platform line separator; assert using lines().
+        String captured = this.captured.toString(StandardCharsets.UTF_8);
+        assertThat(captured.lines().toList())
+                .containsExactly(
+                        MARKER + "1/4",
+                        MARKER + "2/4",
+                        MARKER + "3/4",
+                        MARKER + "4/4");
     }
 
     @Test
-    @DisplayName("width-pads the numerator to the decimal width of the total — keeps in-place "
-            + "updates aligned for terminals that honour \\r")
+    @DisplayName("width-pads the numerator to the decimal width of the total — keeps the "
+            + "rendered counter aligned regardless of where the consumer renders it")
     void widthPadsNumerator() {
         runWith(new AlternatingUseCase(), List.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 
         // total = 11 → width = 2; numerator padded with one leading space for single digits.
-        String expected = "\r 1/11\r 2/11\r 3/11\r 4/11\r 5/11\r 6/11\r 7/11"
-                + "\r 8/11\r 9/11\r10/11\r11/11";
-        assertThat(captured.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
+        assertThat(captured.toString(StandardCharsets.UTF_8).lines().toList())
+                .containsExactly(
+                        MARKER + " 1/11", MARKER + " 2/11", MARKER + " 3/11",
+                        MARKER + " 4/11", MARKER + " 5/11", MARKER + " 6/11",
+                        MARKER + " 7/11", MARKER + " 8/11", MARKER + " 9/11",
+                        MARKER + "10/11", MARKER + "11/11");
     }
 
     @Test
@@ -91,9 +105,9 @@ class SerialSampleExecutorProgressTest {
         };
         runWith(alwaysThrows, List.of(0, 1));
 
-        assertThat(captured.toString(StandardCharsets.UTF_8))
+        assertThat(captured.toString(StandardCharsets.UTF_8).lines().toList())
                 .as("defect path emits the same counter format as the normal path")
-                .isEqualTo("\r1/2\r2/2");
+                .containsExactly(MARKER + "1/2", MARKER + "2/2");
     }
 
     @Test
@@ -104,21 +118,20 @@ class SerialSampleExecutorProgressTest {
             @Override public String id() { return "CounterPeek"; }
             @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
-                // Sample-internal observable: bytes already in the captured
-                // stream when this sample starts. emitProgress is called
-                // *after* observer.onSample, so for sample i (0-indexed)
-                // we expect i prior counter emissions, each of length
-                // 1 + width + 1 + 1 = 4 (e.g. "\r1/4" for total=4).
-                int priorEmissions = input;
-                int emissionLength = 1 + 1 + 1 + 1; // \r + digit + / + digit
-                assertThat(captured.size()).isEqualTo(priorEmissions * emissionLength);
+                // Sample-internal observable: line count visible inside this
+                // sample's invoke. emitProgress is called *after*
+                // observer.onSample, so for sample i (0-indexed) we expect
+                // exactly i prior progress lines in the captured stream.
+                long priorLines = captured.toString(StandardCharsets.UTF_8).lines().count();
+                assertThat(priorLines).isEqualTo(input);
                 return Outcome.ok("pass");
             }
         };
         runWith(counterPeek, List.of(0, 1, 2, 3));
 
-        assertThat(captured.toString(StandardCharsets.UTF_8))
-                .isEqualTo("\r1/4\r2/4\r3/4\r4/4");
+        assertThat(captured.toString(StandardCharsets.UTF_8).lines().toList())
+                .containsExactly(
+                        MARKER + "1/4", MARKER + "2/4", MARKER + "3/4", MARKER + "4/4");
     }
 
     private void runWith(UseCase<Void, Integer, String> useCase, List<Integer> inputs) {

--- a/punit-core/src/test/java/org/javai/punit/engine/SerialSampleExecutorProgressTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/SerialSampleExecutorProgressTest.java
@@ -1,0 +1,161 @@
+package org.javai.punit.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.api.UseCaseOutcome;
+import org.javai.punit.api.spec.SampleObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Progress-glyph behavioural contract for {@link SerialSampleExecutor}.
+ *
+ * <p>Captures {@code System.out} during a controlled sample-loop run
+ * and asserts the executor emits the expected glyph stream — one
+ * non-newline character per sample, immediately flushed, with the
+ * pass/fail discriminant doubly encoded as glyph + colour.
+ */
+@DisplayName("SerialSampleExecutor — per-sample progress glyphs")
+class SerialSampleExecutorProgressTest {
+
+    private static final String GREEN = "[32m";
+    private static final String RED = "[31m";
+    private static final String RESET = "[0m";
+
+    private PrintStream originalOut;
+    private ByteArrayOutputStream captured;
+    private String previousColorProperty;
+
+    @BeforeEach
+    void redirectStdout() {
+        originalOut = System.out;
+        captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        previousColorProperty = System.getProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreStdout() {
+        System.setOut(originalOut);
+        if (previousColorProperty == null) {
+            System.clearProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY);
+        } else {
+            System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, previousColorProperty);
+        }
+    }
+
+    /** Use case whose outcome alternates pass/fail by input parity. */
+    private static final class AlternatingUseCase implements UseCase<Void, Integer, String> {
+        @Override public String id() { return "Alternating"; }
+        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+            return input % 2 == 0
+                    ? Outcome.ok("even-" + input)
+                    : Outcome.fail("odd", "input was " + input);
+        }
+    }
+
+    @Test
+    @DisplayName("default colour mode emits ANSI-wrapped glyphs — green '.' for pass, red 'x' for fail")
+    void emitsAnsiWrappedGlyphsByDefault() {
+        // Property unset → defaults to true.
+        System.clearProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY);
+
+        runWith(new AlternatingUseCase(), List.of(0, 1, 2, 3));
+
+        // 4 samples cycling inputs 0,1,2,3 → pass, fail, pass, fail.
+        String expected = GREEN + '.' + RESET
+                + RED + 'x' + RESET
+                + GREEN + '.' + RESET
+                + RED + 'x' + RESET;
+        assertThat(captured.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("punit.progress.color=false disables the ANSI wrapper but keeps the glyphs — "
+            + "the pass/fail discriminant survives without colour")
+    void disablingColourLeavesGlyphsIntact() {
+        System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, "false");
+
+        runWith(new AlternatingUseCase(), List.of(0, 1, 2, 3));
+
+        assertThat(captured.toString(StandardCharsets.UTF_8))
+                .isEqualTo(".x.x")
+                .doesNotContain("[")
+                .as("no ANSI escape sequences when colour is disabled");
+    }
+
+    @Test
+    @DisplayName("a defect (use case throws) emits an 'x' glyph regardless of cause")
+    void defectEmitsFailureGlyph() {
+        System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, "false");
+
+        UseCase<Void, Integer, String> alwaysThrows = new UseCase<>() {
+            @Override public String id() { return "AlwaysThrows"; }
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+                throw new RuntimeException("synthetic defect");
+            }
+        };
+        runWith(alwaysThrows, List.of(0, 1));
+
+        assertThat(captured.toString(StandardCharsets.UTF_8)).isEqualTo("xx");
+    }
+
+    @Test
+    @DisplayName("each glyph is flushed immediately — no buffering across samples")
+    void eachGlyphFlushedImmediately() {
+        System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, "false");
+
+        UseCase<Void, Integer, String> alwaysPasses = new UseCase<>() {
+            @Override public String id() { return "AlwaysPasses"; }
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+                // Sample-internal observable: bytes already in the captured
+                // stream after this many samples. emitProgress is called
+                // *after* the observer.onSample callback, so the glyph
+                // for sample N has not been emitted yet here.
+                int beforeThisSample = captured.size();
+                assertThat(beforeThisSample).isEqualTo(input);
+                return Outcome.ok("pass");
+            }
+        };
+        runWith(alwaysPasses, List.of(0, 1, 2, 3));
+
+        assertThat(captured.toString(StandardCharsets.UTF_8)).isEqualTo("....");
+    }
+
+    private void runWith(UseCase<Void, Integer, String> useCase, List<Integer> inputs) {
+        new SerialSampleExecutor().runSamples(
+                useCase,
+                inputs,
+                List.of(),
+                Optional.empty(),
+                inputs.size(),
+                0,
+                new IgnoringObserver(),
+                () -> false);
+    }
+
+    /** Observer that records nothing — the test asserts on stdout only. */
+    private static final class IgnoringObserver implements SampleObserver<String> {
+        @Override
+        public void onSample(int index, UseCaseOutcome<?, String> outcome, Duration elapsed) { }
+
+        @Override
+        public void onDefect(int index, Throwable throwable, Duration elapsed) { }
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/SerialSampleExecutorProgressTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/SerialSampleExecutorProgressTest.java
@@ -21,40 +21,29 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Progress-glyph behavioural contract for {@link SerialSampleExecutor}.
+ * Progress-counter behavioural contract for {@link SerialSampleExecutor}.
  *
  * <p>Captures {@code System.out} during a controlled sample-loop run
- * and asserts the executor emits the expected glyph stream — one
- * non-newline character per sample, immediately flushed, with the
- * pass/fail discriminant doubly encoded as glyph + colour.
+ * and asserts the executor emits a per-sample {@code "\r m/n"}
+ * counter — one event per sample, immediately flushed, width-padded
+ * for stable in-place updates outside Gradle.
  */
-@DisplayName("SerialSampleExecutor — per-sample progress glyphs")
+@DisplayName("SerialSampleExecutor — per-sample progress counter")
 class SerialSampleExecutorProgressTest {
-
-    private static final String GREEN = "[32m";
-    private static final String RED = "[31m";
-    private static final String RESET = "[0m";
 
     private PrintStream originalOut;
     private ByteArrayOutputStream captured;
-    private String previousColorProperty;
 
     @BeforeEach
     void redirectStdout() {
         originalOut = System.out;
         captured = new ByteArrayOutputStream();
         System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
-        previousColorProperty = System.getProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY);
     }
 
     @AfterEach
     void restoreStdout() {
         System.setOut(originalOut);
-        if (previousColorProperty == null) {
-            System.clearProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY);
-        } else {
-            System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, previousColorProperty);
-        }
     }
 
     /** Use case whose outcome alternates pass/fail by input parity. */
@@ -69,40 +58,30 @@ class SerialSampleExecutorProgressTest {
     }
 
     @Test
-    @DisplayName("default colour mode emits ANSI-wrapped glyphs — green '.' for pass, red 'x' for fail")
-    void emitsAnsiWrappedGlyphsByDefault() {
-        // Property unset → defaults to true.
-        System.clearProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY);
-
+    @DisplayName("emits a \\r-prefixed m/n counter after every sample, regardless of pass/fail")
+    void emitsCounterPerSample() {
         runWith(new AlternatingUseCase(), List.of(0, 1, 2, 3));
 
-        // 4 samples cycling inputs 0,1,2,3 → pass, fail, pass, fail.
-        String expected = GREEN + '.' + RESET
-                + RED + 'x' + RESET
-                + GREEN + '.' + RESET
-                + RED + 'x' + RESET;
+        assertThat(captured.toString(StandardCharsets.UTF_8))
+                .as("4 samples → 4 counter emissions: 1/4, 2/4, 3/4, 4/4")
+                .isEqualTo("\r1/4\r2/4\r3/4\r4/4");
+    }
+
+    @Test
+    @DisplayName("width-pads the numerator to the decimal width of the total — keeps in-place "
+            + "updates aligned for terminals that honour \\r")
+    void widthPadsNumerator() {
+        runWith(new AlternatingUseCase(), List.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+
+        // total = 11 → width = 2; numerator padded with one leading space for single digits.
+        String expected = "\r 1/11\r 2/11\r 3/11\r 4/11\r 5/11\r 6/11\r 7/11"
+                + "\r 8/11\r 9/11\r10/11\r11/11";
         assertThat(captured.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
     }
 
     @Test
-    @DisplayName("punit.progress.color=false disables the ANSI wrapper but keeps the glyphs — "
-            + "the pass/fail discriminant survives without colour")
-    void disablingColourLeavesGlyphsIntact() {
-        System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, "false");
-
-        runWith(new AlternatingUseCase(), List.of(0, 1, 2, 3));
-
-        assertThat(captured.toString(StandardCharsets.UTF_8))
-                .isEqualTo(".x.x")
-                .doesNotContain("[")
-                .as("no ANSI escape sequences when colour is disabled");
-    }
-
-    @Test
-    @DisplayName("a defect (use case throws) emits an 'x' glyph regardless of cause")
-    void defectEmitsFailureGlyph() {
-        System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, "false");
-
+    @DisplayName("a defect (use case throws) still advances the counter")
+    void defectAlsoAdvancesCounter() {
         UseCase<Void, Integer, String> alwaysThrows = new UseCase<>() {
             @Override public String id() { return "AlwaysThrows"; }
             @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
@@ -112,30 +91,34 @@ class SerialSampleExecutorProgressTest {
         };
         runWith(alwaysThrows, List.of(0, 1));
 
-        assertThat(captured.toString(StandardCharsets.UTF_8)).isEqualTo("xx");
+        assertThat(captured.toString(StandardCharsets.UTF_8))
+                .as("defect path emits the same counter format as the normal path")
+                .isEqualTo("\r1/2\r2/2");
     }
 
     @Test
-    @DisplayName("each glyph is flushed immediately — no buffering across samples")
-    void eachGlyphFlushedImmediately() {
-        System.setProperty(SerialSampleExecutor.PROGRESS_COLOR_PROPERTY, "false");
-
-        UseCase<Void, Integer, String> alwaysPasses = new UseCase<>() {
-            @Override public String id() { return "AlwaysPasses"; }
+    @DisplayName("each emission is flushed before the next sample begins — no buffering across "
+            + "samples, which is the property the feature exists to provide")
+    void eachEmissionFlushedImmediately() {
+        UseCase<Void, Integer, String> counterPeek = new UseCase<>() {
+            @Override public String id() { return "CounterPeek"; }
             @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
                 // Sample-internal observable: bytes already in the captured
-                // stream after this many samples. emitProgress is called
-                // *after* the observer.onSample callback, so the glyph
-                // for sample N has not been emitted yet here.
-                int beforeThisSample = captured.size();
-                assertThat(beforeThisSample).isEqualTo(input);
+                // stream when this sample starts. emitProgress is called
+                // *after* observer.onSample, so for sample i (0-indexed)
+                // we expect i prior counter emissions, each of length
+                // 1 + width + 1 + 1 = 4 (e.g. "\r1/4" for total=4).
+                int priorEmissions = input;
+                int emissionLength = 1 + 1 + 1 + 1; // \r + digit + / + digit
+                assertThat(captured.size()).isEqualTo(priorEmissions * emissionLength);
                 return Outcome.ok("pass");
             }
         };
-        runWith(alwaysPasses, List.of(0, 1, 2, 3));
+        runWith(counterPeek, List.of(0, 1, 2, 3));
 
-        assertThat(captured.toString(StandardCharsets.UTF_8)).isEqualTo("....");
+        assertThat(captured.toString(StandardCharsets.UTF_8))
+                .isEqualTo("\r1/4\r2/4\r3/4\r4/4");
     }
 
     private void runWith(UseCase<Void, Integer, String> useCase, List<Integer> inputs) {

--- a/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
@@ -7,6 +7,9 @@ import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestOutputEvent
+import org.gradle.api.tasks.testing.TestOutputListener
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import java.io.File
@@ -95,6 +98,7 @@ class PUnitPlugin : Plugin<Project> {
 
             forwardPUnitSystemProperties(this)
             applyRunFilter(project, this)
+            installProgressBridge(this)
         }
     }
 
@@ -120,9 +124,15 @@ class PUnitPlugin : Plugin<Project> {
             }
 
             testLogging {
+                // STANDARD_OUT is dropped here so per-sample progress
+                // chunks (see SampleProgressBridge) aren't decorated
+                // with the `STANDARD_OUT` test-name header on every
+                // flush. The bridge takes responsibility for relaying
+                // ALL test-stdout — progress and non-progress alike —
+                // to the build's terminal, so nothing is lost.
                 events = setOf(
                     TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED,
-                    TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR
+                    TestLogEvent.STANDARD_ERROR
                 )
                 showExceptions = true
                 showCauses = true
@@ -130,6 +140,7 @@ class PUnitPlugin : Plugin<Project> {
                 exceptionFormat = TestExceptionFormat.FULL
                 showStandardStreams = true
             }
+            installProgressBridge(this)
 
             reports {
                 html.outputLocation.set(project.layout.buildDirectory.dir("reports/experiment"))
@@ -478,6 +489,98 @@ class PUnitPlugin : Plugin<Project> {
                 task.filter.includeTestsMatching("*$runFilter")
             } else {
                 task.filter.includeTestsMatching("*$runFilter*")
+            }
+        }
+    }
+
+    /**
+     * Wire per-sample progress emission from the test JVM through to
+     * the build's terminal as in-place updates.
+     *
+     * Punit's [SerialSampleExecutor] writes a marker-prefixed line
+     * after every sample. Inside the test JVM that line goes to
+     * stdout, which Gradle captures over a pipe — by default, Gradle
+     * decorates the chunk with a `STANDARD_OUT` test-name header on
+     * every flush, which is fine for ad-hoc test stdout but ruins the
+     * per-sample progress idea (verbose vertical scroll, double
+     * lines around carriage returns, the user complains rightly).
+     *
+     * Approach:
+     *
+     *   1. Drop `STANDARD_OUT` from `testLogging.events` so Gradle
+     *      stops decorating test-stdout chunks. (We re-emit non-progress
+     *      stdout from inside the listener, so nothing is silently lost.)
+     *   2. Register a `TestOutputListener` that pattern-matches the
+     *      marker, strips it, and writes a `\r`-prefixed counter to the
+     *      build process's own stdout. The build's stdout is a real
+     *      terminal handle (not a pipe), so the carriage return
+     *      collapses each emission onto a single updating line.
+     *   3. Non-progress chunks are passed through unmodified — same
+     *      visual effect as the dropped `STANDARD_OUT` event would have
+     *      produced, minus the per-line decoration.
+     *
+     * The marker constant must stay byte-identical with
+     * `SerialSampleExecutor.SAMPLE_PROGRESS_MARKER`. The two live
+     * in different Gradle projects with separate classpaths — this
+     * code runs in the build process, the executor runs in the test
+     * JVM — so a shared Java/Kotlin import is impractical.
+     */
+    private fun installProgressBridge(task: Test) {
+        task.addTestOutputListener(SampleProgressBridge())
+    }
+
+    private companion object {
+        /**
+         * Mirrors `SerialSampleExecutor.SAMPLE_PROGRESS_MARKER` in
+         * punit-core. Cross-module invariant: a change to one is a
+         * change to both.
+         */
+        const val SAMPLE_PROGRESS_MARKER = "[PUNIT-PROGRESS]"
+    }
+
+    /**
+     * Receives every chunk of test JVM stdout/stderr. Recognises
+     * progress lines by their marker prefix, strips the marker, and
+     * writes the counter to the build's terminal as an in-place
+     * `\r`-prefixed update. Non-progress chunks pass through
+     * unmodified.
+     *
+     * Made package-private (default Kotlin visibility) so the
+     * functional-test module can verify the bridge end-to-end.
+     */
+    internal class SampleProgressBridge : TestOutputListener {
+
+        override fun onOutput(testDescriptor: TestDescriptor, outputEvent: TestOutputEvent) {
+            val message = outputEvent.message
+            // The marker may appear at any byte offset in the chunk —
+            // Gradle sometimes batches a leading newline with the
+            // following line into one event. Find the marker rather
+            // than insisting it sit at column 0.
+            val markerIdx = message.indexOf(SAMPLE_PROGRESS_MARKER)
+            if (markerIdx < 0) {
+                System.out.print(message)
+                System.out.flush()
+                return
+            }
+            // Anything before the marker is non-progress content from
+            // the same chunk — pass it through verbatim.
+            if (markerIdx > 0) {
+                System.out.print(message.substring(0, markerIdx))
+            }
+            // Extract the counter content: everything between the
+            // marker and the next newline (the executor terminates
+            // each emission with a newline so chunks line-align).
+            val afterMarker = markerIdx + SAMPLE_PROGRESS_MARKER.length
+            val newlineIdx = message.indexOf('\n', afterMarker)
+            val end = if (newlineIdx < 0) message.length else newlineIdx
+            val counter = message.substring(afterMarker, end)
+            System.out.print('\r' + counter)
+            System.out.flush()
+            // If the chunk carried trailing content beyond the line
+            // (rare), pass it through too.
+            if (newlineIdx >= 0 && newlineIdx + 1 < message.length) {
+                System.out.print(message.substring(newlineIdx + 1))
+                System.out.flush()
             }
         }
     }

--- a/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
@@ -124,12 +124,19 @@ class PUnitPlugin : Plugin<Project> {
             }
 
             testLogging {
-                // STANDARD_OUT is dropped here so per-sample progress
-                // chunks (see SampleProgressBridge) aren't decorated
-                // with the `STANDARD_OUT` test-name header on every
-                // flush. The bridge takes responsibility for relaying
-                // ALL test-stdout — progress and non-progress alike —
-                // to the build's terminal, so nothing is lost.
+                // STANDARD_OUT is dropped from `events` so per-sample
+                // progress chunks (see SampleProgressBridge) aren't
+                // decorated with the `STANDARD_OUT` test-name header
+                // on every flush. The bridge takes responsibility for
+                // relaying ALL test-stdout — progress and non-progress
+                // alike — to the build's terminal, so nothing is lost.
+                //
+                // showStandardStreams is intentionally NOT set here:
+                // setting it to `true` is a shortcut that re-adds
+                // STANDARD_OUT and STANDARD_ERROR to `events`,
+                // undoing the explicit removal above. Setting it to
+                // `false` would also strip STANDARD_ERROR, which we
+                // want to keep.
                 events = setOf(
                     TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED,
                     TestLogEvent.STANDARD_ERROR
@@ -138,7 +145,6 @@ class PUnitPlugin : Plugin<Project> {
                 showCauses = true
                 showStackTraces = true
                 exceptionFormat = TestExceptionFormat.FULL
-                showStandardStreams = true
             }
             installProgressBridge(this)
 


### PR DESCRIPTION
## Summary

Implements [DIR-SAMPLE-PROGRESS-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/archived/DIR-SAMPLE-PROGRESS-punit.md). The branch contains three commits showing the design evolution under user feedback:

1. `7727367` — directive's literal design: per-sample `.`/`x` glyphs, ANSI-coloured. Broken under Gradle (one-line-per-glyph due to `STANDARD_OUT` decoration).
2. `ffe3695` — pivot to `\r m/n` counter, hoping carriage-return semantics would survive. Worse: Gradle splits each chunk on `\r` into two lines per emission.
3. `3d1cb48` — **cross-module bridge**. The honest fix lives at the build-tool boundary, not inside the test JVM.

## Architecture (commit 3d1cb48)

The test-JVM-side cannot bypass Gradle's stdout pipe. The plugin-side can.

- **`SerialSampleExecutor`** (punit-core) declares `SAMPLE_PROGRESS_MARKER = "[PUNIT-PROGRESS]"` and emits `[PUNIT-PROGRESS]  12/100\n` — one newline-terminated line per sample.
- **`SampleProgressBridge`** (punit-gradle-plugin) is a `TestOutputListener` registered on every `Test` task the plugin configures. It:
  - Drops `STANDARD_OUT` from `testLogging.events` so Gradle stops decorating test-stdout chunks.
  - Pattern-matches the marker on every captured chunk; strips it; writes `\r` + counter to the build process's own stdout — a real terminal handle (not a pipe), so `\r` produces a single in-place updating counter.
  - Passes non-progress test stdout through verbatim — nothing is silently lost.

The marker constant is duplicated (Java in punit-core, Kotlin in punit-gradle-plugin) with cross-reference comments — the two live in different Gradle projects with separate classpaths so a shared import isn't possible.

## Two display modes (depending on launcher)

- **Under Gradle** (`./gradlew test`, `./gradlew exp`) — bridge active. Single `\r`-prefixed counter that ticks upward.
- **Outside Gradle** (IntelliJ direct-JVM, Maven Surefire, plain `java`) — bridge not active. Marker visible in raw output (`[PUNIT-PROGRESS]  1/100`, one line per sample). Counter still scrolls; live signal preserved.

## Tests

- `SerialSampleExecutorProgressTest` (4 cases, punit-core) — counter-per-sample, width-padding, defect path, immediate flush. Assertions use `String.lines()` to be platform-line-separator-agnostic.
- Plugin's existing functional test passes (BUILD SUCCESSFUL).

## Documentation

`USER-GUIDE.md` Appendix A's "Per-sample progress counter" section rewritten to describe the two display modes honestly.

## Out of scope (preserved from directive)

- No spinner, percentage, ETA, rate-limit.
- No file or side-channel sink — `System.out` only on the test side; build-process `System.out` on the bridge side.
- No `NO_COLOR` auto-honour, no TTY detection.
- No progress logic in the observer.
- No pass/fail glyph; statistically-aware colouring deferred.

## Test plan

- [x] `./gradlew test` — exit 0, all modules green
- [x] `./gradlew :punit-gradle-plugin:functionalTest` — green
- [ ] **Manual verification under Gradle:** run a long MEASURE in punitexamples, observe the in-place counter
- [ ] Manual: run from IntelliJ, observe marker-prefixed scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)