### PR TITLE
PowerAnalysis: relax precondition to one-sided, admit perfect baselines

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
+++ b/punit-core/src/main/java/org/javai/punit/power/PowerAnalysis.java
@@ -111,10 +111,9 @@ public final class PowerAnalysis {
      * @throws IllegalArgumentException if {@code mde} ∉ (0, 1) or
      *                                  {@code power} ∉ (0, 1) or the
      *                                  supplier yields a non-MEASURE
-     *                                  experiment, or the resolved
-     *                                  baseline rate is incompatible
-     *                                  with the requested MDE
-     *                                  ({@code rate ± mde} outside (0, 1))
+     *                                  experiment, or the alternative-
+     *                                  hypothesis rate {@code rate − mde}
+     *                                  is not strictly positive
      * @throws IllegalStateException    if no matching baseline file is
      *                                  resolvable under {@code baselineDir}
      */
@@ -155,11 +154,19 @@ public final class PowerAnalysis {
                                 + " — run the baseline measure before planning a test against it."));
 
         double observedRate = stats.observedPassRate();
-        if (observedRate - mde <= 0.0 || observedRate + mde >= 1.0) {
+        // One-sided check: degradation testing only cares about the
+        // lower side, so the alternative-hypothesis rate p1 = rate − mde
+        // must be strictly positive. The upper side (rate + mde) is
+        // never used by the formula and intentionally not bounded —
+        // perfect baselines (rate = 1.0) are valid input here, with
+        // σ0 = 0 collapsing the formula to n = (z_β · σ1)² / δ²
+        // inside SampleSizeCalculator.
+        if (observedRate - mde <= 0.0) {
             throw new IllegalArgumentException(
                     "baseline observed rate " + observedRate
                             + " is incompatible with mde=" + mde
-                            + " — the [rate-mde, rate+mde] interval must lie in (0, 1)");
+                            + " — the alternative-hypothesis rate (rate − mde) "
+                            + "must be > 0 for one-sided degradation detection.");
         }
 
         // The sample-size formula lives in SampleSizeCalculator — the

--- a/punit-core/src/main/java/org/javai/punit/statistics/SampleSizeCalculator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/SampleSizeCalculator.java
@@ -164,11 +164,23 @@ public class SampleSizeCalculator {
         return STANDARD_NORMAL.cumulativeProbability(zBeta);
     }
     
