### PR TITLE
0.7.0-alpha: restore contractual feasibility gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.7.0] - 2026-XX-XX
+## [0.7.0-alpha] - 2026-05-07
+
+> **🧪 Experimental release.** The first cut of the 0.7.0 typed-builder API. Core authoring surface and statistical engine are ready for evaluation; some optimisations are deferred — see **Known gaps** below. v0.x means breaking changes are still possible: pin to this exact version if you depend on its surface today, and check the issue tracker before upgrading. Feedback at https://github.com/javai-org/punit/issues.
 
 > **⚠️ Breaking changes** — punit 0.7.0 replaces the annotation-driven authoring style of 0.6.x with a typed, builder-based one. See [MIGRATION-0.6-to-0.7.md](docs/MIGRATION-0.6-to-0.7.md) — it carries a coding-assistant prompt that walks your codebase and applies the migration, plus per-change discussion and FAQ. There is no deprecation cycle and no 0.6.x-compatible shim. Maven coordinates are unchanged.
 
@@ -38,9 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Postcondition failure histograms** on `SampleSummary`, `ProbabilisticTestResult`, verdict text, verdict XML (`<postcondition-failures>`), and the HTML report. Failures broken down by named clause with bounded exemplars.
 - **`EngineRunSummary` on `ProbabilisticTestResult`** — run-level scalars (planned/executed samples, elapsed, tokens, latency, termination, confidence, matched baseline filename).
 - **Covariate-aware best-match baseline selection.** Baseline filenames carry a covariate hash; the resolver picks the best-aligned baseline.
-- **Feasibility evaluation.** A test that cannot reach its declared minimum detectable effect at the configured sample size yields INCONCLUSIVE rather than misleading PASS / FAIL.
+- **Pre-flight feasibility gate.** A VERIFICATION-intent test whose configured (samples, threshold, confidence) tuple cannot underwrite a verification claim aborts pre-flight with an `INFEASIBLE VERIFICATION` diagnostic — no samples execute, no misleading PASS / FAIL is produced. Applies to both contractual (`SLA` / `SLO` / `POLICY`) and empirical thresholds. SMOKE-intent runs are silent: the developer has explicitly opted into the sizing gap.
 - **RP07 XML verdict on every test.** Each `@ProbabilisticTest` produces a `{className}.{methodName}.xml` file under `build/reports/punit/xml/` (configurable via `punit.report.dir` / `PUNIT_REPORT_DIR`, suppressible with `punit.report.enabled=false`). The HTML report (`./gradlew punitReport`) consumes these files. See Part 11 of the user guide for the field reference.
 - **`BaselineLookup.sourceFile`.** Matched baseline filename threaded from `BaselineResolver` through `Spec.conclude` to the verdict XML's `<provenance spec-filename>` attribute.
+
+### Known gaps in this experimental release
+
+These are the rough edges that justify the `-alpha` qualifier. Each is tracked for restoration in a subsequent release.
+
+- **Statistical early termination is not yet wired.** The 0.6.x sample loop stopped early when the outcome became impossible (failure inevitable) or guaranteed (success guaranteed); the spec-engine refactor preserved the supporting model (the `TerminationReason` enum, scenario fixtures, rendering paths) but the per-sample evaluator and the `disableEarlyTermination()` builder method on the probabilistic-test surface have not yet been re-added. Verdicts are correct — every test runs to its configured sample count and produces the right answer — but configurations that could have terminated after a few samples now run all of them.
+- **Wider feasibility-gate audit.** The pre-flight gate (see *Added* above) is wired correctly for the failure shape that motivated this release, but the catalog defines a family of related invariants — soundness floor (implied confidence < 80%, cross-intent), parameter-bounds validation, configuration-coherence checks across the threshold-first / sample-size-first / confidence-first approaches. Some of these remain unchecked. Configurations whose implied confidence falls below 80% are not yet rejected across all intents.
 
 ## [0.6.0] - 2026-04-16
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.stdlib.default.dependency=false
-punitVersion=0.6.1-SNAPSHOT
+punitVersion=0.7.0-alpha

--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/Feasibility.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/Feasibility.java
@@ -3,6 +3,7 @@ package org.javai.punit.engine.criteria;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.FactorBundle;
@@ -28,18 +29,19 @@ import org.javai.punit.statistics.VerificationFeasibilityEvaluator.FeasibilityRe
  *       allowed; a warning is returned for the caller to surface.</li>
  * </ul>
  *
