### PR TITLE
CT04 test-path parity + call-site length precondition for expectedOutputs

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -339,11 +339,17 @@ public final class Experiment implements Spec {
         /**
          * Expected outputs, parallel to {@code sampling.inputs()}.
          * Enables instance-conformance checking when supplied. A
-         * length mismatch is rejected at {@link #build()} with
-         * {@link IllegalStateException}.
+         * length mismatch is rejected at the call site with
+         * {@link IllegalArgumentException}; the {@link #build()} guard
+         * is preserved as defence-in-depth.
          */
         public MeasureBuilder<FT, IT, OT> expectedOutputs(List<OT> outputs) {
             Objects.requireNonNull(outputs, "outputs");
+            if (!outputs.isEmpty() && outputs.size() != sampling.inputs().size()) {
+                throw new IllegalArgumentException(
+                        "expectedOutputs (" + outputs.size() + ") and sampling.inputs() ("
+                                + sampling.inputs().size() + ") must be the same length");
+            }
             this.expected = List.copyOf(outputs);
             return this;
         }
@@ -827,6 +833,11 @@ public final class Experiment implements Spec {
             if (inputs.isEmpty()) {
                 throw new IllegalArgumentException("inputs must be non-empty");
             }
+            if (!expected.isEmpty() && expected.size() != inputs.size()) {
+                throw new IllegalArgumentException(
+                        "expectedOutputs (" + expected.size() + ") and sampling.inputs() ("
+                                + inputs.size() + ") must be the same length");
+            }
             sampling.inputs = List.copyOf(inputs);
             return this;
         }
@@ -881,8 +892,22 @@ public final class Experiment implements Spec {
             return this;
         }
 
+        /**
+         * Expected outputs, parallel to {@code inputs()}. Length is
+         * checked at the call site when {@code inputs} has already been
+         * set on this inline builder; otherwise the check defers to a
+         * subsequent {@code inputs(...)} call (symmetric guard) or to
+         * {@link #build()} (defence-in-depth).
+         */
         public InlineMeasureBuilder<FT, IT, OT> expectedOutputs(List<OT> outputs) {
-            this.expected = List.copyOf(Objects.requireNonNull(outputs, "outputs"));
+            Objects.requireNonNull(outputs, "outputs");
+            if (!outputs.isEmpty() && sampling.inputs != null
+                    && outputs.size() != sampling.inputs.size()) {
+                throw new IllegalArgumentException(
+                        "expectedOutputs (" + outputs.size() + ") and sampling.inputs() ("
+                                + sampling.inputs.size() + ") must be the same length");
+            }
+            this.expected = List.copyOf(outputs);
             return this;
         }
 

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -15,6 +15,7 @@ import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.UseCase;
+import org.javai.punit.api.ValueMatcher;
 
 /**
  * A probabilistic test: runs a {@link Sampling} bound to a factor
@@ -136,6 +137,8 @@ public final class ProbabilisticTest implements Spec {
 
         private final Sampling<FT, IT, OT> sampling;
         private final FT factors;
+        private final List<OT> expected;
+        private final Optional<ValueMatcher<OT>> matcher;
         private final List<Registered<OT>> registered;
         private final TestIntent intent;
 
@@ -144,6 +147,8 @@ public final class ProbabilisticTest implements Spec {
         private Internal(Builder<FT, IT, OT> b) {
             this.sampling = b.sampling;
             this.factors = b.factors;
+            this.expected = b.expected;
+            this.matcher = Optional.ofNullable(b.matcher);
             this.registered = List.copyOf(b.registered);
             this.intent = b.intent;
         }
@@ -152,9 +157,11 @@ public final class ProbabilisticTest implements Spec {
             return sampling.useCaseFactory();
         }
 
+        @Override public Optional<ValueMatcher<OT>> matcher() { return matcher; }
+
         @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
-            return List.of(Configuration.<FT, IT, OT>of(factors, sampling.inputs(), sampling.samples()))
-                    .iterator();
+            return List.of(new Configuration<>(
+                    factors, sampling.inputs(), expected, sampling.samples())).iterator();
         }
 
         @Override public void consume(Configuration<FT, IT, OT> config, SampleSummary<OT> summary) {
@@ -336,6 +343,8 @@ public final class ProbabilisticTest implements Spec {
 
         private final Sampling<FT, IT, OT> sampling;
         private final FT factors;
+        private List<OT> expected = List.of();
+        private ValueMatcher<OT> matcher;
         private final List<Registered<OT>> registered = new ArrayList<>();
         private TestIntent intent = TestIntent.VERIFICATION;
 
@@ -359,6 +368,40 @@ public final class ProbabilisticTest implements Spec {
         }
 
         /**
+         * Expected outputs, parallel to {@code sampling.inputs()}.
+         * Enables instance-conformance checking on the test path: the
+         * engine attaches a {@link org.javai.punit.api.MatchResult} to
+         * each sample and pass-rate criteria see match-driven pass/fail.
+         * Length is checked at the call site with
+         * {@link IllegalArgumentException}.
+         */
+        public Builder<FT, IT, OT> expectedOutputs(List<OT> outputs) {
+            Objects.requireNonNull(outputs, "outputs");
+            if (!outputs.isEmpty() && outputs.size() != sampling.inputs().size()) {
+                throw new IllegalArgumentException(
+                        "expectedOutputs (" + outputs.size() + ") and sampling.inputs() ("
+                                + sampling.inputs().size() + ") must be the same length");
+            }
+            this.expected = List.copyOf(outputs);
+            return this;
+        }
+
+        @SafeVarargs
+        public final Builder<FT, IT, OT> expectedOutputs(OT... outputs) {
+            return expectedOutputs(List.of(outputs));
+        }
+
+        /**
+         * Instance-conformance matcher, invoked per sample when
+         * {@code expectedOutputs} is supplied. Defaults to
+         * {@link ValueMatcher#equality()}.
+         */
+        public Builder<FT, IT, OT> matcher(ValueMatcher<OT> matcher) {
+            this.matcher = Objects.requireNonNull(matcher, "matcher");
+            return this;
+        }
+
+        /**
          * Declares the test's intent. Defaults to
          * {@link TestIntent#VERIFICATION}. Authors of sentinel-grade
          * smoke checks against external providers opt into
@@ -370,6 +413,9 @@ public final class ProbabilisticTest implements Spec {
         }
 
         public ProbabilisticTest build() {
+            if (!expected.isEmpty() && matcher == null) {
+                matcher = ValueMatcher.equality();
+            }
             return new ProbabilisticTest(new Internal<>(this));
         }
     }
@@ -396,6 +442,8 @@ public final class ProbabilisticTest implements Spec {
         private BudgetExhaustionPolicy budgetPolicy = BudgetExhaustionPolicy.FAIL;
         private ExceptionPolicy exceptionPolicy = ExceptionPolicy.ABORT_TEST;
         private int maxExampleFailures = 10;
+        private List<OT> expected = List.of();
+        private ValueMatcher<OT> matcher;
         private final List<Registered<OT>> registered = new ArrayList<>();
         private TestIntent intent = TestIntent.VERIFICATION;
 
@@ -408,6 +456,11 @@ public final class ProbabilisticTest implements Spec {
             Objects.requireNonNull(inputs, "inputs");
             if (inputs.isEmpty()) {
                 throw new IllegalArgumentException("inputs must be non-empty");
+            }
+            if (!expected.isEmpty() && expected.size() != inputs.size()) {
+                throw new IllegalArgumentException(
+                        "expectedOutputs (" + expected.size() + ") and sampling.inputs() ("
+                                + inputs.size() + ") must be the same length");
             }
             this.inputs = List.copyOf(inputs);
             return this;
@@ -473,6 +526,35 @@ public final class ProbabilisticTest implements Spec {
             return this;
         }
 
+        /**
+         * Expected outputs, parallel to {@code inputs()}. Length is
+         * checked at the call site when {@code inputs} has already been
+         * set on this inline builder; otherwise the check defers to a
+         * subsequent {@code inputs(...)} call (symmetric guard) or to
+         * {@link #build()} (defence-in-depth).
+         */
+        public InlineBuilder<FT, IT, OT> expectedOutputs(List<OT> outputs) {
+            Objects.requireNonNull(outputs, "outputs");
+            if (!outputs.isEmpty() && inputs != null
+                    && outputs.size() != inputs.size()) {
+                throw new IllegalArgumentException(
+                        "expectedOutputs (" + outputs.size() + ") and sampling.inputs() ("
+                                + inputs.size() + ") must be the same length");
+            }
+            this.expected = List.copyOf(outputs);
+            return this;
+        }
+
+        @SafeVarargs
+        public final InlineBuilder<FT, IT, OT> expectedOutputs(OT... outputs) {
+            return expectedOutputs(List.of(outputs));
+        }
+
+        public InlineBuilder<FT, IT, OT> matcher(ValueMatcher<OT> matcher) {
+            this.matcher = Objects.requireNonNull(matcher, "matcher");
+            return this;
+        }
+
         public ProbabilisticTest build() {
             // Empirical-criterion guard. The integrity guarantee for an
             // empirical comparison comes from sharing a Sampling value
@@ -521,6 +603,12 @@ public final class ProbabilisticTest implements Spec {
 
             Builder<FT, IT, OT> delegate = new Builder<>(sampling, factors);
             delegate.intent(intent);
+            if (!expected.isEmpty()) {
+                delegate.expectedOutputs(expected);
+            }
+            if (matcher != null) {
+                delegate.matcher(matcher);
+            }
             for (Registered<OT> r : registered) {
                 if (r.role() == CriterionRole.REQUIRED) {
                     delegate.criterion(r.criterion());

--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -587,6 +587,25 @@ public final class PUnit {
             return this;
         }
 
+        /** See {@link ProbabilisticTest.Builder#expectedOutputs(List)}. */
+        public TestBuilder<FT, IT, OT> expectedOutputs(List<OT> outputs) {
+            delegate.expectedOutputs(outputs);
+            return this;
+        }
+
+        /** See {@link ProbabilisticTest.Builder#expectedOutputs(Object[])}. */
+        @SafeVarargs
+        public final TestBuilder<FT, IT, OT> expectedOutputs(OT... outputs) {
+            delegate.expectedOutputs(outputs);
+            return this;
+        }
+
+        /** See {@link ProbabilisticTest.Builder#matcher(ValueMatcher)}. */
+        public TestBuilder<FT, IT, OT> matcher(ValueMatcher<OT> matcher) {
+            delegate.matcher(matcher);
+            return this;
+        }
+
         /**
          * Enables verbose statistical reporting on every verdict —
          * including PASS — with the framework's hypothesis-test

--- a/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EngineIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.MatchResult;
@@ -250,24 +251,197 @@ class EngineIntegrationTest {
     }
 
     @Test
-    @DisplayName("Experiment rejects expectedOutputs whose length does not match sampling.inputs")
+    @DisplayName("MeasureBuilder.expectedOutputs: length mismatch throws IllegalArgumentException at the call site")
     void rejectsMismatchedExpectedOutputsLength() {
+        Sampling<LlmFactors, String, String> sampling = identityStringSampling("a", "b");
+        assertThatThrownBy(() -> Experiment.measuring(sampling, new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("A")) // only one; inputs has two
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expectedOutputs (1) and sampling.inputs() (2) must be the same length");
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest: custom matcher drives the verdict's pass-rate criterion")
+    void testPathInstanceConformanceUsesCustomMatcher() {
+        UseCase<LlmFactors, String, String> returnSameCase = new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+        };
+        ValueMatcher<String> caseInsensitive =
+                (exp, act) -> exp.equalsIgnoreCase(act)
+                        ? MatchResult.pass("equalsIgnoreCase", exp, act)
+                        : MatchResult.fail("equalsIgnoreCase", exp, act,
+                                "case-insensitive comparison failed");
+
         Sampling<LlmFactors, String, String> sampling = Sampling
                 .<LlmFactors, String, String>builder()
-                .useCaseFactory(f -> new UseCase<LlmFactors, String, String>() {
-                    @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
-                    @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
-                        return Outcome.ok(input);
-                    }
-                })
-                .inputs("a", "b")
+                .useCaseFactory(f -> returnSameCase)
+                .inputs("HELLO", "WORLD")
+                .samples(10)
                 .build();
-        assertThatThrownBy(() -> Experiment.measuring(sampling, new LlmFactors("gpt-4o", 0.0))
-                .expectedOutputs("A") // only one; inputs has two
-                .build())
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("hello", "world")
+                .matcher(caseInsensitive)
+                .criterion(PassRate.<String>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsEntry("successes", 10);
+        assertThat(detail).containsEntry("failures", 0);
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest: expectedOutputs without explicit matcher defaults to equality")
+    void testPathDefaultsToEqualityMatcher() {
+        UseCase<LlmFactors, String, String> upperCase = new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input.toUpperCase());
+            }
+        };
+
+        Sampling<LlmFactors, String, String> sampling = Sampling
+                .<LlmFactors, String, String>builder()
+                .useCaseFactory(f -> upperCase)
+                .inputs("a", "b")
+                .samples(4)
+                .build();
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("A", "Q") // first matches under equality, second doesn't
+                .criterion(PassRate.<String>meeting(0.4, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        // 4 samples cycle through 2 expectations: 2 match (A==A), 2 mismatch (B!=Q)
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsEntry("successes", 2);
+        assertThat(detail).containsEntry("failures", 2);
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest.Builder.expectedOutputs: length mismatch throws IllegalArgumentException at the call site")
+    void testPathBoundExpectedOutputsRejectsLengthMismatch() {
+        Sampling<LlmFactors, String, String> sampling = identityStringSampling("a", "b");
+        assertThatThrownBy(() -> ProbabilisticTest.testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("A"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expectedOutputs (1) and sampling.inputs() (2) must be the same length");
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest.Builder.expectedOutputs(varargs): length mismatch throws IllegalArgumentException at the call site")
+    void testPathBoundExpectedOutputsVarargsRejectsLengthMismatch() {
+        Sampling<LlmFactors, String, String> sampling = identityStringSampling("a", "b");
+        assertThatThrownBy(() -> ProbabilisticTest.testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs(new String[] {"A", "B", "C"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expectedOutputs (3) and sampling.inputs() (2) must be the same length");
+    }
+
+    @Test
+    @DisplayName("InlineMeasureBuilder: expectedOutputs after inputs with mismatched length throws IllegalArgumentException at the call site")
+    void inlineMeasureRejectsMismatchedExpectedOutputsAfterInputs() {
+        assertThatThrownBy(() -> Experiment.measuring(
+                        (Function<LlmFactors, UseCase<LlmFactors, String, String>>) f -> identityStringUseCase(),
+                        new LlmFactors("gpt-4o", 0.0))
+                .inputs("a", "b")
+                .expectedOutputs("A"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expectedOutputs (1) and sampling.inputs() (2) must be the same length");
+    }
+
+    @Test
+    @DisplayName("InlineMeasureBuilder: expectedOutputs before inputs is accepted; mismatched inputs(...) afterwards throws")
+    void inlineMeasureDefersThenSymmetricallyRejects() {
+        var builder = Experiment.measuring(
+                        (Function<LlmFactors, UseCase<LlmFactors, String, String>>) f -> identityStringUseCase(),
+                        new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("A");   // no throw — inputs not yet set
+        assertThatThrownBy(() -> builder.inputs("a", "b"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expectedOutputs (1) and sampling.inputs() (2) must be the same length");
+    }
+
+    @Test
+    @DisplayName("InlineMeasureBuilder: expectedOutputs before inputs with matching length builds successfully")
+    void inlineMeasureDeferredCheckPassesOnMatchingInputs() {
+        Experiment spec = Experiment.measuring(
+                        (Function<LlmFactors, UseCase<LlmFactors, String, String>>) f -> identityStringUseCase(),
+                        new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("A", "B")     // set before inputs
+                .inputs("a", "b")               // matching length — symmetric check passes
+                .samples(2)
+                .build();
+        // Run to completion — proves the configured matcher pipeline survives the inline assembly.
+        new Engine().run(spec);
+        assertThat(spec.lastSummary()).isPresent();
+    }
+
+    @Test
+    @DisplayName("InlineProbabilisticTest builder: expectedOutputs after inputs with mismatched length throws at the call site")
+    void inlineTestRejectsMismatchedExpectedOutputsAfterInputs() {
+        assertThatThrownBy(() -> ProbabilisticTest.testing(
+                        (Function<LlmFactors, UseCase<LlmFactors, String, String>>) f -> identityStringUseCase(),
+                        new LlmFactors("gpt-4o", 0.0))
+                .inputs("a", "b")
+                .expectedOutputs("A"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expectedOutputs (1) and sampling.inputs() (2) must be the same length");
+    }
+
+    @Test
+    @DisplayName("InlineProbabilisticTest builder: expectedOutputs before inputs is accepted; mismatched inputs(...) afterwards throws")
+    void inlineTestDefersThenSymmetricallyRejects() {
+        var builder = ProbabilisticTest.testing(
+                        (Function<LlmFactors, UseCase<LlmFactors, String, String>>) f -> identityStringUseCase(),
+                        new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("A");   // no throw — inputs not yet set
+        assertThatThrownBy(() -> builder.inputs("a", "b"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("expectedOutputs (1) and sampling.inputs() (2) must be the same length");
+    }
+
+    @Test
+    @DisplayName("MeasureBuilder.build(): defence-in-depth IllegalStateException still fires when expected/inputs disagree at build time")
+    void measureBuildTimeGuardStillFiresAsDefenceInDepth() throws Exception {
+        // The call-time check on expectedOutputs(...) means the build-time
+        // guard at MeasureBuilder.build() is unreachable through the public
+        // API. Reflection lets us bypass the call-time check to confirm the
+        // build-time guard remains in place — defence-in-depth coverage.
+        Sampling<LlmFactors, String, String> sampling = identityStringSampling("a", "b");
+        var builder = Experiment.measuring(sampling, new LlmFactors("gpt-4o", 0.0));
+        var expectedField = Experiment.MeasureBuilder.class.getDeclaredField("expected");
+        expectedField.setAccessible(true);
+        expectedField.set(builder, List.of("A"));   // bypass call-time check
+
+        assertThatThrownBy(builder::build)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("expectedOutputs")
-                .hasMessageContaining("inputs");
+                .hasMessage("expectedOutputs (1) and sampling.inputs() (2) must be the same length");
+    }
+
+    private Sampling<LlmFactors, String, String> identityStringSampling(String... inputs) {
+        return Sampling.<LlmFactors, String, String>builder()
+                .useCaseFactory(f -> identityStringUseCase())
+                .inputs(inputs)
+                .samples(inputs.length)
+                .build();
+    }
+
+    private static UseCase<LlmFactors, String, String> identityStringUseCase() {
+        return new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+        };
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two coordinated changes around the CT04 instance-conformance surface, per
[`DIR-CT04` in the orchestrator](../../javai-orchestrator/blob/main/plan/directives/DIR-CT04-test-path-punit.md):

- **§ 1 — test-path parity.** `expectedOutputs(List)` / `expectedOutputs(varargs)` /
  `matcher(ValueMatcher)` are now available on `ProbabilisticTest.Builder`,
  `ProbabilisticTest.InlineBuilder`, and `PUnit.TestBuilder`, mirroring the
  measure-side surface exactly. `Internal` carries the new fields, overrides
  `TypedSpec.matcher()`, and propagates `expected` through the full-arity
  `Configuration` constructor. Default to `ValueMatcher.equality()` when
  `expectedOutputs` is set without an explicit matcher — same fallback as the
  measure path. Authors can now author *"this LLM agrees with our golden labels
  at >= 95%"* as a regression-gating CI test, not a baseline-only capability.

- **§ 2 — length precondition relocated to call site.** Every sampling-bound
  `expectedOutputs(...)` overload (measure + test) now throws
  `IllegalArgumentException` at the call site when
  `outputs.size() != sampling.inputs().size()`. Inline-form overloads defer to
  a symmetric guard on `inputs(...)` when `expectedOutputs(...)` is called
  first. The `build()`-time guard is preserved as defence-in-depth (now
  reachable only via reflection — exercised by
  `measureBuildTimeGuardStillFiresAsDefenceInDepth`). Canonical message text
  — `"expectedOutputs (N) and sampling.inputs() (M) must be the same length"`
  — is identical across all four surfaces.

## Note on the existing test

`rejectsMismatchedExpectedOutputsLength` had to be updated in lock-step: it
calls `.expectedOutputs("A").build()` and asserted `IllegalStateException`
from `.build()`. With § 2's call-site relocation that throw moves to
`.expectedOutputs("A")` as `IllegalArgumentException`. The directive's
"all existing tests pass without modification" goal collides with § 2's
behaviour change at exactly this test; the canonical message text is
unchanged, only the type and line of the throw move. Flagging it explicitly
because it's the one existing test the directive's wording would have
preserved.

## Out of scope (per directive)

- `Sampling.matching(...)` semantics — left untouched; `Sampling.expected()` /
  `.matcher()` remain dormant on the test path as on the measure path.
- Unifying the shipped DX with the catalog DX
  (`outcome.expecting(...)` / `StringMatcher` / `JsonMatcher` /
  `ResultExtractor`) — separate, larger piece of work.
- Engine, `SerialSampleExecutor`, `Aggregator` changes — the plumbing was
  already correct; the gap was exclusively in the spec-builder surface and
  in `ProbabilisticTest.Internal.configurations()`.

## Test plan

- [x] `./gradlew test` — full punit gate green (~12s, all modules).
- [x] `./gradlew :punit-core:test --tests "EngineIntegrationTest"` — 26/26 PASSED, including the 11 new/updated tests:
  - test-path happy path with custom matcher
  - test-path default-equality fallback when matcher omitted
  - call-time `IllegalArgumentException` on bound `MeasureBuilder.expectedOutputs(List)` (existing test, updated)
  - call-time `IllegalArgumentException` on bound `ProbabilisticTest.Builder.expectedOutputs(List)` and varargs
  - call-time `IllegalArgumentException` on `InlineMeasureBuilder` and `ProbabilisticTest.InlineBuilder` when inputs already set
  - inline-form deferred check: `expectedOutputs(...)` before `inputs(...)` is accepted; later mismatched `inputs(...)` throws with canonical message; matching `inputs(...)` builds successfully
  - build-time defence-in-depth `IllegalStateException` still fires when bypassed via reflection

After merge: update `inventory/FEATURES.md` to record CT04 test-path support and move
`plan/directives/DIR-CT04-test-path-punit.md` to `plan/directives/archived/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)