+    /**
+     * Validates inputs for {@link #calculateForPower}.
+     *
+     * <p>{@code baselineRate ∈ (0, 1]} — perfect baselines (rate = 1.0)
+     * are admissible. The formula handles {@code σ0 = √(p0(1−p0)) = 0}
+     * cleanly: the first term of {@code n = ((z_α · σ0 + z_β · σ1) / δ)²}
+     * vanishes and the calculation reduces to {@code n = (z_β · σ1)² / δ²},
+     * which is well-defined for any {@code p1 = rate − mde > 0}. The
+     * companion {@code p1 > 0} invariant is enforced separately at the
+     * call site (line 89 below) so the two checks document independently
+     * meaningful preconditions.
+     */
     private void validateInputs(double baselineRate, double minDetectableEffect,
                                 double confidence, double power) {
-        if (baselineRate <= 0.0 || baselineRate >= 1.0) {
+        if (baselineRate <= 0.0 || baselineRate > 1.0) {
             throw new IllegalArgumentException(
-                "Baseline rate must be in (0, 1), got: " + baselineRate);
+                "Baseline rate must be in (0, 1], got: " + baselineRate);
         }
         if (minDetectableEffect <= 0.0 || minDetectableEffect >= 1.0) {
             throw new IllegalArgumentException(

--- a/punit-core/src/test/java/org/javai/punit/power/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/power/PowerAnalysisTest.java
@@ -204,15 +204,44 @@ class PowerAnalysisTest {
     }
 
     @Test
-    @DisplayName("rejects an MDE incompatible with the resolved baseline rate")
+    @DisplayName("rejects an MDE that pushes the alternative-hypothesis rate to or below 0")
     void rejectsIncompatibleMde(@TempDir Path dir) throws IOException {
-        writeBaselineWithRate(dir, 0.50, 1000);
-        // rate=0.5 + mde=0.5 → upper bound 1.0, outside (0, 1).
+        writeBaselineWithRate(dir, 0.10, 1000);
+        // rate=0.10 with mde=0.10 → p1 = 0; rate=0.10 with mde=0.50 → p1 < 0.
+        // Both must be rejected; the diagnostic names the one-sided
+        // alternative-hypothesis rate invariant rather than the obsolete
+        // symmetric [rate-mde, rate+mde] interval.
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> PowerAnalysis.sampleSize(dir, baseline(), 0.5, 0.80))
-                .withMessageContaining("incompatible");
+                .isThrownBy(() -> PowerAnalysis.sampleSize(dir, baseline(), 0.10, 0.80))
+                .withMessageContaining("alternative-hypothesis rate");
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> PowerAnalysis.sampleSize(dir, baseline(), 0.6, 0.80));
+                .isThrownBy(() -> PowerAnalysis.sampleSize(dir, baseline(), 0.50, 0.80));
+    }
+
+    @Test
+    @DisplayName("accepts a perfect baseline (rate = 1.0) — the verdict path is one-sided")
+    void acceptsPerfectBaseline(@TempDir Path dir) throws IOException {
+        // The previous symmetric precondition rejected rate = 1.0
+        // because rate + mde >= 1; the relaxed one-sided check admits
+        // it. Downstream, σ0 = 0 collapses the sample-size formula to
+        // n = (z_β · σ1)² / δ², which the calculator now accepts.
+        writeBaselineWithRate(dir, 1.0, 1000);
+
+        int n = PowerAnalysis.sampleSize(dir, baseline(), 0.05, 0.80);
+
+        assertThat(n).isPositive();
+    }
+
+    @Test
+    @DisplayName("accepts a baseline whose rate is strictly above 1 − mde (rate = 0.99, mde = 0.05)")
+    void acceptsBaselineRateAboveOneMinusMde(@TempDir Path dir) throws IOException {
+        // Previously rejected by the symmetric two-sided check; the
+        // formula handles 0.99 cleanly (both σ0 and σ1 are positive).
+        writeBaselineWithRate(dir, 0.99, 1000);
+
+        int n = PowerAnalysis.sampleSize(dir, baseline(), 0.05, 0.80);
+
+        assertThat(n).isPositive();
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/statistics/SampleSizeCalculatorTest.java
+++ b/punit-core/src/test/java/org/javai/punit/statistics/SampleSizeCalculatorTest.java
@@ -177,15 +177,47 @@ class SampleSizeCalculatorTest {
     class InputValidation {
         
         @Test
-        @DisplayName("rejects baseline rate outside (0, 1)")
+        @DisplayName("rejects baseline rate outside (0, 1] — perfect baselines (rate = 1.0) are admissible")
         void rejectsInvalidBaselineRate() {
+            // rate = 0 has no signal to plan against — keep it rejected.
             assertThatThrownBy(() -> calculator.calculateForPower(0.0, 0.05, 0.95, 0.80))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Baseline rate");
-            
-            assertThatThrownBy(() -> calculator.calculateForPower(1.0, 0.05, 0.95, 0.80))
+
+            // rate > 1 is structurally invalid.
+            assertThatThrownBy(() -> calculator.calculateForPower(1.01, 0.05, 0.95, 0.80))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Baseline rate");
+
+            // rate = 1.0 is admissible — see acceptsPerfectBaseline below.
+        }
+
+        @Test
+        @DisplayName("accepts perfect baseline (rate = 1.0) — σ0 = 0 collapses formula to n = (z_β · σ1)² / δ²")
+        void acceptsPerfectBaseline() {
+            // For rate = 1.0, σ0 = √(1·0) = 0; the first term of the
+            // sample-size formula vanishes. The expected n is
+            // ⌈(z_β · √(p1(1−p1)))² / δ²⌉ where p1 = 1 − mde.
+            SampleSizeRequirement req = calculator.calculateForPower(1.0, 0.05, 0.95, 0.80);
+            assertThat(req.requiredSamples()).isPositive();
+            // Closed-form for σ0 = 0: n = (z_β · σ1 / δ)²
+            double zBeta = 0.8416212335729143; // qnorm(0.80)
+            double p1 = 0.95;
+            double sigma1 = Math.sqrt(p1 * (1.0 - p1));
+            int expected = (int) Math.ceil(Math.pow(zBeta * sigma1 / 0.05, 2));
+            assertThat(req.requiredSamples()).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("accepts rate = 0.99 with mde = 0.05 — formerly rejected by the symmetric two-sided check")
+        void acceptsRateAboveOneMinusMde() {
+            // Under the previous symmetric precondition this combination
+            // failed at PowerAnalysis. SampleSizeCalculator itself never
+            // rejected rate = 0.99, so this test pins that the relaxed
+            // upstream precondition reaches the formula and produces a
+            // sensible n. The full formula (σ0, σ1 both nonzero) governs.
+            SampleSizeRequirement req = calculator.calculateForPower(0.99, 0.05, 0.95, 0.80);
+            assertThat(req.requiredSamples()).isPositive();
         }
         
         @Test


### PR DESCRIPTION
## Summary

Implements [DIR-BUG-POWERANALYSIS-PERFECT-BASELINE-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-BUG-POWERANALYSIS-PERFECT-BASELINE-punit.md). The verdict path is **one-sided** — punit only tests for *degradation*, never for *improvement* — so `PowerAnalysis`'s symmetric `[rate-mde, rate+mde]` precondition was over-strict by exactly one bound, rejecting any baseline rate `≥ 1 − mde` even though the formula handles those cases cleanly. The threshold path (SC03) already supports perfect baselines via the §4.3.2 two-step; this brings the power path into the same regime.

> **Stacked on top of [#133](https://github.com/javai-org/punit/pull/133)** so the reproducer reaches `PowerAnalysis`'s rate-vs-mde precondition rather than the upstream resolver call. Base will be re-targeted to `main` and the branch rebased once #133 merges.

## What changed

- **`PowerAnalysis.java`** — replace the symmetric check with a one-sided one (`rate − mde > 0` only). The diagnostic now names the actual invariant (the alternative-hypothesis rate `p1` must be strictly positive) instead of the mathematically inactive symmetric interval. Javadoc updated.
- **`SampleSizeCalculator.java`** — relax `baselineRate`'s upper bound from strict to inclusive (`(0, 1)` → `(0, 1]`). The formula's first term zeroes out cleanly when `σ0 = √(p0(1−p0)) = 0` (perfect baseline), reducing to `n = (z_β · σ1)² / δ²`. The companion `p1 > 0` invariant is enforced separately at line 89, so the two checks document independently meaningful preconditions; validator Javadoc explains the relaxation.
- No formulation change. No special-case branching for perfect baselines — the existing z-test formula handles `σ0 = 0` algebraically. No widening to two-sided power testing. No relaxation of the lower-side bound (`rate = 0` is still rejected — there's no signal to plan against).

## Test coverage

- **`SampleSizeCalculatorTest`**:
  - `rejectsInvalidBaselineRate` — updated to reflect the relaxed bound (`rate = 1.0` admissible, `rate > 1` still rejected, `rate = 0` still rejected).
  - `acceptsPerfectBaseline` (new) — closed-form `n = ⌈(z_β · σ1)² / δ²⌉` matched against the implementation for `rate = 1.0, mde = 0.05, conf = 0.95, power = 0.80`.
  - `acceptsRateAboveOneMinusMde` (new) — pins `rate = 0.99` (formerly rejected by PowerAnalysis upstream; the calculator itself never rejected it).
- **`PowerAnalysisTest`**:
  - `rejectsIncompatibleMde` — rewritten around the one-sided invariant (`p1 > 0`); the diagnostic must name `alternative-hypothesis rate`.
  - `acceptsPerfectBaseline` (new) — end-to-end through the writer + resolver + sample-size calculation, asserts a positive `n` returned for a `rate = 1.0` baseline.
  - `acceptsBaselineRateAboveOneMinusMde` (new) — pins `rate = 0.99` end-to-end.
- `./gradlew test` — full punit suite passes.
- `ShoppingBasketThresholdApproachesTest.confidenceFirst` — with a recorded perfect baseline, the test now runs to a PASS verdict (was: `IllegalArgumentException` at the precondition).

## Out of scope (per directive)

- No widening to two-sided power testing.
- No relaxation of the lower-side bound (`rate = 0` is genuinely meaningless for confidence-first planning).
- No alternative formulation (binomial-power) for perfect baselines — the existing z-test handles them via `σ0 = 0`.
- Example-project tuning (`MEASURE_EXPERIMENT_SAMPLE_SIZE`, `thresholdFirst()` literal) lands separately in [punitexamples#46](https://github.com/javai-org/punitexamples/pull/46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)