### PR TITLE
Criterion shim: introduce Criterion vocabulary with K=1 default

### DIFF
--- a/punit-core/src/main/java/module-info.java
+++ b/punit-core/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module org.javai.punit.core {
 
     // ── Public API surface ────────────────────────────────────
     exports org.javai.punit.api;
+    exports org.javai.punit.api.criterion;
     exports org.javai.punit.api.spec;
     exports org.javai.punit.api.covariate;
     exports org.javai.punit.api.match;

--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -9,6 +9,9 @@ import java.util.function.Function;
 import org.javai.outcome.Outcome;
 import org.javai.outcome.Outcome.Fail;
 import org.javai.outcome.Outcome.Ok;
+import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criterion;
+import org.javai.punit.api.criterion.DefaultCriterion;
 
 /**
  * The operational layer of a service contract: how to invoke the service for
@@ -114,6 +117,74 @@ public interface Contract<I, O> {
     }
 
     /**
+     * Declare this contract's criteria — the partition of the
+     * functional dimension into named statistical streams — by
+     * calling {@link CriteriaBuilder#add(Criterion) add} on the
+     * supplied builder.
+     *
+     * <p>The default body is empty. A contract that does not
+     * explicitly declare criteria yields a single-criterion list
+     * derived from its existing {@link #postconditions(ContractBuilder)}.
+     * Today's contracts therefore satisfy the criterion model
+     * without code change: the contract <em>is</em> one criterion.
+     *
+     * <p>A contract may not override both this method (so that the
+     * resulting list is non-empty) and
+     * {@link #postconditions(ContractBuilder)} (so that the resulting
+     * chain is non-empty) at the same time. The two overrides
+     * estimate different quantities — one criterion's chain versus
+     * the criteria list — and the framework rejects the ambiguity at
+     * the first {@link #criteria()} access. Move the postconditions
+     * onto the criteria, or remove the explicit
+     * {@code criteria(CriteriaBuilder)} override and let the
+     * single-criterion default apply.
+     *
+     * @param b the builder to populate
+     */
+    default void criteria(CriteriaBuilder<O> b) {
+        // Default: no explicit criteria. The default criteria()
+        // accessor synthesises a single criterion from the contract's
+        // existing postconditions.
+    }
+
+    /**
+     * Resolves the contract's criteria to an immutable list. The
+     * framework hook; do not override. The default implementation
+     * delegates to {@link #criteria(CriteriaBuilder)}; when the
+     * author has not declared explicit criteria, the result is a
+     * single-criterion list whose postconditions are exactly
+     * {@link #postconditions()}.
+     *
+     * @throws IllegalStateException if the contract declares both an
+     *         explicit criteria list (non-empty {@code criteria(CriteriaBuilder)}
+     *         override) and a non-empty postcondition chain
+     *         (non-empty {@code postconditions(ContractBuilder)}
+     *         override). The two are structurally ambiguous; the
+     *         framework will not pick one for the author.
+     */
+    default List<Criterion<O>> criteria() {
+        CriteriaBuilder<O> b = new CriteriaBuilder<>();
+        criteria(b);
+        if (b.isEmpty()) {
+            return List.of(new DefaultCriterion<>(this));
+        }
+        if (!postconditions().isEmpty()) {
+            throw new IllegalStateException(
+                    "Contract " + getClass().getName()
+                            + " declares both a non-empty postcondition chain"
+                            + " (via postconditions(ContractBuilder)) and an"
+                            + " explicit criteria list (via"
+                            + " criteria(CriteriaBuilder)). The two overrides"
+                            + " estimate different quantities; the framework"
+                            + " will not pick one. Move the postconditions"
+                            + " onto a criterion, or remove the explicit"
+                            + " criteria override and rely on the"
+                            + " single-criterion default.");
+        }
+        return b.build();
+    }
+
+    /**
      * Run one sample without an expected value or a matcher.
      * Postconditions are evaluated against the produced value; no
      * match step.
@@ -175,9 +246,21 @@ public interface Contract<I, O> {
     }
 
     private List<PostconditionResult> evaluateClauses(O value) {
+        // Read through criteria() rather than postconditions() directly.
+        // For the single-criterion default (the K=1 case that recovers
+        // today's behaviour), this is a no-op behavioural change: the
+        // synthesised criterion's postconditions() returns the same
+        // list as the contract's. For contracts that declare explicit
+        // criteria, the evaluation walks each criterion's postcondition
+        // chain in the order the criteria were added. Step 1 evaluates
+        // all criteria's postconditions flatly into a single list; the
+        // per-criterion separation required by the composite verdict
+        // is the subject of a later step.
         List<PostconditionResult> out = new ArrayList<>();
-        for (Postcondition<O> p : postconditions()) {
-            out.addAll(p.evaluateAll(value));
+        for (Criterion<O> criterion : criteria()) {
+            for (Postcondition<O> p : criterion.postconditions()) {
+                out.addAll(p.evaluateAll(value));
+            }
         }
         return out;   // ServiceContractOutcome canonical constructor defensive-copies
     }

--- a/punit-core/src/main/java/org/javai/punit/api/ContractBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ContractBuilder.java
@@ -89,9 +89,13 @@ public final class ContractBuilder<O> {
     /**
      * Returns the accumulated clauses as an immutable list. Called by
      * the framework after the author's {@code postconditions} method
-     * has populated the builder. Authors do not call this directly.
+     * has populated the builder. Authors do not call this directly;
+     * the method is part of the framework's public surface only so
+     * that types in sibling packages (notably
+     * {@code org.javai.punit.api.criterion.Criterion}) can resolve a
+     * builder they populated.
      */
-    List<Postcondition<O>> build() {
+    public List<Postcondition<O>> build() {
         return List.copyOf(clauses);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriteriaBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriteriaBuilder.java
@@ -1,0 +1,62 @@
+package org.javai.punit.api.criterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Authoring surface for a contract's criteria list. Authors never
+ * construct one directly — the framework supplies a fresh builder to
+ * the author's
+ * {@link org.javai.punit.api.Contract#criteria(CriteriaBuilder)}
+ * method and collects the result.
+ *
+ * <p>For now the builder is a simple list collector. A contract that
+ * exercises the multi-criterion model adds one criterion per
+ * {@link #add(Criterion)} call; the order of {@code add(...)} calls is
+ * preserved in the resulting list. The methodology does not yet
+ * require any per-criterion configuration beyond the criterion itself
+ * (mode, procedure direction, denominator policy, and so on are
+ * absent from this step); when those land, the builder grows to
+ * carry them.
+ *
+ * @param <O> the value type the contract evaluates against (the
+ *            contract's output type)
+ */
+public final class CriteriaBuilder<O> {
+
+    private final List<Criterion<O>> criteria = new ArrayList<>();
+
+    /**
+     * Add a criterion. Returns this builder for fluent chaining.
+     *
+     * @param criterion the criterion to add. Must be non-null.
+     * @return this builder
+     * @throws NullPointerException if {@code criterion} is null
+     */
+    public CriteriaBuilder<O> add(Criterion<O> criterion) {
+        criteria.add(Objects.requireNonNull(criterion, "criterion"));
+        return this;
+    }
+
+    /**
+     * Whether the builder is empty. Used by the framework's default
+     * {@link org.javai.punit.api.Contract#criteria()} accessor to
+     * decide between the explicit-criteria list and the K=1 default
+     * derived from the contract's postconditions.
+     */
+    public boolean isEmpty() {
+        return criteria.isEmpty();
+    }
+
+    /**
+     * Returns the accumulated criteria as an immutable list. Called
+     * by the framework after the author's
+     * {@link org.javai.punit.api.Contract#criteria(CriteriaBuilder)}
+     * method has populated the builder. Authors do not call this
+     * directly.
+     */
+    public List<Criterion<O>> build() {
+        return List.copyOf(criteria);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
@@ -1,0 +1,85 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.Postcondition;
+
+/**
+ * A named, contract-level partition of the functional dimension. A
+ * criterion groups a set of postconditions whose pass / fail outcomes
+ * form one statistical stream; a {@link org.javai.punit.api.Contract}
+ * may carry one criterion (the common case today) or several, each
+ * tested independently.
+ *
+ * <p>This interface introduces the methodological vocabulary of a
+ * criterion without yet adding the rest of the per-criterion
+ * configuration the statistical companion eventually requires (mode,
+ * procedure direction, denominator policy, confidence level, threshold
+ * derivation rule, validation set). Those are the subject of later
+ * evolution. For now a criterion is the **identity** and the
+ * **postcondition chain**; everything else is inherited from the
+ * surrounding contract.
+ *
+ * <h2>Authoring</h2>
+ *
+ * <p>The {@link #postconditions(ContractBuilder)} method mirrors the
+ * shape today's {@link org.javai.punit.api.Contract#postconditions(ContractBuilder)}
+ * carries: the framework supplies a fresh
+ * {@link ContractBuilder}, the author populates it with
+ * {@code ensure(...)} / {@code deriving(...)} calls, and the framework
+ * collects the result. The default body is empty — a criterion with
+ * no postconditions admits every observation.
+ *
+ * <h2>Single-criterion contracts</h2>
+ *
+ * <p>A contract that does not explicitly declare criteria yields a
+ * single criterion derived from its existing
+ * {@link org.javai.punit.api.Contract#postconditions(ContractBuilder)}.
+ * The K=1 case is the same statistical object as today's single-stream
+ * contract; the methodology recovers it unchanged.
+ *
+ * @param <O> the contract's per-sample output value type
+ */
+public interface Criterion<O> {
+
+    /**
+     * A stable identifier for this criterion, used in reports, in the
+     * verdict tuple, and wherever the criterion needs to be referenced
+     * by name. Must be unique within the criteria of one contract and
+     * must remain stable across runs of the same contract.
+     *
+     * <p>Conventionally a lowercase, hyphen-separated token. The
+     * framework does not enforce a specific format.
+     */
+    String id();
+
+    /**
+     * Declare this criterion's postcondition chain by calling
+     * {@link ContractBuilder#ensure ensure} and
+     * {@link ContractBuilder#deriving deriving} on the supplied
+     * builder.
+     *
+     * <p>The default body is empty. A criterion with no postconditions
+     * admits every observation.
+     *
+     * @param b the builder to populate
+     */
+    default void postconditions(ContractBuilder<O> b) {
+        // Default: no postconditions. Subclasses override to declare
+        // their chain.
+    }
+
+    /**
+     * Resolves this criterion's clauses to an immutable list. The
+     * framework hook; do not override. The default implementation
+     * builds a fresh {@link ContractBuilder}, calls
+     * {@link #postconditions(ContractBuilder)} to populate it, and
+     * returns the built list.
+     */
+    default List<Postcondition<O>> postconditions() {
+        ContractBuilder<O> b = new ContractBuilder<>();
+        postconditions(b);
+        return b.build();
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/DefaultCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/DefaultCriterion.java
@@ -1,0 +1,105 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.javai.punit.api.Contract;
+import org.javai.punit.api.Postcondition;
+
+/**
+ * The single-criterion default a {@link Contract} resolves to when
+ * the author has not explicitly declared criteria. The default
+ * criterion's postconditions are exactly the contract's existing
+ * {@link Contract#postconditions()}; its identifier is derived from
+ * the contract's class name.
+ *
+ * <p>This type exists to make the K=1 isomorphism concrete: a
+ * contract written today, with no awareness of the criterion
+ * vocabulary, is still a single-criterion contract under the new
+ * model. The same postconditions evaluated in the same order produce
+ * the same per-trial pass / fail outcomes as before.
+ *
+ * <p>The class is final and constructible only via its single public
+ * constructor. It is the framework's shim, not an extension point.
+ * Authors wanting the multi-criterion authoring surface implement
+ * {@link Criterion} directly and supply their criteria via
+ * {@link Contract#criteria(CriteriaBuilder)}; they do not extend or
+ * instantiate {@code DefaultCriterion}.
+ *
+ * @param <O> the contract's per-sample output value type
+ */
+public final class DefaultCriterion<O> implements Criterion<O> {
+
+    private final Contract<?, O> contract;
+    private final String id;
+
+    /**
+     * Construct a default criterion for the supplied contract.
+     *
+     * @param contract the contract whose postconditions this
+     *                 criterion delegates to. Must be non-null.
+     * @throws NullPointerException if {@code contract} is null
+     */
+    public DefaultCriterion(Contract<?, O> contract) {
+        this.contract = Objects.requireNonNull(contract, "contract");
+        this.id = deriveId(contract.getClass());
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    /**
+     * Returns the contract's postconditions directly. Bypasses the
+     * default {@link Criterion#postconditions()} materialiser because
+     * the chain already lives on the contract.
+     */
+    @Override
+    public List<Postcondition<O>> postconditions() {
+        return contract.postconditions();
+    }
+
+    /**
+     * Lowercase-hyphenated form of the contract class's simple name.
+     * Stable for a given concrete contract class; unique within the
+     * K=1 criteria list (trivially).
+     *
+     * <p>Examples:
+     * <ul>
+     *   <li>{@code ShoppingBasketContract} → {@code "shopping-basket-contract"}</li>
+     *   <li>{@code PaymentGatewaySLA} → {@code "payment-gateway-sla"}</li>
+     *   <li>An anonymous subclass yields a derived token incorporating
+     *       the enclosing class's simple name; the exact token is an
+     *       implementation detail and is only required to be stable
+     *       and report-readable.</li>
+     * </ul>
+     */
+    private static String deriveId(Class<?> type) {
+        String simple = type.getSimpleName();
+        if (simple.isEmpty()) {
+            // Anonymous inner class. Fall back to a stable derived
+            // token from the enclosing-class hierarchy. getName() is
+            // unique per concrete class and stable for the life of
+            // the JVM; we trim it to keep the id readable.
+            String full = type.getName();
+            int lastDollar = full.lastIndexOf('$');
+            simple = lastDollar >= 0 ? full.substring(0, lastDollar) : full;
+            int lastDot = simple.lastIndexOf('.');
+            if (lastDot >= 0) simple = simple.substring(lastDot + 1);
+            simple = simple + "-anon";
+        }
+        // Camel-case to hyphen-separated lowercase.
+        StringBuilder sb = new StringBuilder(simple.length() + 8);
+        for (int i = 0; i < simple.length(); i++) {
+            char c = simple.charAt(i);
+            if (i > 0 && Character.isUpperCase(c)
+                && !Character.isUpperCase(simple.charAt(i - 1))) {
+                sb.append('-');
+            }
+            sb.append(Character.toLowerCase(c));
+        }
+        return sb.toString().toLowerCase(Locale.ROOT);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
@@ -1,0 +1,208 @@
+package org.javai.punit.api.criterion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Contract;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.Postcondition;
+import org.javai.punit.api.PostconditionResult;
+import org.javai.punit.api.TokenTracker;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the vocabulary shim introduced by the first step of the
+ * multi-criterion rollout. Asserts that:
+ *
+ * <ul>
+ *   <li>A contract with no explicit criteria yields a single-criterion
+ *       list derived from its postconditions, with the same chain in
+ *       the same order.</li>
+ *   <li>A contract that declares both a non-empty postconditions chain
+ *       and a non-empty explicit criteria list throws at first
+ *       criteria() access — the framework refuses the structural
+ *       ambiguity.</li>
+ *   <li>The engine's read-through criteria() produces the same
+ *       per-sample postcondition results as the legacy direct read.</li>
+ *   <li>The default-criterion identifier is stable across calls and
+ *       readable as a report token.</li>
+ * </ul>
+ */
+class CriterionShimTest {
+
+    // A simple contract carrying two postconditions and no explicit
+    // criteria declaration. Represents the common case today.
+    static final class SingleStreamContract implements Contract<String, String> {
+        @Override
+        public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
+
+        @Override
+        public void postconditions(ContractBuilder<String> b) {
+            b.ensure("non-empty", v ->
+                    v == null || v.isEmpty()
+                            ? Outcome.fail("empty", "value was empty")
+                            : Outcome.ok());
+            b.ensure("starts with greeting", v ->
+                    v.startsWith("hello")
+                            ? Outcome.ok()
+                            : Outcome.fail("no-greeting", "missing 'hello'"));
+        }
+    }
+
+    // A contract with explicit criteria (one criterion in this case).
+    static final class ExplicitCriteriaContract implements Contract<String, String> {
+        @Override
+        public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
+
+        @Override
+        public void postconditions(ContractBuilder<String> b) {
+            // Empty: the explicit criteria carry the postconditions.
+        }
+
+        @Override
+        public void criteria(CriteriaBuilder<String> b) {
+            b.add(new Criterion<String>() {
+                @Override
+                public String id() {
+                    return "well-formed";
+                }
+
+                @Override
+                public void postconditions(ContractBuilder<String> cb) {
+                    cb.ensure("non-empty", v ->
+                            v.isEmpty()
+                                    ? Outcome.fail("empty", "")
+                                    : Outcome.ok());
+                }
+            });
+        }
+    }
+
+    // A contract that declares both — the structurally ambiguous case
+    // the framework rejects.
+    static final class BothOverriddenContract implements Contract<String, String> {
+        @Override
+        public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
+
+        @Override
+        public void postconditions(ContractBuilder<String> b) {
+            b.ensure("non-empty", v ->
+                    v.isEmpty() ? Outcome.fail("empty", "") : Outcome.ok());
+        }
+
+        @Override
+        public void criteria(CriteriaBuilder<String> b) {
+            b.add(new Criterion<String>() {
+                @Override
+                public String id() {
+                    return "other";
+                }
+
+                @Override
+                public void postconditions(ContractBuilder<String> cb) {
+                    cb.ensure("starts-with-h", v ->
+                            v.startsWith("h")
+                                    ? Outcome.ok()
+                                    : Outcome.fail("no-h", ""));
+                }
+            });
+        }
+    }
+
+    @Test
+    void singleCriterionDefaultDerivesFromPostconditions() {
+        var contract = new SingleStreamContract();
+        List<Criterion<String>> criteria = contract.criteria();
+
+        assertThat(criteria).hasSize(1);
+        Criterion<String> sole = criteria.get(0);
+
+        List<Postcondition<String>> fromCriterion = sole.postconditions();
+        List<Postcondition<String>> fromContract = contract.postconditions();
+
+        assertThat(fromCriterion).hasSameSizeAs(fromContract);
+        // Same postconditions in the same order — the synthesised
+        // criterion is a thin pass-through.
+        assertThat(fromCriterion).containsExactlyElementsOf(fromContract);
+    }
+
+    @Test
+    void singleCriterionIdIsStableAcrossCalls() {
+        var contract = new SingleStreamContract();
+        String first = contract.criteria().get(0).id();
+        String second = contract.criteria().get(0).id();
+        assertThat(first).isEqualTo(second);
+        assertThat(first).isNotBlank();
+        // Should be a reasonable report-friendly token.
+        assertThat(first).matches("[a-z0-9-]+");
+    }
+
+    @Test
+    void explicitCriteriaListIsReturnedAsIs() {
+        var contract = new ExplicitCriteriaContract();
+        List<Criterion<String>> criteria = contract.criteria();
+
+        assertThat(criteria).hasSize(1);
+        assertThat(criteria.get(0).id()).isEqualTo("well-formed");
+        assertThat(criteria.get(0).postconditions()).hasSize(1);
+    }
+
+    @Test
+    void bothOverriddenThrowsAtCriteriaAccess() {
+        var contract = new BothOverriddenContract();
+        assertThatThrownBy(contract::criteria)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("postconditions(ContractBuilder)")
+                .hasMessageContaining("criteria(CriteriaBuilder)")
+                .hasMessageContaining(BothOverriddenContract.class.getName());
+    }
+
+    @Test
+    void engineReadThroughCriteriaMatchesLegacyDirectRead() {
+        // The K=1 path's evaluation must produce the same per-sample
+        // postcondition results as a direct evaluation of the legacy
+        // postconditions() list. This is the behaviour-preserving
+        // invariant of step 1.
+        var contract = new SingleStreamContract();
+        String value = "hello world";
+
+        // Legacy path — direct read.
+        var legacyResults = new java.util.ArrayList<PostconditionResult>();
+        for (Postcondition<String> p : contract.postconditions()) {
+            legacyResults.addAll(p.evaluateAll(value));
+        }
+
+        // New path — read through criteria().
+        var newResults = new java.util.ArrayList<PostconditionResult>();
+        for (Criterion<String> c : contract.criteria()) {
+            for (Postcondition<String> p : c.postconditions()) {
+                newResults.addAll(p.evaluateAll(value));
+            }
+        }
+
+        assertThat(newResults).hasSameSizeAs(legacyResults);
+        for (int i = 0; i < legacyResults.size(); i++) {
+            PostconditionResult a = legacyResults.get(i);
+            PostconditionResult b = newResults.get(i);
+            assertThat(b.description()).isEqualTo(a.description());
+            assertThat(b.passed()).isEqualTo(a.passed());
+        }
+    }
+
+    @Test
+    void defaultCriterionIdDerivedFromContractClass() {
+        var contract = new SingleStreamContract();
+        String id = contract.criteria().get(0).id();
+        // SingleStreamContract → single-stream-contract.
+        assertThat(id).isEqualTo("single-stream-contract");
+    }
+}


### PR DESCRIPTION
## Summary

Step 1 of the multi-criterion rollout in punit. Vocabulary only — no behavioural change for any contract written today.

- Introduces `org.javai.punit.api.criterion`: `Criterion<O>`, `CriteriaBuilder<O>`, `DefaultCriterion<O>`.
- Adds `Contract.criteria(CriteriaBuilder)` authoring hook and `Contract.criteria()` framework accessor.
- A contract that declares no explicit criteria resolves to a single-criterion list whose postconditions are exactly the contract's existing `postconditions()` chain. The K=1 isomorphism is byte-identical: same chain, same order, same per-sample results.
- Declaring both a non-empty `postconditions(ContractBuilder)` and a non-empty `criteria(CriteriaBuilder)` throws `IllegalStateException` at first `criteria()` access — the framework refuses the structural ambiguity.
- The engine's `evaluateClauses()` now reads through `criteria()`; for K=1 contracts the walk produces the same flat result list as before.

## Why this is safe

- All today's contracts continue to compile and run unchanged — `criteria(CriteriaBuilder)` has an empty default and `criteria()` synthesises the K=1 shim.
- New `CriterionShimTest` pins the isomorphism: a direct read of `contract.postconditions()` vs. a walk through `contract.criteria().get(0).postconditions()` produces the same `PostconditionResult` sequence.
- Full `./gradlew test` suite green, including all ArchUnit guards.

## Commit decomposition

1. Criterion interface
2. ContractBuilder.build() widened to public
3. CriteriaBuilder + DefaultCriterion
4. Contract.criteria() methods + engine migration + coexistence rule
5. module-info export
6. CriterionShimTest

## Tracking

Implements step 1 of the orchestrator directive `DIR-CRITERION-STEP-1-SHIM-punit.md`. Establishes the foundation for inventory entries CR01 (criterion-decomposition vocabulary) and CR03 (K=1 isomorphism), which the orchestrator will refine to step-1 acceptance criteria in a follow-up.

## Test plan

- [x] Unit tests for the shim (CriterionShimTest, 6 cases)
- [x] Full test suite green
- [x] ArchUnit guards green (RequirementCodeIsolationTest, statistics isolation, abstraction levels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)