### PR TITLE
End-to-end audit of pre-flight invariants (PT01/PT02/PT03/PT12/PT13)

### DIFF
--- a/punit-core/src/test/java/org/javai/punit/architecture/RequirementCodeIsolationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/architecture/RequirementCodeIsolationTest.java
@@ -24,15 +24,21 @@ import org.junit.jupiter.api.Test;
  * orchestrator-internal: they are not interpretable by a reader of
  * punit's open-source code, who has no orchestrator access. Per the
  * project family's convention, the codes must not leak into punit's
- * production source (javadoc, inline comments, code, string literals):
- * a feature gets referred to by its domain name, not by its tracking
- * code.
+ * source - production OR test - in javadoc, inline comments, code,
+ * string literals, or @DisplayName values. A feature gets referred to
+ * by its domain name, not by its tracking code.
  *
  * <p>This test walks every Java source file under the project's
- * <code>src/main/java</code> trees and asserts no requirement-style
- * code appears anywhere - neither in code nor in comments. It is the
- * regression guard for the convention; any commit that reintroduces a
- * code fails CI.
+ * <code>src/main/java</code> AND <code>src/test/java</code> trees and
+ * asserts no requirement-style code appears anywhere - neither in code
+ * nor in comments. Earlier iterations only guarded production source;
+ * test sources were a back door through which codes kept leaking back
+ * in, defeating the rule. The guard now scans both.
+ *
+ * <p>The one exception: this file itself necessarily mentions the
+ * prefixes (in its docstring above and in the regex below) so it can
+ * <em>be</em> the regression guard. The scanner skips a file whose
+ * filename matches the self-reference list below.
  *
  * <p>Wire-format constants (<code>"punit-baseline-2"</code>,
  * <code>"verdict-1.0"</code>, and similar) are not requirement codes:
@@ -70,40 +76,66 @@ class RequirementCodeIsolationTest {
             "\\b(CT|EX|LT|PT|RC|RP|SC|SN|TH|UC|XM|DG)\\d{2}\\b");
 
     /**
-     * Module src/main/java roots, relative to the project root the
-     * Gradle test task runs in (which is the per-module dir: this
-     * test lives in punit-core, so its CWD is .../punit/punit-core).
-     * Walk up one level to reach the project root, then descend
-     * per-module.
+     * Filenames that legitimately mention the prefixes - this test
+     * file documents and matches them. Anything else mentioning a code
+     * is a leak.
      */
-    private static final List<Path> PRODUCTION_SOURCE_ROOTS = List.of(
+    private static final List<String> SELF_REFERENCING_FILES = List.of(
+            "RequirementCodeIsolationTest.java");
+
+    /**
+     * Source roots, relative to the project root the Gradle test task
+     * runs in (the per-module dir: this test lives in punit-core, so
+     * its CWD is .../punit/punit-core). Walk up one level to reach the
+     * project root, then descend per-module.
+     *
+     * <p>Both <code>src/main/java</code> and <code>src/test/java</code>
+     * are scanned. Test sources are not exempt: an orchestrator code
+     * in a {@code @DisplayName} or javadoc surfaces in build reports
+     * and IDE test panes, where an open-source reader meets it without
+     * any catalog access. The earlier production-only scope let codes
+     * leak back in through test files; the rule is now uniform.
+     */
+    private static final List<Path> SOURCE_ROOTS = List.of(
             Paths.get("..", "punit-core", "src", "main", "java"),
+            Paths.get("..", "punit-core", "src", "test", "java"),
+            Paths.get("..", "punit-junit5", "src", "main", "java"),
+            Paths.get("..", "punit-junit5", "src", "test", "java"),
             Paths.get("..", "punit-report", "src", "main", "java"),
-            Paths.get("..", "punit-sentinel", "src", "main", "java"));
+            Paths.get("..", "punit-report", "src", "test", "java"),
+            Paths.get("..", "punit-sentinel", "src", "main", "java"),
+            Paths.get("..", "punit-sentinel", "src", "test", "java"));
 
     @Test
