### PR TITLE
Restore statistical early termination + add author opt-out

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Criterion.java
@@ -1,6 +1,7 @@
 package org.javai.punit.api.spec;
 
 import java.util.Map;
+import java.util.OptionalDouble;
 
 /**
  * A spec-level claim evaluated against the observed sample aggregate.
@@ -82,5 +83,26 @@ public interface Criterion<OT, S extends BaselineStatistics> {
      */
     default Map<String, Object> empiricalDetail() {
         return Map.of();
+    }
+
+    /**
+     * The up-front pass-rate threshold this criterion targets, if any.
+     *
+     * <p>Returned non-empty only when the criterion is built against a
+     * contractual rate known before sampling begins (e.g.
+     * {@code PassRate.meeting(0.95, SLA)}). The engine consults this
+     * to short-circuit the sample loop when the threshold is
+     * mathematically unreachable (failure inevitable) or already
+     * guaranteed (success guaranteed). Criteria that derive their
+     * threshold at evaluate time — empirical pass-rate modes,
+     * percentile-latency claims — leave the default empty and run
+     * every planned sample.
+     *
+     * @return the pass-rate threshold in [0, 1], or empty if this
+     *         criterion does not expose an up-front threshold suitable
+     *         for early termination
+     */
+    default OptionalDouble earlyTerminationPassRate() {
+        return OptionalDouble.empty();
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/EarlyTerminationContext.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/EarlyTerminationContext.java
@@ -1,0 +1,37 @@
+package org.javai.punit.api.spec;
+
+/**
+ * Engine-visible context for statistical early termination of a
+ * probabilistic test's sample loop.
+ *
+ * <p>Specs that carry a contractual pass-rate threshold publish this
+ * context through {@link TypedSpec#earlyTermination()}; the engine
+ * then short-circuits the sample loop when the threshold becomes
+ * mathematically unreachable (failure inevitable) or mathematically
+ * guaranteed (success guaranteed). Specs that have no up-front
+ * threshold — measure / explore / optimize runs, and empirical-mode
+ * probabilistic tests — return {@link java.util.Optional#empty()}
+ * from that accessor and run every declared sample.
+ *
+ * @param minPassRate           the contractual pass rate the spec must meet
+ * @param minSamplesForValidity the floor below which a guaranteed-success
+ *                              short-circuit must not fire — the run continues
+ *                              until the normal approximation is meaningful.
+ *                              Zero disables the floor (failure-inevitable
+ *                              termination never needs it).
+ */
+public record EarlyTerminationContext(
+        double minPassRate,
+        int minSamplesForValidity) {
+
+    public EarlyTerminationContext {
+        if (Double.isNaN(minPassRate) || minPassRate < 0.0 || minPassRate > 1.0) {
+            throw new IllegalArgumentException(
+                    "minPassRate must be in [0, 1], got: " + minPassRate);
+        }
+        if (minSamplesForValidity < 0) {
+            throw new IllegalArgumentException(
+                    "minSamplesForValidity must be non-negative, got: " + minSamplesForValidity);
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.OptionalLong;
 import java.util.function.Function;
 
@@ -141,6 +142,7 @@ public final class ProbabilisticTest implements Spec {
         private final Optional<ValueMatcher<OT>> matcher;
         private final List<Registered<OT>> registered;
         private final TestIntent intent;
+        private final boolean earlyTerminationDisabled;
 
         private SampleSummary<OT> summary;
 
@@ -151,6 +153,7 @@ public final class ProbabilisticTest implements Spec {
             this.matcher = Optional.ofNullable(b.matcher);
             this.registered = List.copyOf(b.registered);
             this.intent = b.intent;
+            this.earlyTerminationDisabled = b.earlyTerminationDisabled;
         }
 
         @Override public Function<FT, UseCase<FT, IT, OT>> useCaseFactory() {
@@ -335,6 +338,26 @@ public final class ProbabilisticTest implements Spec {
         @Override public BudgetExhaustionPolicy budgetPolicy() { return sampling.budgetPolicy(); }
         @Override public ExceptionPolicy exceptionPolicy() { return sampling.exceptionPolicy(); }
         @Override public int maxExampleFailures() { return sampling.maxExampleFailures(); }
+
+        @Override
+        public Optional<EarlyTerminationContext> earlyTermination() {
+            if (earlyTerminationDisabled) {
+                return Optional.empty();
+            }
+            for (Registered<OT> entry : registered) {
+                if (entry.role() != CriterionRole.REQUIRED) {
+                    continue;
+                }
+                OptionalDouble threshold = entry.criterion().earlyTerminationPassRate();
+                if (threshold.isPresent()) {
+                    double rate = threshold.getAsDouble();
+                    int floor = new org.javai.punit.statistics.BinomialProportionEstimator()
+                            .minSamplesForNormalApproximation(rate);
+                    return Optional.of(new EarlyTerminationContext(rate, floor));
+                }
+            }
+            return Optional.empty();
+        }
     }
 
     // ── Builder ──────────────────────────────────────────────────────
@@ -347,6 +370,7 @@ public final class ProbabilisticTest implements Spec {
         private ValueMatcher<OT> matcher;
         private final List<Registered<OT>> registered = new ArrayList<>();
         private TestIntent intent = TestIntent.VERIFICATION;
+        private boolean earlyTerminationDisabled = false;
 
         private Builder(Sampling<FT, IT, OT> sampling, FT factors) {
             this.sampling = sampling;
@@ -412,6 +436,31 @@ public final class ProbabilisticTest implements Spec {
             return this;
         }
 
+        /**
+         * Run every declared sample regardless of statistical
+         * determination. Disables the framework's mid-run short-circuit
+         * so the sample loop continues even after the verdict is
+         * mathematically determined (threshold unreachable or
+         * guaranteed).
+         *
+         * <p>Use when the full sample count is wanted for downstream
+         * data (a follow-on baseline emission, a complete latency
+         * distribution, exhaustive failure exemplars) and the
+         * cost-saving short-circuit is not the right behaviour. The
+         * resulting summary's {@code terminationReason} is
+         * {@code COMPLETED} — no spurious {@code IMPOSSIBILITY} /
+         * {@code SUCCESS_GUARANTEED} annotation.
+         *
+         * <p>Unrelated to the optimize loop's
+         * {@code OptimizeBuilder.disableEarlyTermination()}, which
+         * controls a heuristic no-improvement window on a different
+         * builder.
+         */
+        public Builder<FT, IT, OT> disableEarlyTermination() {
+            this.earlyTerminationDisabled = true;
+            return this;
+        }
+
         public ProbabilisticTest build() {
             if (!expected.isEmpty() && matcher == null) {
                 matcher = ValueMatcher.equality();
@@ -446,6 +495,7 @@ public final class ProbabilisticTest implements Spec {
         private ValueMatcher<OT> matcher;
         private final List<Registered<OT>> registered = new ArrayList<>();
         private TestIntent intent = TestIntent.VERIFICATION;
+        private boolean earlyTerminationDisabled = false;
 
         private InlineBuilder(Function<FT, UseCase<FT, IT, OT>> useCaseFactory, FT factors) {
             this.useCaseFactory = useCaseFactory;
@@ -527,6 +577,16 @@ public final class ProbabilisticTest implements Spec {
         }
 
         /**
+         * Run every declared sample regardless of statistical
+         * determination. Mirrors {@link Builder#disableEarlyTermination()}
+         * on the inline builder.
+         */
+        public InlineBuilder<FT, IT, OT> disableEarlyTermination() {
+            this.earlyTerminationDisabled = true;
+            return this;
+        }
+
+        /**
          * Expected outputs, parallel to {@code inputs()}. Length is
          * checked at the call site when {@code inputs} has already been
          * set on this inline builder; otherwise the check defers to a
@@ -603,6 +663,9 @@ public final class ProbabilisticTest implements Spec {
 
             Builder<FT, IT, OT> delegate = new Builder<>(sampling, factors);
             delegate.intent(intent);
+            if (earlyTerminationDisabled) {
+                delegate.disableEarlyTermination();
+            }
             if (!expected.isEmpty()) {
                 delegate.expectedOutputs(expected);
             }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/TerminationReason.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/TerminationReason.java
@@ -17,5 +17,20 @@ public enum TerminationReason {
     TIME_BUDGET,
 
     /** Token budget reached before all samples completed. */
-    TOKEN_BUDGET
+    TOKEN_BUDGET,
+
+    /**
+     * Threshold became mathematically unreachable: even if every remaining
+     * sample passes, the observed pass rate cannot meet the declared
+     * threshold. Verdict is FAIL.
+     */
+    IMPOSSIBILITY,
+
+    /**
+     * Threshold is mathematically guaranteed: enough samples have already
+     * passed that the threshold holds regardless of the remaining outcomes,
+     * and the run has cleared the statistical-validity floor. Verdict is
+     * PASS.
+     */
+    SUCCESS_GUARANTEED
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/TypedSpec.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/TypedSpec.java
@@ -57,4 +57,19 @@ public interface TypedSpec<FT, IT, OT> {
     default BudgetExhaustionPolicy budgetPolicy() { return BudgetExhaustionPolicy.FAIL; }
     default ExceptionPolicy exceptionPolicy() { return ExceptionPolicy.ABORT_TEST; }
     default int maxExampleFailures() { return 10; }
+
+    /**
+     * Engine-facing context for statistical early termination of the
+     * sample loop. Specs that publish a context here cause the engine
+     * to short-circuit when the threshold is unreachable
+     * (failure-inevitable) or mathematically guaranteed.
+     *
+     * <p>Default: {@link Optional#empty()} — every planned sample
+     * runs. Measure / explore / optimize specs leave this default
+     * unchanged; only {@link ProbabilisticTest} with a contractual
+     * pass-rate criterion overrides it.
+     */
+    default Optional<EarlyTerminationContext> earlyTermination() {
+        return Optional.empty();
+    }
 }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/BudgetTracker.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/BudgetTracker.java
@@ -71,6 +71,24 @@ final class BudgetTracker {
         tokenTotal += tokenCharge + sampleReportedTokens;
     }
 
+    /**
+     * Records a statistical early-termination reason
+     * ({@link TerminationReason#IMPOSSIBILITY} or
+     * {@link TerminationReason#SUCCESS_GUARANTEED}). Called by the
+     * Aggregator after a sample whose outcome makes the verdict
+     * mathematically determined.
+     *
+     * <p>Has no effect if a termination reason has already been
+     * recorded — budget-exhaustion reasons that fired earlier in the
+     * same loop are not clobbered. Subsequent calls to
+     * {@link #shouldStopBeforeNextSample()} will return true.
+     */
+    void recordEarlyTermination(TerminationReason reason) {
+        if (termination == TerminationReason.COMPLETED) {
+            termination = reason;
+        }
+    }
+
     /** How many tokens the configuration has consumed so far. */
     long tokenTotal() {
         return tokenTotal;

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
@@ -16,8 +16,10 @@ import org.javai.punit.api.UseCase;
 import org.javai.punit.api.UseCaseOutcome;
 import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.Configuration;
+import org.javai.punit.api.spec.EarlyTerminationContext;
 import org.javai.punit.api.spec.EngineResult;
 import org.javai.punit.api.spec.ExceptionPolicy;
+import org.javai.punit.api.spec.TerminationReason;
 import org.javai.punit.api.spec.FailureCount;
 import org.javai.punit.api.spec.FailureExemplar;
 import org.javai.punit.api.spec.SampleClassification;
@@ -108,7 +110,9 @@ public final class Engine {
                 cycleStart,
                 spec.exceptionPolicy(),
                 spec.maxExampleFailures(),
-                tracker);
+                tracker,
+                spec.earlyTermination(),
+                cfg.samples());
 
         long t0 = System.nanoTime();
         executor.runSamples(
@@ -138,6 +142,10 @@ public final class Engine {
         private final ExceptionPolicy exceptionPolicy;
         private final int maxExampleFailures;
         private final BudgetTracker tracker;
+        private final int plannedSamples;
+        private final Optional<EarlyTerminationContext> earlyTermination;
+        private final int requiredSuccesses;
+        private final int minSamplesForValidity;
         // retained is exposed via the summary; failure detail beyond
         // maxExampleFailures is elided. allForLatency holds durations
         // from every sample so the all-samples latency stats never
@@ -166,13 +174,30 @@ public final class Engine {
                    int cycleStart,
                    ExceptionPolicy exceptionPolicy,
                    int maxExampleFailures,
-                   BudgetTracker tracker) {
+                   BudgetTracker tracker,
+                   Optional<EarlyTerminationContext> earlyTermination,
+                   int plannedSamples) {
             this.useCase = useCase;
             this.inputs = inputs;
             this.cycleStart = cycleStart;
             this.exceptionPolicy = exceptionPolicy;
             this.maxExampleFailures = maxExampleFailures;
             this.tracker = tracker;
+            this.plannedSamples = plannedSamples;
+            this.earlyTermination = earlyTermination;
+            // Cached once: required-successes = ceil(plannedSamples * minPassRate),
+            // and the statistical-validity floor below which a guaranteed-success
+            // short-circuit must not fire. Both zero when no context is supplied
+            // (measure / explore / optimize / empirical / opt-out paths).
+            if (earlyTermination.isPresent()) {
+                EarlyTerminationContext ctx = earlyTermination.get();
+                this.requiredSuccesses =
+                        (int) Math.ceil(plannedSamples * ctx.minPassRate());
+                this.minSamplesForValidity = ctx.minSamplesForValidity();
+            } else {
+                this.requiredSuccesses = 0;
+                this.minSamplesForValidity = 0;
+            }
         }
 
         @Override
@@ -240,6 +265,43 @@ public final class Engine {
             recordPostconditionFailures(index, classification);
             FailureLineEmitter.emit(index, classification);
             tokensConsumed += classification.tokens() + tracker.tokenCharge();
+            checkStatisticalEarlyTermination();
+        }
+
+        /**
+         * After each recorded sample, check whether the spec's
+         * contractual pass-rate threshold is now mathematically
+         * unreachable (failure inevitable) or already met and locked
+         * in (success guaranteed, subject to the
+         * statistical-validity floor). On a hit, signals the
+         * {@link BudgetTracker} so the executor halts before the next
+         * sample.
+         *
+         * <p>No-op when no early-termination context was supplied:
+         * measure / explore / optimize specs, empirical-mode
+         * probabilistic tests, and probabilistic tests whose author
+         * called {@code disableEarlyTermination()}.
+         *
+         * <p>Failure-inevitable wins when both would fire in the
+         * same sample — it takes precedence over a (necessarily
+         * stale) success-guaranteed reading.
+         */
+        private void checkStatisticalEarlyTermination() {
+            if (earlyTermination.isEmpty()) {
+                return;
+            }
+            int observed = successes + failures;
+            int remaining = plannedSamples - observed;
+            int maxPossibleSuccesses = successes + remaining;
+            if (maxPossibleSuccesses < requiredSuccesses) {
+                tracker.recordEarlyTermination(TerminationReason.IMPOSSIBILITY);
+                return;
+            }
+            if (successes >= requiredSuccesses
+                    && observed >= minSamplesForValidity
+                    && remaining > 0) {
+                tracker.recordEarlyTermination(TerminationReason.SUCCESS_GUARANTEED);
+            }
         }
 
         private void recordPostconditionFailures(int index, SampleClassification classification) {

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -180,6 +180,11 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
     }
 
     @Override
+    public OptionalDouble earlyTerminationPassRate() {
+        return contractualTarget();
+    }
+
+    @Override
     public Map<String, Object> empiricalDetail() {
         if (mode == Mode.CONTRACTUAL) {
             return Map.of();

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/VerdictAdapter.java
@@ -265,6 +265,8 @@ public final class VerdictAdapter {
             case COMPLETED -> TerminationReason.COMPLETED;
             case TIME_BUDGET -> TerminationReason.METHOD_TIME_BUDGET_EXHAUSTED;
             case TOKEN_BUDGET -> TerminationReason.METHOD_TOKEN_BUDGET_EXHAUSTED;
+            case IMPOSSIBILITY -> TerminationReason.IMPOSSIBILITY;
+            case SUCCESS_GUARANTEED -> TerminationReason.SUCCESS_GUARANTEED;
         };
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
@@ -216,6 +216,34 @@ public class BinomialProportionEstimator {
         return STANDARD_NORMAL.cumulativeProbability(z);
     }
     
+    /**
+     * Minimum sample count for the normal approximation to the binomial
+     * to be statistically meaningful at the given target rate.
+     *
+     * <p>The classical sufficiency rule is {@code n · p ≥ 5} and
+     * {@code n · (1 − p) ≥ 5}, giving
+     * <pre>
+     *   n_min = ⌈5 / min(p, 1 − p)⌉
+     * </pre>
+     *
+     * <p>Below this floor the sampling distribution is too skewed for
+     * the normal approximation to underwrite a verdict; the run must
+     * continue past a guaranteed-success short-circuit until the floor
+     * is met.
+     *
+     * @param targetRate the proportion at which the floor is evaluated, in (0, 1)
+     * @return the minimum number of trials for the normal approximation
+     *         to be valid at {@code targetRate}
+     */
+    public int minSamplesForNormalApproximation(double targetRate) {
+        if (Double.isNaN(targetRate) || targetRate <= 0.0 || targetRate >= 1.0) {
+            throw new IllegalArgumentException(
+                    "targetRate must be in (0, 1), got: " + targetRate);
+        }
+        double tighter = Math.min(targetRate, 1.0 - targetRate);
+        return (int) Math.ceil(5.0 / tighter);
+    }
+
     private void validateInputs(int successes, int trials) {
         if (trials <= 0) {
             throw new IllegalArgumentException("Trials must be positive, got: " + trials);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
@@ -1,0 +1,235 @@
+package org.javai.punit.internal.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.UseCase;
+import org.javai.punit.api.spec.EngineResult;
+import org.javai.punit.api.spec.Experiment;
+import org.javai.punit.api.spec.ExperimentResult;
+import org.javai.punit.api.spec.ProbabilisticTest;
+import org.javai.punit.api.spec.ProbabilisticTestResult;
+import org.javai.punit.api.spec.TerminationReason;
+import org.javai.punit.api.spec.Verdict;
+import org.javai.punit.internal.engine.criteria.PassRate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Engine-level integration tests for the statistical early-termination
+ * mechanism: failure-inevitable and success-guaranteed short-circuits
+ * on a probabilistic test's sample loop.
+ *
+ * <p>The short-circuit fires on a contractual
+ * {@link PassRate#meeting(double, ThresholdOrigin)} criterion only.
+ * Specs that have no up-front threshold — measure / explore / optimize
+ * runs, empirical-mode probabilistic tests, and probabilistic tests
+ * whose author called {@code disableEarlyTermination()} — run every
+ * planned sample. Each variant has a coverage case below.
+ */
+@DisplayName("Statistical early termination")
+class EarlyTerminationIntegrationTest {
+
+    record Factors() {}
+
+    /** Returns Outcome.ok every sample. */
+    private static class AlwaysPass implements UseCase<Factors, Integer, Boolean> {
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(Boolean.TRUE);
+        }
+    }
+
+    /** Returns Outcome.fail every sample — a clean failure-inevitable shape. */
+    private static class AlwaysFail implements UseCase<Factors, Integer, Boolean> {
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.fail("contract_violation", "scripted failure");
+        }
+    }
+
+    /**
+     * Fails the first {@code failsFirst} invocations, then passes
+     * indefinitely. The counter is per-instance, so one instance per
+     * spec run is the intended use.
+     */
+    private static class FailsThenPasses implements UseCase<Factors, Integer, Boolean> {
+        private final int failsFirst;
+        private int seen = 0;
+        FailsThenPasses(int failsFirst) { this.failsFirst = failsFirst; }
+        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return ++seen <= failsFirst
+                    ? Outcome.fail("contract_violation", "scripted failure")
+                    : Outcome.ok(Boolean.TRUE);
+        }
+    }
+
+    private static Sampling<Factors, Integer, Boolean> sampling(
+            java.util.function.Function<Factors, UseCase<Factors, Integer, Boolean>> factory,
+            int samples) {
+        return Sampling.<Factors, Integer, Boolean>builder()
+                .useCaseFactory(factory)
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    // ── Failure-inevitable short-circuit ─────────────────────────────
+
+    @Test
+    @DisplayName("failure-inevitable: all-fail with 0.95 threshold terminates at sample 6 of 100")
+    void failureInevitableTerminatesEarly() {
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(f -> new AlwaysFail(), 100), new Factors())
+                .criterion(PassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        // requiredSuccesses = ceil(100 * 0.95) = 95. After sample 6 the
+        // failure count is 6 → max-possible-successes = 94 < 95 → fire.
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(6);
+        assertThat(result.engineSummary().terminationReason())
+                .isEqualTo(TerminationReason.IMPOSSIBILITY);
+        assertThat(result.verdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("failure-inevitable: mixed mid-run failures that remain recoverable do not terminate")
+    void failureInevitableNoFireWhenRecoverable() {
+        // threshold 0.80, samples 20, three failures up front. Required =
+        // ceil(16) = 16; after 3 failures the max-possible-successes is
+        // 17 ≥ 16, so the failure-inevitable shortcut never fires and the
+        // run completes. Verdict is PASS (17 successes / 20 = 85%).
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(f -> new FailsThenPasses(3), 20), new Factors())
+                .criterion(PassRate.<Boolean>meeting(0.80, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(20);
+        assertThat(result.engineSummary().terminationReason())
+                .isEqualTo(TerminationReason.COMPLETED);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+    }
+
+    // ── Success-guaranteed short-circuit ─────────────────────────────
+
+    @Test
+    @DisplayName("success-guaranteed: all-pass at 0.5 threshold with floor met terminates early")
+    void successGuaranteedTerminatesAtThresholdCross() {
+        // threshold 0.5, samples 100 → required = 50, validity floor =
+        // ceil(5 / min(0.5, 0.5)) = 10. With all-pass, both conditions
+        // (successes >= required AND total >= floor) become true at
+        // sample 50 → fire.
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(f -> new AlwaysPass(), 100), new Factors())
+                .criterion(PassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(50);
+        assertThat(result.engineSummary().terminationReason())
+                .isEqualTo(TerminationReason.SUCCESS_GUARANTEED);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+    }
+
+    @Test
+    @DisplayName("success-guaranteed: validity floor delays termination past threshold-cross")
+    void successGuaranteedFloorDelaysTermination() {
+        // threshold 0.20, samples 100 → required = 20, validity floor =
+        // ceil(5 / min(0.20, 0.80)) = 25. With all-pass, successes >=
+        // required at sample 20 but total < floor; the run continues to
+        // sample 25 where the floor is met and the short-circuit fires.
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(f -> new AlwaysPass(), 100), new Factors())
+                .criterion(PassRate.<Boolean>meeting(0.20, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(25);
+        assertThat(result.engineSummary().terminationReason())
+                .isEqualTo(TerminationReason.SUCCESS_GUARANTEED);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+    }
+
+    // ── Specs that do not engage the short-circuit ───────────────────
+
+    @Test
+    @DisplayName("non-regression: measure experiment runs every planned sample regardless of failure rate")
+    void measureSpecRunsToCompletion() {
+        Experiment spec = Experiment
+                .measuring(sampling(f -> new AlwaysFail(), 50), new Factors())
+                .build();
+
+        EngineResult outcome = new Engine().run(spec);
+
+        assertThat(outcome).isInstanceOf(ExperimentResult.class);
+        // Measure specs don't publish an early-termination context, so the
+        // sample loop runs the full count even with all-fail outcomes.
+        // The artefact message records the planned sample count.
+        ExperimentResult artefact = (ExperimentResult) outcome;
+        assertThat(artefact.message()).contains("samples=50");
+    }
+
+    @Test
+    @DisplayName("non-regression: empirical-mode probabilistic test runs to completion")
+    void empiricalModeRunsToCompletion() {
+        // The empirical pass-rate criterion derives its threshold from
+        // a baseline at evaluate time, so no up-front threshold is
+        // available to the engine; the spec returns Optional.empty()
+        // from earlyTermination() and the run is not short-circuited.
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(f -> new AlwaysPass(), 30), new Factors())
+                .criterion(PassRate.<Boolean>empirical())
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(30);
+        assertThat(result.engineSummary().terminationReason())
+                .isEqualTo(TerminationReason.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("disableEarlyTermination(): a near-impossible run reaches the planned sample count")
+    void disableEarlyTerminationDefeatsFailureInevitable() {
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(f -> new AlwaysFail(), 20), new Factors())
+                .criterion(PassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLA))
+                .disableEarlyTermination()
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(20);
+        assertThat(result.engineSummary().terminationReason())
+                .isEqualTo(TerminationReason.COMPLETED);
+        assertThat(result.verdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("disableEarlyTermination(): a near-guaranteed run reaches the planned sample count")
+    void disableEarlyTerminationDefeatsSuccessGuaranteed() {
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(f -> new AlwaysPass(), 100), new Factors())
+                .criterion(PassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
+                .disableEarlyTermination()
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(100);
+        assertThat(result.engineSummary().terminationReason())
+                .isEqualTo(TerminationReason.COMPLETED);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -137,6 +137,11 @@ class EngineIntegrationTest {
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling, new LlmFactors("gpt-4o", 0.3))
                 .criterion(PassRate.<Boolean>meeting(0.95, ThresholdOrigin.SLO))
+                // Opt this test out of statistical early termination —
+                // its assertion exercises the verdict for an all-fail
+                // run with the full declared sample count, not the
+                // failure-inevitable short-circuit.
+                .disableEarlyTermination()
                 .build();
 
         EngineResult outcome = new Engine().run(spec);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
@@ -153,6 +153,11 @@ class PostconditionFailureHistogramTest {
                         .testing(sampling, new Factors())
                         .criterion(PassRate.<Integer>meeting(
                                 0.5, org.javai.punit.api.ThresholdOrigin.SLA))
+                        // Opt out of statistical early termination —
+                        // this test exercises the histogram pipeline
+                        // across all four declared samples, not the
+                        // failure-inevitable short-circuit.
+                        .disableEarlyTermination()
                         .build();
 
         var result = (ProbabilisticTestResult) new Engine().run(spec);

--- a/punit-core/src/test/java/org/javai/punit/internal/runtime/VerdictAdapterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/runtime/VerdictAdapterTest.java
@@ -421,6 +421,24 @@ class VerdictAdapterTest {
             assertThat(verdict.termination().reason())
                     .isEqualTo(TerminationReason.METHOD_TOKEN_BUDGET_EXHAUSTED);
         }
+
+        @Test
+        @DisplayName("IMPOSSIBILITY → IMPOSSIBILITY")
+        void impossibility() {
+            ProbabilisticTestVerdict verdict = adapt(resultWithTermination(
+                    org.javai.punit.api.spec.TerminationReason.IMPOSSIBILITY));
+            assertThat(verdict.termination().reason())
+                    .isEqualTo(TerminationReason.IMPOSSIBILITY);
+        }
+
+        @Test
+        @DisplayName("SUCCESS_GUARANTEED → SUCCESS_GUARANTEED")
+        void successGuaranteed() {
+            ProbabilisticTestVerdict verdict = adapt(resultWithTermination(
+                    org.javai.punit.api.spec.TerminationReason.SUCCESS_GUARANTEED));
+            assertThat(verdict.termination().reason())
+                    .isEqualTo(TerminationReason.SUCCESS_GUARANTEED);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

Statistical early termination — the per-sample threshold check that
stops a probabilistic test the moment the verdict is mathematically
determined — was dropped by the spec-engine refactor and never
restored; the inventory marked it "done" while the code path had
ceased to exist. This restores the mechanism and adds the
author-facing opt-out the catalog now calls for.

- **Failure-inevitable**: stops when `maxPossibleSuccesses < requiredSuccesses`,
  records `IMPOSSIBILITY`, verdict `FAIL`.
- **Success-guaranteed**: stops when `successes >= requiredSuccesses`
  AND the run has cleared the statistical-validity floor, records
  `SUCCESS_GUARANTEED`, verdict `PASS`. Failure-inevitable wins on tie.
- **Opt-out**: `ProbabilisticTest.Builder.disableEarlyTermination()`
  (and mirror on `InlineBuilder`) keeps the run going through every
  declared sample with termination reason `COMPLETED`. Distinct from
  `OptimizeBuilder.disableEarlyTermination()`, which controls a
  heuristic no-improvement window.

The validity floor is sourced once at spec-build time from
`BinomialProportionEstimator.minSamplesForNormalApproximation(rate)` —
the classical `n*p >= 5` and `n*(1-p) >= 5` sufficiency rule.

## Design notes

- `Criterion.earlyTerminationPassRate()` is the new optional accessor
  (default empty) that lets any criterion publish an up-front pass-rate
  threshold suitable for the short-circuit. `PassRate.meeting(...)`
  overrides; empirical modes and `PercentileLatency` leave the default
  empty.
- The engine stays spec-opaque: no `instanceof Spec` checks, no
  reflection. The flow is `Spec.dispatch → TypedSpec.earlyTermination →
  Optional<EarlyTerminationContext>`, with the `Engine.Aggregator`
  consuming the context.
- The signal flows back through `BudgetTracker.recordEarlyTermination(reason)`
  rather than a separate predicate slot, so the executor's existing
  `shouldStopBeforeNextSample` hook is the single stop axis.

## Open question — empirical-mode coverage

The directive's body specifies that empirical-mode pass-rate criteria
(`PassRate.empirical()`, `PassRate.empiricalFrom(...)`) run to
completion because their threshold is resolved from a baseline at
evaluate time, not known up front. The directive's own *Open question*
section recommends instead resolving the empirical threshold once at
spec-build time and feeding it into the short-circuit. This PR
implements the **narrower body-prescribed path**: empirical-mode
probabilistic tests are exempt from the short-circuit and run every
declared sample. The recommended-but-deferred enhancement can land as
a follow-up without breaking this shape — the accessor remains the
single integration seam.

## Test plan

- [x] `EarlyTerminationIntegrationTest` (new): failure-inevitable fires
      at sample 6 of 100 for 0.95 threshold all-fail; failure-inevitable
      does not fire for recoverable mid-run failures; success-guaranteed
      fires at threshold-cross (sample 50 of 100, threshold 0.5);
      success-guaranteed fires at the floor (sample 25 of 100, threshold
      0.2) past the threshold-cross at sample 20; measure-spec
      non-regression; empirical-mode non-regression; opt-out in both
      failure and success directions.
- [x] `VerdictAdapterTest` extended with `IMPOSSIBILITY → IMPOSSIBILITY`
      and `SUCCESS_GUARANTEED → SUCCESS_GUARANTEED` mapping cases.
- [x] Two existing tests opted out of early termination so they continue
      to assert their original concerns rather than incidentally
      exercising the short-circuit.
- [x] `./gradlew :punit-core:build :punit-report:build :punit-sentinel:build`
      green across all three modules.
- [x] ArchUnit rules pass — statistics package stays isolated; the
      new helper lives inside `org.javai.punit.statistics` per the
      isolation rule.

## Follow-ups (out of scope here)

- Orchestrator-side inventory update: PT09 / PT10 punit columns
  `done → PR` (and to `done` on merge); bump `Last updated`.
- Optional: implement the directive's *Open question* option 1 —
  resolve the empirical baseline rate once at spec-build time and
  feed it into the short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)