### PR TITLE
Enforce PT08 soundness floor — confidence below 80% aborts regardless of intent

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/engine/criteria/Feasibility.java
+++ b/punit-core/src/main/java/org/javai/punit/engine/criteria/Feasibility.java
@@ -10,6 +10,7 @@ import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.Criterion;
 import org.javai.punit.api.spec.PassRateStatistics;
 import org.javai.punit.reporting.InfeasibilityMessageRenderer;
+import org.javai.punit.statistics.StatisticalDefaults;
 import org.javai.punit.statistics.VerificationFeasibilityEvaluator;
 import org.javai.punit.statistics.VerificationFeasibilityEvaluator.FeasibilityResult;
 
@@ -29,6 +30,13 @@ import org.javai.punit.statistics.VerificationFeasibilityEvaluator.FeasibilityRe
  *       undersized; treat it as a sentinel." The gate produces no
  *       warning and the run proceeds.</li>
  * </ul>
+ *
+ * <p>The one exception is the <strong>soundness floor</strong>: a
+ * configured confidence level below
+ * {@link StatisticalDefaults#SOUNDNESS_FLOOR_CONFIDENCE} aborts
+ * regardless of intent. A test that cannot make a claim at the floor's
+ * confidence level cannot underwrite a verdict, and Smoke-intent does
+ * not buy past that.
  *
  * <p>The check applies to {@link PassRate} criteria — both contractual
  * (declared SLA / SLO / POLICY threshold) and empirical (threshold
@@ -71,6 +79,20 @@ public final class Feasibility {
             BaselineProvider provider) {
         if (!(criterion instanceof PassRate<?> bernoulli)) {
             return List.of();
+        }
+        // Soundness floor — applies regardless of intent. A test
+        // configured below the framework's confidence floor cannot
+        // underwrite a verdict; even a Smoke-intent test does not
+        // silently produce results at that confidence. This check
+        // runs before the rate resolution below, so an empirical
+        // criterion configured below the floor aborts here regardless
+        // of whether its baseline is on disk yet.
+        if (bernoulli.confidence() < StatisticalDefaults.SOUNDNESS_FLOOR_CONFIDENCE) {
+            throw new IllegalStateException(
+                    InfeasibilityMessageRenderer.renderSoundnessFloorBreach(
+                            useCaseId,
+                            bernoulli.confidence(),
+                            StatisticalDefaults.SOUNDNESS_FLOOR_CONFIDENCE));
         }
         double rate;
         if (bernoulli.isEmpirical()) {

--- a/punit-core/src/main/java/org/javai/punit/reporting/InfeasibilityMessageRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/reporting/InfeasibilityMessageRenderer.java
@@ -72,6 +72,45 @@ public final class InfeasibilityMessageRenderer {
         return sb.toString();
     }
 
+    /**
+     * Builds a soundness-floor breach message — the configured
+     * confidence level is below the framework's hard floor and the
+     * test cannot underwrite a verdict at that confidence regardless
+     * of sampling. Distinct from the
+     * {@link #render(String, FeasibilityResult, boolean) "INFEASIBLE
+     * VERIFICATION"} message: that one is intent-gated (silent under
+     * SMOKE); the soundness-floor breach fires under SMOKE too.
+     *
+     * @param testName the test identity (use case id) — appears
+     *                 verbatim in the output
+     * @param confidence the configured confidence level that breached
+     *                   the floor
+     * @param floor      the framework's soundness-floor constant
+     * @return a formatted message explaining the breach and the fix
+     */
+    public static String renderSoundnessFloorBreach(
+            String testName, double confidence, double floor) {
+        String configured = formatTargetAsPercentage(confidence);
+        String floorPercent = formatTargetAsPercentage(floor);
+        StringBuilder sb = new StringBuilder();
+        sb.append("\nINFEASIBLE: confidence below soundness floor\n\n");
+        sb.append(testName).append("\n\n");
+        sb.append(String.format(
+                "The configured confidence level (%s) is below the framework's\n",
+                configured));
+        sb.append(String.format(
+                "soundness floor (%s). A test that cannot make a claim at the\n",
+                floorPercent));
+        sb.append("floor's confidence level cannot underwrite a verdict — even a\n");
+        sb.append("Smoke-intent test does not silently produce results below this\n");
+        sb.append("floor.\n\n");
+        sb.append("REMEDIATION\n");
+        sb.append("  • Raise confidence to at least ").append(floorPercent)
+                .append(" (e.g. .atConfidence(0.95))\n");
+        sb.append("  • Or remove the .atConfidence(...) override to use the framework default");
+        return sb.toString();
+    }
+
     static String formatTargetAsPercentage(double target) {
         double percent = target * 100.0;
         if (percent == Math.floor(percent)) {

--- a/punit-core/src/main/java/org/javai/punit/statistics/StatisticalDefaults.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/StatisticalDefaults.java
@@ -78,6 +78,22 @@ public final class StatisticalDefaults {
      */
     public static final double DEFAULT_ALPHA = 1.0 - DEFAULT_CONFIDENCE;
 
+    /**
+     * Soundness floor for the configured confidence level: 80%.
+     *
+     * <p>Configurations whose confidence falls below this floor cannot
+     * underwrite a verdict — even a Smoke-intent test should not
+     * silently produce results at confidence levels this low. The
+     * framework rejects such configurations pre-flight, regardless of
+     * declared {@code TestIntent}. This is the only feasibility check
+     * that is not intent-gated; every other infeasibility (sample-size
+     * adequacy, threshold achievability) is silent under Smoke.
+     *
+     * <p>Authors who want to assert against this floor in tests can
+     * reference the constant directly rather than hard-coding 0.8.
+     */
+    public static final double SOUNDNESS_FLOOR_CONFIDENCE = 0.80;
+
     private StatisticalDefaults() {
         // utility class
     }

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/SoundnessFloorTest.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/SoundnessFloorTest.java
@@ -1,0 +1,123 @@
+package org.javai.punit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.javai.punit.engine.baseline.BaselineResolver;
+import org.javai.punit.junit5.testsubjects.SoundnessFloorSubjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * Audits the soundness floor — the minimum confidence level the
+ * framework will accept on a probabilistic test. The floor is the
+ * one feasibility check that is <em>not</em> intent-gated: a Smoke
+ * test below the floor aborts just as a Verification test below the
+ * floor aborts. A test that cannot make a claim at the floor's
+ * confidence level cannot underwrite a verdict, regardless of how
+ * the developer described their intent.
+ *
+ * <p>Each abort-shaped test verifies the engine never ran via a
+ * counter probe on the use case's {@code invoke}.
+ */
+@DisplayName("Soundness floor — confidence-floor enforcement, not intent-gated")
+class SoundnessFloorTest {
+
+    private static final String JUNIT_ENGINE_ID = "junit-jupiter";
+
+    @TempDir Path baselineDir;
+    private String savedProperty;
+
+    @BeforeEach
+    void setUp() {
+        savedProperty = System.getProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+        SoundnessFloorSubjects.INVOKE_COUNT.set(0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedProperty == null) {
+            System.clearProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        } else {
+            System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, savedProperty);
+        }
+    }
+
+    @Test
+    @DisplayName("VERIFICATION + confidence below floor → abort, no samples")
+    void verificationBelowFloorAborts() {
+        Events events = run(SoundnessFloorSubjects.VerificationBelowFloor.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+        assertSoundnessFloorBreach(events);
+        assertThat(SoundnessFloorSubjects.INVOKE_COUNT.get())
+                .as("floor abort must precede sampling — engine never runs")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("SMOKE + confidence below floor → abort, no samples (floor is not intent-gated)")
+    void smokeBelowFloorAborts() {
+        Events events = run(SoundnessFloorSubjects.SmokeBelowFloor.class);
+        events.assertStatistics(stats -> stats.started(1).failed(1));
+        assertSoundnessFloorBreach(events);
+        assertThat(SoundnessFloorSubjects.INVOKE_COUNT.get())
+                .as("Smoke does not buy past the floor — engine never runs")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("VERIFICATION + confidence at the floor boundary (0.80) → no floor abort")
+    void verificationAtFloorBoundaryRuns() {
+        Events events = run(SoundnessFloorSubjects.VerificationAtFloorBoundary.class);
+        events.assertStatistics(stats -> stats.started(1));
+        long terminal = events.failed().count() + events.succeeded().count();
+        assertThat(terminal)
+                .as("at the floor boundary the test runs to a verdict, not aborted by the floor")
+                .isEqualTo(1);
+        assertThat(SoundnessFloorSubjects.INVOKE_COUNT.get())
+                .as("engine runs the configured number of samples")
+                .isPositive();
+    }
+
+    @Test
+    @DisplayName("VERIFICATION at framework default confidence → no floor abort")
+    void verificationAtFrameworkDefaultRuns() {
+        Events events = run(SoundnessFloorSubjects.VerificationAtFrameworkDefault.class);
+        events.assertStatistics(stats -> stats.started(1).succeeded(1));
+        assertThat(SoundnessFloorSubjects.INVOKE_COUNT.get())
+                .as("engine runs the configured number of samples")
+                .isPositive();
+    }
+
+    private static void assertSoundnessFloorBreach(Events events) {
+        events.failed()
+                .assertThatEvents()
+                .anySatisfy(event -> {
+                    Throwable t = event.getRequiredPayload(TestExecutionResult.class)
+                            .getThrowable().orElseThrow();
+                    assertThat(t).isInstanceOf(IllegalStateException.class);
+                    assertThat(t.getMessage())
+                            .contains("INFEASIBLE: confidence below soundness floor")
+                            .contains(SoundnessFloorSubjects.USE_CASE_ID)
+                            .contains("80%")
+                            .contains("Raise confidence")
+                            .contains(".atConfidence(0.95)");
+                });
+    }
+
+    private static Events run(Class<?> testClass) {
+        return EngineTestKit.engine(JUNIT_ENGINE_ID)
+                .selectors(DiscoverySelectors.selectClass(testClass))
+                .execute()
+                .testEvents();
+    }
+}

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -88,15 +88,15 @@ public final class CovariateSubjects {
     public static final class TestWithMatchingCovariate {
         @ProbabilisticTest
         void shouldMatchBaseline() {
-            // Wilson lower bound at observed=1.0, n=20, c=0.95 ≈ 0.83;
-            // baseline observed rate is 1.0 → bound 0.83 < threshold
-            // 1.0 → would FAIL on a strict-rate baseline. We instead
-            // assert resolution-time correctness: when the baseline
-            // matches we get a real verdict (not INCONCLUSIVE), and
-            // when it doesn't we get INCONCLUSIVE.
-            PUnit.testing(sampling(20))
-                    .criterion(PassRate.<Boolean>empirical()
-                            .atConfidence(0.50))
+            // The point of this subject is resolution-time correctness:
+            // when the baseline matches we get a real verdict (not
+            // INCONCLUSIVE), and when it doesn't we get INCONCLUSIVE.
+            // Sample count matches the measure phase (100) so the
+            // sample-size constraint holds; baseline rate is 1.0
+            // (always-passes), so feasibility silently skips the
+            // degenerate-rate case.
+            PUnit.testing(sampling(100))
+                    .criterion(PassRate.<Boolean>empirical())
                     .assertPasses();
         }
     }

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
@@ -115,8 +115,14 @@ public final class PreflightSubjects {
     public static final class EmpiricalWithBaselineTest {
         @ProbabilisticTest
         void empiricalWithBaseline() {
-            PUnit.testing(sampling(20))
-                    .criterion(PassRate.<Boolean>empirical().atConfidence(0.50))
+            // Sample count matches the measure phase (100) so the
+            // sample-size constraint holds; baseline rate is 1.0
+            // (always-passes), which silently skips feasibility's
+            // degenerate-rate case. No .atConfidence(...) override —
+            // the framework default sits comfortably above the
+            // soundness floor.
+            PUnit.testing(sampling(100))
+                    .criterion(PassRate.<Boolean>empirical())
                     .assertPasses();
         }
     }

--- a/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/SoundnessFloorSubjects.java
+++ b/punit-junit5/src/test/java/org/javai/punit/junit5/testsubjects/SoundnessFloorSubjects.java
@@ -1,0 +1,110 @@
+package org.javai.punit.junit5.testsubjects;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ProbabilisticTest;
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.NoFactors;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.engine.criteria.PassRate;
+import org.javai.punit.runtime.PUnit;
+
+/**
+ * Subjects for {@code SoundnessFloorTest}. The framework enforces a
+ * minimum confidence level (the "soundness floor") regardless of
+ * declared {@link TestIntent}: a test configured below the floor
+ * cannot underwrite a verdict, and Smoke does not buy past that.
+ *
+ * <p>The hosting test counts samples actually executed via
+ * {@link #INVOKE_COUNT} so the abort-before-sampling guarantee can be
+ * asserted directly.
+ */
+public final class SoundnessFloorSubjects {
+
+    public static final String USE_CASE_ID = "soundness-floor-subject";
+    public static final AtomicInteger INVOKE_COUNT = new AtomicInteger();
+
+    private SoundnessFloorSubjects() { }
+
+    private static UseCase<NoFactors, Integer, Boolean> countingAlwaysPasses() {
+        return new UseCase<>() {
+            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                INVOKE_COUNT.incrementAndGet();
+                return Outcome.ok(true);
+            }
+            @Override public String id() { return USE_CASE_ID; }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .useCaseFactory(f -> countingAlwaysPasses())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    /** VERIFICATION + confidence below the floor → abort, no samples. */
+    public static final class VerificationBelowFloor {
+        @ProbabilisticTest
+        void belowFloor() {
+            PUnit.testing(sampling(50))
+                    .criterion(PassRate.<Boolean>meeting(0.90, ThresholdOrigin.SLA)
+                            .atConfidence(0.50))
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * SMOKE + confidence below the floor → abort, no samples. The
+     * floor's distinguishing property: it fires under SMOKE too,
+     * unlike the (samples, target, confidence) feasibility check.
+     */
+    public static final class SmokeBelowFloor {
+        @ProbabilisticTest
+        void belowFloor() {
+            PUnit.testing(sampling(50))
+                    .criterion(PassRate.<Boolean>meeting(0.90, ThresholdOrigin.SLA)
+                            .atConfidence(0.50))
+                    .intent(TestIntent.SMOKE)
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * VERIFICATION + confidence exactly at the floor (0.80) → no
+     * floor abort. The boundary is inclusive at the floor's value.
+     */
+    public static final class VerificationAtFloorBoundary {
+        @ProbabilisticTest
+        void atFloor() {
+            // Use a permissive target so this passes feasibility too;
+            // the test's purpose is to assert the floor doesn't
+            // wrongly fire at exactly 0.80.
+            PUnit.testing(sampling(100))
+                    .criterion(PassRate.<Boolean>meeting(0.50, ThresholdOrigin.SLA)
+                            .atConfidence(0.80))
+                    .assertPasses();
+        }
+    }
+
+    /**
+     * VERIFICATION at the framework default (0.95) → no floor abort.
+     * Sanity check that the floor doesn't wrongly fire on an
+     * ordinarily-configured test.
+     */
+    public static final class VerificationAtFrameworkDefault {
+        @ProbabilisticTest
+        void atDefault() {
+            PUnit.testing(sampling(100))
+                    .criterion(PassRate.<Boolean>meeting(0.50, ThresholdOrigin.SLA))
+                    .assertPasses();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the one gap identified by the feasibility-verification audit:
configurations whose configured confidence falls below the framework's
soundness floor must abort regardless of intent. The floor is the
single feasibility check that is **not** intent-gated — a Smoke-intent
test below the floor aborts just as a Verification-intent test does.
Until this PR, only the `(samples, target, confidence)` feasibility
check fired, and SMOKE silently bought past arbitrarily low confidence
configurations.

## Changes

- **`StatisticalDefaults.SOUNDNESS_FLOOR_CONFIDENCE = 0.80`** — public so authors can assert against it in tests.
- **`InfeasibilityMessageRenderer.renderSoundnessFloorBreach`** — new helper, default-mode diagnostic distinct from the existing "INFEASIBLE VERIFICATION" banner (this one fires under SMOKE too). Carries configured confidence, the floor, and a two-bullet remediation.
- **`Feasibility.check`** — floor branch inserted before rate resolution. An empirical criterion configured below the floor aborts here regardless of whether its baseline is on disk yet.

## Test fallout

Two existing test classes used `.atConfidence(0.50)` as a feasibility workaround for n=20 against a baseline rate of 1.0:

- `CovariateSubjects.TestWithMatchingCovariate`
- `PreflightSubjects.EmpiricalWithBaselineTest`

The `.atConfidence` override was incidental to each test's purpose (covariate round-trip; preflight short-circuit). Both re-tuned to sample at 100 (matching the measure phase's sample size) so the sample-size constraint and feasibility checks both pass at the framework default confidence — no `.atConfidence(...)` override needed.

## New tests

`SoundnessFloorTest` covers the four corners:

- VERIFICATION + below floor → abort, no samples.
- SMOKE + below floor → abort, no samples (the floor's distinguishing property).
- VERIFICATION + at the floor boundary (0.80) → no floor abort.
- VERIFICATION at framework default (0.95) → no floor abort.

Each abort case verifies the engine never ran via a counter probe.

## Test plan

- [x] `./gradlew test` — full suite green.
- [x] `SoundnessFloorTest` — all four cases pass.
- [x] `CovariateRoundTripTest` and `PreflightBaselineExistenceTest` continue to pass after re-tuning their subjects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)