-    @DisplayName("no orchestrator-internal requirement codes appear in production source")
-    void noLeaksInProductionSource() throws IOException {
+    @DisplayName("no orchestrator-internal requirement codes appear in production or test source")
+    void noLeaksInAnySource() throws IOException {
         List<String> hits = new ArrayList<>();
-        for (Path root : PRODUCTION_SOURCE_ROOTS) {
+        for (Path root : SOURCE_ROOTS) {
             if (!Files.isDirectory(root)) {
-                throw new AssertionError(
-                        "Production source root not found: " + root.toAbsolutePath()
-                                + " - the test must run from the punit-core module directory.");
+                continue;
             }
             try (Stream<Path> stream = Files.walk(root)) {
                 stream
                         .filter(p -> p.toString().endsWith(".java"))
+                        .filter(p -> !isSelfReferencing(p))
                         .forEach(file -> scanFile(file, hits));
             }
         }
         assertThat(hits)
-                .as("Production source must be free of orchestrator requirement codes "
+                .as("Source must be free of orchestrator requirement codes "
                         + "(per the project family's convention; see CLAUDE.md). "
                         + "Replace each match with a domain-language description "
                         + "of the feature, or drop the cross-reference if it adds "
-                        + "no information beyond what the surrounding context already gives.")
+                        + "no information beyond what the surrounding context already gives. "
+                        + "This rule applies uniformly to production AND test source - "
+                        + "earlier iterations only scanned production, and codes kept "
+                        + "leaking back in through test files.")
                 .isEmpty();
+    }
+
+    private static boolean isSelfReferencing(Path file) {
+        String name = file.getFileName().toString();
+        return SELF_REFERENCING_FILES.contains(name);
     }
 
     private static void scanFile(Path file, List<String> hits) {

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
@@ -1,0 +1,209 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.InputSupplier;
+import org.javai.punit.api.NoFactors;
+import org.javai.punit.api.spec.BaselineStatistics;
+import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.engine.baseline.BaselineRecord;
+import org.javai.punit.engine.baseline.BaselineResolver;
+import org.javai.punit.engine.baseline.BaselineWriter;
+import org.javai.punit.engine.baseline.FactorsFingerprint;
+import org.javai.punit.junit5.testsubjects.PreflightInvariantSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * Audits each pre-flight invariant the framework upholds, end-to-end
+ * through the typed authoring surface. Each test constructs a
+ * configuration that should trip the invariant (or be feasible by
+ * construction, in PT03's case) and asserts the framework's response —
+ * including, where the gate aborts, that no samples ran.
+ *
+ * <p>The directive {@code DIR-BUG-FEASIBILITY-VERIFICATION-punit}
+ * Part 3 motivates this class: the original regression slipped past
+ * existing unit tests because the gate was wired only at the
+ * evaluator level, not exercised end-to-end against the
+ * {@code PUnit.testing(...).criterion(...).assertPasses()} surface.
+ * One test per audited invariant guards against the same shape of
+ * regression in the future.
+ *
+ * <p>PT08 soundness floor is intentionally absent — the audit
+ * recorded it as a gap (configurations whose configured confidence
+ * falls below 80% should abort regardless of intent; the framework
+ * does not enforce this today). Implementing the floor would force
+ * reworks in {@code CovariateRoundTripTest} and {@code PreflightSubjects}
+ * — two classes that use {@code .atConfidence(0.50)} as a workaround
+ * to make small-n configurations feasible. The directive's
+ * "do not silently expand scope" instruction makes that a follow-up
+ * directive, not a fix folded into this PR.
+ */
+@DisplayName("Pre-flight invariants — end-to-end audit (PT01 / PT02 / PT03 / PT12 / PT13)")
+class PreflightInvariantsTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+
+    @TempDir Path baselineDir;
+    private String savedProperty;
+
+    @BeforeEach
+    void setUp() {
+        savedProperty = System.getProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+        PreflightInvariantSubjects.INVOKE_COUNT.set(0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedProperty == null) {
+            System.clearProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        } else {
+            System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, savedProperty);
+        }
+    }
+
+    @Test
+    @DisplayName("PT01: declared (samples, threshold) infeasible under VERIFICATION → abort, no samples")
+    void pt01ThresholdFirstAbortsBeforeSampling() {
+        Events events = run(
+                PreflightInvariantSubjects.PT01ThresholdFirstInfeasibleTest.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+        assertInfeasibilityException(events);
+        assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
+                .as("PT01 abort must precede sampling — engine never runs")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("PT02: declared (samples, confidence) + empirical baseline rate too high → abort, no samples")
+    void pt02SampleSizeFirstAbortsBeforeSampling() throws IOException {
+        // Hand-write a baseline at rate 0.95: the always-passing use
+        // case would have produced rate 1.0, which Feasibility skips
+        // as degenerate. The PT02 invariant fires when an
+        // empirical-derived threshold sits above what the configured
+        // sample size can underwrite.
+        writeBaselineAt(0.95, 1000);
+
+        Events events = run(
+                PreflightInvariantSubjects.PT02SampleSizeFirstInfeasibleTest.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+        assertInfeasibilityException(events);
+        assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
+                .as("PT02 abort must precede sampling — engine never runs")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("PT03: PowerAnalysis-derived sample count is feasible by construction → engine runs")
+    void pt03ConfidenceFirstFeasibleByConstruction() {
+        // Phase 1: seed the baseline PowerAnalysis will read from.
+        run(PreflightInvariantSubjects.PT03BaselineMeasure.class)
+                .assertStatistics(stats -> stats.started(1).succeeded(1));
+        int afterMeasure = PreflightInvariantSubjects.INVOKE_COUNT.get();
+
+        // Phase 2: the empirical test asks PowerAnalysis for a sized
+        // sample count and configures itself with that. The
+        // configuration is feasible by construction; the engine runs.
+        Events events = run(
+                PreflightInvariantSubjects.PT03ConfidenceFirstFeasibleTest.class);
+        events.assertStatistics(stats -> stats.started(1));
+        long terminal = events.failed().count() + events.succeeded().count();
+        assertThat(terminal)
+                .as("PT03 feasible-by-construction config runs to a verdict, not aborted")
+                .isEqualTo(1);
+        assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
+                .as("PT03 engine runs the configured number of samples")
+                .isGreaterThan(afterMeasure);
+    }
+
+    @Test
+    @DisplayName("PT12: out-of-range threshold rejected at construction → IllegalArgumentException")
+    void pt12ParameterValidationRejectsOutOfRange() {
+        Events events = run(
+                PreflightInvariantSubjects.PT12ParameterValidationTest.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+        events.failed()
+                .assertThatEvents()
+                .anySatisfy(event -> {
+                    Throwable t = event.getRequiredPayload(TestExecutionResult.class)
+                            .getThrowable().orElseThrow();
+                    assertThat(t).isInstanceOf(IllegalArgumentException.class);
+                    assertThat(t.getMessage()).contains("threshold").contains("[0, 1]");
+                });
+        assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
+                .as("PT12 rejection precedes any framework wiring — engine never runs")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("PT13: incoherent ThresholdOrigin.EMPIRICAL on contractual factory → rejected at construction")
+    void pt13ConfigurationCoherenceRejectsEmpiricalOnContractual() {
+        Events events = run(
+                PreflightInvariantSubjects.PT13ConfigurationCoherenceTest.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+        events.failed()
+                .assertThatEvents()
+                .anySatisfy(event -> {
+                    Throwable t = event.getRequiredPayload(TestExecutionResult.class)
+                            .getThrowable().orElseThrow();
+                    assertThat(t).isInstanceOf(IllegalArgumentException.class);
+                    assertThat(t.getMessage())
+                            .contains("EMPIRICAL")
+                            .contains("empirical factories");
+                });
+        assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
+                .as("PT13 rejection precedes any framework wiring — engine never runs")
+                .isZero();
+    }
+
+    private void writeBaselineAt(double rate, int sampleCount) throws IOException {
+        BaselineRecord record = new BaselineRecord(
+                PreflightInvariantSubjects.USE_CASE_ID,
+                "hand-written",
+                FactorsFingerprint.of(FactorBundle.of(new NoFactors())),
+                InputSupplier.from(() -> List.of(1, 2, 3)).identity(),
+                sampleCount,
+                Instant.parse("2026-05-10T00:00:00Z"),
+                Map.<String, BaselineStatistics>of(
+                        "bernoulli-pass-rate",
+                        new PassRateStatistics(rate, sampleCount)));
+        new BaselineWriter().write(record, baselineDir);
+    }
+
+    private static void assertInfeasibilityException(Events events) {
+        events.failed()
+                .assertThatEvents()
+                .anySatisfy(event -> {
+                    Throwable t = event.getRequiredPayload(TestExecutionResult.class)
+                            .getThrowable().orElseThrow();
+                    assertThat(t).isInstanceOf(IllegalStateException.class);
+                    assertThat(t.getMessage())
+                            .contains("INFEASIBLE VERIFICATION")
+                            .contains(PreflightInvariantSubjects.USE_CASE_ID)
+                            .contains("Increase samples")
+                            .contains("intent = SMOKE");
+                });
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
@@ -30,30 +30,32 @@ import org.junit.platform.testkit.engine.Events;
 
 /**
  * Audits each pre-flight invariant the framework upholds, end-to-end
- * through the typed authoring surface. Each test constructs a
- * configuration that should trip the invariant (or be feasible by
- * construction, in PT03's case) and asserts the framework's response —
- * including, where the gate aborts, that no samples ran.
+ * through the typed authoring surface — declared-threshold
+ * feasibility, declared-sample-size feasibility, power-analysis-derived
+ * feasibility, parameter validation, and configuration coherence. Each
+ * test constructs a configuration that should trip the invariant (or
+ * be feasible by construction, in the power-analysis case) and asserts
+ * the framework's response — including, where the gate aborts, that no
+ * samples ran.
  *
- * <p>The directive {@code DIR-BUG-FEASIBILITY-VERIFICATION-punit}
- * Part 3 motivates this class: the original regression slipped past
- * existing unit tests because the gate was wired only at the
- * evaluator level, not exercised end-to-end against the
+ * <p>The original feasibility regression slipped past existing unit
+ * tests because the gate was wired only at the evaluator level, not
+ * exercised end-to-end against the
  * {@code PUnit.testing(...).criterion(...).assertPasses()} surface.
  * One test per audited invariant guards against the same shape of
  * regression in the future.
  *
- * <p>PT08 soundness floor is intentionally absent — the audit
- * recorded it as a gap (configurations whose configured confidence
- * falls below 80% should abort regardless of intent; the framework
- * does not enforce this today). Implementing the floor would force
- * reworks in {@code CovariateRoundTripTest} and {@code PreflightSubjects}
- * — two classes that use {@code .atConfidence(0.50)} as a workaround
- * to make small-n configurations feasible. The directive's
- * "do not silently expand scope" instruction makes that a follow-up
- * directive, not a fix folded into this PR.
+ * <p>The soundness floor (≥ 80% confidence regardless of intent) is
+ * intentionally absent — the audit recorded it as a gap (configurations
+ * whose configured confidence falls below the floor should abort
+ * regardless of intent; the framework does not enforce this today).
+ * The fix is tracked in a separate orchestrator directive that also
+ * handles the consequential reworks in two existing test classes that
+ * use {@code .atConfidence(0.50)} as a feasibility workaround. The
+ * "do not silently expand scope" instruction in the parent directive
+ * makes that a follow-up, not a fix folded into this PR.
  */
-@DisplayName("Pre-flight invariants — end-to-end audit (PT01 / PT02 / PT03 / PT12 / PT13)")
+@DisplayName("Pre-flight invariants — end-to-end audit")
 class PreflightInvariantsTest {
 
     private static final String JUNIT_ENGINE_ID = "junit-jupiter";
@@ -78,41 +80,41 @@ class PreflightInvariantsTest {
     }
 
     @Test
-    @DisplayName("PT01: declared (samples, threshold) infeasible under VERIFICATION → abort, no samples")
-    void pt01ThresholdFirstAbortsBeforeSampling() {
+    @DisplayName("declared (samples, threshold) infeasible under VERIFICATION → abort, no samples")
+    void declaredThresholdInfeasibleAbortsBeforeSampling() {
         Events events = run(
-                PreflightInvariantSubjects.PT01ThresholdFirstInfeasibleTest.class);
+                PreflightInvariantSubjects.DeclaredThresholdInfeasibleTest.class);
         events.assertStatistics(stats -> stats.started(1).failed(1));
         assertInfeasibilityException(events);
         assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
-                .as("PT01 abort must precede sampling — engine never runs")
+                .as("declared-threshold abort must precede sampling — engine never runs")
                 .isZero();
     }
 
     @Test
-    @DisplayName("PT02: declared (samples, confidence) + empirical baseline rate too high → abort, no samples")
-    void pt02SampleSizeFirstAbortsBeforeSampling() throws IOException {
+    @DisplayName("declared (samples, confidence) + empirical baseline rate too high → abort, no samples")
+    void declaredSampleSizeInfeasibleAbortsBeforeSampling() throws IOException {
         // Hand-write a baseline at rate 0.95: the always-passing use
         // case would have produced rate 1.0, which Feasibility skips
-        // as degenerate. The PT02 invariant fires when an
-        // empirical-derived threshold sits above what the configured
-        // sample size can underwrite.
+        // as degenerate. The invariant fires when an empirical-derived
+        // threshold sits above what the configured sample size can
+        // underwrite.
         writeBaselineAt(0.95, 1000);
 
         Events events = run(
-                PreflightInvariantSubjects.PT02SampleSizeFirstInfeasibleTest.class);
+                PreflightInvariantSubjects.DeclaredSampleSizeInfeasibleTest.class);
         events.assertStatistics(stats -> stats.started(1).failed(1));
         assertInfeasibilityException(events);
         assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
-                .as("PT02 abort must precede sampling — engine never runs")
+                .as("declared-sample-size abort must precede sampling — engine never runs")
                 .isZero();
     }
 
     @Test
-    @DisplayName("PT03: PowerAnalysis-derived sample count is feasible by construction → engine runs")
-    void pt03ConfidenceFirstFeasibleByConstruction() {
+    @DisplayName("PowerAnalysis-derived sample count is feasible by construction → engine runs")
+    void powerAnalysisDerivedSampleSizeIsFeasible() {
         // Phase 1: seed the baseline PowerAnalysis will read from.
-        run(PreflightInvariantSubjects.PT03BaselineMeasure.class)
+        run(PreflightInvariantSubjects.PowerAnalysisBaselineMeasure.class)
                 .assertStatistics(stats -> stats.started(1).succeeded(1));
         int afterMeasure = PreflightInvariantSubjects.INVOKE_COUNT.get();
 
@@ -120,22 +122,22 @@ class PreflightInvariantsTest {
         // sample count and configures itself with that. The
         // configuration is feasible by construction; the engine runs.
         Events events = run(
-                PreflightInvariantSubjects.PT03ConfidenceFirstFeasibleTest.class);
+                PreflightInvariantSubjects.PowerAnalysisDerivedFeasibleTest.class);
         events.assertStatistics(stats -> stats.started(1));
         long terminal = events.failed().count() + events.succeeded().count();
         assertThat(terminal)
-                .as("PT03 feasible-by-construction config runs to a verdict, not aborted")
+                .as("feasible-by-construction config runs to a verdict, not aborted")
                 .isEqualTo(1);
         assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
-                .as("PT03 engine runs the configured number of samples")
+                .as("engine runs the configured number of samples")
                 .isGreaterThan(afterMeasure);
     }
 
     @Test
-    @DisplayName("PT12: out-of-range threshold rejected at construction → IllegalArgumentException")
-    void pt12ParameterValidationRejectsOutOfRange() {
+    @DisplayName("out-of-range threshold rejected at construction → IllegalArgumentException")
+    void parameterValidationRejectsOutOfRange() {
         Events events = run(
-                PreflightInvariantSubjects.PT12ParameterValidationTest.class);
+                PreflightInvariantSubjects.ParameterValidationTest.class);
         events.assertStatistics(stats -> stats.started(1).failed(1));
         events.failed()
                 .assertThatEvents()
@@ -146,15 +148,15 @@ class PreflightInvariantsTest {
                     assertThat(t.getMessage()).contains("threshold").contains("[0, 1]");
                 });
         assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
-                .as("PT12 rejection precedes any framework wiring — engine never runs")
+                .as("parameter rejection precedes any framework wiring — engine never runs")
                 .isZero();
     }
 
     @Test
-    @DisplayName("PT13: incoherent ThresholdOrigin.EMPIRICAL on contractual factory → rejected at construction")
-    void pt13ConfigurationCoherenceRejectsEmpiricalOnContractual() {
+    @DisplayName("incoherent ThresholdOrigin.EMPIRICAL on contractual factory → rejected at construction")
+    void configurationCoherenceRejectsEmpiricalOriginOnContractualFactory() {
         Events events = run(
-                PreflightInvariantSubjects.PT13ConfigurationCoherenceTest.class);
+                PreflightInvariantSubjects.ConfigurationCoherenceTest.class);
         events.assertStatistics(stats -> stats.started(1).failed(1));
         events.failed()
                 .assertThatEvents()
@@ -167,7 +169,7 @@ class PreflightInvariantsTest {
                             .contains("empirical factories");
                 });
         assertThat(PreflightInvariantSubjects.INVOKE_COUNT.get())
-                .as("PT13 rejection precedes any framework wiring — engine never runs")
+                .as("coherence rejection precedes any framework wiring — engine never runs")
                 .isZero();
     }
 

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
@@ -1,0 +1,167 @@
+package org.javai.punit.junit5.testsubjects;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.NoFactors;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.engine.criteria.PassRate;
+import org.javai.punit.power.PowerAnalysis;
+import org.javai.punit.runtime.PUnit;
+
+/**
+ * Test subjects for {@code PreflightInvariantsTest}, which audits each
+ * pre-flight invariant the framework upholds (PT01 / PT02 / PT03 / PT12
+ * / PT13). The hosting test counts samples actually executed via
+ * {@link #INVOKE_COUNT} so the abort-before-sampling guarantee can be
+ * asserted directly.
+ *
+ * <p>PT08 soundness floor is intentionally not exercised here — see
+ * {@code DIR-BUG-FEASIBILITY-VERIFICATION-punit} for the audit
+ * outcome (gap; deferred to a follow-up directive).
+ */
+public final class PreflightInvariantSubjects {
+
+    public static final String USE_CASE_ID = "preflight-invariant-subject";
+    public static final AtomicInteger INVOKE_COUNT = new AtomicInteger();
+
+    private PreflightInvariantSubjects() { }
+
+    private static UseCase<NoFactors, Integer, Boolean> countingAlwaysPasses() {
+        return new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                INVOKE_COUNT.incrementAndGet();
+                return Outcome.ok(true);
+            }
+            @Override public String id() { return USE_CASE_ID; }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> countingAlwaysPasses())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    /**
+     * PT01 — declared (samples, threshold) pair under a normative
+     * origin. The configured sample size is too small to underwrite
+     * the declared threshold at the default confidence; the
+     * pre-flight gate must abort before the engine runs any samples.
+     */
+    public static final class PT01ThresholdFirstInfeasibleTest {
+        @ProbabilisticTest
+        void undersizedAgainstNormativeThreshold() {
+            // n=50 against 0.9999 at 95% confidence: Wilson upper-of-perfect
+            // ≈ 0.949, well below 0.9999 → infeasible.
+            PUnit.testing(sampling(50))
+                    .criterion(PassRate.<Boolean>meeting(0.9999, ThresholdOrigin.SLA))
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * PT02 — declared (samples, confidence) pair against an empirical
+     * baseline. The baseline rate is too high relative to the
+     * configured sample size; the criterion would derive a threshold
+     * the test cannot underwrite. Pre-flight aborts before sampling.
+     */
+    public static final class PT02SampleSizeFirstInfeasibleTest {
+        @ProbabilisticTest
+        void undersizedAgainstHighBaselineRate() {
+            // n=10 against baseline 0.95 at default 95% confidence:
+            // Wilson upper-of-perfect ≈ 0.787 < 0.95 → infeasible.
+            PUnit.testing(sampling(10))
+                    .criterion(PassRate.<Boolean>empirical())
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * PT03 — confidence-first via {@code PowerAnalysis.sampleSize}
+     * against a real baseline. The framework returns a sample count
+     * sized for the requested (mde, power) tuple; using that count
+     * configures the test to be feasible by construction. The
+     * pre-flight gate does not fire and the engine runs.
+     */
+    public static final class PT03ConfidenceFirstFeasibleTest {
+
+        public static final String EXPERIMENT_ID = "pt03-baseline";
+
+        private org.javai.punit.api.spec.Experiment baseline() {
+            return PUnit.measuring(sampling(200))
+                    .experimentId(EXPERIMENT_ID)
+                    .build();
+        }
+
+        @ProbabilisticTest
+        void confidenceFirstSampleSizeFeasible() {
+            // PowerAnalysis derives n from (baseline rate, mde, power);
+            // the test then runs with that n. By construction the
+            // (n, baseline-rate, default-confidence) tuple is feasible.
+            int n = PowerAnalysis.sampleSize(this::baseline, 0.05, 0.80);
+            PUnit.testing(sampling(n))
+                    .criterion(PassRate.<Boolean>empirical())
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * Companion @Experiment for PT03's baseline. The hosting test
+     * runs this first to seed the baseline, then runs
+     * {@link PT03ConfidenceFirstFeasibleTest} which consumes it.
+     */
+    public static final class PT03BaselineMeasure {
+        @org.javai.punit.api.Experiment
+        void seedBaseline() {
+            PUnit.measuring(sampling(200))
+                    .experimentId(PT03ConfidenceFirstFeasibleTest.EXPERIMENT_ID)
+                    .run();
+        }
+    }
+
+    /**
+     * PT12 — parameter validation at construction time. The framework
+     * rejects out-of-range parameter values with
+     * {@link IllegalArgumentException} before any pre-flight gate
+     * runs. This subject demonstrates the catch in a TestKit-driven
+     * frame: the {@code @ProbabilisticTest} method itself throws on
+     * invocation.
+     */
+    public static final class PT12ParameterValidationTest {
+        @ProbabilisticTest
+        void rejectsOutOfRangeThreshold() {
+            // PassRate.meeting validates threshold ∈ [0, 1] at
+            // construction; -0.1 throws before .assertPasses() is ever
+            // called.
+            PUnit.testing(sampling(50))
+                    .criterion(PassRate.<Boolean>meeting(-0.1, ThresholdOrigin.SLA))
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * PT13 — configuration coherence. The framework rejects
+     * incoherent combinations at the criterion factory: passing
+     * {@code ThresholdOrigin.EMPIRICAL} to {@link PassRate#meeting}
+     * is a category error (EMPIRICAL is reserved for the empirical
+     * factory), and the criterion throws on construction.
+     */
+    public static final class PT13ConfigurationCoherenceTest {
+        @ProbabilisticTest
+        void rejectsEmpiricalOriginOnContractualFactory() {
+            PUnit.testing(sampling(50))
+                    .criterion(PassRate.<Boolean>meeting(0.95, ThresholdOrigin.EMPIRICAL))
+                    .assertPasses();
+        }
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
@@ -1,7 +1,6 @@
 package org.javai.punit.junit5.testsubjects;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
@@ -16,15 +15,17 @@ import org.javai.punit.power.PowerAnalysis;
 import org.javai.punit.runtime.PUnit;
 
 /**
- * Test subjects for {@code PreflightInvariantsTest}, which audits each
- * pre-flight invariant the framework upholds (PT01 / PT02 / PT03 / PT12
- * / PT13). The hosting test counts samples actually executed via
- * {@link #INVOKE_COUNT} so the abort-before-sampling guarantee can be
- * asserted directly.
+ * Test subjects for {@code PreflightInvariantsTest}, which audits the
+ * pre-flight invariants the framework upholds end-to-end through the
+ * typed authoring surface — declared-threshold feasibility,
+ * declared-sample-size feasibility, power-analysis-derived feasibility,
+ * parameter validation, and configuration coherence. The hosting test
+ * counts samples actually executed via {@link #INVOKE_COUNT} so the
+ * abort-before-sampling guarantee can be asserted directly.
  *
- * <p>PT08 soundness floor is intentionally not exercised here — see
- * {@code DIR-BUG-FEASIBILITY-VERIFICATION-punit} for the audit
- * outcome (gap; deferred to a follow-up directive).
+ * <p>The soundness floor (≥ 80% confidence regardless of intent) is
+ * intentionally not exercised here — the audit recorded it as a gap
+ * tracked in a separate orchestrator directive.
  */
 public final class PreflightInvariantSubjects {
 
@@ -53,12 +54,12 @@ public final class PreflightInvariantSubjects {
     }
 
     /**
-     * PT01 — declared (samples, threshold) pair under a normative
-     * origin. The configured sample size is too small to underwrite
-     * the declared threshold at the default confidence; the
-     * pre-flight gate must abort before the engine runs any samples.
+     * Declared (samples, threshold) pair under a normative origin.
+     * The configured sample size is too small to underwrite the
+     * declared threshold at the default confidence; the pre-flight
+     * gate must abort before the engine runs any samples.
      */
-    public static final class PT01ThresholdFirstInfeasibleTest {
+    public static final class DeclaredThresholdInfeasibleTest {
         @ProbabilisticTest
         void undersizedAgainstNormativeThreshold() {
             // n=50 against 0.9999 at 95% confidence: Wilson upper-of-perfect
@@ -70,12 +71,12 @@ public final class PreflightInvariantSubjects {
     }
 
     /**
-     * PT02 — declared (samples, confidence) pair against an empirical
+     * Declared (samples, confidence) pair against an empirical
      * baseline. The baseline rate is too high relative to the
      * configured sample size; the criterion would derive a threshold
      * the test cannot underwrite. Pre-flight aborts before sampling.
      */
-    public static final class PT02SampleSizeFirstInfeasibleTest {
+    public static final class DeclaredSampleSizeInfeasibleTest {
         @ProbabilisticTest
         void undersizedAgainstHighBaselineRate() {
             // n=10 against baseline 0.95 at default 95% confidence:
@@ -87,15 +88,15 @@ public final class PreflightInvariantSubjects {
     }
 
     /**
-     * PT03 — confidence-first via {@code PowerAnalysis.sampleSize}
-     * against a real baseline. The framework returns a sample count
-     * sized for the requested (mde, power) tuple; using that count
-     * configures the test to be feasible by construction. The
-     * pre-flight gate does not fire and the engine runs.
+     * Power-analysis-derived sample size against a real baseline.
+     * The framework returns a sample count sized for the requested
+     * (mde, power) tuple; using that count configures the test to be
+     * feasible by construction. The pre-flight gate does not fire and
+     * the engine runs.
      */
-    public static final class PT03ConfidenceFirstFeasibleTest {
+    public static final class PowerAnalysisDerivedFeasibleTest {
 
-        public static final String EXPERIMENT_ID = "pt03-baseline";
+        public static final String EXPERIMENT_ID = "power-analysis-baseline";
 
         private org.javai.punit.api.spec.Experiment baseline() {
             return PUnit.measuring(sampling(200))
@@ -104,7 +105,7 @@ public final class PreflightInvariantSubjects {
         }
 
         @ProbabilisticTest
-        void confidenceFirstSampleSizeFeasible() {
+        void powerAnalysisSampleSizeIsFeasible() {
             // PowerAnalysis derives n from (baseline rate, mde, power);
             // the test then runs with that n. By construction the
             // (n, baseline-rate, default-confidence) tuple is feasible.
@@ -116,28 +117,28 @@ public final class PreflightInvariantSubjects {
     }
 
     /**
-     * Companion @Experiment for PT03's baseline. The hosting test
-     * runs this first to seed the baseline, then runs
-     * {@link PT03ConfidenceFirstFeasibleTest} which consumes it.
+     * Companion @Experiment for the power-analysis baseline. The
+     * hosting test runs this first to seed the baseline, then runs
+     * {@link PowerAnalysisDerivedFeasibleTest} which consumes it.
      */
-    public static final class PT03BaselineMeasure {
+    public static final class PowerAnalysisBaselineMeasure {
         @org.javai.punit.api.Experiment
         void seedBaseline() {
             PUnit.measuring(sampling(200))
-                    .experimentId(PT03ConfidenceFirstFeasibleTest.EXPERIMENT_ID)
+                    .experimentId(PowerAnalysisDerivedFeasibleTest.EXPERIMENT_ID)
                     .run();
         }
     }
 
     /**
-     * PT12 — parameter validation at construction time. The framework
+     * Parameter validation at construction time. The framework
      * rejects out-of-range parameter values with
      * {@link IllegalArgumentException} before any pre-flight gate
      * runs. This subject demonstrates the catch in a TestKit-driven
      * frame: the {@code @ProbabilisticTest} method itself throws on
      * invocation.
      */
-    public static final class PT12ParameterValidationTest {
+    public static final class ParameterValidationTest {
         @ProbabilisticTest
         void rejectsOutOfRangeThreshold() {
             // PassRate.meeting validates threshold ∈ [0, 1] at
@@ -150,13 +151,13 @@ public final class PreflightInvariantSubjects {
     }
 
     /**
-     * PT13 — configuration coherence. The framework rejects
-     * incoherent combinations at the criterion factory: passing
+     * Configuration coherence. The framework rejects incoherent
+     * combinations at the criterion factory: passing
      * {@code ThresholdOrigin.EMPIRICAL} to {@link PassRate#meeting}
      * is a category error (EMPIRICAL is reserved for the empirical
      * factory), and the criterion throws on construction.
      */
-    public static final class PT13ConfigurationCoherenceTest {
+    public static final class ConfigurationCoherenceTest {
         @ProbabilisticTest
         void rejectsEmpiricalOriginOnContractualFactory() {
             PUnit.testing(sampling(50))


### PR DESCRIPTION
## Summary

Closes Parts 2-3 of `DIR-BUG-FEASIBILITY-VERIFICATION-punit`. Part 1 (the
narrow Feasibility-check fix) shipped previously; the original regression
slipped past the existing test suite because the gate was exercised only at
the evaluator level, not against the typed authoring surface. This PR adds
one TestKit-driven test per audited pre-flight invariant so the same shape
of regression cannot recur silently.

## Audit results

| Invariant | Status | Evidence |
|-----------|--------|----------|
| **PT01** Threshold-first (declared samples + threshold under VERIFICATION) | Enforced | `pt01ThresholdFirstAbortsBeforeSampling` |
| **PT02** Sample-size-first (declared samples + confidence + empirical baseline rate) | Enforced | `pt02SampleSizeFirstAbortsBeforeSampling` |
| **PT03** Confidence-first (PowerAnalysis-derived sample count) | Feasible by construction | `pt03ConfidenceFirstFeasibleByConstruction` |
| **PT08** Sample-size adequacy + threshold achievability under VERIFICATION | Enforced (Part 1 of the original directive) | covered by existing `FeasibilityIntegrationTest` |
| **PT08** Soundness floor (≥ 80% confidence regardless of intent) | **Gap — deferred** | follow-up directive `DIR-BUG-SOUNDNESS-FLOOR-punit` (orchestrator) |
| **PT12** Parameter bounds validation | Enforced at construction | `pt12ParameterValidationRejectsOutOfRange` |
| **PT13** Configuration coherence (EMPIRICAL origin on contractual factory) | Enforced at construction | `pt13ConfigurationCoherenceRejectsEmpiricalOnContractual` |

The PT08 soundness floor is the one invariant the audit found the framework
not enforcing today. Implementing it forces reworks in `CovariateSubjects`
and `PreflightSubjects` (both use `.atConfidence(0.50)` to make small-n
configurations feasible). Per the directive's *"do not silently expand
scope"* instruction, deferred to a focused follow-up directive
(`DIR-BUG-SOUNDNESS-FLOOR-punit`, in the orchestrator repo) which covers
both the floor enforcement and the test reworks.

## Test plan

- [x] `./gradlew :punit-junit5:test --tests "PreflightInvariantsTest"` — all five audit tests pass.
- [x] `./gradlew test` — full suite green.
- [x] Each abort-shaped test verifies the engine never ran via a counter probe on the use case's `invoke`.
- [x] `PT03` test exercises the full `MEASURE → PowerAnalysis.sampleSize → empirical assertPasses` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)