### PR TITLE
Preflight baseline-existence probe: short-circuit empirical-no-baseline before sampling

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Criterion.java
@@ -1,5 +1,7 @@
 package org.javai.punit.api.spec;
 
+import java.util.Map;
+
 /**
  * A spec-level claim evaluated against the observed sample aggregate.
  *
@@ -56,5 +58,29 @@ public interface Criterion<OT, S extends BaselineStatistics> {
      */
     default boolean isEmpirical() {
         return false;
+    }
+
+    /**
+     * Snapshot of this criterion's configuration as a flat detail map.
+     * Empirical criteria override to surface keys like
+     * {@code confidence} (Bernoulli pass-rate) or
+     * {@code assertedPercentiles} (percentile latency); contractual
+     * criteria return an empty map.
+     *
+     * <p>Used wherever the framework synthesises an INCONCLUSIVE
+     * {@link CriterionResult} on this criterion's behalf (e.g. the
+     * preflight short-circuit when no baseline is resolvable) so the
+     * result carries the same diagnostic shape the criterion's own
+     * post-sampling path would have produced. Each empirical
+     * criterion's {@code evaluate} also reads this map to populate
+     * the corresponding keys on its own results, keeping one source
+     * of truth.
+     *
+     * @return an ordered map of detail keys — possibly empty — that
+     *         the criterion contributes to any diagnostic result
+     *         produced on its behalf
+     */
+    default Map<String, Object> empiricalDetail() {
+        return Map.of();
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/EmpiricalChecks.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/EmpiricalChecks.java
@@ -29,6 +29,54 @@ public final class EmpiricalChecks {
     private EmpiricalChecks() {}
 
     /**
+     * No-baseline rule: an empirical criterion has no resolvable
+     * baseline matching the run's (use-case-id, factors fingerprint,
+     * covariate profile) lookup tuple. The criterion cannot proceed —
+     * an empirical comparison requires a baseline to compare against.
+     *
+     * <p>Single source of truth for the INCONCLUSIVE-no-baseline
+     * shape. Called by each empirical criterion's {@code evaluate}
+     * (the post-sampling fallback) and by the framework's preflight
+     * existence probe (which short-circuits before the engine takes
+     * any samples — there is nothing the sampling step can contribute
+     * when the verdict is structurally guaranteed to be INCONCLUSIVE).
+     *
+     * <p>Returns {@link Verdict#INCONCLUSIVE} rather than
+     * {@link Verdict#FAIL}: missing baseline is a configuration gap,
+     * not service degradation. The diagnostic names the corrective
+     * action (run a measure experiment under this configuration).
+     *
+     * @param criterionName    the criterion's stable name
+     *                         ({@link Criterion#name()}) — used in the
+     *                         returned {@code CriterionResult}
+     * @param additionalDetail criterion-specific entries to include in
+     *                         the no-baseline detail map (e.g.
+     *                         {@code confidence}, {@code assertedPercentiles}).
+     *                         May be empty.
+     * @return an INCONCLUSIVE {@code CriterionResult} carrying the
+     *         {@link InconclusiveReasons#NO_BASELINE_AVAILABLE}
+     *         discriminant on its detail map
+     */
+    public static CriterionResult noBaseline(
+            String criterionName,
+            Map<String, Object> additionalDetail) {
+        Objects.requireNonNull(criterionName, "criterionName");
+        Objects.requireNonNull(additionalDetail, "additionalDetail");
+        Map<String, Object> detail = new LinkedHashMap<>(additionalDetail);
+        detail.putIfAbsent("origin", ThresholdOrigin.EMPIRICAL.name());
+        detail.put(InconclusiveReasons.DETAIL_KEY,
+                InconclusiveReasons.NO_BASELINE_AVAILABLE);
+        String reason = "no baseline was resolvable for the empirical "
+                + "comparison — the framework matches by use-case id, "
+                + "factors fingerprint, and (when declared) covariate "
+                + "profile; no on-disk baseline aligned with the run's "
+                + "configuration. Run a measure experiment under this "
+                + "configuration first.";
+        return new CriterionResult(
+                criterionName, Verdict.INCONCLUSIVE, reason, detail);
+    }
+
+    /**
      * Sample-size rule: the test's sample count must not exceed the
      * resolved baseline's sample count. In punit's authoring model
      * the baseline is the rigorous-truth measurement; the test is a

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
@@ -114,6 +114,14 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
     }
 
     @Override
+    public Map<String, Object> empiricalDetail() {
+        if (mode == Mode.CONTRACTUAL) {
+            return Map.of();
+        }
+        return Map.of("assertedPercentiles", assertedCsv());
+    }
+
+    @Override
     public CriterionResult evaluate(EvaluationContext<OT, LatencyStatistics> ctx) {
         Objects.requireNonNull(ctx, "ctx");
         SampleSummary<OT> summary = ctx.summary();
@@ -131,14 +139,7 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
         } else {
             LatencyStatistics stats = ctx.baseline().orElse(null);
             if (stats == null) {
-                return inconclusive(
-                        "no baseline was resolvable for the empirical thresholds — "
-                                + "the framework matches by use-case id, factors "
-                                + "fingerprint, and (when declared) covariate profile; "
-                                + "no on-disk baseline aligned with the run's "
-                                + "configuration. Run a measure experiment under this "
-                                + "configuration first.",
-                        Map.of("assertedPercentiles", assertedCsv(), "origin", ThresholdOrigin.EMPIRICAL.name()));
+                return EmpiricalChecks.noBaseline(NAME, empiricalDetail());
             }
             Map<String, Object> empiricalDetail = Map.of("assertedPercentiles", assertedCsv());
             // Inputs-identity rule precedes the sample-size rule: an identity

--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/PassRate.java
@@ -13,7 +13,6 @@ import org.javai.punit.api.spec.CriterionResult;
 import org.javai.punit.api.spec.EmpiricalChecks;
 import org.javai.punit.api.spec.EvaluationContext;
 import org.javai.punit.api.spec.Experiment;
-import org.javai.punit.api.spec.InconclusiveReasons;
 import org.javai.punit.api.spec.PassRateStatistics;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.Verdict;
@@ -181,6 +180,14 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
     }
 
     @Override
+    public Map<String, Object> empiricalDetail() {
+        if (mode == Mode.CONTRACTUAL) {
+            return Map.of();
+        }
+        return Map.of("confidence", confidence);
+    }
+
+    @Override
     public CriterionResult evaluate(EvaluationContext<OT, PassRateStatistics> ctx) {
         Objects.requireNonNull(ctx, "ctx");
         SampleSummary<OT> summary = ctx.summary();
@@ -200,19 +207,7 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
         } else {
             PassRateStatistics stats = ctx.baseline().orElse(null);
             if (stats == null) {
-                Map<String, Object> detail = new LinkedHashMap<>();
-                detail.put("confidence", confidence);
-                detail.put("origin", ThresholdOrigin.EMPIRICAL.name());
-                detail.put(InconclusiveReasons.DETAIL_KEY,
-                        InconclusiveReasons.NO_BASELINE_AVAILABLE);
-                return inconclusive(
-                        "no baseline was resolvable for the empirical threshold — "
-                                + "the framework matches by use-case id, factors "
-                                + "fingerprint, and (when declared) covariate profile; "
-                                + "no on-disk baseline aligned with the run's "
-                                + "configuration. Run a measure experiment under this "
-                                + "configuration first.",
-                        detail);
+                return EmpiricalChecks.noBaseline(NAME, empiricalDetail());
             }
             Map<String, Object> empiricalDetail = Map.of("confidence", confidence);
             // Inputs-identity rule precedes the sample-size rule: an identity

--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -2,7 +2,9 @@ package org.javai.punit.runtime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
@@ -15,10 +17,15 @@ import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.UseCase;
 import org.javai.punit.api.ValueMatcher;
+import org.javai.punit.api.spec.BaselineLookup;
 import org.javai.punit.api.spec.BaselineProvider;
+import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.Criterion;
 import org.javai.punit.api.spec.CriterionResult;
+import org.javai.punit.api.spec.CriterionRole;
+import org.javai.punit.api.spec.EmpiricalChecks;
 import org.javai.punit.api.spec.EngineResult;
+import org.javai.punit.api.spec.EngineRunSummary;
 import org.javai.punit.api.spec.EvaluatedCriterion;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.FactorsStepper;
@@ -173,33 +180,29 @@ public final class PUnit {
     }
 
     /**
-     * Resolves the use case's covariate profile from {@code spec}'s
-     * first configuration. Returns {@link CovariateProfile#empty()}
-     * when the use case declared no covariates.
+     * Generic-binding helper for the baseline-existence probe. The
+     * caller has a {@code Criterion<?, ?>} (statistics type wildcarded);
+     * this method binds {@code S} via the criterion's
+     * {@link Criterion#statisticsType() statisticsType} so the typed
+     * {@link BaselineProvider#baselineLookup} call compiles.
      *
-     * <p>The profile is resolved once per run, before any samples
-     * execute.
+     * <p>{@code baselineLookup} (not {@code baselineFor}) is used so
+     * the lookup's rejection notes flow through to the synthesised
+     * result's warnings. {@link #translate} reads those notes to
+     * distinguish "no candidates existed" (legitimate INCONCLUSIVE
+     * → JUnit-aborted) from "candidates existed but all rejected"
+     * (misconfiguration → JUnit-failed).
      */
-    private static CovariateProfile resolveCovariateProfile(
-            Spec spec) {
-        return spec.dispatch(new Spec.Dispatcher<CovariateProfile>() {
-            @Override
-            public <FT, IT, OT> CovariateProfile apply(
-                    TypedSpec<FT, IT, OT> typed) {
-                var configs = typed.configurations();
-                if (!configs.hasNext()) {
-                    return CovariateProfile.empty();
-                }
-                FT factors = configs.next().factors();
-                UseCase<FT, IT, OT> useCase = typed.useCaseFactory().apply(factors);
-                List<Covariate> declarations = useCase.covariates();
-                if (declarations.isEmpty()) {
-                    return CovariateProfile.empty();
-                }
-                return CovariateResolver.defaults()
-                        .resolve(declarations, useCase.customCovariateResolvers());
-            }
-        });
+    private static <S extends BaselineStatistics> BaselineLookup<S> probeBaseline(
+            BaselineProvider provider,
+            String useCaseId,
+            FactorBundle bundle,
+            Criterion<?, S> criterion,
+            CovariateProfile profile,
+            List<Covariate> declarations) {
+        return provider.baselineLookup(
+                useCaseId, bundle, criterion.name(),
+                criterion.statisticsType(), profile, declarations);
     }
 
     /**
@@ -676,25 +679,46 @@ public final class PUnit {
 
         public void assertPasses() {
             ProbabilisticTest spec = build();
-            List<String> warnings = preflightFeasibility();
+            UseCase<FT, IT, OT> useCase = sampling.useCaseFactory().apply(factors);
+            String useCaseId = useCase.id();
+            CovariateProfile observed = resolveCovariates(useCase);
+            BaselineProvider provider = boundProvider(useCase, observed);
+
+            // Existence probe runs before sampling: when any required
+            // empirical criterion has no resolvable baseline the verdict
+            // is structurally guaranteed to be INCONCLUSIVE-no-baseline,
+            // and sampling cannot influence the outcome — every sample
+            // would just be charged to the user's account before the
+            // criterion's evaluate() discovered the missing baseline.
+            // Short-circuit through the same emitVerdict / translate
+            // pipeline the post-sampling path uses; the operator-visible
+            // diagnostic is byte-equivalent modulo samplesExecuted = 0.
+            Optional<ProbabilisticTestResult> shortCircuit =
+                    baselineExistencePreflight(useCase, observed, provider);
+            if (shortCircuit.isPresent()) {
+                ProbabilisticTestResult synthesised = shortCircuit.get();
+                maybeRenderTransparentStats(synthesised);
+                emitVerdict(synthesised, useCaseId);
+                translate(synthesised, useCaseId);
+                return;
+            }
+
+            List<String> warnings = preflightFeasibility(useCase, provider);
             EngineResult result = drive(spec);
             if (!(result instanceof ProbabilisticTestResult typed)) {
                 throw new IllegalStateException(
                         "Engine produced unexpected result type: " + result.getClass().getName());
             }
             warnings.forEach(System.err::println);
-            // Resolve the run's observed covariate profile and stamp
-            // it onto the result alongside the baseline profile that
-            // conclude collected. The structured CovariateAlignment
-            // flows downstream — to the verbose renderer here, and
-            // to HTML / XML / JSON sinks.
-            CovariateProfile observed = resolveCovariateProfile(spec);
+            // Stamp the run's observed covariate profile onto the result
+            // alongside the baseline profile conclude collected. The
+            // structured CovariateAlignment flows downstream — to the
+            // verbose renderer here, and to HTML / XML / JSON sinks.
             ProbabilisticTestResult stamped = typed.withCovariates(
                             CovariateAlignment.compute(
                                     observed, typed.covariates().baseline()))
                     .withContractRef(contractRef);
             maybeRenderTransparentStats(stamped);
-            String useCaseId = sampling.useCaseFactory().apply(factors).id();
             emitVerdict(stamped, useCaseId);
             translate(stamped, useCaseId);
         }
@@ -707,21 +731,87 @@ public final class PUnit {
             System.err.println(TransparentStatsRenderer.render(testIdentity, result));
         }
 
-        private List<String> preflightFeasibility() {
-            UseCase<FT, IT, OT> useCase = sampling.useCaseFactory().apply(factors);
+        private CovariateProfile resolveCovariates(UseCase<FT, IT, OT> useCase) {
+            List<Covariate> declarations = useCase.covariates();
+            if (declarations.isEmpty()) {
+                return CovariateProfile.empty();
+            }
+            return CovariateResolver.defaults()
+                    .resolve(declarations, useCase.customCovariateResolvers());
+        }
+
+        private BaselineProvider boundProvider(
+                UseCase<FT, IT, OT> useCase, CovariateProfile observed) {
+            BaselineProvider raw = BaselineProviderResolver.resolve();
+            return ProfileBoundBaselineProvider.bind(
+                    raw, observed, useCase.covariates());
+        }
+
+        /**
+         * Probes baseline existence per required empirical criterion.
+         * Returns a synthesised INCONCLUSIVE-no-baseline result when
+         * any required empirical criterion is missing its baseline;
+         * empty when sampling can proceed.
+         *
+         * <p>Lookup notes (rejected candidates, partial-match
+         * announcements) are pulled from each probed criterion and
+         * propagated into the synthesised result's
+         * {@link ProbabilisticTestResult#warnings()} list — that's
+         * what {@link #translate} reads to distinguish the
+         * "candidates existed but all rejected" misconfiguration FAIL
+         * from the "no candidates at all" legitimate-skip ABORT.
+         */
+        private Optional<ProbabilisticTestResult> baselineExistencePreflight(
+                UseCase<FT, IT, OT> useCase,
+                CovariateProfile observed,
+                BaselineProvider provider) {
             String useCaseId = useCase.id();
             FactorBundle bundle = FactorBundle.of(factors);
-            BaselineProvider raw = BaselineProviderResolver.resolve();
-            // Bind the run's covariate profile so Feasibility sees the
-            // baseline that will actually drive evaluation, not a sibling
-            // covariate-tagged file that happens to share useCaseId+ff.
             List<Covariate> declarations = useCase.covariates();
-            CovariateProfile profile = declarations.isEmpty()
-                    ? CovariateProfile.empty()
-                    : CovariateResolver.defaults()
-                            .resolve(declarations, useCase.customCovariateResolvers());
-            BaselineProvider provider = ProfileBoundBaselineProvider.bind(
-                    raw, profile, declarations);
+            List<EvaluatedCriterion> noBaselineResults = new ArrayList<>();
+            List<String> notes = new ArrayList<>();
+            for (Criterion<OT, ?> c : requiredCriteria) {
+                if (!c.isEmpirical()) {
+                    continue;
+                }
+                BaselineLookup<?> lookup = probeBaseline(
+                        provider, useCaseId, bundle, c, observed, declarations);
+                if (lookup.selected().isPresent()) {
+                    continue;
+                }
+                CriterionResult r = EmpiricalChecks.noBaseline(c.name(), c.empiricalDetail());
+                noBaselineResults.add(new EvaluatedCriterion(r, CriterionRole.REQUIRED));
+                notes.addAll(lookup.notes());
+            }
+            if (noBaselineResults.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(synthesiseNoBaselineResult(noBaselineResults, notes, observed));
+        }
+
+        private ProbabilisticTestResult synthesiseNoBaselineResult(
+                List<EvaluatedCriterion> noBaselineResults,
+                List<String> warnings,
+                CovariateProfile observed) {
+            Optional<String> contractRefOpt = (contractRef == null || contractRef.isBlank())
+                    ? Optional.empty()
+                    : Optional.of(contractRef);
+            return new ProbabilisticTestResult(
+                    Verdict.compose(noBaselineResults),
+                    FactorBundle.of(factors),
+                    noBaselineResults,
+                    intent,
+                    warnings,
+                    CovariateAlignment.compute(observed, CovariateProfile.empty()),
+                    contractRefOpt,
+                    Map.of(),
+                    EngineRunSummary.empty());
+        }
+
+        private List<String> preflightFeasibility(
+                UseCase<FT, IT, OT> useCase, BaselineProvider provider) {
+            String useCaseId = useCase.id();
+            FactorBundle bundle = FactorBundle.of(factors);
             List<String> warnings = new ArrayList<>();
             for (Criterion<OT, ?> c : requiredCriteria) {
                 warnings.addAll(Feasibility.check(
@@ -810,36 +900,72 @@ public final class PUnit {
 
         public void assertPasses() {
             ProbabilisticTest spec = build();
-            List<String> warnings = preflightFeasibility(spec);
+            SpecContext ctx = resolveSpecContext(spec);
+
+            // Existence probe runs before sampling: see TestBuilder.assertPasses
+            // for the rationale.
+            Optional<ProbabilisticTestResult> shortCircuit =
+                    baselineExistencePreflight(ctx);
+            if (shortCircuit.isPresent()) {
+                ProbabilisticTestResult synthesised = shortCircuit.get();
+                maybeRenderTransparentStats(ctx, synthesised);
+                emitVerdict(synthesised, ctx.useCaseId);
+                translate(synthesised, ctx.useCaseId);
+                return;
+            }
+
+            List<String> warnings = preflightFeasibility(ctx);
             EngineResult result = drive(spec);
             if (!(result instanceof ProbabilisticTestResult typed)) {
                 throw new IllegalStateException(
                         "Engine produced unexpected result type: " + result.getClass().getName());
             }
             warnings.forEach(System.err::println);
-            CovariateProfile observed = resolveCovariateProfile(spec);
             ProbabilisticTestResult stamped = typed.withCovariates(
                             CovariateAlignment.compute(
-                                    observed, typed.covariates().baseline()))
+                                    ctx.profile, typed.covariates().baseline()))
                     .withContractRef(contractRef);
-            maybeRenderTransparentStats(spec, stamped);
-            String useCaseId = resolveUseCaseId(spec);
-            emitVerdict(stamped, useCaseId);
-            translate(stamped, useCaseId);
+            maybeRenderTransparentStats(ctx, stamped);
+            emitVerdict(stamped, ctx.useCaseId);
+            translate(stamped, ctx.useCaseId);
         }
 
-        @SuppressWarnings("unchecked")
-        private List<String> preflightFeasibility(ProbabilisticTest spec) {
+        /**
+         * Captures the per-run state every preflight step needs:
+         * useCaseId, factor bundle, configured samples, resolved
+         * covariate profile, declarations, and a profile-bound
+         * baseline provider.
+         */
+        private static final class SpecContext {
+            final String useCaseId;
+            final FactorBundle bundle;
+            final int samples;
+            final CovariateProfile profile;
+            final List<Covariate> declarations;
+            final BaselineProvider provider;
+            final FactorBundle resultFactors;
+
+            SpecContext(String useCaseId, FactorBundle bundle, int samples,
+                    CovariateProfile profile, List<Covariate> declarations,
+                    BaselineProvider provider, FactorBundle resultFactors) {
+                this.useCaseId = useCaseId;
+                this.bundle = bundle;
+                this.samples = samples;
+                this.profile = profile;
+                this.declarations = declarations;
+                this.provider = provider;
+                this.resultFactors = resultFactors;
+            }
+        }
+
+        private SpecContext resolveSpecContext(ProbabilisticTest spec) {
             BaselineProvider raw = BaselineProviderResolver.resolve();
-            List<String> warnings = new ArrayList<>();
-            spec.dispatch(new Spec.Dispatcher<Void>() {
+            return spec.dispatch(new Spec.Dispatcher<SpecContext>() {
                 @Override
-                public <FT, IT, OT> Void apply(
-                        TypedSpec<FT, IT, OT> typed) {
+                public <FT, IT, OT> SpecContext apply(TypedSpec<FT, IT, OT> typed) {
                     var cfg = typed.configurations().next();
                     FT factors = cfg.factors();
                     UseCase<FT, IT, OT> useCase = typed.useCaseFactory().apply(factors);
-                    String useCaseId = useCase.id();
                     FactorBundle bundle = FactorBundle.of(factors);
                     List<Covariate> declarations = useCase.covariates();
                     CovariateProfile profile = declarations.isEmpty()
@@ -848,35 +974,64 @@ public final class PUnit {
                                     .resolve(declarations, useCase.customCovariateResolvers());
                     BaselineProvider provider = ProfileBoundBaselineProvider.bind(
                             raw, profile, declarations);
-                    warnings.addAll(Feasibility.check(
-                            cfg.samples(),
-                            (Criterion<Object, ?>) criterion,
-                            useCaseId, bundle, intent, provider));
-                    return null;
+                    return new SpecContext(
+                            useCase.id(), bundle, cfg.samples(),
+                            profile, declarations, provider, bundle);
                 }
             });
-            return warnings;
+        }
+
+        @SuppressWarnings("unchecked")
+        private Optional<ProbabilisticTestResult> baselineExistencePreflight(
+                SpecContext ctx) {
+            // EmpiricalTestBuilder enforces criterion.isEmpirical() at
+            // .criterion(...) time, so the wildcarded cast is safe.
+            Criterion<Object, ?> c = (Criterion<Object, ?>) criterion;
+            BaselineLookup<?> lookup = probeBaseline(
+                    ctx.provider, ctx.useCaseId, ctx.bundle,
+                    c, ctx.profile, ctx.declarations);
+            if (lookup.selected().isPresent()) {
+                return Optional.empty();
+            }
+            CriterionResult r = EmpiricalChecks.noBaseline(c.name(), c.empiricalDetail());
+            EvaluatedCriterion evaluated = new EvaluatedCriterion(r, CriterionRole.REQUIRED);
+            return Optional.of(synthesiseNoBaselineResult(
+                    ctx, List.of(evaluated), lookup.notes()));
+        }
+
+        private ProbabilisticTestResult synthesiseNoBaselineResult(
+                SpecContext ctx,
+                List<EvaluatedCriterion> noBaselineResults,
+                List<String> warnings) {
+            Optional<String> contractRefOpt = (contractRef == null || contractRef.isBlank())
+                    ? Optional.empty()
+                    : Optional.of(contractRef);
+            return new ProbabilisticTestResult(
+                    Verdict.compose(noBaselineResults),
+                    ctx.resultFactors,
+                    noBaselineResults,
+                    intent,
+                    warnings,
+                    CovariateAlignment.compute(ctx.profile, CovariateProfile.empty()),
+                    contractRefOpt,
+                    Map.of(),
+                    EngineRunSummary.empty());
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<String> preflightFeasibility(SpecContext ctx) {
+            return new ArrayList<>(Feasibility.check(
+                    ctx.samples,
+                    (Criterion<Object, ?>) criterion,
+                    ctx.useCaseId, ctx.bundle, intent, ctx.provider));
         }
 
         private void maybeRenderTransparentStats(
-                ProbabilisticTest spec, ProbabilisticTestResult result) {
+                SpecContext ctx, ProbabilisticTestResult result) {
             if (!TransparentStatsConfig.resolve(transparentStatsOverride).enabled()) {
                 return;
             }
-            System.err.println(TransparentStatsRenderer.render(
-                    resolveUseCaseId(spec), result));
-        }
-
-        private String resolveUseCaseId(ProbabilisticTest spec) {
-            return spec.dispatch(
-                    new Spec.Dispatcher<String>() {
-                        @Override
-                        public <FT, IT, OT> String apply(
-                                TypedSpec<FT, IT, OT> typed) {
-                            FT factors = typed.configurations().next().factors();
-                            return typed.useCaseFactory().apply(factors).id();
-                        }
-                    });
+            System.err.println(TransparentStatsRenderer.render(ctx.useCaseId, result));
         }
     }
 }

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PreflightBaselineExistenceTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PreflightBaselineExistenceTest.java
@@ -1,0 +1,109 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.javai.punit.engine.baseline.BaselineResolver;
+import org.javai.punit.junit5.testsubjects.PreflightSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * Pins the baseline-existence preflight: when a required empirical
+ * criterion has no resolvable baseline the framework short-circuits
+ * before the engine takes any samples, and the operator-visible
+ * outcome (JUnit-aborted INCONCLUSIVE) is the same as the post-sampling
+ * path used to produce. The asymmetry the framework removes is that
+ * the post-sampling path used to charge {@code N} LLM calls' worth of
+ * cost first; the preflight charges zero.
+ */
+@DisplayName("Preflight baseline-existence short-circuit")
+class PreflightBaselineExistenceTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+
+    @TempDir Path baselineDir;
+    private String savedBaselineProperty;
+
+    @BeforeEach
+    void setUp() {
+        savedBaselineProperty = System.getProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+        PreflightSubjects.INVOKE_COUNT.set(0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedBaselineProperty == null) {
+            System.clearProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        } else {
+            System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, savedBaselineProperty);
+        }
+    }
+
+    @Test
+    @DisplayName("required empirical without baseline aborts before any sample is taken")
+    void requiredEmpiricalNoBaselineShortCircuits() {
+        Events events = run(PreflightSubjects.EmpiricalNoBaselineTest.class);
+        events.assertStatistics(stats -> stats.started(1).aborted(1).failed(0));
+        assertThat(PreflightSubjects.INVOKE_COUNT.get())
+                .as("engine must not run when the required empirical criterion has no baseline")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("mixed required-empirical (no baseline) + contractual still short-circuits")
+    void mixedRequiredEmpiricalAndContractualShortCircuits() {
+        Events events = run(PreflightSubjects.MixedEmpiricalAndContractualNoBaselineTest.class);
+        events.assertStatistics(stats -> stats.started(1).aborted(1).failed(0));
+        assertThat(PreflightSubjects.INVOKE_COUNT.get())
+                .as("a required empirical criterion missing its baseline guarantees "
+                        + "INCONCLUSIVE; the contractual criterion's evaluation cannot "
+                        + "rescue the verdict, so sampling is structurally pointless")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("report-only empirical (no baseline) does NOT short-circuit; engine runs")
+    void reportOnlyEmpiricalNoBaselineRunsEngine() {
+        Events events = run(PreflightSubjects.ReportOnlyEmpiricalNoBaselineTest.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1));
+        assertThat(PreflightSubjects.INVOKE_COUNT.get())
+                .as("a report-only criterion's INCONCLUSIVE does not gate the verdict; "
+                        + "the required contractual criterion still drives sampling")
+                .isPositive();
+    }
+
+    @Test
+    @DisplayName("required empirical WITH a resolvable baseline runs the engine (no short-circuit)")
+    void requiredEmpiricalWithBaselineRunsEngine() throws IOException {
+        // Phase 1: stamp a baseline so the paired test resolves.
+        run(PreflightSubjects.MeasureBaseline.class)
+                .assertStatistics(stats -> stats.started(1).succeeded(1));
+        int afterMeasure = PreflightSubjects.INVOKE_COUNT.get();
+        assertThat(afterMeasure).isPositive();
+
+        // Phase 2: the empirical test runs to a verdict, taking real samples.
+        Events events = run(PreflightSubjects.EmpiricalWithBaselineTest.class);
+        events.assertStatistics(stats -> stats.started(1));
+        assertThat(PreflightSubjects.INVOKE_COUNT.get())
+                .as("a resolvable baseline must not trigger the short-circuit; "
+                        + "the test phase contributes its own invocations")
+                .isGreaterThan(afterMeasure);
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
@@ -1,0 +1,123 @@
+package org.javai.punit.junit5.testsubjects;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Experiment;
+import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.NoFactors;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.engine.criteria.PassRate;
+import org.javai.punit.runtime.PUnit;
+
+/**
+ * Test subjects for the baseline-existence preflight short-circuit.
+ *
+ * <p>The use case carries a static invoke counter. Tests that exercise
+ * the short-circuit assert the counter ends at zero — the framework
+ * must not have driven the engine when the verdict was structurally
+ * guaranteed to be INCONCLUSIVE-no-baseline.
+ */
+public final class PreflightSubjects {
+
+    public static final String USE_CASE_ID = "preflight-subject";
+    public static final AtomicInteger INVOKE_COUNT = new AtomicInteger();
+
+    private PreflightSubjects() { }
+
+    /** Always-passing use case that records every invocation. */
+    private static UseCase<NoFactors, Integer, Boolean> countingUseCase() {
+        return new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                INVOKE_COUNT.incrementAndGet();
+                return Outcome.ok(true);
+            }
+            @Override public String id() { return USE_CASE_ID; }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> countingUseCase())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    /**
+     * Empirical test against a baseline directory that holds nothing for
+     * this use case → preflight short-circuit, engine never runs, JUnit
+     * aborts.
+     */
+    public static final class EmpiricalNoBaselineTest {
+        @ProbabilisticTest
+        void empiricalWithoutBaseline() {
+            PUnit.testing(sampling(20))
+                    .criterion(PassRate.<Boolean>empirical())
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * Mixed required-empirical (no baseline) + required-contractual
+     * criteria. Per the rule "any required empirical criterion missing
+     * its baseline short-circuits", the contractual criterion does not
+     * get the chance to evaluate — the verdict is structurally
+     * INCONCLUSIVE regardless of what the contractual claim would have
+     * concluded. Engine never runs.
+     */
+    public static final class MixedEmpiricalAndContractualNoBaselineTest {
+        @ProbabilisticTest
+        void mixed() {
+            PUnit.testing(sampling(20))
+                    .criterion(PassRate.<Boolean>empirical())
+                    .criterion(PassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * Required contractual + report-only empirical (no baseline). Only
+     * <em>required</em> empirical criteria short-circuit; a report-only
+     * criterion's INCONCLUSIVE is informational. Engine runs.
+     */
+    public static final class ReportOnlyEmpiricalNoBaselineTest {
+        @ProbabilisticTest
+        void reportOnlyDoesNotShortCircuit() {
+            PUnit.testing(sampling(20))
+                    .criterion(PassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
+                    .reportOnly(PassRate.<Boolean>empirical())
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * Phase 1 of the resolved-baseline regression: stamp a baseline so
+     * the paired test below has something to resolve.
+     */
+    public static final class MeasureBaseline {
+        @Experiment
+        void measure() {
+            PUnit.measuring(sampling(100)).run();
+        }
+    }
+
+    /**
+     * Phase 2 of the resolved-baseline regression: empirical test against
+     * a baseline that <em>does</em> exist → preflight does not
+     * short-circuit, engine runs.
+     */
+    public static final class EmpiricalWithBaselineTest {
+        @ProbabilisticTest
+        void empiricalWithBaseline() {
+            PUnit.testing(sampling(20))
+                    .criterion(PassRate.<Boolean>empirical().atConfidence(0.50))
+                    .assertPasses();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- When a required empirical criterion has no resolvable baseline the verdict is structurally guaranteed to be INCONCLUSIVE-no-baseline. Before this change, the framework still drove the spec through the engine — burning every configured sample's cost (N LLM API calls in the typical use case) before the criterion's evaluate() discovered the missing baseline and produced the same INCONCLUSIVE.
- `PUnit.TestBuilder` and `EmpiricalTestBuilder` now probe baseline existence after resolving the run's covariate profile. When any required empirical criterion's `BaselineLookup` returns no candidate, the framework synthesises an INCONCLUSIVE-no-baseline result (propagating the lookup's rejection notes through `ProbabilisticTestResult.warnings`) and routes it through the same `emitVerdict + translate` pipeline. The operator-visible diagnostic is byte-equivalent modulo `samplesExecuted = 0`; the existing `candidatesWereRejected` branch in `translate` keeps distinguishing "all candidates rejected" (FAIL) from "no candidates at all" (TestAbortedException).
- The criterion stays the authoritative producer of the INCONCLUSIVE shape. New `EmpiricalChecks.noBaseline(name, detail)` helper centralises the canonical wording + discriminant; both criteria's `evaluate(...)` no-baseline branches now go through it, and so does the framework's preflight via `Criterion.empiricalDetail()` (default empty; PassRate / PercentileLatency override).

## Behavioural contract
- Required empirical criterion with **no resolvable baseline** → preflight short-circuits; zero samples taken; INCONCLUSIVE-no-baseline verdict; `TestAbortedException` (or `AssertionFailedError` if rejection notes are present).
- Required empirical criterion **with** a resolvable baseline → no short-circuit; sampling proceeds.
- Mixed required-empirical (no baseline) + required-contractual → still short-circuits — the empirical no-baseline is decisive.
- **Report-only** empirical no-baseline → no short-circuit; the report-only INCONCLUSIVE is informational and the verdict comes from the required path.

## Test plan
- [x] `./gradlew test` — full suite green, including `PreflightBaselineExistenceTest` (4 cases: no-baseline short-circuit, mixed required+contractual short-circuit, report-only does NOT short-circuit, with-baseline runs the engine).
- [x] `CovariateMisalignmentTrichotomyTest` keeps passing — the baseline-existence preflight propagates `BaselineLookup.notes` so `candidatesWereRejected` still discriminates the misconfiguration FAIL (Case 2) from the legitimate INCONCLUSIVE ABORT (Case 1).
- [x] Reproducer verified end-to-end against `punitexamples` — `ShoppingBasketCovariateTest.runsUnderLowTemperature` now emits zero `[PUNIT-PROGRESS]` lines before `[PUNIT-INCONCLUSIVE]`, JUnit-aborted, full diagnostic body and observed covariates intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)