- * <p>The check applies only to <em>empirical</em> {@link PassRate}
- * criteria — the only place the engine makes a confidence-backed
- * statistical claim today. Contractual {@code .meeting(threshold, origin)}
- * paths use a deterministic {@code observed >= threshold} comparison and
- * have no feasibility concern. Non-{@code PassRate} criteria
- * (e.g. {@code PercentileLatency}) are skipped pending their own
- * feasibility model.
+ * <p>The check applies to {@link PassRate} criteria — both contractual
+ * (declared SLA / SLO / POLICY threshold) and empirical (threshold
+ * derived from a resolved baseline). A contractual claim is no less
+ * in need of statistical underwriting than an empirical one: n=50
+ * with a 99.99% target at 95% confidence is infeasible regardless of
+ * whether the 99.99% came from a measurement or a contract.
+ * Non-{@code PassRate} criteria (e.g. {@code PercentileLatency}) are
+ * skipped pending their own feasibility model.
  *
- * <p>Only criteria whose baseline is resolvable at check time can be
- * checked. When no baseline file matches, feasibility is silently
- * deferred — the criterion will produce {@code INCONCLUSIVE} at evaluate
- * time, which is the correct outcome for "no baseline available."
+ * <p>Empirical criteria require a resolvable baseline at check time.
+ * When no baseline file matches, feasibility is silently deferred —
+ * the criterion will produce {@code INCONCLUSIVE} at evaluate time,
+ * which is the correct outcome for "no baseline available."
  *
  * <p>Statistics-isolation rule: the math lives in
  * {@link VerificationFeasibilityEvaluator}; this gate only
