### PR TITLE
Strip orchestrator-internal requirement codes from punit source

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/InputSupplier.java
+++ b/punit-core/src/main/java/org/javai/punit/api/InputSupplier.java
@@ -21,11 +21,8 @@ import java.util.function.Supplier;
  * framework can't tell). Hashing the content removes the gap —
  * identity equality strictly implies sampling-frame equivalence.
  *
- * <p>See {@code docs/DES-INPUTS-IDENTITY-SUPPLIER.md} for the
- * design intent and {@code DG01-sampling/README.md} for the
- * integrity mechanism on top of which this type sits. The user
- * guide will document the authoring patterns (TODO when the user
- * guide lands).
+ * <p>The user guide will document the authoring patterns (TODO when
+ * the user guide lands).
  *
  * <h2>Two authoring shapes</h2>
  *

--- a/punit-core/src/main/java/org/javai/punit/api/spec/EngineRunSummary.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/EngineRunSummary.java
@@ -119,10 +119,10 @@ public record EngineRunSummary(
      * {@link #passingLatencyResult()} to the supplied
      * {@code latencyResult} so callers that haven't yet
      * differentiated passing-only data see the descriptive latency
-     * dimension populated as it was before the LT01 amendment.
-     * Production code in the engine constructs summaries via the
-     * canonical 12-arg constructor with the proper passing-only
-     * result.
+     * dimension populated as it was before the passing/all-samples
+     * split landed. Production code in the engine constructs
+     * summaries via the canonical 12-arg constructor with the proper
+     * passing-only result.
      */
     public EngineRunSummary(
             int plannedSamples,

--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -174,7 +174,8 @@ public final class Experiment implements Spec {
      * {@link SampleSummary} parallel to {@link #history()}, in the
      * same execution order. Empty for measure and explore. Consumed
      * by the OPTIMIZE artefact emitter when it needs per-sample
-     * trial detail (the {@code resultProjection:} block of EX06).
+     * trial detail (the {@code resultProjection:} block of the
+     * optimize-experiment output).
      */
     public List<SampleSummary<?>> iterationSummaries() {
         if (internal instanceof OptimizeInternal<?, ?, ?> o) {

--- a/punit-core/src/main/java/org/javai/punit/api/spec/FactorsStepper.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/FactorsStepper.java
@@ -81,7 +81,7 @@ public interface FactorsStepper<FT> {
          * {@code samplesExecuted}) to {@code 0}; call sites that
          * have access to the iteration's {@link SampleSummary}
          * should use the canonical 7-field constructor so the
-         * counts reach the optimize artefact (EX06).
+         * counts reach the optimize-experiment output artefact.
          */
         public IterationResult(
                 FT factors,

--- a/punit-core/src/main/java/org/javai/punit/api/spec/InconclusiveReasons.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/InconclusiveReasons.java
@@ -1,10 +1,10 @@
 package org.javai.punit.api.spec;
 
 /**
- * The RP01 vocabulary for the verdict-reason field on an
- * INCONCLUSIVE verdict.
+ * The vocabulary for the verdict-reason field on an INCONCLUSIVE
+ * verdict.
  *
- * <p>RP01 distinguishes six reasons. Two are detected at the run
+ * <p>Six reasons are distinguished. Two are detected at the run
  * level (covariate alignment and budget exhaustion); the other four
  * arise inside a criterion's {@link Criterion#evaluate} and are
  * surfaced via the criterion's {@link CriterionResult#detail()}
@@ -20,11 +20,7 @@ package org.javai.punit.api.spec;
  * package; placing the vocabulary anywhere else would force one
  * direction of the dependency to go upward through the layering.
  *
- * <p>This class is the single point of change for any future
- * RP01-vocabulary tweak — the catalog text and these constants
- * must stay in lockstep.
- *
- * @see <a href="https://github.com/javai-org/javai-orchestrator/blob/main/inventory/catalog/reporting/RP01-verdict-record/README.md">RP01 — Verdict record</a>
+ * <p>This class is the single point of change for the vocabulary.
  */
 public final class InconclusiveReasons {
 

--- a/punit-core/src/main/java/org/javai/punit/api/spec/Trial.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Trial.java
@@ -23,8 +23,8 @@ import org.javai.punit.api.UseCaseOutcome;
  * round-robin across samples, so for a run with N samples and M
  * inputs the trial at sample index i has
  * {@code inputIndex == (cycleStart + i) mod M}. Stored explicitly so
- * downstream artefacts (per EX07) can correlate a sample to its
- * driver without re-deriving the cycling formula.
+ * downstream artefacts can correlate a sample to its driver without
+ * re-deriving the cycling formula.
  *
  * @param input      the per-sample input that drove this trial
  * @param outcome    the outcome the use case returned (success or fail)

--- a/punit-core/src/main/java/org/javai/punit/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/Engine.java
@@ -143,10 +143,11 @@ public final class Engine {
         // from every sample so the all-samples latency stats never
         // skew on drop. passingForLatency holds durations from samples
         // that passed (Outcome.Ok at the contract layer per
-        // UseCaseOutcome.value()), feeding the LT01 passing-only
-        // descriptive percentiles emitted into EX04 / EX05 / EX06 /
-        // RP01 artefacts. trials carries the full ordered (input,
-        // outcome, duration) history regardless of the failure cap.
+        // UseCaseOutcome.value()), feeding the passing-only descriptive
+        // percentiles emitted into baseline, exploration, optimize,
+        // and verdict artefacts. trials carries the full ordered
+        // (input, outcome, duration) history regardless of the failure
+        // cap.
         private final List<UseCaseOutcome<?, OT>> retained = new ArrayList<>();
         private final List<UseCaseOutcome<?, OT>> allForLatency = new ArrayList<>();
         private final List<UseCaseOutcome<?, OT>> passingForLatency = new ArrayList<>();

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineIntegrity.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineIntegrity.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 import org.javai.punit.util.HashUtils;
 
 /**
- * EX10 baseline-integrity helper. Computes and verifies the
+ * Baseline-integrity helper. Computes and verifies the
  * {@code contentFingerprint:} field appended as the last line of
  * every measure baseline.
  *
@@ -19,17 +19,16 @@ import org.javai.punit.util.HashUtils;
  * measure produced it. The check is a soft warning on the verdict —
  * not a hard abort. The live test data is independently informative;
  * a verdict warning is loud, durable, and routes through the same
- * observability channel as every other test signal (per the EX10
- * "consequence of failure" prose).
+ * observability channel as every other test signal.
  *
  * <p>Three states:
  *
  * <ol>
  *   <li><b>OK</b> — line present, computed digest matches stored
  *       value. {@link #verify} returns {@link Optional#empty()}.</li>
- *   <li><b>MISSING</b> — line absent (typically a pre-EX10 baseline
- *       on disk). Returns the softer "predates integrity verification"
- *       wording.</li>
+ *   <li><b>MISSING</b> — line absent (typically a baseline on disk
+ *       that predates the integrity-verification feature). Returns
+ *       the softer "predates integrity verification" wording.</li>
  *   <li><b>MISMATCH</b> — line present, computed digest disagrees.
  *       Returns the louder "modified since generation" wording with
  *       expected and computed digests in the diagnostic.</li>

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineReader.java
@@ -53,9 +53,9 @@ public final class BaselineReader {
     /**
      * Reads, parses, and integrity-verifies the file at
      * {@code baselineFile}. Returns the parsed {@link BaselineRecord}
-     * paired with an optional integrity warning per EX10 — empty
-     * when the {@code contentFingerprint:} field's stored digest
-     * matches the recomputed body digest, populated otherwise.
+     * paired with an optional integrity warning — empty when the
+     * {@code contentFingerprint:} field's stored digest matches the
+     * recomputed body digest, populated otherwise.
      *
      * <p>Integrity failure does <em>not</em> propagate as an
      * exception; the warning is reported through the verdict's
@@ -116,7 +116,7 @@ public final class BaselineReader {
             entries.put(e.getKey(), parseStatisticsEntry(e.getKey(), e.getValue()));
         }
 
-        // Canonical EX04 location for latency: the top-level
+        // Canonical location for latency: the top-level
         // `latency:` block. When present, it sources the
         // PercentileLatency criterion's in-memory entry under
         // "percentile-latency" and overrides any legacy entry that
@@ -138,11 +138,11 @@ public final class BaselineReader {
     }
 
     /**
-     * Parse the top-level {@code latency:} block (the canonical EX04
-     * location post-LT01). Returns {@link LatencyIndicator#empty()}
-     * when the block is absent — legacy baselines that carry latency
-     * only under {@code statistics.percentile-latency} continue to
-     * load via the regular statistics-map path.
+     * Parse the top-level {@code latency:} block (the canonical
+     * location). Returns {@link LatencyIndicator#empty()} when the
+     * block is absent — legacy baselines that carry latency only
+     * under {@code statistics.percentile-latency} continue to load
+     * via the regular statistics-map path.
      */
     private LatencyIndicator parseLatencyIndicator(Map<String, Object> root) {
         if (!root.containsKey("latency")) {

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineResolver.java
@@ -156,9 +156,9 @@ public final class BaselineResolver {
                     Optional.empty());
         }
         Optional<String> sourceFile = Optional.of(selected.get().filename());
-        // EX10: surface the integrity warning (if any) for the
-        // *selected* candidate only — warnings about candidates that
-        // didn't influence the verdict would be noise.
+        // Surface the integrity warning (if any) for the *selected*
+        // candidate only — warnings about candidates that didn't
+        // influence the verdict would be noise.
         List<String> notes = withIntegrityWarning(
                 report.notes(), enumerated, selected.get());
         CovariateProfile baselineProfile = selected.get().covariateProfile();

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/BaselineWriter.java
@@ -71,18 +71,18 @@ public final class BaselineWriter {
      *
      * <p>The MEASURE baseline carries aggregate signal only —
      * pass-rate statistics, latency percentiles, covariate profile,
-     * footprint, fingerprint. Per-sample diagnostic detail (the EX07
+     * footprint, fingerprint. Per-sample diagnostic detail (the
      * result-projection shape) lives on EXPLORE / OPTIMIZE artefacts;
      * MEASURE per-sample failure context is emitted to {@code System.err}
      * as the engine processes each sample (one {@code [PUNIT-FAIL]}
      * line per failed clause), keeping the baseline file size constant
-     * in sample count and keeping the EX10 integrity fingerprint over
+     * in sample count and keeping the integrity fingerprint over
      * content the resolver actually reads.
      */
     public String toYaml(BaselineRecord record) {
         Objects.requireNonNull(record, "record");
         String body = yaml().dump(toYamlMap(record));
-        // EX10: append the SHA-256 of the body as the last field. The
+        // Append the SHA-256 of the body as the last field. The
         // reader recomputes the digest over the same prefix at load
         // time and surfaces a verdict warning when the file has been
         // modified since the measure produced it.
@@ -100,8 +100,8 @@ public final class BaselineWriter {
         root.put(FIELD_GENERATED_AT, DateTimeFormatter.ISO_INSTANT.format(record.generatedAt()));
 
         // The legacy criterion-named "percentile-latency" entry is
-        // no longer emitted to YAML — the canonical EX04 location
-        // for latency data is the top-level `latency:` block written
+        // no longer emitted to YAML — the canonical location for
+        // latency data is the top-level `latency:` block written
         // below. The in-memory map keeps the entry for the
         // PercentileLatency criterion's lookup; the reader
         // re-synthesises it from the top-level block on load.
@@ -121,13 +121,12 @@ public final class BaselineWriter {
             root.put(FIELD_COVARIATES,
                     new LinkedHashMap<>(record.covariateProfile().values()));
         }
-        // EX04 latency block — passing-only percentiles + LT01
-        // population indicator. Emitted top-level (not under
-        // statistics) per the catalog amendment landed via
-        // orchestrator PR #21. The block is omitted entirely when
-        // zero samples passed; individual percentiles within it are
-        // omitted per LT01's minimum-samples rule (1 / 10 / 20 /
-        // 100 for p50 / p90 / p95 / p99).
+        // Latency block — passing-only percentiles + population
+        // indicator. Emitted top-level (not under statistics). The
+        // block is omitted entirely when zero samples passed;
+        // individual percentiles within it are omitted per the
+        // minimum-samples rule (1 / 10 / 20 / 100 for p50 / p90 /
+        // p95 / p99).
         LatencyIndicator latency = record.latencyIndicator();
         if (latency.hasData()) {
             org.javai.punit.engine.output.LatencySection.blockFor(

--- a/punit-core/src/main/java/org/javai/punit/engine/baseline/LatencyIndicator.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/baseline/LatencyIndicator.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import org.javai.punit.api.LatencyResult;
 
 /**
- * Bundles a passing-only {@link LatencyResult} with the LT01
+ * Bundles a passing-only {@link LatencyResult} with the
  * population-indicator counts ({@code contributingSamples},
  * {@code totalSamples}). Carried on a {@link BaselineRecord} so the
  * baseline writer can emit the normative {@code latency:} YAML

--- a/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/explore/ExploreOutputWriter.java
@@ -19,21 +19,22 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * Serialises one EXPLORE configuration's outcome to the EX05 YAML
- * schema and resolves its readable-stem filename.
+ * Serialises one EXPLORE configuration's outcome to the
+ * explore-output YAML schema and resolves its readable-stem
+ * filename.
  *
  * <p>Both methods are pure — the writer performs no I/O. The
  * {@link org.javai.punit.runtime.ExploreEmitter EXPLORE emitter}
  * orchestrates persistence (writing to disk or to an in-memory
  * sink for tests).
  *
- * <p>Schema follows the canonical EX05 YAML shape: {@code factors:}
- * block in {@code FT}-component declaration order, descriptive
- * statistics only (no inferential statistics), small sample counts
- * accepted without warning. Per-sample result projections (EX07)
- * are not emitted here yet — when the trial path threads projection
- * metadata through, a {@code resultProjection:} block can be
- * appended additively.
+ * <p>Schema follows the canonical explore-output YAML shape:
+ * {@code factors:} block in factor-record declaration order,
+ * descriptive statistics only (no inferential statistics), small
+ * sample counts accepted without warning. Per-sample result
+ * projections are not emitted here yet — when the trial path threads
+ * projection metadata through, a {@code resultProjection:} block can
+ * be appended additively.
  */
 public final class ExploreOutputWriter {
 
@@ -50,14 +51,15 @@ public final class ExploreOutputWriter {
     private static final String EMPTY_BUNDLE_STEM = "no-factors";
 
     /**
-     * Build the EX05 YAML for one configuration. Pure — no I/O.
+     * Build the explore-output YAML for one configuration. Pure -
+     * no I/O.
      *
      * @param useCaseId the use case identifier (becomes the
      *                  {@code useCaseId:} field).
      * @param factorBundle the configuration's factor bundle (becomes
      *                     the {@code factors:} block).
      * @param entry the per-config summary plus planned sample count.
-     * @return YAML matching the EX05 canonical schema.
+     * @return YAML matching the canonical explore-output schema.
      */
     public String writeYaml(String useCaseId, FactorBundle factorBundle, PerConfigSummary<?, ?> entry) {
         Map<String, Object> root = new LinkedHashMap<>();
@@ -68,7 +70,7 @@ public final class ExploreOutputWriter {
         root.put("execution", executionBlock(entry));
         root.put("statistics", statisticsBlock(entry.summary()));
         root.put("cost", costBlock(entry.summary()));
-        // EX05 latency block — passing-only percentiles + LT01
+        // Latency block - passing-only percentiles + population
         // indicator. Inserted before resultProjection so the
         // aggregate latency precedes the per-sample timing data.
         // Omitted entirely when zero samples passed.
@@ -83,7 +85,7 @@ public final class ExploreOutputWriter {
 
     /**
      * Compute the readable-stem filename (without extension) for a
-     * factor bundle, per the algorithm in EX05 §Configuration naming.
+     * factor bundle.
      *
      * <p>For each entry in declaration order: produce
      * {@code {fieldName}-{canonicalValue}}, optionally truncated and

--- a/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/optimize/OptimizeOutputWriter.java
@@ -17,8 +17,8 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * Serialises a completed OPTIMIZE run's history to the EX06 YAML
- * schema. Pure — performs no I/O. The
+ * Serialises a completed OPTIMIZE run's history to the
+ * optimize-output YAML schema. Pure — performs no I/O. The
  * {@link org.javai.punit.runtime.OptimizeEmitter OPTIMIZE emitter}
  * orchestrates persistence (writing to disk or to an in-memory sink
  * for tests).
@@ -34,7 +34,8 @@ public final class OptimizeOutputWriter {
     public static final String SCHEMA_VERSION = "punit-spec-1";
 
     /**
-     * Build the EX06 YAML for one optimize run. Pure — no I/O.
+     * Build the optimize-output YAML for one optimize run. Pure —
+     * no I/O.
      *
      * @param useCaseId the use case identifier
      * @param experimentId the experiment identifier (becomes the
@@ -51,7 +52,7 @@ public final class OptimizeOutputWriter {
      *                          {@code NO_IMPROVEMENT},
      *                          {@code STEPPER_STOP}, or another
      *                          framework-recognised value)
-     * @return YAML matching the EX06 canonical schema
+     * @return YAML matching the canonical optimize-output schema
      */
     public String writeYaml(
             String useCaseId,
@@ -104,7 +105,7 @@ public final class OptimizeOutputWriter {
             entry.put("failures", ir.failures());
             entry.put("samplesExecuted", ir.samplesExecuted());
             // Per-iteration latency block — passing-only percentiles
-            // + LT01 indicator, scoped to this iteration's samples.
+            // + population indicator, scoped to this iteration's samples.
             // Omitted when zero samples passed in the iteration.
             // Per-iteration result projection: one sample[N]: block
             // per trial, carrying input / postconditions / etc. The

--- a/punit-core/src/main/java/org/javai/punit/engine/output/LatencySection.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/output/LatencySection.java
@@ -9,16 +9,15 @@ import org.javai.punit.api.spec.SampleSummary;
 
 /**
  * Produces the normative {@code latency:} YAML block emitted by
- * EX04 (baseline spec), EX05 (exploration row), EX06 (optimize
- * iteration), and the descriptive latency dimension of RP01
- * verdict records.
+ * the baseline spec, exploration rows, optimize iterations, and
+ * the descriptive latency dimension of verdict records.
  *
- * <p>Every emitted block carries the LT01 population-indicator
- * triple — {@code basis} (currently always {@code passing-samples}),
+ * <p>Every emitted block carries the population-indicator triple —
+ * {@code basis} (currently always {@code passing-samples}),
  * {@code contributingSamples}, and {@code totalSamples} — alongside
  * the four percentiles. The percentiles are computed from passing
- * samples only (per LT01); the indicator names that population so
- * a reader can verify it without external context.
+ * samples only; the indicator names that population so a reader
+ * can verify it without external context.
  *
  * <p>When zero samples passed, no block is emitted —
  * {@link #blockFor(SampleSummary)} returns {@link Optional#empty()}.
@@ -34,7 +33,7 @@ public final class LatencySection {
     /** The only currently defined population basis. */
     public static final String BASIS_PASSING_SAMPLES = "passing-samples";
 
-    /** Minimum contributing samples required to emit each percentile (LT01). */
+    /** Minimum contributing samples required to emit each percentile. */
     public static final int MIN_SAMPLES_P50 = 1;
     public static final int MIN_SAMPLES_P90 = 10;
     public static final int MIN_SAMPLES_P95 = 20;
@@ -44,8 +43,8 @@ public final class LatencySection {
      * Sentinel value carried in latency-percentile fields (e.g.
      * {@code p50Ms}, {@code p95Ms}, {@code p99Ms}, {@code maxMs}) to
      * mean "not reliably estimated" — the contributing-sample count
-     * fell below this percentile's LT01 minimum, so no value is
-     * emitted. Producers (the verdict adapter) write this; consumers
+     * fell below this percentile's minimum, so no value is emitted.
+     * Producers (the verdict adapter) write this; consumers
      * (text and HTML renderers) recognise it and substitute a dash
      * rather than the literal {@code -1}.
      */
@@ -54,7 +53,7 @@ public final class LatencySection {
     private LatencySection() { }
 
     /**
-     * Whether {@code contributingSamples} meets the LT01
+     * Whether {@code contributingSamples} meets the
      * minimum-sample threshold for the given percentile.
      *
      * @param percentileLabel one of {@code "p50"}, {@code "p90"},
@@ -63,14 +62,14 @@ public final class LatencySection {
      *                            available for the percentile
      *                            computation.
      * @return {@code true} if the count meets or exceeds the
-     *         minimum for that percentile per LT01's
+     *         minimum for that percentile per the
      *         {@code n ≥ 1 / (1 − p)} rule.
      */
     public static boolean isPercentileEmittable(String percentileLabel, int contributingSamples) {
         return contributingSamples >= minimumSamplesFor(percentileLabel);
     }
 
-    /** The LT01 minimum-contributing-samples threshold for a percentile label. */
+    /** The minimum-contributing-samples threshold for a percentile label. */
     public static int minimumSamplesFor(String percentileLabel) {
         return switch (percentileLabel) {
             case "p50" -> MIN_SAMPLES_P50;
@@ -108,10 +107,10 @@ public final class LatencySection {
         block.put("basis", BASIS_PASSING_SAMPLES);
         block.put("contributingSamples", contributingSamples);
         block.put("totalSamples", totalSamples);
-        // Per LT01, omit each percentile key when contributingSamples
-        // is below that percentile's minimum (1 / 10 / 20 / 100 for
-        // p50 / p90 / p95 / p99). The artefact carries only the
-        // percentiles that can be estimated reliably.
+        // Omit each percentile key when contributingSamples is below
+        // that percentile's minimum (1 / 10 / 20 / 100 for p50 / p90 /
+        // p95 / p99). The artefact carries only the percentiles that
+        // can be estimated reliably.
         if (isPercentileEmittable("p50", contributingSamples)) {
             block.put("p50Ms", passingPercentiles.p50().toMillis());
         }

--- a/punit-core/src/main/java/org/javai/punit/engine/output/ResultProjections.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/output/ResultProjections.java
@@ -16,15 +16,14 @@ import org.javai.punit.api.spec.Trial;
 
 /**
  * Shared helpers for the per-sample {@code resultProjection:} block
- * emitted by EXPLORE and OPTIMIZE artefacts (per the EX07 catalog
- * shape). Used by both
+ * emitted by EXPLORE and OPTIMIZE artefacts. Used by both
  * {@link org.javai.punit.engine.explore.ExploreOutputWriter} and
  * {@link org.javai.punit.engine.optimize.OptimizeOutputWriter}.
  *
  * <p>Two responsibilities:
  *
  * <ol>
- *   <li>{@link #projectionFor(Trial)} renders one trial as the EX07
+ *   <li>{@link #projectionFor(Trial)} renders one trial as the
  *       per-sample map (input / postconditions / executionTimeMs /
  *       content-or-failureDetail / optional tokensUsed).</li>
  *   <li>{@link #injectAnchorComments(String, List)} post-processes
@@ -47,7 +46,7 @@ public final class ResultProjections {
     private static final char[] HEX = "0123456789abcdef".toCharArray();
 
     /**
-     * Render one trial as the EX07 per-sample projection map.
+     * Render one trial as the per-sample projection map.
      *
      * @param trial one per-sample observation
      * @return ordered map carrying {@code input},
@@ -58,8 +57,8 @@ public final class ResultProjections {
      */
     public static Map<String, Object> projectionFor(Trial<?, ?> trial) {
         Map<String, Object> entry = new LinkedHashMap<>();
-        // EX07: emit the input's position in the inputs list, not
-        // the input's value. Punit's deterministic-inputs-list model
+        // Emit the input's position in the inputs list, not the
+        // input's value. Punit's deterministic-inputs-list model
         // means the developer has the inputs in hand; rendering
         // arbitrary IT types as canonical strings is fragile
         // (Object.toString → "com.example.Foo@1a2b3c4d") and bulks
@@ -106,10 +105,9 @@ public final class ResultProjections {
      * {@code SHA-256(i + ":" + inputIndex)}. Same trial position +
      * same inputIndex → same anchor → diff aligns. The hash uses
      * the inputIndex rather than a canonical-string rendering of
-     * the input value (per EX07): the input value itself isn't
-     * persisted to the artefact, and two runs of the same spec
-     * produce identical inputIndex sequences by virtue of
-     * deterministic cycling.
+     * the input value: the input value itself isn't persisted to
+     * the artefact, and two runs of the same spec produce identical
+     * inputIndex sequences by virtue of deterministic cycling.
      */
     public static List<String> anchorsFor(List<? extends Trial<?, ?>> trials) {
         List<String> anchors = new ArrayList<>(trials.size());

--- a/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/BaselineEmitter.java
@@ -144,8 +144,8 @@ final class BaselineEmitter {
         // LatencyStatistics retained on the in-memory record under
         // the criterion-name "percentile-latency" so the
         // PercentileLatency criterion's lookup path keeps working.
-        // Sourced from passingLatencyResult per LT01 — only samples
-        // whose contract evaluated to Outcome.ok contribute. The
+        // Sourced from passingLatencyResult: only samples whose
+        // contract evaluated to Outcome.ok contribute. The
         // legacy YAML emission of this entry under
         // statistics.percentile-latency is retired; the data lives
         // canonically in the top-level latency: block, and the
@@ -168,10 +168,9 @@ final class BaselineEmitter {
                 : CovariateResolver.defaults()
                         .resolve(declarations, useCase.customCovariateResolvers());
 
-        // EX04 descriptive latency: passing-only percentiles plus
-        // the LT01 population indicator. Empty when no samples
-        // passed; BaselineWriter omits the block entirely in that
-        // case.
+        // Descriptive latency: passing-only percentiles plus the
+        // population indicator. Empty when no samples passed;
+        // BaselineWriter omits the block entirely in that case.
         LatencyResult passing = summary.passingLatencyResult();
         LatencyIndicator latencyIndicator = passing.sampleCount() == 0
                 ? LatencyIndicator.empty()

--- a/punit-core/src/main/java/org/javai/punit/runtime/ExploreEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/ExploreEmitter.java
@@ -18,8 +18,8 @@ import org.javai.punit.api.spec.TypedSpec;
 import org.javai.punit.engine.explore.ExploreOutputWriter;
 
 /**
- * Translates a completed EXPLORE {@link Experiment} into one EX05
- * YAML file per configuration. Called from
+ * Translates a completed EXPLORE {@link Experiment} into one
+ * explore-output YAML file per configuration. Called from
  * {@link PUnit.ExploreBuilder#run} after the engine finishes the
  * sampling loop across the grid.
  *

--- a/punit-core/src/main/java/org/javai/punit/runtime/OptimizeEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/OptimizeEmitter.java
@@ -18,9 +18,10 @@ import org.javai.punit.api.spec.TypedSpec;
 import org.javai.punit.engine.optimize.OptimizeOutputWriter;
 
 /**
- * Translates a completed OPTIMIZE {@link Experiment} into the EX06
- * YAML artefact. Called from {@link PUnit.OptimizeBuilder#run} after
- * the engine finishes the iteration loop.
+ * Translates a completed OPTIMIZE {@link Experiment} into the
+ * optimize-output YAML artefact. Called from
+ * {@link PUnit.OptimizeBuilder#run} after the engine finishes the
+ * iteration loop.
  *
  * <p>One file per optimize run at
  * {@code {baseDir}/{useCaseId}/{experimentId}.yaml}. The file

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
@@ -208,9 +208,9 @@ public record ProbabilisticTestVerdict(
         /**
          * Backward-compatible 13-arg constructor that defaults
          * {@link #basis()} to {@code "passing-samples"} (the only
-         * currently defined population per LT01). Test fixtures and
-         * older call sites that haven't yet adopted the canonical
-         * 14-field shape can construct via this overload.
+         * currently defined population). Test fixtures and older
+         * call sites that haven't yet adopted the canonical 14-field
+         * shape can construct via this overload.
          */
         public LatencyDimension(
                 int successfulSamples,

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -109,9 +109,8 @@ public class ProbabilisticTestVerdictBuilder {
     // run can override via criterionVerdict(...).
     private Verdict criterionVerdict = Verdict.FAIL;
     // The criterion results carry the inconclusive-reason discriminant
-    // (per RP01 / InconclusiveReasons.DETAIL_KEY). When empty, the
-    // reason synthesis falls back to "insufficient evidence" — the
-    // RP01 catch-all.
+    // (see InconclusiveReasons.DETAIL_KEY). When empty, the reason
+    // synthesis falls back to "insufficient evidence" — the catch-all.
     private List<EvaluatedCriterion> criterionResults = List.of();
 
     // ── Postcondition failure histogram ───────────────────────────────────
@@ -263,8 +262,8 @@ public class ProbabilisticTestVerdictBuilder {
      * value is preserved through to {@link #derivePUnitVerdict} so an
      * INCONCLUSIVE result from the criterion (no baseline, sample-size
      * violation, identity mismatch) does not silently collapse to FAIL
-     * just because the run's covariates happen to be aligned (per
-     * RP01's verdict-consistent-with-statistical-analysis invariant).
+     * just because the run's covariates happen to be aligned, keeping
+     * the verdict consistent with the statistical analysis.
      */
     public ProbabilisticTestVerdictBuilder criterionVerdict(Verdict verdict) {
         this.criterionVerdict = java.util.Objects.requireNonNull(verdict, "verdict");
@@ -282,7 +281,7 @@ public class ProbabilisticTestVerdictBuilder {
      * violation, statistical insufficiency).
      *
      * <p>When unset, the verdict reason falls back to
-     * {@link InconclusiveReasons#INSUFFICIENT_EVIDENCE} — the RP01
+     * {@link InconclusiveReasons#INSUFFICIENT_EVIDENCE} — the
      * catch-all.
      */
     public ProbabilisticTestVerdictBuilder criterionResults(List<EvaluatedCriterion> results) {

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictAdapter.java
@@ -68,8 +68,8 @@ import org.javai.punit.verdict.ProbabilisticTestVerdictBuilder.MisalignmentInput
  *       INCONCLUSIVE regardless of what the criterion concluded).
  *       This preserves a non-covariate INCONCLUSIVE — no baseline,
  *       sample-size violation, identity mismatch — through to the
- *       rendered verdict, per the RP01 invariant that "the verdict
- *       is consistent with the statistical analysis."</li>
+ *       rendered verdict, preserving the invariant that the verdict
+ *       is consistent with the statistical analysis.</li>
  * </ul>
  *
  * <h2>What the adapter cannot fill</h2>
@@ -203,14 +203,15 @@ public final class VerdictAdapter {
     }
 
     private static LatencyInput toLatencyInput(EngineRunSummary engine) {
-        // LT01: only samples whose contract evaluated to Outcome.ok
+        // Only samples whose contract evaluated to Outcome.ok
         // contribute to the percentiles. Emit the descriptive
-        // dimension whenever ≥ 1 sample passed, independent of LT04
-        // activation; threshold/verdict sub-fields stay LT04-gated
-        // and are populated separately when assertions are configured.
-        // Each percentile is set to LatencySection.PERCENTILE_UNAVAILABLE_MS
-        // (the "unavailable" sentinel) when contributingSamples is below
-        // the LT01 minimum-samples threshold for that percentile.
+        // dimension whenever ≥ 1 sample passed, independent of
+        // latency-assertion activation; threshold/verdict sub-fields
+        // stay assertion-gated and are populated separately when
+        // assertions are configured. Each percentile is set to
+        // LatencySection.PERCENTILE_UNAVAILABLE_MS (the "unavailable"
+        // sentinel) when contributingSamples is below the
+        // minimum-samples threshold for that percentile.
         LatencyResult lat = engine.passingLatencyResult();
         if (lat.sampleCount() == 0) {
             return null;
@@ -219,14 +220,14 @@ public final class VerdictAdapter {
         return new LatencyInput(
                 contributing,                          // contributing (passing) samples
                 engine.samplesExecuted(),              // total samples
-                false,                                 // skipped (LT04 concept; descriptive emitted regardless)
+                false,                                 // skipped (assertion-side concept; descriptive emitted regardless)
                 null,                                  // skipReason
                 msIfEmittable("p50", lat.p50(), contributing),
                 msIfEmittable("p90", lat.p90(), contributing),
                 msIfEmittable("p95", lat.p95(), contributing),
                 msIfEmittable("p99", lat.p99(), contributing),
                 LatencySection.PERCENTILE_UNAVAILABLE_MS, // maxMs unavailable
-                List.of(),                             // assertions (LT04-gated; populated separately when active)
+                List.of(),                             // assertions (gated; populated separately when active)
                 List.of(),                             // caveats
                 contributing,                          // dimensionSuccesses
                 0);                                    // dimensionFailures
@@ -234,7 +235,7 @@ public final class VerdictAdapter {
 
     /**
      * Returns {@code duration.toMillis()} when the contributing-sample
-     * count meets the LT01 minimum-samples threshold for the named
+     * count meets the minimum-samples threshold for the named
      * percentile; otherwise returns
      * {@link LatencySection#PERCENTILE_UNAVAILABLE_MS} to signal "not
      * computed reliably." Renderers and serialisers recognise this

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictTextRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictTextRenderer.java
@@ -848,7 +848,7 @@ public final class VerdictTextRenderer {
     /**
      * Format a percentile's milliseconds value, rendering the
      * {@link LatencySection#PERCENTILE_UNAVAILABLE_MS} sentinel as
-     * {@code "-"} (LT01: contributingSamples below this percentile's
+     * {@code "-"} (contributingSamples below this percentile's
      * minimum threshold means the value is not reliably estimated).
      */
     private static String formatMsOrDash(long ms) {
@@ -869,10 +869,10 @@ public final class VerdictTextRenderer {
                         func.successes(), func.successes() + func.failures())));
 
         verdict.latency().ifPresent(lat -> {
-            // LT01 descriptive one-liner: surfaces the passing-only
+            // Descriptive one-liner: surfaces the passing-only
             // percentiles + indicator counts alongside the pass/fail
             // block so a reader sees latency at a glance, independent
-            // of LT04 activation. Percentiles below LT01's
+            // of latency-assertion activation. Percentiles below the
             // minimum-samples threshold render as "-" rather than a
             // misleading number.
             if (lat.successfulSamples() > 0) {
@@ -883,8 +883,8 @@ public final class VerdictTextRenderer {
                                 formatMsOrDash(lat.p95Ms()),
                                 formatMsOrDash(lat.p99Ms()))));
             }
-            // LT04 threshold-side summary — only when latency
-            // assertions are actually configured.
+            // Threshold-side summary - only when latency assertions
+            // are actually configured.
             if (!lat.skipped() && !lat.assertions().isEmpty()) {
                 sb.append(PUnitReporter.labelValueLn("Latency assertions:",
                         String.format("%d/%d within limit",

--- a/punit-core/src/test/java/org/javai/punit/api/spec/EmpiricalChecksTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/EmpiricalChecksTest.java
@@ -38,7 +38,7 @@ class EmpiricalChecksTest {
         assertThat(r.detail()).containsEntry("baselineSampleCount", 100);
         assertThat(r.detail()).containsEntry("origin", "EMPIRICAL");
         assertThat(r.detail())
-                .as("RP01 vocabulary discriminant for the verdict-builder")
+                .as("InconclusiveReasons discriminant for the verdict-builder")
                 .containsEntry(
                         InconclusiveReasons.DETAIL_KEY,
                         InconclusiveReasons.BASELINE_SAMPLE_SIZE_EXCEEDED);
@@ -105,7 +105,7 @@ class EmpiricalChecksTest {
         assertThat(r.detail()).containsEntry("baselineInputsIdentity", "sha256:baseline");
         assertThat(r.detail()).containsEntry("origin", "EMPIRICAL");
         assertThat(r.detail())
-                .as("RP01 vocabulary discriminant for the verdict-builder")
+                .as("InconclusiveReasons discriminant for the verdict-builder")
                 .containsEntry(
                         InconclusiveReasons.DETAIL_KEY,
                         InconclusiveReasons.BASELINE_INPUTS_MISMATCH);

--- a/punit-core/src/test/java/org/javai/punit/architecture/RequirementCodeIsolationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/architecture/RequirementCodeIsolationTest.java
@@ -1,0 +1,132 @@
+package org.javai.punit.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Requirement-code isolation rule.
+ *
+ * <p>The orchestrator catalog tracks features by short letter-prefix
+ * codes (CT04, EX04, LT01, RP01, and similar). Those codes are
+ * orchestrator-internal: they are not interpretable by a reader of
+ * punit's open-source code, who has no orchestrator access. Per the
+ * project family's convention, the codes must not leak into punit's
+ * production source (javadoc, inline comments, code, string literals):
+ * a feature gets referred to by its domain name, not by its tracking
+ * code.
+ *
+ * <p>This test walks every Java source file under the project's
+ * <code>src/main/java</code> trees and asserts no requirement-style
+ * code appears anywhere - neither in code nor in comments. It is the
+ * regression guard for the convention; any commit that reintroduces a
+ * code fails CI.
+ *
+ * <p>Wire-format constants (<code>"punit-baseline-2"</code>,
+ * <code>"verdict-1.0"</code>, and similar) are not requirement codes:
+ * they have a different shape (lowercase prefix, not two uppercase
+ * letters) and the regex below does not match them.
+ */
+@DisplayName("Requirement-code isolation")
+class RequirementCodeIsolationTest {
+
+    /**
+     * Matches the catalog's letter-prefix-plus-two-digit convention.
+     * Letters cover every prefix currently in use across the
+     * orchestrator catalog and design docs:
+     * <ul>
+     *   <li>CT - conformance testing</li>
+     *   <li>EX - experiments</li>
+     *   <li>LT - latency dimension</li>
+     *   <li>PT - probabilistic tests</li>
+     *   <li>RC - resource controls</li>
+     *   <li>RP - reporting</li>
+     *   <li>SC - statistics core</li>
+     *   <li>SN - sentinel</li>
+     *   <li>TH - test-harness integration</li>
+     *   <li>UC - use-case model</li>
+     *   <li>XM - examples</li>
+     *   <li>DG - design guides (orchestrator docs/)</li>
+     * </ul>
+     *
+     * <p>Two letters then exactly two digits, with word boundaries on
+     * either side. Matches RP01, LT04, EX10; does not match
+     * FT/IT/OT type-parameter conventions, nor lowercase-prefixed
+     * wire-format constants.
+     */
+    private static final Pattern REQUIREMENT_CODE = Pattern.compile(
+            "\\b(CT|EX|LT|PT|RC|RP|SC|SN|TH|UC|XM|DG)\\d{2}\\b");
+
+    /**
+     * Module src/main/java roots, relative to the project root the
+     * Gradle test task runs in (which is the per-module dir: this
+     * test lives in punit-core, so its CWD is .../punit/punit-core).
+     * Walk up one level to reach the project root, then descend
+     * per-module.
+     */
+    private static final List<Path> PRODUCTION_SOURCE_ROOTS = List.of(
+            Paths.get("..", "punit-core", "src", "main", "java"),
+            Paths.get("..", "punit-report", "src", "main", "java"),
+            Paths.get("..", "punit-sentinel", "src", "main", "java"));
+
+    @Test
+    @DisplayName("no orchestrator-internal requirement codes appear in production source")
+    void noLeaksInProductionSource() throws IOException {
+        List<String> hits = new ArrayList<>();
+        for (Path root : PRODUCTION_SOURCE_ROOTS) {
+            if (!Files.isDirectory(root)) {
+                throw new AssertionError(
+                        "Production source root not found: " + root.toAbsolutePath()
+                                + " - the test must run from the punit-core module directory.");
+            }
+            try (Stream<Path> stream = Files.walk(root)) {
+                stream
+                        .filter(p -> p.toString().endsWith(".java"))
+                        .forEach(file -> scanFile(file, hits));
+            }
+        }
+        assertThat(hits)
+                .as("Production source must be free of orchestrator requirement codes "
+                        + "(per the project family's convention; see CLAUDE.md). "
+                        + "Replace each match with a domain-language description "
+                        + "of the feature, or drop the cross-reference if it adds "
+                        + "no information beyond what the surrounding context already gives.")
+                .isEmpty();
+    }
+
+    private static void scanFile(Path file, List<String> hits) {
+        String content;
+        try {
+            content = Files.readString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read " + file, e);
+        }
+        Matcher matcher = REQUIREMENT_CODE.matcher(content);
+        while (matcher.find()) {
+            int line = lineNumberOf(content, matcher.start());
+            hits.add(file.normalize() + ":" + line + " - " + matcher.group());
+        }
+    }
+
+    private static int lineNumberOf(String content, int offset) {
+        int line = 1;
+        for (int i = 0; i < offset; i++) {
+            if (content.charAt(i) == '\n') {
+                line++;
+            }
+        }
+        return line;
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineIntegrityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineIntegrityTest.java
@@ -9,7 +9,7 @@ import org.javai.punit.util.HashUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("BaselineIntegrity — EX10 fingerprint emission and verification")
+@DisplayName("BaselineIntegrity — fingerprint emission and verification")
 class BaselineIntegrityTest {
 
     private static final Path FAKE_FILE = Path.of("/baselines/ShoppingBasket.measure-a1b2c3d4.yaml");
@@ -77,7 +77,7 @@ class BaselineIntegrityTest {
 
     @Test
     @DisplayName("verify returns the softer missing warning when no contentFingerprint: "
-            + "field is present (legacy pre-EX10 baseline)")
+            + "field is present (legacy baseline pre-dating the integrity feature)")
     void verifyMissingOnLegacyBaseline() {
         String legacy = "schemaVersion: punit-baseline-2\nuseCaseId: X\n";
 

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/BaselineWriterTest.java
@@ -156,7 +156,7 @@ class BaselineWriterTest {
 
     @Test
     @DisplayName("emits a contentFingerprint: line as the last field — SHA-256 of the body "
-            + "preceding it (EX10 integrity)")
+            + "preceding it (integrity check)")
     void emitsContentFingerprintAsLastField() {
         String yaml = writer.toYaml(recordWith(Map.of(
                 "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));

--- a/punit-core/src/test/java/org/javai/punit/engine/baseline/YamlBaselineProviderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/baseline/YamlBaselineProviderTest.java
@@ -108,7 +108,7 @@ class YamlBaselineProviderTest {
                 "ShoppingBasket", bundle, "bernoulli-pass-rate", PassRateStatistics.class);
 
         assertThat(lookup.selected())
-                .as("test runs to completion — verdict is not dismissed out of hand (EX10)")
+                .as("test runs to completion — verdict is not dismissed out of hand on integrity warning")
                 .isPresent();
         assertThat(lookup.notes())
                 .as("integrity warning lands in notes → ProbabilisticTestResult.warnings()")
@@ -117,13 +117,13 @@ class YamlBaselineProviderTest {
 
     @Test
     @DisplayName("baselineLookup propagates the softer missing-fingerprint warning when "
-            + "the selected baseline predates EX10")
+            + "the selected baseline predates the integrity-verification feature")
     void lookupSurfacesMissingWarning(@TempDir Path dir) throws IOException {
         FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
         BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
                 Map.of("bernoulli-pass-rate", new PassRateStatistics(0.88, 500)));
         Path file = writer.write(record, dir);
-        // Strip the trailing fingerprint line — synthesises a pre-EX10 baseline.
+        // Strip the trailing fingerprint line — synthesises a pre-integrity baseline.
         String stripped = Files.readString(file)
                 .replaceAll("(?m)^contentFingerprint:.*\\R?", "");
         Files.writeString(file, stripped);

--- a/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/explore/ExploreOutputWriterTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * Pure / in-memory tests for the EX05 explore output writer.
+ * Pure / in-memory tests for the explore output writer.
  *
  * <p>The writer is exercised both directly ({@link #writeYamlAndFilenameForOneConfig})
  * and through {@link ExploreEmitter}'s in-memory sink overload
  * ({@link #emitterCapturesOnePerConfig}) — neither test touches
  * disk.
  */
-@DisplayName("ExploreOutputWriter — EX05 schema, filename, end-to-end via in-memory sink")
+@DisplayName("ExploreOutputWriter — schema, filename, end-to-end via in-memory sink")
 class ExploreOutputWriterTest {
 
     record LlmFactors(String model, double temperature) {}
@@ -44,7 +44,7 @@ class ExploreOutputWriterTest {
     }
 
     @Test
-    @DisplayName("writeYaml emits the EX05 schema with factors / execution / statistics / cost / resultProjection blocks")
+    @DisplayName("writeYaml emits the schema with factors / execution / statistics / cost / resultProjection blocks")
     void writeYamlAndFilenameForOneConfig() {
         // Drive a 1-config explore through the engine to produce a
         // real PerConfigSummary, then feed the writer directly.
@@ -93,7 +93,7 @@ class ExploreOutputWriterTest {
         assertThat(projection).containsKeys("sample[0]", "sample[1]");
         @SuppressWarnings("unchecked")
         Map<String, Object> sample0 = (Map<String, Object>) projection.get("sample[0]");
-        // EX07 per-sample fields: input, postconditions, executionTimeMs;
+        // Per-sample fields: input, postconditions, executionTimeMs;
         // content present on success, failureDetail on failure (LengthUseCase
         // never fails so content is the expected key here).
         assertThat(sample0).containsKeys("inputIndex", "postconditions", "executionTimeMs", "content");
@@ -199,7 +199,7 @@ class ExploreOutputWriterTest {
         assertThat(sink).containsKeys(
                 "explore-test/model-gpt-4o_temperature-0.3.yaml",
                 "explore-test/model-gpt-4o_temperature-0.7.yaml");
-        // Each captured value parses as YAML carrying the EX05 schema header.
+        // Each captured value parses as YAML carrying the explore-output schema header.
         for (String yaml : sink.values()) {
             Map<String, Object> parsed = new Yaml().load(yaml);
             assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");

--- a/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/optimize/OptimizeOutputWriterTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * Pure / in-memory tests for the EX06 optimize output writer.
+ * Pure / in-memory tests for the optimize output writer.
  *
  * <p>The writer is exercised through {@link OptimizeEmitter}'s
  * in-memory sink overload — neither test touches disk.
  */
-@DisplayName("OptimizeOutputWriter — EX06 schema, end-to-end via in-memory sink")
+@DisplayName("OptimizeOutputWriter — schema, end-to-end via in-memory sink")
 class OptimizeOutputWriterTest {
 
     record LlmFactors(String model, double temperature) {}

--- a/punit-core/src/test/java/org/javai/punit/engine/output/LatencySectionTest.java
+++ b/punit-core/src/test/java/org/javai/punit/engine/output/LatencySectionTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for the LT01 {@code latency:} block builder.
+ * Unit tests for the {@code latency:} block builder.
  *
  * <p>Three cases:
  * <ul>
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
  *   <li>All samples passing → contributingSamples == totalSamples.</li>
  * </ul>
  */
-@DisplayName("LatencySection — LT01 block shape, indicator triple, zero-passing edge case")
+@DisplayName("LatencySection — block shape, indicator triple, zero-passing edge case")
 class LatencySectionTest {
 
     @Test
@@ -55,7 +55,7 @@ class LatencySectionTest {
     }
 
     @Test
-    @DisplayName("LT01 minimum-sample rule: 18 passing → only p50 / p90 keys emitted")
+    @DisplayName("minimum-sample rule: 18 passing → only p50 / p90 keys emitted")
     void omitsPercentilesBelowThreshold() {
         LatencyResult passing = new LatencyResult(
                 Duration.ofMillis(42),
@@ -89,7 +89,7 @@ class LatencySectionTest {
     }
 
     @Test
-    @DisplayName("isPercentileEmittable encodes the LT01 thresholds (1 / 10 / 20 / 100)")
+    @DisplayName("isPercentileEmittable encodes the thresholds (1 / 10 / 20 / 100)")
     void thresholdRule() {
         assertThat(LatencySection.isPercentileEmittable("p50", 1)).isTrue();
         assertThat(LatencySection.isPercentileEmittable("p90", 9)).isFalse();

--- a/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -26,12 +26,12 @@ import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * End-to-end integration test for the LT01 directive: every artefact
- * type — EX04 (MEASURE baseline), EX05 (EXPLORE per-row), EX06
- * (OPTIMIZE per-iteration), and RP01 (probabilistic-test verdict
- * descriptive latency dimension) — must emit a {@code latency:}
- * block carrying the population-indicator triple, computed from
- * passing samples only.
+ * End-to-end integration test for the descriptive-latency
+ * surfaces: every artefact type — MEASURE baseline, EXPLORE
+ * per-row, OPTIMIZE per-iteration, and the probabilistic-test
+ * verdict's descriptive latency dimension — must emit a
+ * {@code latency:} block carrying the population-indicator triple,
+ * computed from passing samples only.
  *
  * <p>Uses a deliberately mixed pass/fail population (input length
  * triggers the contract's failure clause for some inputs, success
@@ -41,14 +41,14 @@ import org.yaml.snakeyaml.Yaml;
  *
  * <p>All assertions run against in-memory sinks (no disk).
  */
-@DisplayName("LT01 — passing-only latency block surfaces in EX04 / EX05 / EX06 / RP01")
+@DisplayName("passing-only latency block surfaces in baseline / explore / optimize / verdict")
 class LatencyEverywhereIntegrationTest {
 
     record F(String label) {}
 
     /** Use case that succeeds when input length is even, fails otherwise. */
     private static class EvenLengthUseCase implements UseCase<F, String, Integer> {
-        @Override public String id() { return "lt01-test"; }
+        @Override public String id() { return "latency-everywhere-test"; }
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
@@ -63,7 +63,7 @@ class LatencyEverywhereIntegrationTest {
             "ab", "cdef", "ghij", "klmn", "x", "yz1");
 
     @Test
-    @DisplayName("EX05 EXPLORE row carries latency block with passing-only indicator")
+    @DisplayName("EXPLORE row carries latency block with passing-only indicator")
     void exploreRowCarriesLatency() {
         Sampling<F, String, Integer> sampling = Sampling
                 .<F, String, Integer>builder()
@@ -84,7 +84,7 @@ class LatencyEverywhereIntegrationTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> latency = (Map<String, Object>) parsed.get("latency");
         assertThat(latency)
-                .as("EX05 row must carry latency block when at least one sample passed")
+                .as("EXPLORE row must carry latency block when at least one sample passed")
                 .isNotNull();
         assertThat(latency).containsEntry("basis", "passing-samples");
         assertThat(latency).containsEntry("totalSamples", 6);
@@ -93,7 +93,7 @@ class LatencyEverywhereIntegrationTest {
                 .as("contributingSamples must be ≤ totalSamples and > 0")
                 .isPositive()
                 .isLessThanOrEqualTo(6);
-        // LT01 minimum-samples rule: with ≤ 6 contributing samples,
+        // Minimum-samples rule: with ≤ 6 contributing samples,
         // only p50Ms (needs ≥ 1) is emittable. p90 / p95 / p99 keys
         // are correctly absent — explore is the canonical
         // small-sample case the rule protects.
@@ -102,7 +102,7 @@ class LatencyEverywhereIntegrationTest {
     }
 
     @Test
-    @DisplayName("EX06 OPTIMIZE iterations each carry a latency block")
+    @DisplayName("OPTIMIZE iterations each carry a latency block")
     void optimizeIterationsCarryLatency() {
         Sampling<F, String, Integer> sampling = Sampling
                 .<F, String, Integer>builder()
@@ -117,7 +117,7 @@ class LatencyEverywhereIntegrationTest {
                         : NextFactor.stop())
                 .maximize(s -> 1.0 * s.successes() / Math.max(1, s.total()))
                 .maxIterations(3)
-                .experimentId("lt01-opt")
+                .experimentId("latency-everywhere-opt")
                 .build();
         new Engine().run(experiment);
 
@@ -143,7 +143,7 @@ class LatencyEverywhereIntegrationTest {
     }
 
     @Test
-    @DisplayName("EX04 MEASURE baseline carries latency block")
+    @DisplayName("MEASURE baseline carries latency block")
     void measureBaselineCarriesLatency() {
         Sampling<F, String, Integer> sampling = Sampling
                 .<F, String, Integer>builder()
@@ -162,18 +162,18 @@ class LatencyEverywhereIntegrationTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> latency = (Map<String, Object>) parsed.get("latency");
         assertThat(latency)
-                .as("EX04 baseline must carry latency block when at least one sample passed")
+                .as("MEASURE baseline must carry latency block when at least one sample passed")
                 .isNotNull();
         assertThat(latency).containsEntry("basis", "passing-samples");
         assertThat(latency).containsKey("contributingSamples");
         assertThat(latency).containsKey("totalSamples");
-        // LT01: 6 samples, ≤ 6 contributing → only p50Ms emits.
+        // 6 samples, ≤ 6 contributing → only p50Ms emits.
         assertThat(latency).containsKey("p50Ms");
         assertThat(latency).doesNotContainKeys("p95Ms", "p99Ms");
     }
 
     @Test
-    @DisplayName("RP01 verdict carries descriptive latency dimension when ≥1 passing sample")
+    @DisplayName("verdict record carries descriptive latency dimension when ≥1 passing sample")
     void verdictCarriesDescriptiveLatency() {
         Sampling<F, String, Integer> sampling = Sampling
                 .<F, String, Integer>builder()
@@ -201,7 +201,7 @@ class LatencyEverywhereIntegrationTest {
                 .isEqualTo(verdict.functional().get().successes());
         assertThat(lat.totalSamples()).isEqualTo(6);
         assertThat(lat.assertions())
-                .as("descriptive verdict must not carry assertions when LT04 is not active")
+                .as("descriptive verdict must not carry assertions when latency assertions are not active")
                 .isEmpty();
     }
 

--- a/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/verdict/VerdictAdapterTest.java
@@ -143,7 +143,7 @@ class VerdictAdapterTest {
 
         @Test
         @DisplayName("INCONCLUSIVE with the 'no baseline available' criterion discriminant "
-                + "renders that reason on the verdict (RP01 vocabulary)")
+                + "renders that reason on the verdict (verdict-reason vocabulary)")
         void inconclusiveNoBaselineAvailable() {
             ProbabilisticTestVerdict verdict = adapt(inconclusiveWithReason(
                     InconclusiveReasons.NO_BASELINE_AVAILABLE));
@@ -187,7 +187,7 @@ class VerdictAdapterTest {
 
         @Test
         @DisplayName("INCONCLUSIVE with no discriminant on the criterion-result detail "
-                + "map falls back to 'insufficient evidence' — RP01 catch-all "
+                + "map falls back to 'insufficient evidence' — the catch-all "
                 + "(backward compat for criteria pre-dating the vocabulary expansion)")
         void inconclusiveNoDiscriminantFallsBack() {
             // No criterion result on the test result — the builder's
@@ -200,15 +200,15 @@ class VerdictAdapterTest {
 
         @Test
         @DisplayName("INCONCLUSIVE with aligned covariates produces PUnitVerdict.INCONCLUSIVE "
-                + "with reason 'insufficient evidence' (RP01 verdict-fidelity regression)")
+                + "with reason 'insufficient evidence' (verdict-fidelity regression)")
         void inconclusiveSurvivesAlignedCovariates() {
             // The reproducer: a criterion that returns Verdict.INCONCLUSIVE
             // for a non-covariate reason (no baseline, sample-size violation,
             // identity mismatch) must not silently collapse to FAIL just
-            // because the run's covariates happen to be aligned. RP01
-            // requires the punit verdict to be consistent with the
-            // statistical analysis and the verdict reason to be consistent
-            // with the verdict enum.
+            // because the run's covariates happen to be aligned. The
+            // punit verdict must be consistent with the statistical
+            // analysis and the verdict reason must be consistent with
+            // the verdict enum.
             ProbabilisticTestVerdict verdict = adapt(minimalResult(Verdict.INCONCLUSIVE));
 
             assertThat(verdict.covariates().aligned())
@@ -216,7 +216,7 @@ class VerdictAdapterTest {
                     .isTrue();
             assertThat(verdict.punitVerdict()).isEqualTo(PUnitVerdict.INCONCLUSIVE);
             assertThat(verdict.verdictReason())
-                    .as("RP01: verdict reason consistent with verdict enum value")
+                    .as("verdict reason consistent with verdict enum value")
                     .isEqualTo("insufficient evidence");
         }
 
@@ -275,7 +275,7 @@ class VerdictAdapterTest {
         }
 
         @Test
-        @DisplayName("LT01 minimum-samples rule: at n=50 contributing, p99Ms is the omit-sentinel")
+        @DisplayName("minimum-samples rule: at n=50 contributing, p99Ms is the omit-sentinel")
         void omitsP99BelowThreshold() {
             // 50 contributing samples → p50 (≥ 1) and p90 (≥ 10)
             // and p95 (≥ 20) all emit; p99 (≥ 100) does not.

--- a/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
@@ -273,8 +273,8 @@ final class HtmlReportWriter {
     private static void appendLatencyCell(StringBuilder html, LatencyDimension lat,
                                              String label, long observedMs) {
         if (observedMs == LatencySection.PERCENTILE_UNAVAILABLE_MS) {
-            // Below the LT01 minimum-samples threshold for this
-            // percentile — render as a dash rather than the literal
+            // Below the minimum-samples threshold for this
+            // percentile - render as a dash rather than the literal
             // sentinel value or a misleading number.
             html.append("<td class=\"latency-observed\">-</td>\n");
             return;

--- a/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
@@ -475,9 +475,9 @@ class HtmlReportWriterTest {
         }
 
         @Test
-        @DisplayName("unavailable percentile (LT01 below-minimum sentinel) renders as a dash")
+        @DisplayName("unavailable percentile (below-minimum sentinel) renders as a dash")
         void unavailablePercentileRendersAsDash() {
-            // p99 below LT01 minimum (100 contributing samples) is
+            // p99 below the minimum (100 contributing samples) is
             // emitted as PERCENTILE_UNAVAILABLE_MS by the adapter; the
             // HTML cell must show "-" rather than "-1ms" or a literal
             // sentinel value.

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictTextRendererTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictTextRendererTest.java
@@ -74,13 +74,13 @@ class VerdictTextRendererTest {
         }
 
         @Test
-        @DisplayName("includes contract line and LT01 descriptive latency one-liner")
+        @DisplayName("includes contract line and descriptive latency one-liner")
         void includesDimensionBreakdown() {
             String text = VerdictTextRenderer.renderSummary(verdictWithBothDimensions());
 
             assertThat(text).contains("Contract:");
             assertThat(text).contains("95/100 passed");
-            // LT01 descriptive line: passing-only count + percentiles
+            // Descriptive line: passing-only count + percentiles
             // surfaced alongside the pass/fail block.
             assertThat(text).contains("Latency:");
             assertThat(text).contains("(90/100 passing)");
@@ -94,7 +94,7 @@ class VerdictTextRendererTest {
         void contractAloneWhenZeroPassing() {
             String text = VerdictTextRenderer.renderSummary(verdictWithSkippedLatency());
 
-            // Per LT01, the Contract line is independent of latency
+            // The Contract line is independent of latency
             // emission; it shows whenever functional dimension is
             // populated. The descriptive Latency line is omitted
             // when no samples passed (no contributing population).


### PR DESCRIPTION
## Summary
- Strips ~84 orchestrator catalog codes (CT04, EX06, LT01, RP01, …) from punit's javadoc, inline comments, `@DisplayName`, and assertion messages across punit-core and punit-report
- Replaces each with a domain-language description ("baseline integrity check", "passing-only latency block", "verdict-reason vocabulary", …) so a reader of the open-source code can interpret the prose without orchestrator access
- Adds `RequirementCodeIsolationTest` as a regression guard — walks every `*/src/main/java` tree and fails on the regex `\b(CT\|EX\|LT\|PT\|RC\|RP\|SC\|SN\|TH\|UC\|XM\|DG)\d{2}\b`

The codes are tracking shorthand internal to the javai orchestrator's feature catalog. Punit ships open-source; references to that catalog are noise to outside readers (and break when the catalog renumbers). Domain language carries the same information without the dependency.

## Test plan
- [x] `./gradlew :punit-core:test --tests "RequirementCodeIsolationTest"` passes
- [x] `./gradlew test` — full suite green across all modules
- [x] `grep -rE '\b(CT\|EX\|LT\|PT\|RC\|RP\|SC\|SN\|TH\|UC\|XM\|DG)[0-9]{2}\b' punit-*/src/main/java` returns zero hits
- [x] Test sources also swept for `@DisplayName` / comment leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)