### PR TITLE
Empirical threshold derivation: Wilson at n_test (companion §3.4 / §4.3.2)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
@@ -18,6 +18,8 @@ import org.javai.punit.api.spec.PassRateStatistics;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.statistics.BinomialProportionEstimator;
+import org.javai.punit.statistics.DerivedThreshold;
+import org.javai.punit.statistics.ThresholdDeriver;
 
 /**
  * A Bernoulli pass-rate criterion. Reads {@link PassRateStatistics}
@@ -35,15 +37,16 @@ import org.javai.punit.statistics.BinomialProportionEstimator;
  *       derived from the explicitly supplied baseline.</li>
  * </ul>
  *
- * <p>The empirical paths wrap the observed pass rate in a Wilson-score
- * one-sided lower bound at the criterion's
- * {@link #atConfidence(double) confidence} (default 0.95) and PASS
- * iff that bound respects the baseline-derived threshold. The
- * underlying statistical machinery is
- * {@link BinomialProportionEstimator}; this criterion holds no
- * statistical code of its own — that's the punit design rule
- * (statistics live only in {@code org.javai.punit.statistics}). See
- * {@code CLAUDE.md} §"Statistics isolation rule".
+ * <p>The empirical paths derive a threshold by applying the one-sided
+ * Wilson lower bound at the test sample size to the baseline rate
+ * (with a perfect-baseline two-step refinement when {@code k = n};
+ * statistical companion §3.4 / §4.3.2), and PASS iff the observed
+ * pass rate respects that derived threshold (§5.1). The underlying
+ * statistical machinery is {@link BinomialProportionEstimator}; this
+ * criterion holds no statistical code of its own — that's the punit
+ * design rule (statistics live only in
+ * {@code org.javai.punit.statistics}). See {@code CLAUDE.md}
+ * §"Statistics isolation rule".
  *
  * <p>The contractual path keeps a deterministic
  * {@code observed >= threshold} check: an SLA-style threshold is an
@@ -59,7 +62,7 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
 
     private static final String NAME = "bernoulli-pass-rate";
     private static final double DEFAULT_CONFIDENCE = 0.95;
-    private static final BinomialProportionEstimator ESTIMATOR = new BinomialProportionEstimator();
+    private static final ThresholdDeriver DERIVER = new ThresholdDeriver();
 
     private enum Mode { CONTRACTUAL, EMPIRICAL_DEFAULT, EMPIRICAL_PINNED }
 
@@ -189,6 +192,7 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
         double resolvedThreshold;
         ThresholdOrigin resolvedOrigin;
         Integer baselineSampleCount = null;
+        Double baselineRate = null;
 
         if (mode == Mode.CONTRACTUAL) {
             resolvedThreshold = threshold;
@@ -224,25 +228,22 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
             if (sizeViolation.isPresent()) {
                 return sizeViolation.get();
             }
-            resolvedThreshold = stats.observedPassRate();
+            // Empirical: derive the threshold via the sample-size-first
+            // construction at the test sample size (statistical companion
+            // §3.4 / §4.3.2). The decision rule (§5.1) compares the raw
+            // observed pass rate against this derived threshold.
+            int baselineSuccesses = (int) Math.round(
+                    stats.observedPassRate() * stats.sampleCount());
+            DerivedThreshold derived = DERIVER.deriveSampleSizeFirst(
+                    stats.sampleCount(), baselineSuccesses, total, confidence);
+            resolvedThreshold = derived.value();
             resolvedOrigin = ThresholdOrigin.EMPIRICAL;
             baselineSampleCount = stats.sampleCount();
+            baselineRate = stats.observedPassRate();
         }
 
         double observed = (double) summary.successes() / (double) total;
-        Verdict verdict;
-        Double wilsonLower = null;
-        if (mode == Mode.CONTRACTUAL) {
-            verdict = observed >= resolvedThreshold ? Verdict.PASS : Verdict.FAIL;
-        } else {
-            // Empirical: wrap the observed value in a Wilson-score one-sided
-            // lower bound at the criterion's confidence; PASS iff the bound
-            // respects the baseline-derived threshold. The calculation lives
-            // in the dedicated statistics package — see CLAUDE.md
-            // §"Statistics isolation rule".
-            wilsonLower = ESTIMATOR.lowerBound(summary.successes(), total, confidence);
-            verdict = wilsonLower >= resolvedThreshold ? Verdict.PASS : Verdict.FAIL;
-        }
+        Verdict verdict = observed >= resolvedThreshold ? Verdict.PASS : Verdict.FAIL;
 
         Map<String, Object> detail = new LinkedHashMap<>();
         detail.put("observed", observed);
@@ -253,8 +254,8 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
         detail.put("total", total);
         if (mode != Mode.CONTRACTUAL) {
             detail.put("confidence", confidence);
-            detail.put("wilsonLowerBound", wilsonLower);
             detail.put("baselineSampleCount", baselineSampleCount);
+            detail.put("baselineRate", baselineRate);
         }
 
         String explanation = mode == Mode.CONTRACTUAL
@@ -262,10 +263,10 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
                         "observed=%.4f, threshold=%.4f (origin=%s) over %d samples",
                         observed, resolvedThreshold, resolvedOrigin, total)
                 : String.format(
-                        "observed=%.4f (Wilson-%.0f%% lower=%.4f) vs threshold=%.4f "
-                                + "(origin=%s) over %d samples",
-                        observed, confidence * 100.0, wilsonLower, resolvedThreshold,
-                        resolvedOrigin, total);
+                        "observed=%.4f vs threshold=%.4f (Wilson-%.0f%% lower of "
+                                + "baseline rate %.4f at n_test=%d; origin=%s) over %d samples",
+                        observed, resolvedThreshold, confidence * 100.0,
+                        baselineRate, total, resolvedOrigin, total);
 
         return new CriterionResult(NAME, verdict, explanation, detail);
     }

--- a/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
@@ -117,17 +117,38 @@ public class BinomialProportionEstimator {
      */
     public double lowerBound(int successes, int trials, double confidenceLevel) {
         validateInputs(successes, trials);
-        validateConfidenceLevel(confidenceLevel);
-        
         double pHat = (double) successes / trials;
-        
-        // z-score for one-sided bound: z_α
-        // For 95% confidence: α = 0.05, so we need z_{0.95} ≈ 1.645
+        return lowerBoundFromRate(pHat, trials, confidenceLevel);
+    }
+
+    /**
+     * Computes the one-sided Wilson lower bound from a continuous rate.
+     *
+     * <p>Same Wilson formula as {@link #lowerBound}, but takes a continuous
+     * proportion {@code pHat} rather than discrete successes. Used by the
+     * two-step threshold construction (statistical companion §4.3.2),
+     * where the second step needs to apply Wilson at {@code n_test} with
+     * a rate already derived from the baseline.
+     *
+     * @param pHat            the rate to wrap, in [0, 1]
+     * @param trials          the sample size n at which to evaluate Wilson
+     * @param confidenceLevel one-sided confidence level (1 − α)
+     * @return Wilson one-sided lower bound at the given rate and sample size
+     */
+    public double lowerBoundFromRate(double pHat, int trials, double confidenceLevel) {
+        if (Double.isNaN(pHat) || pHat < 0.0 || pHat > 1.0) {
+            throw new IllegalArgumentException(
+                    "pHat must be in [0, 1], got: " + pHat);
+        }
+        if (trials <= 0) {
+            throw new IllegalArgumentException("Trials must be positive, got: " + trials);
+        }
+        validateConfidenceLevel(confidenceLevel);
+
         double alpha = 1.0 - confidenceLevel;
         double z = STANDARD_NORMAL.inverseCumulativeProbability(1.0 - alpha);
-		CenterMargin centerMargin = getCenterMargin(trials, z, pHat);
-
-		return Math.max(0.0, centerMargin.lower());
+        CenterMargin centerMargin = getCenterMargin(trials, z, pHat);
+        return Math.max(0.0, centerMargin.lower());
     }
     
     /**

--- a/punit-core/src/main/java/org/javai/punit/statistics/ThresholdDeriver.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/ThresholdDeriver.java
@@ -75,19 +75,35 @@ public class ThresholdDeriver {
             int baselineSuccesses,
             int testSamples,
             double thresholdConfidence) {
-        
+
         validateInputs(baselineSamples, baselineSuccesses, testSamples, thresholdConfidence);
-        
+
         double baselineRate = (double) baselineSuccesses / baselineSamples;
-        
-        // Derive threshold as Wilson one-sided lower bound
-        // This accounts for uncertainty in the baseline estimate
-        double threshold = estimator.lowerBound(baselineSuccesses, baselineSamples, thresholdConfidence);
-        
+        double effectiveBaselineRate = effectiveBaselineRate(
+                baselineSuccesses, baselineSamples, thresholdConfidence);
+        double threshold = estimator.lowerBoundFromRate(
+                effectiveBaselineRate, testSamples, thresholdConfidence);
+
         DerivationContext context = new DerivationContext(
             baselineRate, baselineSamples, testSamples, thresholdConfidence);
-        
+
         return new DerivedThreshold(threshold, OperationalApproach.SAMPLE_SIZE_FIRST, context, true);
+    }
+
+    /**
+     * Effective baseline rate per the statistical companion's two-step
+     * construction (§4.3.2): when the baseline observed perfect success
+     * (k = n) the raw rate of 1.0 has zero variance and would force the
+     * threshold to 1.0; instead the discrete one-sided Wilson lower
+     * bound at {@code n_baseline} carries forward as the rate. Otherwise
+     * the effective rate is simply the observed proportion.
+     */
+    private double effectiveBaselineRate(
+            int baselineSuccesses, int baselineSamples, double confidence) {
+        if (baselineSuccesses == baselineSamples) {
+            return estimator.lowerBound(baselineSuccesses, baselineSamples, confidence);
+        }
+        return (double) baselineSuccesses / baselineSamples;
     }
     
     /**
@@ -128,79 +144,52 @@ public class ThresholdDeriver {
         }
         
         double baselineRate = (double) baselineSuccesses / baselineSamples;
-        
-        // Compute implied confidence by finding what confidence level would
-        // produce this threshold from the baseline data
+
         double impliedConfidence = computeImpliedConfidence(
-            baselineSuccesses, baselineSamples, explicitThreshold);
-        
+            baselineSuccesses, baselineSamples, testSamples, explicitThreshold);
+
         // Consider statistically sound if implied confidence ≥ 80%
         boolean isStatisticallySound = impliedConfidence >= 0.80;
-        
+
         DerivationContext context = new DerivationContext(
             baselineRate, baselineSamples, testSamples, impliedConfidence);
-        
+
         return new DerivedThreshold(
             explicitThreshold, OperationalApproach.THRESHOLD_FIRST, context, isStatisticallySound);
     }
-    
+
     /**
-     * Computes the implied confidence level for a given threshold.
-     * 
-     * <p>This inverts the Wilson lower bound calculation: given a threshold,
-     * find what confidence level would produce it.
-     * 
-     * <p>Uses binary search since the inverse has no closed form.
-     * 
-     * @param successes Baseline successes
-     * @param trials Baseline trials
-     * @param threshold The target threshold
-     * @return Implied confidence level
+     * Implied confidence level for a given target threshold (statistical
+     * companion §6.3): the confidence at which
+     * {@link #deriveSampleSizeFirst} would produce the same threshold.
+     *
+     * <p>Uses binary search; the inverse has no closed form.
      */
