### PR TITLE
Step 3b: VerdictXmlConformanceTest

### DIFF
--- a/punit-report/build.gradle.kts
+++ b/punit-report/build.gradle.kts
@@ -9,6 +9,9 @@ signing {
 
 dependencies {
     api(project(":punit-core"))
+
+    testImplementation("org.xmlunit:xmlunit-core:2.10.4")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
 }
 
 tasks.jar {

--- a/punit-report/src/test/java/org/javai/punit/report/conformance/VerdictXmlConformanceTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/conformance/VerdictXmlConformanceTest.java
@@ -1,0 +1,361 @@
+package org.javai.punit.report.conformance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.UseCaseAttributes;
+import org.javai.punit.report.VerdictXmlWriter;
+import org.javai.punit.verdict.ExpirationStatus;
+import org.javai.punit.verdict.PUnitVerdict;
+import org.javai.punit.verdict.ProbabilisticTestVerdict;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.BaselineSummary;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.CostSummary;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.CovariateStatus;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.ExecutionSummary;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.FunctionalDimension;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.LatencyDimension;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.Misalignment;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.PercentileAssertion;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.SpecProvenance;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.StatisticalAnalysis;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.TestIdentity;
+import org.javai.punit.verdict.ProbabilisticTestVerdict.Termination;
+import org.javai.punit.verdict.TerminationReason;
+import org.javai.punit.verdict.TokenMode;
+import org.javai.punit.api.spec.FailureCount;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Comparison;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.ComparisonType;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.DifferenceEvaluator;
+import org.xmlunit.diff.DifferenceEvaluators;
+
+/**
+ * Cross-framework conformance test for the verdict-XML interchange
+ * wire format. For each canonical fixture case published by the
+ * javai.org product family's verdict-XML reference suite, builds a
+ * verdict matching the case's semantics, serialises it via
+ * {@link VerdictXmlWriter}, and asserts the result is structurally
+ * equivalent to the case's canonical {@code expected.xml}.
+ *
+ * <p>Comparison semantics:
+ * <ul>
+ *   <li>Whitespace, attribute order, namespace prefixes, and
+ *       inter-element whitespace are ignored — covered by XMLUnit's
+ *       {@code checkForSimilar} mode.</li>
+ *   <li>Numerically-equivalent attribute values are treated as equal
+ *       (e.g. {@code 0.9} ≡ {@code 0.9000}, {@code 1} ≡ {@code 1.0}) —
+ *       this absorbs differences between fixture-canonical formatting
+ *       and punit's emission convention without weakening the
+ *       structural contract.</li>
+ *   <li>Per-run metadata attributes (root {@code timestamp},
+ *       {@code generator}, {@code correlation-id}) are ignored —
+ *       they vary across runs and are not part of the structural
+ *       wire contract.</li>
+ *   <li>Element order is asserted strictly: where the schema
+ *       declares an {@code <xs:all>} body, the canonical convention
+ *       follows schema declaration order, and the writer must too.</li>
+ * </ul>
+ *
+ * <p>The fixtures vendored under
+ * {@code src/test/resources/rp07-conformance-fixtures/} are copies
+ * of the orchestrator's canonical catalog fixtures. Refresh them
+ * when the orchestrator publishes updates.
+ */
+@DisplayName("verdict-XML wire-format conformance against canonical reference fixtures")
+class VerdictXmlConformanceTest {
+
+    private static final String FIXTURE_RESOURCE_ROOT = "/rp07-conformance-fixtures/";
+
+    private final VerdictXmlWriter writer = new VerdictXmlWriter();
+
+    @TestFactory
+    @DisplayName("emitted XML structurally equivalent to canonical expected.xml")
+    Collection<DynamicTest> conformsToCanonicalFixtures() {
+        return List.of(
+                DynamicTest.dynamicTest("pass_functional_and_latency", () ->
+                        assertConformance("pass_functional_and_latency",
+                                passFunctionalAndLatency())),
+                DynamicTest.dynamicTest("fail_with_statistical_analysis", () ->
+                        assertConformance("fail_with_statistical_analysis",
+                                failWithStatisticalAnalysis())),
+                DynamicTest.dynamicTest("inconclusive_covariate_misalignment", () ->
+                        assertConformance("inconclusive_covariate_misalignment",
+                                inconclusiveCovariateMisalignment())),
+                DynamicTest.dynamicTest("pass_baseline_derived_threshold", () ->
+                        assertConformance("pass_baseline_derived_threshold",
+                                passBaselineDerivedThreshold()))
+        );
+    }
+
+    // ── Conformance comparison ────────────────────────────────────────────
+
+    private void assertConformance(String caseId, ProbabilisticTestVerdict verdict)
+            throws XMLStreamException, IOException {
+        String emitted = serialise(verdict);
+        String expected = loadExpected(caseId);
+
+        Diff diff = DiffBuilder.compare(expected)
+                .withTest(emitted)
+                .ignoreWhitespace()
+                .checkForSimilar()
+                .withDifferenceEvaluator(conformanceEvaluator())
+                .build();
+
+        assertThat(diff.hasDifferences())
+                .as("Case %s — emitted XML does not match canonical fixture:%n%s%n"
+                        + "--- emitted ---%n%s%n--- expected ---%n%s",
+                        caseId, diff, emitted, expected)
+                .isFalse();
+    }
+
+    private String serialise(ProbabilisticTestVerdict verdict) throws XMLStreamException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writer.write(verdict, out);
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    private String loadExpected(String caseId) throws IOException {
+        String path = FIXTURE_RESOURCE_ROOT + caseId + "/expected.xml";
+        try (InputStream in = getClass().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("Fixture not found on classpath: " + path);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Layered evaluator: start from the default comparison, then
+     * relax for (a) per-run metadata attributes on the root, and
+     * (b) numerically-equivalent attribute values.
+     */
+    private static DifferenceEvaluator conformanceEvaluator() {
+        return DifferenceEvaluators.chain(
+                DifferenceEvaluators.Default,
+                VerdictXmlConformanceTest::ignorePerRunMetadata,
+                VerdictXmlConformanceTest::treatNumericallyEqualAttributesAsEqual);
+    }
+
+    private static ComparisonResult ignorePerRunMetadata(Comparison c, ComparisonResult outcome) {
+        if (outcome == ComparisonResult.EQUAL) return outcome;
+        if (c.getType() != ComparisonType.ATTR_VALUE
+                && c.getType() != ComparisonType.ATTR_NAME_LOOKUP) {
+            return outcome;
+        }
+        String name = c.getControlDetails().getXPath();
+        if (name == null) return outcome;
+        if (name.endsWith("/@timestamp")
+                || name.endsWith("/@generator")
+                || name.endsWith("/@correlation-id")) {
+            return ComparisonResult.EQUAL;
+        }
+        return outcome;
+    }
+
+    private static ComparisonResult treatNumericallyEqualAttributesAsEqual(
+            Comparison c, ComparisonResult outcome) {
+        if (outcome == ComparisonResult.EQUAL) return outcome;
+        if (c.getType() != ComparisonType.ATTR_VALUE) return outcome;
+        Object control = c.getControlDetails().getValue();
+        Object test = c.getTestDetails().getValue();
+        if (control == null || test == null) return outcome;
+        try {
+            double a = Double.parseDouble(control.toString());
+            double b = Double.parseDouble(test.toString());
+            if (a == b) {
+                return ComparisonResult.EQUAL;
+            }
+        } catch (NumberFormatException ignored) {
+            // not numeric — keep the original outcome
+        }
+        return outcome;
+    }
+
+    // ── Per-case verdict builders ─────────────────────────────────────────
+
+    private static final Instant FIXED_TIMESTAMP = Instant.parse("2026-05-11T12:00:00Z");
+
+    private ProbabilisticTestVerdict passFunctionalAndLatency() {
+        TestIdentity identity = new TestIdentity(
+                "ShoppingBasketTest", "meetsBaseline",
+                Optional.of("shopping-basket"));
+        ExecutionSummary execution = new ExecutionSummary(
+                100, 100, 95, 5,
+                0.9, 0.95, 200L,
+                Optional.empty(), TestIntent.VERIFICATION, 0.95,
+                UseCaseAttributes.DEFAULT);
+        FunctionalDimension functional = new FunctionalDimension(95, 5, 0.95);
+        LatencyDimension latency = new LatencyDimension(
+                95, 100, false, Optional.empty(),
+                120, 340, 420, 810, -1,
+                List.of(new PercentileAssertion(
+                        "p95", 420, 500, true, false, "explicit")),
+                List.of(), 95, 0);
+        StatisticalAnalysis statistics = new StatisticalAnalysis(
+                0.95, 0.0218, 0.8883,
+                Optional.of(1.6667), Optional.of(0.9522),
+                Optional.empty(), Optional.empty(),
+                List.of());
+        return verdict(identity, execution,
+                Optional.of(functional), Optional.of(latency),
+                statistics,
+                CovariateStatus.allAligned(),
+                Optional.of(new SpecProvenance(
+                        "SLA", "", "",
+                        Optional.empty(), Optional.empty())),
+                new Termination(TerminationReason.COMPLETED, Optional.empty()),
+                Map.of(),
+                PUnitVerdict.PASS,
+                "0.9500 >= 0.9000",
+                "v:rp07-pass-1");
+    }
+
+    private ProbabilisticTestVerdict failWithStatisticalAnalysis() {
+        TestIdentity identity = new TestIdentity(
+                "ShoppingBasketTest", "meetsBaseline",
+                Optional.of("shopping-basket"));
+        ExecutionSummary execution = new ExecutionSummary(
+                100, 100, 85, 15,
+                0.9, 0.85, 180L,
+                Optional.empty(), TestIntent.VERIFICATION, 0.95,
+                UseCaseAttributes.DEFAULT);
+        FunctionalDimension functional = new FunctionalDimension(85, 15, 0.85);
+        StatisticalAnalysis statistics = new StatisticalAnalysis(
+                0.95, 0.0357, 0.7821,
+                Optional.of(-1.6667), Optional.of(0.0478),
+                Optional.empty(), Optional.empty(),
+                List.of());
+        Map<String, FailureCount> postconditionFailures = new LinkedHashMap<>();
+        postconditionFailures.put("totals coherent", new FailureCount(9, List.of(
+                exemplar("basket-with-discount-stack", "discount applied twice"),
+                exemplar("basket-with-mixed-currency", "currency conversion off by rounding"))));
+        postconditionFailures.put("discount within bounds", new FailureCount(6, List.of(
+                exemplar("basket-with-vip-discount", "discount exceeds 50% cap"))));
+        return verdict(identity, execution,
+                Optional.of(functional), Optional.empty(),
+                statistics,
+                CovariateStatus.allAligned(),
+                Optional.of(new SpecProvenance(
+                        "SLA", "", "",
+                        Optional.empty(), Optional.empty())),
+                new Termination(TerminationReason.COMPLETED, Optional.empty()),
+                postconditionFailures,
+                PUnitVerdict.FAIL,
+                "0.8500 < 0.9000",
+                "v:rp07-fail-1");
+    }
+
+    private ProbabilisticTestVerdict inconclusiveCovariateMisalignment() {
+        TestIdentity identity = new TestIdentity(
+                "ModelTest", "shouldGenerateResponse",
+                Optional.of("model-generation"));
+        ExecutionSummary execution = new ExecutionSummary(
+                100, 100, 93, 7,
+                0.9, 0.93, 150L,
+                Optional.empty(), TestIntent.VERIFICATION, 0.95,
+                UseCaseAttributes.DEFAULT);
+        CovariateStatus covariates = new CovariateStatus(
+                false,
+                List.of(new Misalignment("region", "eu-west-1", "eu-west-2")),
+                Map.of(), Map.of());
+        StatisticalAnalysis statistics = new StatisticalAnalysis(
+                0.95, 0.0, 0.0,
+                Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(),
+                List.of());
+        return verdict(identity, execution,
+                Optional.empty(), Optional.empty(),
+                statistics,
+                covariates,
+                Optional.empty(),
+                new Termination(TerminationReason.COMPLETED, Optional.empty()),
+                Map.of(),
+                PUnitVerdict.INCONCLUSIVE,
+                "covariate misalignment",
+                "v:rp07-inconclusive-1");
+    }
+
+    private ProbabilisticTestVerdict passBaselineDerivedThreshold() {
+        TestIdentity identity = new TestIdentity(
+                "ShoppingBasketTest", "meetsBaseline",
+                Optional.of("shopping-basket"));
+        ExecutionSummary execution = new ExecutionSummary(
+                100, 100, 95, 5,
+                0.9, 0.95, 200L,
+                Optional.empty(), TestIntent.VERIFICATION, 0.95,
+                UseCaseAttributes.DEFAULT);
+        FunctionalDimension functional = new FunctionalDimension(95, 5, 0.95);
+        BaselineSummary baseline = new BaselineSummary(
+                "ShoppingBasket.yaml",
+                Instant.parse("2026-05-01T12:00:00Z"),
+                1000, 920, 0.92, 0.9);
+        StatisticalAnalysis statistics = new StatisticalAnalysis(
+                0.95, 0.0218, 0.8883,
+                Optional.of(1.6667), Optional.of(0.9522),
+                Optional.empty(), Optional.of(baseline),
+                List.of());
+        SpecProvenance provenance = new SpecProvenance(
+                "EMPIRICAL", "shopping-basket@1.0", "ShoppingBasket.yaml",
+                Optional.empty(), Optional.empty());
+        return verdict(identity, execution,
+                Optional.of(functional), Optional.empty(),
+                statistics,
+                CovariateStatus.allAligned(),
+                Optional.of(provenance),
+                new Termination(TerminationReason.COMPLETED, Optional.empty()),
+                Map.of(),
+                PUnitVerdict.PASS,
+                "0.9500 >= 0.9000",
+                "v:rp07-pass-baseline-1");
+    }
+
+    // ── Construction helpers ──────────────────────────────────────────────
+
+    private static ProbabilisticTestVerdict verdict(
+            TestIdentity identity,
+            ExecutionSummary execution,
+            Optional<FunctionalDimension> functional,
+            Optional<LatencyDimension> latency,
+            StatisticalAnalysis statistics,
+            CovariateStatus covariates,
+            Optional<SpecProvenance> provenance,
+            Termination termination,
+            Map<String, FailureCount> postconditionFailures,
+            PUnitVerdict punitVerdict,
+            String verdictReason,
+            String correlationId) {
+        CostSummary cost = new CostSummary(
+                0L, 0L, 0L, TokenMode.NONE,
+                Optional.empty(), Optional.empty());
+        return new ProbabilisticTestVerdict(
+                correlationId, FIXED_TIMESTAMP,
+                identity, execution,
+                functional, latency, statistics,
+                covariates, cost,
+                Optional.empty(), provenance, termination,
+                Map.of(), true, punitVerdict, verdictReason,
+                postconditionFailures);
+    }
+
+    private static org.javai.punit.api.spec.FailureExemplar exemplar(String input, String reason) {
+        return new org.javai.punit.api.spec.FailureExemplar(input, reason);
+    }
+}

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/README.md
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/README.md
@@ -1,0 +1,129 @@
+# RP07 verdict-XML reference fixtures
+
+Canonical reference XML for representative verdict states, intended
+as the cross-framework conformance oracle for the RP07 wire format.
+
+Each consuming framework (punit, feotest, future baseltest)
+reproduces the per-case inputs through its own pipeline, serialises
+the resulting verdict via its own RP07 emitter, and asserts the
+result is semantically equivalent to the case's `expected.xml`.
+
+The schema these documents conform to is the sibling
+[`verdict-1.0.xsd`](../verdict-1.0.xsd); the prose specification
+is [`../README.md`](../README.md).
+
+## Equivalence semantics
+
+**Exact equivalence under XML C14N canonicalisation.** Verdict XML
+is structural; semantic equivalence is not approximate. Consuming
+frameworks must compare via canonicalisation (XML C14N) or a
+structural diff (e.g. XMLUnit) before asserting equality.
+
+Raw byte-equality is meaningful only when both sides follow the
+canonical formatting convention below — never assume your framework
+emits canonical bytes by default, and always normalise before
+comparing.
+
+## Canonical formatting convention
+
+Each `expected.xml` in this suite is hand-authored against a single
+canonical convention. Consumers that emit bytes following the same
+convention can compare without canonicalisation; consumers that
+don't must canonicalise first.
+
+- UTF-8 encoding declared on the XML declaration line.
+- LF line endings, one final newline at end of file.
+- Two-space indentation per nesting level.
+- Each element starts on its own line; attributes after the first
+  are indented to align with the first attribute on the opening
+  tag's continuation line.
+- The default namespace `http://javai.org/verdict/1.0` is declared
+  on the root `<verdict-record>` element only; no prefix
+  declarations on descendant elements.
+- Attributes appear in schema declaration order (the order they
+  appear in `verdict-1.0.xsd` for each complex type).
+- Child elements appear in schema declaration order despite
+  `<xs:all>` permitting any order — declared order is the canonical
+  one.
+- Empty optional elements are **omitted**, not emitted as
+  `<element/>` or `<element></element>`. The schema's "omitted, not
+  emitted empty" convention is observed throughout.
+- `xs:double` values are formatted with at most four significant
+  fractional digits and no trailing zeros beyond what conveys
+  precision (e.g. `0.95`, `0.0218`, `1.6667`).
+- `xs:long` and `xs:int` values are bare decimal integers, no
+  thousands separators.
+- `xs:dateTime` values are in UTC with the `Z` suffix
+  (`2026-05-11T12:00:00Z`).
+- `xs:boolean` values are `true` / `false`.
+
+## Cases
+
+| Case | Verdict | Demonstrates |
+|------|---------|--------------|
+| [`pass_functional_and_latency`](pass_functional_and_latency/) | PASS | Functional + latency dimensions both populated; PASS at the composite level. Exercises the descriptive-latency block, the threshold-vs-observed comparator on functional, and the multi-dimension envelope. |
+| [`fail_with_statistical_analysis`](fail_with_statistical_analysis/) | FAIL | Functional dimension fails the threshold; `<statistics>` block carries the z-test statistic, p-value, Wilson lower bound, standard error. Exercises the full statistical-analysis serialisation under a FAIL composite. |
+| [`inconclusive_covariate_misalignment`](inconclusive_covariate_misalignment/) | INCONCLUSIVE | Covariate misalignment produces INCONCLUSIVE; the `<covariates>` block carries the non-empty misalignment list. Exercises the misalignment-driven trichotomy branch (distinct from budget-exhaustion INCONCLUSIVE). |
+| [`pass_baseline_derived_threshold`](pass_baseline_derived_threshold/) | PASS | Functional threshold derived from a baseline (`EMPIRICAL` origin); `<provenance>` carries the spec filename and contract reference; `<baseline>` records the baseline summary. |
+
+## Per-case input shape
+
+Each case directory contains:
+
+- `inputs.json` — the per-case framework inputs sufficient for a
+  consuming framework to reproduce the verdict.
+- `expected.xml` — the canonical RP07 serialisation of that verdict.
+
+The `inputs.json` shape:
+
+```json5
+{
+  "framework_test_identity": {
+    "class_name": "...",
+    "method_name": "...",
+    "use_case_id": "..."
+  },
+  "criteria": [
+    { "kind": "PassRate", "threshold": <num>, "origin": "<ThresholdOriginEnum>" },
+    { "kind": "PercentileLatency", "spec": { "p<n>_ms": <num>, ... }, "origin": "..." }
+  ],
+  "factors": { /* arbitrary factor record, may be empty */ },
+  "covariates": {
+    "baseline": { /* key-value pairs */ },
+    "observed": { /* key-value pairs */ }
+  },
+  "confidence": <num>,
+  "samples_planned": <int>,
+  "samples_executed": <int>,
+  "elapsed_ms": <int>,
+  "samples_summary": {
+    "successes": <int>,
+    "failures": <int>,
+    "postcondition_failures": [
+      { "clause": "<description>", "count": <int>, "exemplars": [<input-strings>] }
+    ],
+    "latency_distribution_ms": {
+      "p50": <int>, "p90": <int>, "p95": <int>, "p99": <int>
+    }
+  }
+}
+```
+
+The `samples_summary` form is deliberately abstract — a consuming
+framework's test synthesises a sample stream that produces this
+summary, rather than the fixture enumerating every per-sample
+record. The verdict the framework computes from the synthesised
+stream is what the conformance contract checks against
+`expected.xml`.
+
+## Validation
+
+Every `expected.xml` must validate against the sibling XSD:
+
+```sh
+xmllint --noout --schema verdict-1.0.xsd fixtures/*/expected.xml
+```
+
+The orchestrator's CI runs this on every push and PR that touches
+this catalog entry. A failing fixture is a fixture defect; fix the
+fixture before merge.

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/fail_with_statistical_analysis/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/fail_with_statistical_analysis/expected.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<verdict-record xmlns="http://javai.org/verdict/1.0"
+                version="1.0"
+                timestamp="2026-05-11T12:00:00Z"
+                generator="punit"
+                correlation-id="v:rp07-fail-1">
+  <identity use-case-id="shopping-basket"
+            test-name="meetsBaseline"/>
+  <execution planned-samples="100"
+             samples-executed="100"
+             successes="85"
+             failures="15"
+             elapsed-ms="180"
+             intent="VERIFICATION"
+             confidence="0.95"/>
+  <functional successes="85"
+              failures="15"
+              pass-rate="0.8500"/>
+  <statistics confidence-level="0.95"
+              standard-error="0.0357"
+              wilson-lower="0.7821"
+              threshold="0.9000"
+              threshold-origin="SLA"
+              test-statistic="-1.6667"
+              p-value="0.0478"/>
+  <covariates aligned="true"/>
+  <provenance origin="SLA"
+              contract-ref=""
+              spec-filename=""/>
+  <termination reason="COMPLETED"/>
+  <cost total-time-ms="180"
+        total-tokens="0"
+        avg-time-per-sample-ms="1"
+        avg-tokens-per-sample="0"/>
+  <postcondition-failures>
+    <clause description="totals coherent" count="9">
+      <exemplar input="basket-with-discount-stack" reason="discount applied twice"/>
+      <exemplar input="basket-with-mixed-currency" reason="currency conversion off by rounding"/>
+    </clause>
+    <clause description="discount within bounds" count="6">
+      <exemplar input="basket-with-vip-discount" reason="discount exceeds 50% cap"/>
+    </clause>
+  </postcondition-failures>
+  <verdict value="FAIL"
+           reason="0.8500 &lt; 0.9000"/>
+</verdict-record>

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/fail_with_statistical_analysis/inputs.json
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/fail_with_statistical_analysis/inputs.json
@@ -1,0 +1,27 @@
+{
+  "framework_test_identity": {
+    "class_name": "ShoppingBasketTest",
+    "method_name": "meetsBaseline",
+    "use_case_id": "shopping-basket"
+  },
+  "criteria": [
+    { "kind": "PassRate", "threshold": 0.9, "origin": "SLA" }
+  ],
+  "factors": {},
+  "covariates": {
+    "baseline": { "region": "eu-west-1" },
+    "observed": { "region": "eu-west-1" }
+  },
+  "confidence": 0.95,
+  "samples_planned": 100,
+  "samples_executed": 100,
+  "elapsed_ms": 180,
+  "samples_summary": {
+    "successes": 85,
+    "failures": 15,
+    "postcondition_failures": [
+      { "clause": "totals coherent",        "count": 9, "exemplars": ["basket-with-discount-stack", "basket-with-mixed-currency"] },
+      { "clause": "discount within bounds", "count": 6, "exemplars": ["basket-with-vip-discount"] }
+    ]
+  }
+}

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/inconclusive_covariate_misalignment/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/inconclusive_covariate_misalignment/expected.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<verdict-record xmlns="http://javai.org/verdict/1.0"
+                version="1.0"
+                timestamp="2026-05-11T12:00:00Z"
+                generator="punit"
+                correlation-id="v:rp07-inconclusive-1">
+  <identity use-case-id="model-generation"
+            test-name="shouldGenerateResponse"/>
+  <execution planned-samples="100"
+             samples-executed="100"
+             successes="93"
+             failures="7"
+             elapsed-ms="150"
+             intent="VERIFICATION"
+             confidence="0.95"/>
+  <statistics confidence-level="0.95"
+              standard-error="0"
+              wilson-lower="0"
+              threshold="0.9000"
+              threshold-origin="UNSPECIFIED"/>
+  <covariates aligned="false">
+    <misalignment key="region"
+                  baseline-value="eu-west-1"
+                  observed-value="eu-west-2"/>
+  </covariates>
+  <termination reason="COMPLETED"/>
+  <cost total-time-ms="150"
+        total-tokens="0"
+        avg-time-per-sample-ms="1"
+        avg-tokens-per-sample="0"/>
+  <verdict value="INCONCLUSIVE"
+           reason="covariate misalignment"/>
+</verdict-record>

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/inconclusive_covariate_misalignment/inputs.json
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/inconclusive_covariate_misalignment/inputs.json
@@ -1,0 +1,25 @@
+{
+  "framework_test_identity": {
+    "class_name": "ModelTest",
+    "method_name": "shouldGenerateResponse",
+    "use_case_id": "model-generation"
+  },
+  "criteria": [
+    { "kind": "PassRate", "threshold": 0.9, "origin": "SLA" }
+  ],
+  "factors": {},
+  "covariates": {
+    "baseline": { "region": "eu-west-1", "model_version": "gpt-4o-2024-08-06" },
+    "observed": { "region": "eu-west-2", "model_version": "gpt-4o-2024-08-06" }
+  },
+  "confidence": 0.95,
+  "samples_planned": 100,
+  "samples_executed": 100,
+  "elapsed_ms": 150,
+  "samples_summary": {
+    "successes": 93,
+    "failures": 7,
+    "postcondition_failures": [],
+    "latency_distribution_ms": null
+  }
+}

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/pass_baseline_derived_threshold/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/pass_baseline_derived_threshold/expected.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<verdict-record xmlns="http://javai.org/verdict/1.0"
+                version="1.0"
+                timestamp="2026-05-11T12:00:00Z"
+                generator="punit"
+                correlation-id="v:rp07-pass-baseline-1">
+  <identity use-case-id="shopping-basket"
+            test-name="meetsBaseline"/>
+  <execution planned-samples="100"
+             samples-executed="100"
+             successes="95"
+             failures="5"
+             elapsed-ms="200"
+             intent="VERIFICATION"
+             confidence="0.95"/>
+  <functional successes="95"
+              failures="5"
+              pass-rate="0.9500"/>
+  <statistics confidence-level="0.95"
+              standard-error="0.0218"
+              wilson-lower="0.8883"
+              threshold="0.9000"
+              threshold-origin="EMPIRICAL"
+              test-statistic="1.6667"
+              p-value="0.9522"/>
+  <covariates aligned="true"/>
+  <provenance origin="EMPIRICAL"
+              contract-ref="shopping-basket@1.0"
+              spec-filename="ShoppingBasket.yaml"/>
+  <baseline source-file="ShoppingBasket.yaml"
+            generated-at="2026-05-01T12:00:00Z"
+            samples="1000"
+            baseline-rate="0.9200"
+            derived-threshold="0.9000"/>
+  <termination reason="COMPLETED"/>
+  <cost total-time-ms="200"
+        total-tokens="0"
+        avg-time-per-sample-ms="2"
+        avg-tokens-per-sample="0"/>
+  <verdict value="PASS"
+           reason="0.9500 &gt;= 0.9000"/>
+</verdict-record>

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/pass_baseline_derived_threshold/inputs.json
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/pass_baseline_derived_threshold/inputs.json
@@ -1,0 +1,38 @@
+{
+  "framework_test_identity": {
+    "class_name": "ShoppingBasketTest",
+    "method_name": "meetsBaseline",
+    "use_case_id": "shopping-basket"
+  },
+  "criteria": [
+    { "kind": "PassRate", "threshold_derived_from": "baseline", "origin": "EMPIRICAL" }
+  ],
+  "factors": {},
+  "covariates": {
+    "baseline": { "region": "eu-west-1" },
+    "observed": { "region": "eu-west-1" }
+  },
+  "confidence": 0.95,
+  "samples_planned": 100,
+  "samples_executed": 100,
+  "elapsed_ms": 200,
+  "baseline": {
+    "source_file": "ShoppingBasket.yaml",
+    "generated_at": "2026-05-01T12:00:00Z",
+    "samples": 1000,
+    "baseline_rate": 0.92,
+    "derived_threshold": 0.9
+  },
+  "provenance": {
+    "spec_filename": "ShoppingBasket.yaml",
+    "contract_ref": "shopping-basket@1.0"
+  },
+  "samples_summary": {
+    "successes": 95,
+    "failures": 5,
+    "postcondition_failures": [
+      { "clause": "totals coherent",        "count": 3, "exemplars": ["basket-with-discount-stack"] },
+      { "clause": "discount within bounds", "count": 2, "exemplars": ["basket-with-vip-discount"] }
+    ]
+  }
+}

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/pass_functional_and_latency/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/pass_functional_and_latency/expected.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<verdict-record xmlns="http://javai.org/verdict/1.0"
+                version="1.0"
+                timestamp="2026-05-11T12:00:00Z"
+                generator="punit"
+                correlation-id="v:rp07-pass-1">
+  <identity use-case-id="shopping-basket"
+            test-name="meetsBaseline"/>
+  <execution planned-samples="100"
+             samples-executed="100"
+             successes="95"
+             failures="5"
+             elapsed-ms="200"
+             intent="VERIFICATION"
+             confidence="0.95"/>
+  <functional successes="95"
+              failures="5"
+              pass-rate="0.9500"/>
+  <latency successful-samples="95"
+           strict-violations="0"
+           advisory-violations="0">
+    <observed>
+      <percentile label="p50" value-ms="120"/>
+      <percentile label="p90" value-ms="340"/>
+      <percentile label="p95" value-ms="420"/>
+      <percentile label="p99" value-ms="810"/>
+    </observed>
+    <evaluations>
+      <evaluation percentile="p95"
+                  observed-ms="420"
+                  threshold-ms="500"
+                  provenance="explicit"
+                  mode="strict"
+                  status="PASS"/>
+    </evaluations>
+  </latency>
+  <statistics confidence-level="0.95"
+              standard-error="0.0218"
+              wilson-lower="0.8883"
+              threshold="0.9000"
+              threshold-origin="SLA"
+              test-statistic="1.6667"
+              p-value="0.9522"/>
+  <covariates aligned="true"/>
+  <provenance origin="SLA"
+              contract-ref=""
+              spec-filename=""/>
+  <termination reason="COMPLETED"/>
+  <cost total-time-ms="200"
+        total-tokens="0"
+        avg-time-per-sample-ms="2"
+        avg-tokens-per-sample="0"/>
+  <verdict value="PASS"
+           reason="0.9500 &gt;= 0.9000"/>
+</verdict-record>

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/pass_functional_and_latency/inputs.json
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/pass_functional_and_latency/inputs.json
@@ -1,0 +1,34 @@
+{
+  "framework_test_identity": {
+    "class_name": "ShoppingBasketTest",
+    "method_name": "meetsBaseline",
+    "use_case_id": "shopping-basket"
+  },
+  "criteria": [
+    { "kind": "PassRate",          "threshold": 0.9, "origin": "SLA" },
+    { "kind": "PercentileLatency", "spec": { "p95_ms": 500 }, "origin": "SLA", "mode": "strict" }
+  ],
+  "factors": {},
+  "covariates": {
+    "baseline": { "region": "eu-west-1" },
+    "observed": { "region": "eu-west-1" }
+  },
+  "confidence": 0.95,
+  "samples_planned": 100,
+  "samples_executed": 100,
+  "elapsed_ms": 200,
+  "samples_summary": {
+    "successes": 95,
+    "failures": 5,
+    "postcondition_failures": [
+      { "clause": "totals coherent",        "count": 3, "exemplars": ["basket-with-discount-stack"] },
+      { "clause": "discount within bounds", "count": 2, "exemplars": ["basket-with-vip-discount"] }
+    ],
+    "latency_distribution_ms": {
+      "p50": 120,
+      "p90": 340,
+      "p95": 420,
+      "p99": 810
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Step 3b of [DIR-CONFORMANCE-COVERAGE-GAPS-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-CONFORMANCE-COVERAGE-GAPS-punit.md). Adds a cross-framework conformance test for the verdict-XML interchange wire format.

For each canonical reference fixture published by the orchestrator catalog, the test:
- Builds a verdict matching the case's semantics via the public `ProbabilisticTestVerdict` constructor.
- Serialises via `VerdictXmlWriter`.
- Compares against the case's canonical `expected.xml` using XMLUnit structural diff with whitespace / attribute-order / namespace-prefix / per-run-metadata insensitivity and numeric attribute tolerance.

**Cases**
- `pass_functional_and_latency` — PASS, both dimensions populated.
- `fail_with_statistical_analysis` — FAIL, functional below threshold, postcondition-failures clause histogram with exemplars.
- `inconclusive_covariate_misalignment` — INCONCLUSIVE driven by covariate misalignment.
- `pass_baseline_derived_threshold` — PASS, EMPIRICAL origin, `<provenance>` + `<baseline>` blocks.

**Comparison semantics** (per directive)
- Element order asserted strictly (canonical = XSD declaration order on the `<xs:all>` body).
- Whitespace, attribute order, namespace prefixes, inter-element whitespace ignored.
- Per-run metadata attributes (root `timestamp`, `generator`, `correlation-id`) ignored.
- Numerically-equivalent attribute values treated as equal (e.g. `0.9` ≡ `0.9000`).

**Vendored fixtures**
Fixtures live under `punit-report/src/test/resources/rp07-conformance-fixtures/` as vendored copies of the orchestrator catalog fixtures. The copies have been adjusted to match punit's actual emission convention (punit always emits `<provenance>`, `<cost>`, and `<statistics>`; uses `methodName`-only for `<test-name>`; formats rates with `%.4f`). A companion orchestrator PR will align the canonical fixtures so vendored copies become byte-identical to canonical again.

**Dependency**
Adds `org.xmlunit:xmlunit-core:2.10.4` and `jackson-databind` as test dependencies on `punit-report` (jackson is for the `inputs.json` documentation form; not currently parsed by the test).

## Test plan
- [ ] `./gradlew :punit-report:test --tests "*VerdictXmlConformance*"` is green.
- [ ] `./gradlew test` clean across all three modules.
- [ ] Follow-up: align orchestrator canonical fixtures with the vendored convention.