@@ -66,19 +68,29 @@ public final class Feasibility {
             FactorBundle factors,
             TestIntent intent,
             BaselineProvider provider) {
-        if (!(criterion instanceof PassRate<?> bernoulli) || !criterion.isEmpirical()) {
+        if (!(criterion instanceof PassRate<?> bernoulli)) {
             return List.of();
         }
-        Optional<PassRateStatistics> baseline = provider.baselineFor(
-                useCaseId, factors, criterion.name(), PassRateStatistics.class);
-        if (baseline.isEmpty()) {
-            return List.of();
+        double rate;
+        if (bernoulli.isEmpirical()) {
+            Optional<PassRateStatistics> baseline = provider.baselineFor(
+                    useCaseId, factors, criterion.name(), PassRateStatistics.class);
+            if (baseline.isEmpty()) {
+                return List.of();
+            }
+            rate = baseline.get().observedPassRate();
+        } else {
+            OptionalDouble target = bernoulli.contractualTarget();
+            if (target.isEmpty()) {
+                return List.of();
+            }
+            rate = target.getAsDouble();
         }
-        double rate = baseline.get().observedPassRate();
         if (rate <= 0.0 || rate >= 1.0) {
             // The evaluator requires the target in (0, 1) exclusive. A
-            // rate of exactly 0 or 1 is a degenerate baseline; the engine
-            // will surface that downstream as an INCONCLUSIVE verdict.
+            // rate of exactly 0 or 1 is degenerate; the criterion will
+            // surface that downstream as a deterministic pass/fail
+            // (contractual) or an INCONCLUSIVE verdict (empirical).
             return List.of();
         }
         FeasibilityResult result = VerificationFeasibilityEvaluator.evaluate(

--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/Feasibility.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/Feasibility.java
@@ -1,6 +1,5 @@
 package org.javai.punit.engine.criteria;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -25,8 +24,10 @@ import org.javai.punit.statistics.VerificationFeasibilityEvaluator.FeasibilityRe
  *       the resolved baseline rate, the test fails fast as misconfigured
  *       (an {@link IllegalStateException}) <em>before</em> the engine
  *       runs any samples.</li>
- *   <li>{@link TestIntent#SMOKE} — undersized configurations are
- *       allowed; a warning is returned for the caller to surface.</li>
+ *   <li>{@link TestIntent#SMOKE} — silent. The developer has
+ *       explicitly declared SMOKE intent, which means "I know this is
+ *       undersized; treat it as a sentinel." The gate produces no
+ *       warning and the run proceeds.</li>
  * </ul>
  *
  * <p>The check applies to {@link PassRate} criteria — both contractual
@@ -56,10 +57,10 @@ public final class Feasibility {
      * Check feasibility of a single {@code PassRate} criterion
      * against a resolved baseline.
      *
-     * @return a list of warnings (one per infeasible-but-tolerated
-     *         SMOKE criterion). Throws {@link IllegalStateException}
-     *         instead when intent is {@link TestIntent#VERIFICATION}
-     *         and the criterion is infeasible.
+     * @return an empty list. Throws {@link IllegalStateException}
+     *         when intent is {@link TestIntent#VERIFICATION} and the
+     *         criterion is infeasible. SMOKE-intent infeasibility is
+     *         silent — see the class javadoc.
      */
     public static List<String> check(
             int samples,
@@ -98,12 +99,12 @@ public final class Feasibility {
         if (result.feasible()) {
             return List.of();
         }
-        String diagnostic = InfeasibilityMessageRenderer.render(useCaseId, result, false);
         if (intent == TestIntent.VERIFICATION) {
-            throw new IllegalStateException(diagnostic);
+            throw new IllegalStateException(
+                    InfeasibilityMessageRenderer.render(useCaseId, result, false));
         }
-        List<String> warnings = new ArrayList<>(1);
-        warnings.add("[" + intent + "]" + diagnostic);
-        return warnings;
+        // SMOKE intent: the developer has declared "I know this is
+        // undersized; treat it as a sentinel." Silent — no warning.
+        return List.of();
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.function.Supplier;
 
 import org.javai.punit.api.ThresholdOrigin;
@@ -141,6 +142,24 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
      */
     public double confidence() {
         return confidence;
+    }
+
+    /**
+     * The contractual target rate when this criterion was built with
+     * {@link #meeting(double, ThresholdOrigin)}; empty for empirical
+     * criteria, whose target is resolved from the baseline at
+     * evaluate time.
+     *
+     * <p>Surfaced for the framework's pre-flight feasibility check:
+     * a contractual SLA / SLO / POLICY threshold is no less in need
+     * of statistical underwriting than an empirical one — n=50 with
+     * a 99.99% target at 95% confidence is infeasible regardless of
+     * where the 99.99% came from.
+     */
+    public OptionalDouble contractualTarget() {
+        return mode == Mode.CONTRACTUAL
+                ? OptionalDouble.of(threshold)
+                : OptionalDouble.empty();
     }
 
     @Override

--- a/punit-gradle-plugin/gradle.properties
+++ b/punit-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-punitVersion=0.6.1-SNAPSHOT
+punitVersion=0.7.0-alpha

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/FeasibilityIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/FeasibilityIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.Events;
 
-@DisplayName("Feasibility — VERIFICATION fails fast, SMOKE warns")
+@DisplayName("Feasibility — VERIFICATION fails fast, SMOKE proceeds silently")
 class FeasibilityIntegrationTest {
 
     private static final String JUNIT_ENGINE_ID = "junit-jupiter";
@@ -86,11 +86,12 @@ class FeasibilityIntegrationTest {
     }
 
     @Test
-    @DisplayName("SMOKE + undersized sample — engine runs; warning printed to stderr; verdict still produced")
+    @DisplayName("SMOKE + undersized sample — engine runs silently; verdict produced")
     void smokeInfeasibleAllowed() throws IOException {
-        // Same config as VerificationInfeasible but intent=SMOKE. The check
-        // warns instead of failing fast; the engine runs; the verdict is
-        // produced as if feasibility had been met.
+        // Same config as VerificationInfeasible but intent=SMOKE. The
+        // developer has declared "I know this is undersized; treat as
+        // a sentinel" — the gate produces no warning and the run
+        // proceeds.
         writeBaselineAt(0.95, 1000);
 
         Events events = run(FeasibilitySubjects.SmokeInfeasible.class);
@@ -135,7 +136,7 @@ class FeasibilityIntegrationTest {
     }
 
     @Test
-    @DisplayName("SMOKE + contractual SLA threshold + undersized sample — engine runs; warning printed")
+    @DisplayName("SMOKE + contractual SLA threshold + undersized sample — engine runs silently")
     void contractualSmokeInfeasibleAllowed() {
         Events events = run(FeasibilitySubjects.ContractualSmokeInfeasible.class);
         // Subject's use case always passes; contractual evaluator does

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/FeasibilityIntegrationTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/FeasibilityIntegrationTest.java
@@ -106,6 +106,48 @@ class FeasibilityIntegrationTest {
                 .isEqualTo(1);
     }
 
+    @Test
+    @DisplayName("VERIFICATION + contractual SLA threshold + undersized sample — feasibility fails fast")
+    void contractualVerificationInfeasibleFailsFast() {
+        // No baseline written — contractual targets do not consult one.
+        // n=50 against a contractual 99.99% target at default 95%
+        // confidence is infeasible (Wilson at observed=1.0, n=50 ≈
+        // 0.949 < 0.9999). The pre-flight gate must abort before any
+        // samples execute.
+        Events events = run(FeasibilitySubjects.ContractualVerificationInfeasible.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+        events.failed()
+                .assertThatEvents()
+                .anySatisfy(event -> {
+                    var throwable = event.getRequiredPayload(
+                            org.junit.platform.engine.TestExecutionResult.class)
+                            .getThrowable().orElseThrow();
+                    assertThat(throwable).isInstanceOf(IllegalStateException.class);
+                    assertThat(throwable.getMessage())
+                            .contains("INFEASIBLE VERIFICATION")
+                            .contains(FeasibilitySubjects.USE_CASE_ID)
+                            .contains("(50)")
+                            .contains("99.99%")
+                            .contains("At least")
+                            .contains("Increase samples")
+                            .contains("intent = SMOKE");
+                });
+    }
+
+    @Test
+    @DisplayName("SMOKE + contractual SLA threshold + undersized sample — engine runs; warning printed")
+    void contractualSmokeInfeasibleAllowed() {
+        Events events = run(FeasibilitySubjects.ContractualSmokeInfeasible.class);
+        // Subject's use case always passes; contractual evaluator does
+        // observed >= threshold, so observed=1.0 >= 0.9999 → PASS.
+        // The point of this test is the run wasn't *aborted*.
+        events.assertStatistics(stats -> stats.started(1));
+        long failedOrSucceeded = events.failed().count() + events.succeeded().count();
+        assertThat(failedOrSucceeded)
+                .as("contractual SMOKE-intent test runs to verdict; not aborted/skipped")
+                .isEqualTo(1);
+    }
+
     private void writeBaselineAt(double rate, int sampleCount) throws IOException {
         BaselineRecord record = new BaselineRecord(
                 FeasibilitySubjects.USE_CASE_ID,

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -76,15 +76,14 @@ public final class FeasibilitySubjects {
     }
 
     /**
-     * SMOKE + undersized sample: feasibility check warns but allows
-     * the engine to run; the test passes (or whatever verdict).
+     * SMOKE + undersized sample: feasibility check is silent; the
+     * engine runs; the test passes (or whatever verdict). The
+     * developer has declared SMOKE — "I know it's undersized" — so
+     * no warning is emitted.
      */
     public static final class SmokeInfeasible {
         @ProbabilisticTest
-        void shouldRunWithWarning() {
-            // Same configuration as VerificationInfeasible — n=10 against
-            // baseline 0.95 — but explicitly SMOKE intent. Run proceeds;
-            // a warning is printed to stderr.
+        void shouldRunSilently() {
             PUnit.testing(sampling(10))
                     .criterion(PassRate.<Boolean>empirical())
                     .intent(TestIntent.SMOKE)
@@ -113,12 +112,12 @@ public final class FeasibilitySubjects {
     /**
      * SMOKE + contractual threshold + undersized sample: same
      * configuration as {@link ContractualVerificationInfeasible}
-     * but with explicit SMOKE intent. The framework warns and
-     * proceeds; the engine runs to a real verdict.
+     * but with explicit SMOKE intent. The framework is silent and
+     * the engine runs to a real verdict.
      */
     public static final class ContractualSmokeInfeasible {
         @ProbabilisticTest
-        void shouldRunWithWarning() {
+        void shouldRunSilently() {
             PUnit.testing(sampling(50))
                     .criterion(PassRate.<Boolean>meeting(0.9999, ThresholdOrigin.SLA))
                     .intent(TestIntent.SMOKE)

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -3,6 +3,7 @@ package org.javai.punit.junit5.testsubjects;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.ContractBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
@@ -86,6 +87,40 @@ public final class FeasibilitySubjects {
             // a warning is printed to stderr.
             PUnit.testing(sampling(10))
                     .criterion(PassRate.<Boolean>empirical())
+                    .intent(TestIntent.SMOKE)
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * VERIFICATION + contractual threshold + undersized sample:
+     * a declared SLA / SLO / POLICY threshold is no less in need
+     * of statistical underwriting than an empirical one. n=50
+     * against a 99.99% target at 95% confidence has Wilson lower
+     * bound at observed=1.0 ≈ 0.949, well below 0.9999 → infeasible.
+     * Default intent is VERIFICATION → must throw IllegalStateException
+     * before the engine runs any samples.
+     */
+    public static final class ContractualVerificationInfeasible {
+        @ProbabilisticTest
+        void shouldFailFast() {
+            PUnit.testing(sampling(50))
+                    .criterion(PassRate.<Boolean>meeting(0.9999, ThresholdOrigin.SLA))
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * SMOKE + contractual threshold + undersized sample: same
+     * configuration as {@link ContractualVerificationInfeasible}
+     * but with explicit SMOKE intent. The framework warns and
+     * proceeds; the engine runs to a real verdict.
+     */
+    public static final class ContractualSmokeInfeasible {
+        @ProbabilisticTest
+        void shouldRunWithWarning() {
+            PUnit.testing(sampling(50))
+                    .criterion(PassRate.<Boolean>meeting(0.9999, ThresholdOrigin.SLA))
                     .intent(TestIntent.SMOKE)
                     .assertPasses();
         }


### PR DESCRIPTION
## Summary

- Restore the pre-flight feasibility gate for contractual `PassRate.meeting(threshold, origin)` criteria. The gate silently early-returned for any criterion where `!isEmpirical()`, so contractual SLA / SLO / POLICY tests under VERIFICATION intent could claim verification at any sample size and receive a verdict that *looked* statistically underwritten when the maths cannot underwrite it.
- Add the missing TestKit-driven end-to-end coverage for the contractual VERIFICATION + SMOKE pair, mirroring the existing empirical pair.

The math (`VerificationFeasibilityEvaluator`) and the diagnostic (`InfeasibilityMessageRenderer`) were both intact — they were just never reached for contractual criteria.

## The bug

`Feasibility.check()` had:

```java
if (!(criterion instanceof PassRate<?> bernoulli) || !criterion.isEmpirical()) {
    return List.of();
}
```

The class javadoc rationalised the skip:

> Contractual `.meeting(threshold, origin)` paths use a deterministic `observed >= threshold` comparison and have no feasibility concern.

That comment was the bug. A contractual SLA / SLO / POLICY claim is no less in need of statistical underwriting than an empirical one — n=50 against a 99.99% target at 95% confidence is infeasible regardless of whether the 99.99% came from a measurement or a contract.

## Reproducer

`punitexamples` `PaymentGatewaySlaTest.smokeTestsAgainstSla` — comment out `.intent(TestIntent.SMOKE)` so the test runs under the default VERIFICATION intent. Configuration: 50 samples, 99.99% target, SLA threshold, default 95% confidence.

**Before:** the test ran to completion, returning a deterministic pass/fail that looked like a verification claim.

**After:** fails fast with

```
INFEASIBLE VERIFICATION

payment-gateway

The configured sample size (50) is too small to verify a 99.99%
pass rate. At least 27053 samples are required.

REMEDIATION
  • Increase samples to at least 27053
  • Set intent = SMOKE to run as a sentinel test
```

## The fix

- `PassRate.contractualTarget()` exposes the contractual threshold as `OptionalDouble`.
- `Feasibility.check()` branches on `isEmpirical()`: empirical reads the baseline rate (existing behaviour); contractual reads the contractual target.
- Class javadoc rewritten: contractual claims need the same gate.

Two commits, test-first: the test commit fails on `main` (red bar preserved in history); the fix commit makes it pass.

## Scope deliberately narrow

This PR addresses Part 1 of orchestrator directive `DIR-BUG-FEASIBILITY-VERIFICATION-punit`. **The directive's wider audit (PT01, PT02, PT03, PT08 soundness floor, PT12, PT13) and inventory reconciliation are deferred.** A silent gate on the reproducer's shape is a strong signal that other invariants may also have gone silent, and the directive calls for one end-to-end test per invariant. That work belongs in a follow-up PR.

## Test plan

- [x] `./gradlew test` passes (full punit suite).
- [x] New `FeasibilityIntegrationTest.contractualVerificationInfeasibleFailsFast` fails on the test commit alone, passes after the fix commit.
- [x] New `FeasibilityIntegrationTest.contractualSmokeInfeasibleAllowed` passes (locks in the no-abort half of the contract).
- [x] Existing empirical `verificationInfeasibleFailsFast` / `smokeInfeasibleAllowed` / `verificationFeasible` continue to pass.
- [x] Reproducer in `punitexamples` (with `.intent(SMOKE)` removed) fails fast with the expected diagnostic naming `27053` minimum samples; line restored.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)