-    private double computeImpliedConfidence(int successes, int trials, double threshold) {
-        double pHat = (double) successes / trials;
-        
-        // If threshold >= baseline rate, implied confidence is very low
-        if (threshold >= pHat) {
-            // Find the exact value by binary search
-            // Lower bound on confidence = 0.5 (50%) when threshold = baseline
-            return binarySearchConfidence(successes, trials, threshold, 0.01, 0.5);
-        }
-        
-        // Binary search for the confidence level that produces this threshold
-        // Use a very high upper bound to handle thresholds well below the point estimate
-        return binarySearchConfidence(successes, trials, threshold, 0.5, 0.9999999);
-    }
-    
-    /**
-     * Binary search to find confidence level that produces target threshold.
-     */
-    private double binarySearchConfidence(
-            int successes, int trials, double targetThreshold,
-            double lowConf, double highConf) {
-        
+    private double computeImpliedConfidence(
+            int baselineSuccesses, int baselineSamples, int testSamples, double targetThreshold) {
         double tolerance = 1e-10;
         int maxIterations = 100;
-        
+        double lowConf = 1e-6;
+        double highConf = 1.0 - 1e-6;
+
         for (int i = 0; i < maxIterations; i++) {
             double midConf = (lowConf + highConf) / 2.0;
-            double derivedThreshold = estimator.lowerBound(successes, trials, midConf);
-            
+            double effectiveRate = effectiveBaselineRate(
+                    baselineSuccesses, baselineSamples, midConf);
+            double derivedThreshold = estimator.lowerBoundFromRate(
+                    effectiveRate, testSamples, midConf);
+
             if (Math.abs(derivedThreshold - targetThreshold) < tolerance) {
                 return midConf;
             }
-            
-            // Wilson lower bound DECREASES with confidence level:
-            // Higher confidence → higher z-score → larger margin → lower lower bound
+            // Derived threshold decreases with confidence: higher z → larger margin.
             if (derivedThreshold > targetThreshold) {
-                // Current lower bound is too high → need more confidence to lower it
                 lowConf = midConf;
             } else {
-                // Current lower bound is too low → need less confidence to raise it
                 highConf = midConf;
             }
         }
-        
+
         return (lowConf + highConf) / 2.0;
     }
     

--- a/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/EmpiricalEndToEndIntegrationTest.java
@@ -101,8 +101,10 @@ class EmpiricalEndToEndIntegrationTest {
         assertThat(result.verdict()).isEqualTo(Verdict.PASS);
         var detail = result.criterionResults().get(0).result().detail();
         assertThat(detail).containsEntry("origin", "EMPIRICAL");
-        assertThat(detail).containsEntry("threshold", 0.80);
         assertThat(detail).containsEntry("baselineSampleCount", 1000);
+        assertThat(detail).containsEntry("baselineRate", 0.80);
+        // Companion §3.4: derived threshold sits below the baseline rate.
+        assertThat((double) detail.get("threshold")).isLessThan(0.80);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/engine/criteria/PassRateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/criteria/PassRateTest.java
@@ -147,96 +147,100 @@ class PassRateTest {
     }
 
     @Test
-    @DisplayName("empirical() PASS when Wilson lower bound clears the baseline threshold")
+    @DisplayName("empirical() PASS when observed pass rate clears the derived threshold")
     void empiricalWithBaselinePass() {
         PassRate<String> criterion = PassRate.empirical();
         PassRateStatistics baseline = new PassRateStatistics(0.88, 2000);
 
-        // p=0.95, n=1000, c=0.95 → Wilson lower ≈ 0.934 ≥ 0.88 → PASS
+        // baseline rate 0.88, test n=1000, c=0.95 → derived threshold ≈ 0.862;
+        // observed 0.95 ≥ 0.862 → PASS.
         CriterionResult pass = criterion.evaluate(ctx(summary(950, 50), Optional.of(baseline)));
 
         assertThat(pass.verdict()).isEqualTo(Verdict.PASS);
         assertThat(pass.detail()).containsEntry("origin", "EMPIRICAL");
         assertThat(pass.detail()).containsEntry("baselineSampleCount", 2000);
-        assertThat((double) pass.detail().get("threshold")).isEqualTo(0.88);
-        assertThat((double) pass.detail().get("wilsonLowerBound"))
-                .isGreaterThanOrEqualTo(0.88);
+        assertThat((double) pass.detail().get("threshold")).isLessThan(0.88);
+        assertThat((double) pass.detail().get("observed"))
+                .isGreaterThanOrEqualTo((double) pass.detail().get("threshold"));
     }
 
     @Test
-    @DisplayName("empirical() FAIL when Wilson lower bound dips below the baseline threshold")
+    @DisplayName("empirical() FAIL when observed pass rate dips below the derived threshold")
     void empiricalWithBaselineFail() {
         PassRate<String> criterion = PassRate.empirical();
-        PassRateStatistics baseline = new PassRateStatistics(0.88, 2000);
+        PassRateStatistics baseline = new PassRateStatistics(0.95, 2000);
 
-        // p=0.85, n=1000, c=0.95 → Wilson lower ≈ 0.827 < 0.88 → FAIL
-        CriterionResult fail = criterion.evaluate(ctx(summary(850, 150), Optional.of(baseline)));
+        // baseline rate 0.95, test n=1000, c=0.95 → derived threshold ≈ 0.937;
+        // observed 0.92 < 0.937 → FAIL.
+        CriterionResult fail = criterion.evaluate(ctx(summary(920, 80), Optional.of(baseline)));
 
         assertThat(fail.verdict()).isEqualTo(Verdict.FAIL);
-        assertThat((double) fail.detail().get("wilsonLowerBound")).isLessThan(0.88);
+        assertThat((double) fail.detail().get("observed"))
+                .isLessThan((double) fail.detail().get("threshold"));
     }
 
     @Test
-    @DisplayName("empirical() Wilson-score wrap: small n + observed-just-above-threshold → FAIL "
-            + "(this was an incorrect PASS under the Stage-3.5 placeholder)")
-    void empiricalWilsonRejectsSmallSampleNearThreshold() {
+    @DisplayName("empirical() smaller test n widens the interval and lowers the threshold")
+    void empiricalSmallerTestSampleLowersThreshold() {
         PassRate<String> criterion = PassRate.empirical();
         PassRateStatistics baseline = new PassRateStatistics(0.88, 1000);
 
-        // p=0.90, n=50, c=0.95 → Wilson lower ≈ 0.788 — below the 0.88 threshold.
-        // Under the placeholder `observed >= threshold` this would PASS (0.90 > 0.88);
-        // under Wilson-score it correctly FAILs because 50 samples is not enough
-        // to confidently claim ≥ 0.88.
-        CriterionResult result = criterion.evaluate(ctx(summary(45, 5), Optional.of(baseline)));
+        // Companion §3.5 / §3.4: smaller n_test → wider Wilson interval → lower
+        // threshold. The threshold compensates for sampling uncertainty in the
+        // test, so a small-n test is permitted a more lenient bar.
+        CriterionResult small = criterion.evaluate(ctx(summary(45, 5), Optional.of(baseline)));
+        CriterionResult large = criterion.evaluate(ctx(summary(450, 50), Optional.of(baseline)));
 
-        assertThat(result.verdict()).isEqualTo(Verdict.FAIL);
-        assertThat((double) result.detail().get("observed")).isEqualTo(0.9);
-        assertThat((double) result.detail().get("wilsonLowerBound")).isLessThan(0.88);
+        double smallThreshold = (double) small.detail().get("threshold");
+        double largeThreshold = (double) large.detail().get("threshold");
+        assertThat(smallThreshold).isLessThan(largeThreshold);
     }
 
     @Test
-    @DisplayName("empirical() detail map carries confidence and wilsonLowerBound")
-    void empiricalDetailMapCarriesWilsonFields() {
+    @DisplayName("empirical() detail map carries confidence, threshold, and baseline rate")
+    void empiricalDetailMapCarriesMethodologyFields() {
         PassRate<String> criterion = PassRate.empirical();
         PassRateStatistics baseline = new PassRateStatistics(0.88, 2000);
 
         CriterionResult result = criterion.evaluate(ctx(summary(950, 50), Optional.of(baseline)));
 
-        assertThat(result.detail()).containsKeys("confidence", "wilsonLowerBound");
-        assertThat(result.detail()).doesNotContainKey("wilsonUpperBound");
+        assertThat(result.detail()).containsKeys(
+                "confidence", "threshold", "baselineRate", "baselineSampleCount");
+        assertThat(result.detail()).doesNotContainKey("wilsonLowerBound");
         assertThat((double) result.detail().get("confidence")).isEqualTo(0.95);
-        double lower = (double) result.detail().get("wilsonLowerBound");
-        assertThat(lower).isLessThan(0.95);
-        assertThat(lower).isGreaterThan(0.88);
+        assertThat((double) result.detail().get("baselineRate")).isEqualTo(0.88);
+        // Derived threshold sits below the baseline rate (companion §3.4): we
+        // are 95% confident the true rate is at least this low under sampling.
+        assertThat((double) result.detail().get("threshold")).isLessThan(0.88);
     }
 
     @Test
-    @DisplayName("empirical() explanation names the Wilson lower bound at the configured confidence")
-    void empiricalExplanationMentionsWilsonBound() {
+    @DisplayName("empirical() explanation names the threshold and its baseline-rate provenance")
+    void empiricalExplanationMentionsDerivedThreshold() {
         PassRate<String> criterion = PassRate.empirical();
         PassRateStatistics baseline = new PassRateStatistics(0.88, 2000);
 
         CriterionResult result = criterion.evaluate(ctx(summary(950, 50), Optional.of(baseline)));
 
         assertThat(result.explanation())
-                .contains("Wilson-95% lower=")
-                .contains("threshold=");
+                .contains("threshold=")
+                .contains("baseline rate")
+                .contains("Wilson-95% lower");
     }
 
     @Test
-    @DisplayName("atConfidence(higher) widens the interval — more conservative PASS criterion")
-    void higherConfidenceWidensInterval() {
+    @DisplayName("atConfidence(higher) lowers the derived threshold — less willing to claim degradation")
+    void higherConfidenceLowersThreshold() {
         PassRateStatistics baseline = new PassRateStatistics(0.88, 2000);
-        // p=0.92, n=1000 — passes at 95% (wilson lower ≈ 0.901), fails at 99.9%
         PassRate<String> at95 = PassRate.<String>empirical().atConfidence(0.95);
         PassRate<String> at999 = PassRate.<String>empirical().atConfidence(0.999);
 
         CriterionResult r95 = at95.evaluate(ctx(summary(920, 80), Optional.of(baseline)));
         CriterionResult r999 = at999.evaluate(ctx(summary(920, 80), Optional.of(baseline)));
 
-        double lower95 = (double) r95.detail().get("wilsonLowerBound");
-        double lower999 = (double) r999.detail().get("wilsonLowerBound");
-        assertThat(lower999).isLessThan(lower95);
+        double threshold95 = (double) r95.detail().get("threshold");
+        double threshold999 = (double) r999.detail().get("threshold");
+        assertThat(threshold999).isLessThan(threshold95);
     }
 
     // ── sample-size constraint (test_N ≤ baseline_N) ───────────────

--- a/punit-core/src/test/java/org/javai/punit/statistics/TestVerdictEvaluatorTest.java
+++ b/punit-core/src/test/java/org/javai/punit/statistics/TestVerdictEvaluatorTest.java
@@ -318,29 +318,27 @@ class TestVerdictEvaluatorTest {
         @Test
         @DisplayName("test failure with qualified interpretation")
         void testFailureWithQualifiedInterpretation() {
-            // From STATISTICAL-COMPANION:
-            // Baseline: 951/1000 (95.1%)
-            // Threshold: ≈93.6% (Wilson lower bound at 95% confidence)
-            // Test result: 90/100 (90%)
-            
+            // STATISTICAL-COMPANION §3.4: threshold is Wilson lower at n_test
+            // applied to the baseline rate. Baseline 951/1000 → threshold
+            // ≈ 0.902 at n_test=100, 95% confidence. Test result 80/100.
             DerivedThreshold threshold = deriver.deriveSampleSizeFirst(
                 1000, 951, 100, 0.95);
-            
-            VerdictWithConfidence verdict = evaluator.evaluate(90, 100, threshold);
-            
-            // Decision: FAIL (90% < 93.6%)
+
+            VerdictWithConfidence verdict = evaluator.evaluate(80, 100, threshold);
+
+            // Decision: FAIL (0.80 < ~0.902)
             assertThat(verdict.passed()).isFalse();
-            
+
             // False positive probability: 5%
             assertThat(verdict.falsePositiveProbability()).isCloseTo(0.05, within(0.001));
-            
+
             // Interpretation should be qualified
             assertThat(verdict.interpretation())
                 .as("Interpretation should include qualification")
-                .containsPattern("0\\.9000 < 0\\.9[34]\\d+")  // observed < threshold
-                .contains("95%")                               // confidence level
-                .contains("5.0%")                              // false positive probability
-                .contains("sampling variance");                // statistical caveat
+                .containsPattern("0\\.8000 < 0\\.90\\d+")     // observed < threshold
+                .contains("95%")                              // confidence level
+                .contains("5.0%")                             // false positive probability
+                .contains("sampling variance");               // statistical caveat
         }
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/statistics/ThresholdDeriverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/statistics/ThresholdDeriverTest.java
@@ -46,26 +46,27 @@ class ThresholdDeriverTest {
         void derivesThresholdFromBaselineData() {
             // Baseline: 951 successes out of 1000 trials (95.1%)
             // Test: 100 samples at 95% confidence
+            // Companion §3.4: threshold is Wilson lower at n_test from
+            // baseline rate ≈ 0.902.
             DerivedThreshold threshold = deriver.deriveSampleSizeFirst(
                 1000, 951, 100, 0.95);
-            
-            // Threshold should be the Wilson lower bound ≈ 93.6%
-            assertThat(threshold.value()).isCloseTo(0.936, within(0.01));
+
+            assertThat(threshold.value()).isCloseTo(0.902, within(0.01));
             assertThat(threshold.approach()).isEqualTo(OperationalApproach.SAMPLE_SIZE_FIRST);
             assertThat(threshold.isStatisticallySound()).isTrue();
         }
-        
+
         @Test
         @DisplayName("threshold is lower than baseline rate")
         void thresholdIsLowerThanBaselineRate() {
             DerivedThreshold threshold = deriver.deriveSampleSizeFirst(
                 1000, 951, 100, 0.95);
-            
-            // Gap accounts for sampling uncertainty
+
+            // Gap accounts for sampling uncertainty at the test sample size.
             assertThat(threshold.value()).isLessThan(0.951);
             assertThat(threshold.gapFromBaseline()).isGreaterThan(0);
         }
-        
+
         @Test
         @DisplayName("higher confidence produces lower threshold")
         void higherConfidenceProducesLowerThreshold() {
@@ -73,36 +74,36 @@ class ThresholdDeriverTest {
                 1000, 951, 100, 0.95);
             DerivedThreshold threshold99 = deriver.deriveSampleSizeFirst(
                 1000, 951, 100, 0.99);
-            
+
             // 99% confidence → more conservative threshold
             assertThat(threshold99.value()).isLessThan(threshold95.value());
         }
-        
+
         @Test
-        @DisplayName("larger baseline sample produces higher threshold (more precise)")
-        void largerBaselineSampleProducesHigherThreshold() {
-            // Same observed rate (95%), different baseline sample sizes
-            DerivedThreshold smallBaseline = deriver.deriveSampleSizeFirst(
-                100, 95, 50, 0.95);
-            DerivedThreshold largeBaseline = deriver.deriveSampleSizeFirst(
-                10000, 9500, 50, 0.95);
-            
-            // Larger baseline → narrower CI → higher lower bound
-            assertThat(largeBaseline.value()).isGreaterThan(smallBaseline.value());
+        @DisplayName("smaller test sample size produces lower threshold")
+        void smallerTestSampleProducesLowerThreshold() {
+            // Companion §3.5 / §3.4: the threshold is Wilson lower at the
+            // test sample size. A smaller test produces a wider interval
+            // and therefore a lower bound, regardless of baseline size.
+            DerivedThreshold smallTest = deriver.deriveSampleSizeFirst(
+                1000, 950, 50, 0.95);
+            DerivedThreshold largeTest = deriver.deriveSampleSizeFirst(
+                1000, 950, 200, 0.95);
+
+            assertThat(largeTest.value()).isGreaterThan(smallTest.value());
         }
-        
+
         @Test
         @DisplayName("handles perfect baseline (100% success) correctly")
         void handlesPerfectBaseline() {
-            // All 1000 trials succeeded
+            // All 1000 trials succeeded; test 100 at 95%.
+            // Companion §4.3.2: p₀ = Wilson_lower(1000, 1000) ≈ 0.9973,
+            // then Wilson_lower_from_rate(p₀, 100, 0.95) ≈ 0.9686.
             DerivedThreshold threshold = deriver.deriveSampleSizeFirst(
                 1000, 1000, 100, 0.95);
-            
-            // Should NOT be 1.0 (that would cause every failure to fail)
+
             assertThat(threshold.value()).isLessThan(1.0);
-            
-            // Wilson one-sided lower bound for 1000/1000 at 95% ≈ 99.73%
-            assertThat(threshold.value()).isCloseTo(0.9973, within(0.001));
+            assertThat(threshold.value()).isCloseTo(0.9686, within(0.001));
         }
         
         @Test
@@ -126,18 +127,16 @@ class ThresholdDeriverTest {
         @Test
         @DisplayName("computes implied confidence for given threshold")
         void computesImpliedConfidenceForGivenThreshold() {
-            // Baseline: 951/1000 (95.1%)
-            // Explicit threshold: 93% (slightly below the 95% CI lower bound of ~93.6%)
+            // Baseline: 951/1000 (95.1%); test=100; explicit threshold 0.85.
+            // Companion §6.3: the implied confidence is the conf at which
+            // deriveSampleSizeFirst would produce 0.85. With baseline rate
+            // 0.951 at n_test=100, that confidence sits comfortably above
+            // 90% and the result is statistically sound.
             DerivedThreshold result = deriver.deriveThresholdFirst(
-                1000, 951, 100, 0.93);
-            
-            // Threshold should be exactly what was specified
-            assertThat(result.value()).isEqualTo(0.93);
+                1000, 951, 100, 0.85);
+
+            assertThat(result.value()).isEqualTo(0.85);
             assertThat(result.approach()).isEqualTo(OperationalApproach.THRESHOLD_FIRST);
-            
-            // Implied confidence should be high (threshold slightly below the 95% CI lower bound)
-            // Since the Wilson lower bound at 95% is about 93.6%, 
-            // a threshold of 93% implies a confidence level around 97-99%
             assertThat(result.context().confidence()).isGreaterThan(0.90);
             assertThat(result.isStatisticallySound()).isTrue();
         }
@@ -225,27 +224,21 @@ class ThresholdDeriverTest {
         @Test
         @DisplayName("baseline experiment: 951/1000 with 100-sample test")
         void baselineExperimentWorkedExample() {
-            // From STATISTICAL-COMPANION document:
-            // Baseline: 951 successes in 1000 trials (p̂ = 0.951)
-            // Test samples: 100
-            // Confidence: 95%
-            
+            // Statistical companion §3.4: threshold is Wilson one-sided
+            // lower bound at the test sample size, applied to the baseline
+            // rate. For 951/1000 baseline → p̂_baseline = 0.951; at
+            // n_test=100 and 95% confidence → threshold ≈ 0.902.
+
             DerivedThreshold threshold = deriver.deriveSampleSizeFirst(
                 1000, 951, 100, 0.95);
-            
-            // The document states threshold should be around 93-94%
-            // This accounts for:
-            // 1. Uncertainty in baseline (Wilson lower bound)
-            // 2. 95% confidence level
+
             assertThat(threshold.value())
-                .as("Threshold for 951/1000 baseline at 95% confidence")
-                .isCloseTo(0.936, within(0.01));
-            
-            // Gap from baseline should be meaningful
+                .as("Threshold for 951/1000 baseline at n_test=100, 95% confidence")
+                .isCloseTo(0.902, within(0.01));
+
             assertThat(threshold.gapFromBaseline())
                 .as("Gap from baseline")
-                .isGreaterThan(0.01)
-                .isLessThan(0.05);
+                .isGreaterThan(0.01);
         }
     }
 
@@ -254,16 +247,17 @@ class ThresholdDeriverTest {
     class ScenarioValidation {
 
         @Test
-        @DisplayName("derives π₀=0.9374 from baseline 950/1000 at 95% confidence")
+        @DisplayName("derives π₀ ≈ 0.9008 from baseline 950/1000 at n_test=100, 95% confidence")
         void scenarioAB_thresholdMatchesPlanValue() {
-            // Scenarios A and B use baseline: 1000 samples, 950 successes, rate=0.9500
-            // At 95% confidence, Wilson one-sided lower bound → π₀ ≈ 0.9374
+            // Scenarios A and B use baseline: 1000 samples, 950 successes,
+            // p̂_baseline = 0.95. Companion §3.4: Wilson one-sided lower
+            // bound at n_test=100, conf=0.95 → π₀ ≈ 0.9008.
             DerivedThreshold result =
                     deriver.deriveSampleSizeFirst(1000, 950, 100, 0.95);
 
             assertThat(result.value())
                     .as("Threshold used in Scenarios A and B")
-                    .isCloseTo(0.9374, within(0.001));
+                    .isCloseTo(0.9008, within(0.001));
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the directive [DIR-BUG-EMPIRICAL-THRESHOLD-DERIVATION-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-BUG-EMPIRICAL-THRESHOLD-DERIVATION-punit.md). The empirical pass-rate criterion was using the baseline's raw `observedPassRate` as the verdict threshold, which under the corrected methodology is the *baseline rate*, not the threshold. Most visible symptom: a baseline recorded with a perfect rate (`observedPassRate = 1.0`) was structurally impossible to clear on re-run, even by an unchanged system.

The methodology that resolves this — and the source of truth for this PR — is the [Statistical Companion](https://github.com/javai-org/javai-R/blob/main/docs/STATISTICAL-COMPANION.md):

- **§3.4** The threshold is the one-sided Wilson lower bound at the *test* sample size applied to the baseline rate.
- **§4.3.2** When the baseline observed perfect success (k = n), the raw rate of 1.0 has zero variance and would force the threshold to 1.0; instead a two-step construction takes the discrete Wilson lower bound at n_baseline as the rate to carry into step 2.
- **§5.1** The decision rule compares the raw observed test rate against the derived threshold (`observed ≥ threshold`), not a Wilson-wrapped version of the test observation.

`ThresholdDeriver.deriveSampleSizeFirst` had the same defect — it computed Wilson at `n_baseline`, ignoring its `testSamples` parameter. The conformance test passed only because the R fixture generator carried the same fault; **javai-R v0.6.0** fixes the oracle and exposes the defect on the Java side.

## What changed

- **`BinomialProportionEstimator.lowerBoundFromRate(pHat, n, conf)`** — new continuous-rate companion to the existing discrete `lowerBound(successes, trials, conf)`. The two-step §4.3.2 construction needs Wilson applied to a rate already derived from the baseline, not to integer counts.
- **`ThresholdDeriver.deriveSampleSizeFirst`** — now picks the effective baseline rate (Wilson at `n_baseline` if `k = n`, else raw rate) and applies `lowerBoundFromRate` at `n_test`. `computeImpliedConfidence` (§6.3) mirrors the same construction so threshold-first inversion remains the inverse of sample-size-first derivation.
- **`PassRate.evaluate` (empirical mode)** — derives the threshold via `ThresholdDeriver` at evaluation time and compares `observed ≥ threshold` per §5.1. Detail map carries `threshold`, `baselineRate`, `baselineSampleCount`, `confidence`. The `wilsonLowerBound` key is removed — it was the wrong concept under the corrected methodology.
- **No baseline schema change.** `PassRateStatistics` stays at its 2-arg shape (`observedPassRate`, `sampleCount`); the schema stays at `punit-baseline-2`. Computing the threshold at evaluation time means it doesn't need to live in the baseline file.
- **Locked-in unit tests updated** to the corrected expected values: the worked example, the scenario-A/B target, the perfect-baseline case, and the empirical pass / fail / explanation suite.

## Conformance

`ProportionConformanceTest > threshold_derivation` now passes against javai-R v0.6.0 — 16 cases including the perfect-baseline §4.3.2 worked example. The `fetchConformanceData` Gradle task pulls the latest GitHub release on each build, so this is automatic going forward.

## Out of scope (deferred)

The earlier draft of this PR bundled a baseline-3 schema bump (`minPassRate` field), a one-sided Wilson audit, and a verdict-XML wire-format change. The corrected approach makes most of that unnecessary or premature:

- **Baseline-3 schema / `minPassRate` field** — abandoned. Threshold is no longer a baseline-side property.
- **One-sided Wilson audit / `ci-upper` removal / `ci-lower` → `wilson-lower` rename** — these are separate cleanup items, not required by the methodology fix. Will be tracked as their own directives if and when they're worth doing.
- **`stteval` baseline regeneration** — operator step that lands once this PR is merged and the consuming projects pick up the fixed punit. Not part of this branch.

## Test plan

- [x] `./gradlew test` — full suite passes locally (1725 tests).
- [x] `ProportionConformanceTest > threshold_derivation` passes against javai-R v0.6.0 fixtures (16 cases).
- [x] `ThresholdDeriverTest` worked example, scenario A/B, perfect baseline, smaller-test-samples-lower-threshold all assert against the §3.4 / §4.3.2 expected values.
- [x] `PassRateTest` empirical pass / fail / explanation / detail-map / `atConfidence` suite reflects observed-vs-threshold semantics.
- [x] `EmpiricalEndToEndIntegrationTest` PASS path asserts derived threshold is strictly below the baseline rate (the perfect-baseline pathology is structurally impossible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)