### PR TITLE
Honour Sampling's matcher on the test and measure paths

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -533,6 +533,92 @@ This test gates on the SLA pass rate AND the SLA latency target, and
 elsewhere) for diagnostic purposes — without letting that comparison
 fail the test.
 
+### Instance conformance — comparing produced values against expected outputs
+
+Postconditions on the service contract (Part 1) describe what *any*
+acceptable output looks like — a basket translation is a parseable JSON
+object, every action is valid for its context, every quantity is a
+positive integer. Some tests need a sharper question: for *this*
+input, did the service produce *that* specific output? That is
+**instance conformance** — per-sample comparison against an expected
+value indexed alongside the inputs.
+
+Instance conformance is opt-in. When configured, the engine pairs each
+input with the expected value at the same index and runs a
+`ValueMatcher<O>` against the service's produced value. The match
+outcome contributes to the sample's pass/fail in exactly the same way
+a failed postcondition does — pass-rate criteria see one pass-or-fail
+verdict per sample, regardless of whether the failure came from a
+postcondition or a mismatched expectation.
+
+The default matcher is `ValueMatcher.equality()` — strict `equals`.
+Authors supply a custom `ValueMatcher` when equality is too brittle:
+case-insensitive string equality, structural JSON equivalence,
+numeric tolerance, normalised transcript comparison, and so on.
+
+**Where to configure it.** Two call shapes are supported, and they
+mean different things.
+
+**Shape A — on the `Sampling` fixture.** The matcher is a property
+of the fixture itself: every consumer of this `Sampling` (one test,
+multiple tests against different factors, the paired measure run, a
+future explore or optimize run) sees the same comparison strategy:
+
+```java
+Sampling<Provider, AudioSample, TranscriptionResult> sampling = Sampling
+        .<Provider, AudioSample, TranscriptionResult>builder()
+        .serviceContractFactory(SpeechToTextServiceContract::new)
+        .inputs(audioSamples)
+        .samples(audioSamples.size())
+        .matching(expectedTranscripts, normalisedTranscript)  // ← lives on the fixture
+        .build();
+
+PUnit.testing(sampling, Provider.DEEPGRAM)
+        .criterion(PassRate.meeting(0.5, ThresholdOrigin.SLO))
+        .assertPasses();
+```
+
+This is the **recommended default for production suites**. It
+eliminates test/measure drift by construction — the matcher lives in
+exactly one place, so an empirical baseline collected with the same
+`Sampling` is checked against the same comparison strategy the test
+uses.
+
+**Shape B — on the spec builder.** The matcher is a property of the
+spec, not the fixture. Two situations call for this:
+
+```java
+PUnit.testing(sampling, Provider.DEEPGRAM)
+        .expectedOutputs(expectedTranscripts)        // ← lives on the spec
+        .matcher(normalisedTranscript)
+        .criterion(PassRate.meeting(0.5, ThresholdOrigin.SLO))
+        .assertPasses();
+```
+
+Use shape B when:
+
+- **Inline sampling form.** There is no separate `Sampling` value to
+  carry the matcher because the `Sampling` is being assembled on the
+  spec builder itself:
+  ```java
+  PUnit.testing(factors)
+          .serviceContractFactory(MyServiceContract::new)
+          .inputs(inputs)
+          .samples(50)
+          .expectedOutputs(expected)
+          .matcher(normalisedTranscript)
+          .criterion(...)
+          .assertPasses();
+  ```
+- **Per-spec override.** The same fixture is consumed by multiple
+  specs with different comparison strategies — strict in one test,
+  lenient in another. Spec-builder values always override values
+  carried on `Sampling`.
+
+When both shape A and shape B are used on the same call, **shape B
+wins**: the spec builder's `expectedOutputs(...)` and `matcher(...)`
+override what the fixture carries.
+
 ### The verdict
 
 `assertPasses()` translates the engine's verdict into a JUnit outcome:

