### PR TITLE
Close -alpha exit criterion: feasibility-gate audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **`-alpha` exit criterion closed.** Both gaps the original
+  0.7.0-alpha CHANGELOG declared as the qualifier's exit criteria
+  are now in:
+  - *Statistical early termination* (PT09 / PT10) landed via #150
+    in 0.7.0-alpha5's window. Failure-inevitable and
+    success-guaranteed short-circuits fire from
+    `Engine.Aggregator`; `disableEarlyTermination()` on
+    `ProbabilisticTest.Builder` covers the opt-out cases.
+  - *Wider feasibility-gate audit* — the headline concern,
+    "configurations whose implied confidence falls below 80% are
+    not yet rejected across all intents," was already closed in
+    `Feasibility.check` (the soundness-floor branch aborts before
+    the intent-specific path, so VERIFICATION and SMOKE trip the
+    same abort). `SoundnessFloorTest` is the end-to-end audit. The
+    alpha4 / alpha5 release notes carried the gap text by inertia;
+    code-side it had been resolved in the alpha2 feasibility-gate
+    arc.
+- **Test-class doc:** `PreflightInvariantsTest` class-level
+  javadoc previously called the soundness floor "intentionally
+  absent — recorded as a gap." That note no longer matched the
+  code path; rewritten to point at `SoundnessFloorTest` as the
+  dedicated audit and `Feasibility.check`'s cross-intent abort as
+  the enforcement seam.
+
+The implication: the next punit release can drop the `-alpha`
+qualifier. The remaining 0.7.x churn is around catalog-vs-code
+documentation alignment (PT12 / PT13 `java.md` describe a
+construction surface punit did not adopt — that alignment is
+orchestrator-side, not punit-side, and tracked there).
+
 ## [0.7.0-alpha5] - 2026-05-11
 
 > **🧪 Experimental release.** Adopts `org.javai:outcome` 0.3.0,

--- a/punit-core/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
@@ -46,14 +46,14 @@ import org.junit.platform.testkit.engine.Events;
  * regression in the future.
  *
  * <p>The soundness floor (≥ 80% confidence regardless of intent) is
- * intentionally absent — the audit recorded it as a gap (configurations
- * whose configured confidence falls below the floor should abort
- * regardless of intent; the framework does not enforce this today).
- * The fix is tracked in a separate orchestrator directive that also
- * handles the consequential reworks in two existing test classes that
- * use {@code .atConfidence(0.50)} as a feasibility workaround. The
- * "do not silently expand scope" instruction in the parent directive
- * makes that a follow-up, not a fix folded into this PR.
+ * covered by its own end-to-end audit, {@code SoundnessFloorTest}.
+ * The cross-intent enforcement lives in {@code Feasibility.check},
+ * which aborts on a below-floor configuration before the
+ * intent-specific branch — so both VERIFICATION and SMOKE trip the
+ * same abort. Keeping the soundness-floor coverage in a separate
+ * test file mirrors the catalog's split between the broader
+ * infeasibility family (here) and the floor-as-its-own-invariant
+ * (there).
  */
 @DisplayName("Pre-flight invariants — end-to-end audit")
 class PreflightInvariantsTest {


### PR DESCRIPTION
## Summary

Wraps up the wider feasibility-gate audit the 0.7.0-alpha4 / alpha5
release notes named as the qualifier's remaining exit criterion. The
audit turned up: **the headline code-side concern is already closed.**

- The 0.7.0-alpha CHANGELOG named *"configurations whose implied
  confidence falls below 80% are not yet rejected across all intents"*
  as the open gap. That gap was actually closed in the alpha2
  *"feasibility-gate audit closes"* arc — `Feasibility.check` aborts
  on a below-floor configuration **before** the intent-specific path,
  so both VERIFICATION and SMOKE trip the same abort.
  `SoundnessFloorTest` covers this end-to-end.
- The alpha4 / alpha5 release notes carried the open-gap wording by
  inertia. This PR adds an [Unreleased] CHANGELOG entry declaring the
  exit criterion closed, clearing the path to dropping `-alpha` on the
  next release.

Two doc cleanups in this PR:

1. **`PreflightInvariantsTest` class-level javadoc** previously said
   *"The soundness floor (≥ 80% confidence regardless of intent) is
   intentionally absent — the audit recorded it as a gap... the fix
   is tracked in a separate orchestrator directive."* That note no
   longer matched the code path. Rewritten to point at
   `SoundnessFloorTest` (the dedicated audit) and to name
   `Feasibility.check`'s cross-intent abort as the enforcement seam.

2. **CHANGELOG [Unreleased] entry** documenting the closure.

## What this PR does not include

- **Catalog `java.md` realignment for PT12 / PT13.** The audit also
  found that those catalog files describe an aspirational
  `ProbabilisticTestSpec.normative()` / `.basedOn(...)` design with
  `.threshold` / `.confidence` / `.power` / `.minDetectableEffect`
  setters that punit did not adopt — the typed-builder reality is
  `Sampling.Builder`, `PassRate.meeting / empirical / empiricalFrom`,
  and `ProbabilisticTest.Builder` / `InlineBuilder`. The validations
  the catalog requires all exist, just on different surfaces. That
  realignment is orchestrator-side and lands in a separate commit on
  `javai-orchestrator/main`.

## What this PR confirms

- Setter-by-setter sweep of the current typed-builder surface against
  PT12 / PT13 invariants confirms: no actual code gaps. Sampling
  parameters, criterion thresholds, criterion confidence,
  early-termination context, power-analysis record arguments — all
  validate at construction with `IllegalArgumentException`, matching
  the catalog's "name the parameter, the invalid value, and the valid
  range" requirement.
- Soundness-floor and feasibility-gate end-to-end coverage:
  `Feasibility.java:90-96` (cross-intent abort), `SoundnessFloorTest`,
  `PreflightInvariantsTest`, `FeasibilityIntegrationTest` —
  all green.

## Test plan

- [x] `./gradlew :punit-core:build` — green.
- [x] `PreflightInvariantsTest` (5 tests) — green.
- [x] `SoundnessFloorTest` (4 tests) — green.
- [x] No code changes outside javadoc + CHANGELOG; no test changes.

## Next step (out of scope here)

Cut **0.7.0** (no `-alpha` qualifier) on the next release. Both gaps
the original 0.7.0-alpha CHANGELOG declared as exit criteria are now
in: statistical early termination (PT09 / PT10) via #150, the
feasibility-gate audit's headline concern via the alpha2 arc. The
catalog-vs-code drift for PT12 / PT13 java.md is non-blocking — those
are documentation alignment, not a code or capability gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)