### PR TITLE
Strip orchestrator-internal requirement codes from runtime diagnostics

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
@@ -132,8 +132,12 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
             LatencyStatistics stats = ctx.baseline().orElse(null);
             if (stats == null) {
                 return inconclusive(
-                        "no matching baseline was resolvable for empirical thresholds; "
-                                + "see DG02 §'Baseline relationship' for the resolution mechanism",
+                        "no baseline was resolvable for the empirical thresholds — "
+                                + "the framework matches by use-case id, factors "
+                                + "fingerprint, and (when declared) covariate profile; "
+                                + "no on-disk baseline aligned with the run's "
+                                + "configuration. Run a measure experiment under this "
+                                + "configuration first.",
                         Map.of("assertedPercentiles", assertedCsv(), "origin", ThresholdOrigin.EMPIRICAL.name()));
             }
             Map<String, Object> empiricalDetail = Map.of("assertedPercentiles", assertedCsv());

--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
@@ -206,8 +206,12 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
                 detail.put(InconclusiveReasons.DETAIL_KEY,
                         InconclusiveReasons.NO_BASELINE_AVAILABLE);
                 return inconclusive(
-                        "no matching baseline was resolvable for empirical threshold; "
-                                + "see DG02 §'Baseline relationship' for the resolution mechanism",
+                        "no baseline was resolvable for the empirical threshold — "
+                                + "the framework matches by use-case id, factors "
+                                + "fingerprint, and (when declared) covariate profile; "
+                                + "no on-disk baseline aligned with the run's "
+                                + "configuration. Run a measure experiment under this "
+                                + "configuration first.",
                         detail);
             }
             Map<String, Object> empiricalDetail = Map.of("confidence", confidence);

--- a/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
@@ -148,6 +148,13 @@ class PercentileLatencyTest {
 
         assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
         assertThat(result.detail()).containsEntry("assertedPercentiles", "p95,p99");
+        // The diagnostic must explain what happened in domain language
+        // (no orchestrator-internal requirement codes leaking into the
+        // developer-facing message).
+        assertThat(result.explanation())
+                .contains("no baseline was resolvable")
+                .contains("Run a measure experiment under this configuration first")
+                .doesNotContainPattern("\\b[A-Z]{2,3}\\d{2}\\b");
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/engine/criteria/PassRateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/criteria/PassRateTest.java
@@ -131,16 +131,23 @@ class PassRateTest {
 
     @Test
     @DisplayName("empirical() with no baseline returns INCONCLUSIVE with the "
-            + "'no baseline available' RP01 discriminant on the detail map")
+            + "'no baseline available' discriminant on the detail map")
     void empiricalNoBaselineInconclusive() {
         PassRate<String> criterion = PassRate.empirical();
 
         CriterionResult result = criterion.evaluate(ctx(summary(90, 10), Optional.empty()));
 
         assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
-        assertThat(result.explanation()).contains("baseline");
+        // The diagnostic must explain what happened in domain language
+        // (no orchestrator-internal requirement codes leaking into the
+        // developer-facing message — see the project family's
+        // requirement-ID convention in the orchestrator's CLAUDE.md).
+        assertThat(result.explanation())
+                .contains("no baseline was resolvable")
+                .contains("Run a measure experiment under this configuration first")
+                .doesNotContainPattern("\\b[A-Z]{2,3}\\d{2}\\b");
         assertThat(result.detail())
-                .as("RP01 vocabulary discriminant for the verdict-builder")
+                .as("verdict-builder vocabulary discriminant")
                 .containsEntry(
                         org.javai.punit.api.spec.InconclusiveReasons.DETAIL_KEY,
                         org.javai.punit.api.spec.InconclusiveReasons.NO_BASELINE_AVAILABLE);


### PR DESCRIPTION
## Summary

The empirical-no-baseline INCONCLUSIVE message in `PassRate` and `PercentileLatency` directed the developer to "see DG02 §'Baseline relationship' for the resolution mechanism" — leaking an orchestrator-internal requirement ID into a **developer-facing diagnostic**. This violates the project family's documented convention (orchestrator's `CLAUDE.md`):

> Requirement IDs (`PT13`, `EX06`, `RP07`, …) are orchestrator-internal tracking codes. They belong in this repo — inventory, catalog, and directive files — and must not leak into source comments or doc strings of per-project engineering code, which is public. A reader of the open-source source cannot interpret these codes.

The leak is even worse here than a comment leak: it shows up in the runtime `[PUNIT-INCONCLUSIVE]` block on the build console, where a developer trying to diagnose a configuration problem hits an opaque "see DG02 §'Baseline relationship'" with no way to look up what DG02 is.

## What changed

Both messages replaced with domain-language explanations. New wording:

> "no baseline was resolvable for the empirical threshold — the framework matches by use-case id, factors fingerprint, and (when declared) covariate profile; no on-disk baseline aligned with the run's configuration. Run a measure experiment under this configuration first."

(`PercentileLatency`'s variant says `thresholds` plural; otherwise identical.)

## Regression guard

The corresponding unit tests (`PassRateTest.empiricalNoBaselineInconclusive`, `PercentileLatencyTest.empiricalNoBaselineInconclusive`) now assert:

- the new wording is present (`no baseline was resolvable`, `Run a measure experiment under this configuration first`); and
- `.doesNotContainPattern("\\b[A-Z]{2,3}\\d{2}\\b")` — a regex that matches any orchestrator-style code (`DG02`, `RP01`, `EX04`, `LT01`, `SC03`, …) and ensures none of them creep back into either developer-facing message in future edits.

## Out of scope

This patch fixes the **runtime-output leak only**. A broader audit of javadoc / source-comment leaks across `punit-core` is a separate concern — references like "RP01's verdict-consistent-with-statistical-analysis invariant" appear in class docstrings and inline comments that show up on GitHub but not in user-facing runtime output. That cleanup deserves its own scoped pass; this PR does not bundle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)