### PR TITLE
Echo INCONCLUSIVE diagnostics to stderr

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -262,13 +262,23 @@ public final class PUnit {
         VerdictSinkBus.dispatch(verdict);
     }
 
-    private static void translate(ProbabilisticTestResult result) {
+    static void translate(ProbabilisticTestResult result, String useCaseId) {
         Verdict verdict = result.verdict();
         if (verdict == Verdict.PASS) {
             return;
         }
         String message = formatMessage(result);
         if (verdict == Verdict.INCONCLUSIVE) {
+            // INCONCLUSIVE diagnostics are echoed to stderr regardless
+            // of which JUnit-side throwable the trichotomy below
+            // selects — the abort exception's message reaches the IDE
+            // pane but not necessarily the build console (Gradle's
+            // default text reporter only surfaces the throwable's
+            // message for FAIL-style outcomes, leaving aborts silent).
+            // Mirrors the PASS-with-warnings stderr emission so the
+            // operator's view of an INCONCLUSIVE run is symmetric with
+            // PASS and FAIL.
+            emitInconclusiveDiagnostics(result, useCaseId, message);
             // The covariate-alignment contract has three INCONCLUSIVE
             // sub-cases that we resolve here — see the project's
             // covariate-misalignment trichotomy:
@@ -295,6 +305,15 @@ public final class PUnit {
             throw new TestAbortedException(message);
         }
         throw new AssertionFailedError(message);
+    }
+
+    private static void emitInconclusiveDiagnostics(
+            ProbabilisticTestResult result, String useCaseId, String message) {
+        String header = useCaseId == null || useCaseId.isBlank()
+                ? "[PUNIT-INCONCLUSIVE]"
+                : "[PUNIT-INCONCLUSIVE] " + useCaseId;
+        System.err.println(header);
+        System.err.println(message);
     }
 
     private static boolean candidatesWereRejected(ProbabilisticTestResult result) {
@@ -675,8 +694,9 @@ public final class PUnit {
                                     observed, typed.covariates().baseline()))
                     .withContractRef(contractRef);
             maybeRenderTransparentStats(stamped);
-            emitVerdict(stamped, sampling.useCaseFactory().apply(factors).id());
-            translate(stamped);
+            String useCaseId = sampling.useCaseFactory().apply(factors).id();
+            emitVerdict(stamped, useCaseId);
+            translate(stamped, useCaseId);
         }
 
         private void maybeRenderTransparentStats(ProbabilisticTestResult result) {
@@ -803,8 +823,9 @@ public final class PUnit {
                                     observed, typed.covariates().baseline()))
                     .withContractRef(contractRef);
             maybeRenderTransparentStats(spec, stamped);
-            emitVerdict(stamped, resolveUseCaseId(spec));
-            translate(stamped);
+            String useCaseId = resolveUseCaseId(spec);
+            emitVerdict(stamped, useCaseId);
+            translate(stamped, useCaseId);
         }
 
         @SuppressWarnings("unchecked")