--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -330,6 +330,8 @@ public final class Experiment implements Spec {
         private MeasureBuilder(Sampling<FT, IT, OT> sampling, FT factors) {
             this.sampling = sampling;
             this.factors = factors;
+            this.expected = sampling.expected();
+            this.matcher = sampling.matcher().orElse(null);
         }
 
         public MeasureBuilder<FT, IT, OT> experimentId(String id) {

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -375,6 +375,8 @@ public final class ProbabilisticTest implements Spec {
         private Builder(Sampling<FT, IT, OT> sampling, FT factors) {
             this.sampling = sampling;
             this.factors = factors;
+            this.expected = sampling.expected();
+            this.matcher = sampling.matcher().orElse(null);
         }
 
         /** Register a criterion that contributes to the combined verdict. */

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -332,6 +332,172 @@ class EngineIntegrationTest {
     }
 
     @Test
+    @DisplayName("ProbabilisticTest: matcher configured on Sampling.Builder.matching(...) drives the verdict")
+    void testPathPropagatesMatcherFromSampling() {
+        ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+        };
+        ValueMatcher<String> caseInsensitive =
+                (exp, act) -> exp.equalsIgnoreCase(act)
+                        ? MatchResult.pass("equalsIgnoreCase", exp, act)
+                        : MatchResult.fail("equalsIgnoreCase", exp, act,
+                                "case-insensitive comparison failed");
+
+        Sampling<LlmFactors, String, String> sampling = Sampling
+                .<LlmFactors, String, String>builder()
+                .serviceContractFactory(f -> returnSameCase)
+                .inputs("HELLO", "WORLD")
+                .samples(10)
+                .matching(List.of("hello", "world"), caseInsensitive)
+                .build();
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .criterion(PassRate.<String>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsEntry("successes", 10);
+        assertThat(detail).containsEntry("failures", 0);
+    }
+
+    @Test
+    @DisplayName("Experiment: matcher configured on Sampling.Builder.matching(...) drives the measure run")
+    void measurePathPropagatesMatcherFromSampling() {
+        ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+        };
+        ValueMatcher<String> caseInsensitive =
+                (exp, act) -> exp.equalsIgnoreCase(act)
+                        ? MatchResult.pass("equalsIgnoreCase", exp, act)
+                        : MatchResult.fail("equalsIgnoreCase", exp, act,
+                                "case-insensitive comparison failed");
+
+        Sampling<LlmFactors, String, String> sampling = Sampling
+                .<LlmFactors, String, String>builder()
+                .serviceContractFactory(f -> returnSameCase)
+                .inputs("HELLO", "WORLD")
+                .samples(2)
+                .matching(List.of("hello", "world"), caseInsensitive)
+                .build();
+
+        Experiment spec = Experiment.measuring(sampling, new LlmFactors("gpt-4o", 0.0)).build();
+        EngineResult outcome = new Engine().run(spec);
+        assertThat(((ExperimentResult) outcome).message())
+                .contains("passRate=1.000");
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest: spec-builder matcher overrides the matcher carried on Sampling")
+    void testPathSpecBuilderMatcherOverridesSampling() {
+        ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+        };
+        ValueMatcher<String> alwaysFail = (exp, act) ->
+                MatchResult.fail("alwaysFail", exp, act, "fixture matcher must not run");
+        ValueMatcher<String> caseInsensitive =
+                (exp, act) -> exp.equalsIgnoreCase(act)
+                        ? MatchResult.pass("equalsIgnoreCase", exp, act)
+                        : MatchResult.fail("equalsIgnoreCase", exp, act,
+                                "case-insensitive comparison failed");
+
+        Sampling<LlmFactors, String, String> sampling = Sampling
+                .<LlmFactors, String, String>builder()
+                .serviceContractFactory(f -> returnSameCase)
+                .inputs("HELLO", "WORLD")
+                .samples(4)
+                .matching(List.of("hello", "world"), alwaysFail)
+                .build();
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .matcher(caseInsensitive)  // override
+                .criterion(PassRate.<String>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsEntry("successes", 4);
+        assertThat(detail).containsEntry("failures", 0);
+    }
+
+    @Test
+    @DisplayName("Experiment: spec-builder matcher overrides the matcher carried on Sampling")
+    void measurePathSpecBuilderMatcherOverridesSampling() {
+        ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+        };
+        ValueMatcher<String> alwaysFail = (exp, act) ->
+                MatchResult.fail("alwaysFail", exp, act, "fixture matcher must not run");
+        ValueMatcher<String> caseInsensitive =
+                (exp, act) -> exp.equalsIgnoreCase(act)
+                        ? MatchResult.pass("equalsIgnoreCase", exp, act)
+                        : MatchResult.fail("equalsIgnoreCase", exp, act,
+                                "case-insensitive comparison failed");
+
+        Sampling<LlmFactors, String, String> sampling = Sampling
+                .<LlmFactors, String, String>builder()
+                .serviceContractFactory(f -> returnSameCase)
+                .inputs("HELLO", "WORLD")
+                .samples(2)
+                .matching(List.of("hello", "world"), alwaysFail)
+                .build();
+
+        Experiment spec = Experiment.measuring(sampling, new LlmFactors("gpt-4o", 0.0))
+                .matcher(caseInsensitive)  // override
+                .build();
+        EngineResult outcome = new Engine().run(spec);
+        assertThat(((ExperimentResult) outcome).message())
+                .contains("passRate=1.000");
+    }
+
+    @Test
+    @DisplayName("ProbabilisticTest: spec-builder expectedOutputs overrides the expected list carried on Sampling")
+    void testPathSpecBuilderExpectedOverridesSampling() {
+        ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
+            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+        };
+
+        // Sampling carries deliberately-wrong expected values; spec builder
+        // restates them correctly. The spec list must win.
+        Sampling<LlmFactors, String, String> sampling = Sampling
+                .<LlmFactors, String, String>builder()
+                .serviceContractFactory(f -> returnSameCase)
+                .inputs("a", "b")
+                .samples(4)
+                .matching(List.of("X", "Y"))   // wrong; equality matcher will fail every sample
+                .build();
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling, new LlmFactors("gpt-4o", 0.0))
+                .expectedOutputs("a", "b")     // override with correct values
+                .criterion(PassRate.<String>meeting(0.95, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        var detail = result.criterionResults().get(0).result().detail();
+        assertThat(detail).containsEntry("successes", 4);
+        assertThat(detail).containsEntry("failures", 0);
+    }
+
+    @Test
     @DisplayName("ProbabilisticTest.Builder.expectedOutputs: length mismatch throws IllegalArgumentException at the call site")
     void testPathBoundExpectedOutputsRejectsLengthMismatch() {
         Sampling<LlmFactors, String, String> sampling = identityStringSampling("a", "b");


### PR DESCRIPTION
## Summary

- Closes #156. `Sampling.Builder.matching(expected, matcher)` was a documented no-op on the `PUnit.testing(...)` and `PUnit.measuring(...)` paths — both spec builders initialised their own `expected`/`matcher` independent of the supplied `Sampling`.
- Seed `expected` and `matcher` from the supplied `Sampling` at builder construction in `ProbabilisticTest.Builder` and `Experiment.MeasureBuilder`. The existing setters keep their override semantics, so per-spec overrides still work.
- New end-to-end coverage in `EngineIntegrationTest`: propagation on each path, spec-builder matcher override on each path, spec-builder `expectedOutputs` override.
- User guide gains an "Instance conformance — comparing produced values against expected outputs" section under Part 3, explaining both call shapes and when to prefer each (fixture-carried = test/measure-drift-free; spec-side = inline form, or per-spec override).

Directive: `plan/directives/DIR-SAMPLING-MATCHER-PROPAGATION-punit.md` in the orchestrator.

## Test plan

- [x] `./gradlew test` — full suite green across all modules
- [x] New `EngineIntegrationTest` cases pass (propagation × test/measure paths, override × matcher/expectedOutputs)
- [ ] STT-style consumer can collapse the workaround (issue repro lines 50-57) back to `Sampling.Builder.matching(...)` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)