--- a/punit-core/src/test/java/org/javai/punit/runtime/PUnitTranslateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/PUnitTranslateTest.java
@@ -1,0 +1,203 @@
+package org.javai.punit.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.covariate.CovariateAlignment;
+import org.javai.punit.api.spec.CriterionResult;
+import org.javai.punit.api.spec.CriterionRole;
+import org.javai.punit.api.spec.EvaluatedCriterion;
+import org.javai.punit.api.spec.InconclusiveReasons;
+import org.javai.punit.api.spec.ProbabilisticTestResult;
+import org.javai.punit.api.spec.Verdict;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.TestAbortedException;
+
+/**
+ * Behavioural contract for {@link PUnit#translate(ProbabilisticTestResult, String)}'s
+ * INCONCLUSIVE-side stderr emission.
+ *
+ * <p>An INCONCLUSIVE verdict carries a fully-formed explanation
+ * inside the {@link TestAbortedException}/{@link AssertionFailedError}
+ * it throws. JUnit propagates that as the abort reason and IDEs
+ * surface it in their per-test detail panes, but Gradle's default
+ * text reporter does not. The framework therefore mirrors the
+ * PASS-with-warnings stderr emission for INCONCLUSIVE: a
+ * {@code [PUNIT-INCONCLUSIVE]} marker line followed by the
+ * formatted body, written to {@link System#err} synchronously
+ * before the abort exception is thrown — so an operator watching
+ * the build console sees the diagnostic regardless of which
+ * trichotomy leg fired.
+ */
+@DisplayName("PUnit.translate — INCONCLUSIVE stderr emission")
+class PUnitTranslateTest {
+
+    record Factors(String label) {}
+
+    private static final FactorBundle FACTORS = FactorBundle.of(new Factors("test"));
+    private static final String USE_CASE_ID = "shopping-basket";
+
+    private PrintStream originalErr;
+    private ByteArrayOutputStream captured;
+
+    @BeforeEach
+    void redirectStderr() {
+        originalErr = System.err;
+        captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void restoreStderr() {
+        System.setErr(originalErr);
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE no-baseline → marker + criterion explanation on stderr; aborts")
+    void inconclusiveNoBaselineEmitsMarkerAndAborts() {
+        ProbabilisticTestResult result = inconclusiveResult(
+                "no baseline candidate available for shopping-basket",
+                List.of(),
+                InconclusiveReasons.NO_BASELINE_AVAILABLE);
+
+        assertThatExceptionOfType(TestAbortedException.class)
+                .isThrownBy(() -> PUnit.translate(result, USE_CASE_ID));
+
+        String stderr = captured.toString(StandardCharsets.UTF_8);
+        assertThat(stderr).contains("[PUNIT-INCONCLUSIVE] " + USE_CASE_ID);
+        assertThat(stderr).contains("INCONCLUSIVE");
+        assertThat(stderr).contains("no baseline candidate available for shopping-basket");
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE with rejection notes → marker + warnings on stderr; fails (not aborts)")
+    void inconclusiveWithRejectionsEmitsMarkerAndFails() {
+        // Trichotomy case 2: candidates were considered but rejected.
+        // PUnit.translate throws AssertionFailedError (not
+        // TestAbortedException), but the stderr emission fires
+        // regardless — both legs of the INCONCLUSIVE branch deserve
+        // the same console-side surfacing.
+        ProbabilisticTestResult result = inconclusiveResult(
+                "no covariate-aligned baseline for shopping-basket",
+                List.of(
+                        "rejected shopping-basket.baseline-v1-b60d8a8b-7a8b.yaml — "
+                                + "CONFIGURATION mismatch on llm_model",
+                        "rejected shopping-basket.baseline-v1-b60d8a8b-c1d2.yaml — "
+                                + "no overlap with the current covariate profile"),
+                "covariate-misalignment");
+
+        assertThatExceptionOfType(AssertionFailedError.class)
+                .isThrownBy(() -> PUnit.translate(result, USE_CASE_ID));
+
+        String stderr = captured.toString(StandardCharsets.UTF_8);
+        assertThat(stderr).contains("[PUNIT-INCONCLUSIVE] " + USE_CASE_ID);
+        assertThat(stderr).contains("rejected shopping-basket.baseline-v1-b60d8a8b-7a8b.yaml");
+        assertThat(stderr).contains("CONFIGURATION mismatch on llm_model");
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE with blank useCaseId → marker without identifier suffix")
+    void inconclusiveBlankUseCaseIdEmitsBareMarker() {
+        ProbabilisticTestResult result = inconclusiveResult(
+                "no baseline available", List.of(),
+                InconclusiveReasons.NO_BASELINE_AVAILABLE);
+
+        assertThatExceptionOfType(TestAbortedException.class)
+                .isThrownBy(() -> PUnit.translate(result, ""));
+
+        String stderr = captured.toString(StandardCharsets.UTF_8);
+        // Bare marker line — no trailing whitespace / no identifier
+        assertThat(stderr.lines().findFirst())
+                .hasValueSatisfying(line -> assertThat(line).isEqualTo("[PUNIT-INCONCLUSIVE]"));
+    }
+
+    @Test
+    @DisplayName("PASS → no stderr emission (translate returns normally)")
+    void passEmitsNothing() {
+        ProbabilisticTestResult result = passResult();
+
+        PUnit.translate(result, USE_CASE_ID);
+
+        assertThat(captured.toString(StandardCharsets.UTF_8)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FAIL → no INCONCLUSIVE marker on stderr; throws AssertionFailedError")
+    void failDoesNotEmitInconclusiveMarker() {
+        // The FAIL path is intentionally unchanged by this directive —
+        // its message reaches the build log via the surefire/Gradle
+        // reporter's failure-summary block. Asserting the absence of
+        // [PUNIT-INCONCLUSIVE] keeps the two paths from drifting into
+        // shared emission.
+        ProbabilisticTestResult result = failResult();
+
+        assertThatExceptionOfType(AssertionFailedError.class)
+                .isThrownBy(() -> PUnit.translate(result, USE_CASE_ID));
+
+        assertThat(captured.toString(StandardCharsets.UTF_8))
+                .doesNotContain("[PUNIT-INCONCLUSIVE]");
+    }
+
+    // ── Synthetic results ─────────────────────────────────────────────
+
+    private static ProbabilisticTestResult inconclusiveResult(
+            String explanation, List<String> warnings, String reasonDiscriminant) {
+        Map<String, Object> detail = Map.of(
+                InconclusiveReasons.DETAIL_KEY, reasonDiscriminant);
+        EvaluatedCriterion ec = new EvaluatedCriterion(
+                new CriterionResult(
+                        "bernoulli-pass-rate",
+                        Verdict.INCONCLUSIVE,
+                        explanation,
+                        detail),
+                CriterionRole.REQUIRED);
+        return new ProbabilisticTestResult(
+                Verdict.INCONCLUSIVE,
+                FACTORS,
+                List.of(ec),
+                TestIntent.VERIFICATION,
+                warnings,
+                CovariateAlignment.none(),
+                Optional.empty(),
+                Map.of());
+    }
+
+    private static ProbabilisticTestResult passResult() {
+        EvaluatedCriterion ec = new EvaluatedCriterion(
+                new CriterionResult(
+                        "bernoulli-pass-rate",
+                        Verdict.PASS,
+                        "observed=0.9500, threshold=0.9020",
+                        Map.of()),
+                CriterionRole.REQUIRED);
+        return new ProbabilisticTestResult(
+                Verdict.PASS, FACTORS, List.of(ec),
+                TestIntent.VERIFICATION, List.of());
+    }
+
+    private static ProbabilisticTestResult failResult() {
+        EvaluatedCriterion ec = new EvaluatedCriterion(
+                new CriterionResult(
+                        "bernoulli-pass-rate",
+                        Verdict.FAIL,
+                        "observed=0.7000, threshold=0.9020",
+                        Map.of()),
+                CriterionRole.REQUIRED);
+        return new ProbabilisticTestResult(
+                Verdict.FAIL, FACTORS, List.of(ec),
+                TestIntent.VERIFICATION, List.of());
+    }
+}


### PR DESCRIPTION
## Summary

Implements [DIR-BUG-INCONCLUSIVE-CONSOLE-SILENCE-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-BUG-INCONCLUSIVE-CONSOLE-SILENCE-punit.md). `PUnit.translate` threw `TestAbortedException` (or, for the rejected-candidates trichotomy leg, `AssertionFailedError`) carrying a fully-formed explanation, but emitted nothing to `System.err`. The IDE's per-test detail pane showed the abort reason; Gradle's default text reporter does not surface it for aborts, so an operator watching the build console saw only `[PUNIT-PROGRESS]` lines and a row of skipped icons with no account of why.

This was asymmetric with the PASS path (which echoes warnings to stderr) and the FAIL path (whose throwable's message reaches the failure-summary block).

## What changed

- `PUnit.translate` now emits a `[PUNIT-INCONCLUSIVE] {useCaseId}` block on `System.err` immediately before the trichotomy chooses between `TestAbortedException` (no candidates) and `AssertionFailedError` (candidates rejected). Both legs get the same console-side surfacing.
- The marker matches the existing `[PUNIT-FAIL]` / `[PUNIT-PROGRESS]` convention so log-collectors can filter on it.
- `translate(...)` now takes the use-case id (already known at both call sites in `TestBuilder.assertPasses` and the typed builder's equivalent) and the marker line carries it; multi-test runs interleave on stderr without ambiguity.
- `translate(...)` and the new `emitInconclusiveDiagnostics(...)` helper are package-private to keep `PUnitTranslateTest`'s stderr-capture path off reflective machinery.
- The verdict-to-JUnit mapping (PASS / FAIL / INCONCLUSIVE-aborted / INCONCLUSIVE-failed) is unchanged. `formatMessage` is unchanged. Only the new emission is added.

## Verification

- `PUnitTranslateTest` (new, 5 cases): captures `System.err`, drives an INCONCLUSIVE result through `translate`, and asserts the marker, the criterion explanation, and rejection notes are present. Symmetry tests confirm PASS emits nothing and FAIL emits no `[PUNIT-INCONCLUSIVE]` marker.
- `./gradlew test` — full punit suite passes (1726 tests).
- Reproducer `punitexamples/.../ShoppingBasketCovariateTest` now produces three labelled `[PUNIT-INCONCLUSIVE] shopping-basket` blocks on stderr — one per skipped configuration, each carrying the resolved covariate profile (`llm_model=gpt-4-turbo, temperature=0.3`; `temperature=0.1`; `temperature=0.7`) — and the default-configuration test still PASSES with no `[PUNIT-INCONCLUSIVE]` emission for it.

## Out of scope (per directive)

- No change to the verdict-to-JUnit mapping or the FAIL emission path.
- No suppression knob for the new emission — operators who want to filter can do so by marker prefix, the same way they filter `[PUNIT-FAIL]`.
- No structured-logging abstraction; the emission stays line-shaped, marker-prefixed, synchronous, on `System.err`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)