### PR TITLE
Criterion step 2: derivation becomes a pure criterion-level transform

### DIFF
--- a/.idea/csv-editor.xml
+++ b/.idea/csv-editor.xml
@@ -10,13 +10,6 @@
             </Attribute>
           </value>
         </entry>
-        <entry key="/punit-junit5/src/test/resources/input/test-inputs.csv">
-          <value>
-            <Attribute>
-              <option name="separator" value="," />
-            </Attribute>
-          </value>
-        </entry>
       </map>
     </option>
   </component>

--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -249,7 +249,7 @@ public interface Contract<I, O> {
         // (which consumes a flat List<PostconditionResult>) is fed the
         // per-postcondition results on PASS / FAIL, and a single synthetic
         // failed PostconditionResult on INCONCLUSIVE — preserving the
-        // transform Failure's name and message for diagnostics. The
+        // reason's name and message for diagnostics. The
         // synthetic-result-on-INCONCLUSIVE mapping is the step-2 default
         // for the denominator policy; a configurable policy is the subject
         // of a later step.
@@ -259,11 +259,10 @@ public interface Contract<I, O> {
             switch (result.outcome()) {
                 case PASS, FAIL -> out.addAll(result.postconditionResults());
                 case INCONCLUSIVE -> {
-                    Outcome.Fail<?> transformFailure =
-                            result.transformFailure().orElseThrow();
+                    Outcome.Fail<?> reason = result.reason().orElseThrow();
                     out.add(PostconditionResult.failed(
-                            criterion.id() + " transform",
-                            transformFailure));
+                            criterion.id(),
+                            reason));
                 }
             }
         }

--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -11,6 +11,7 @@ import org.javai.outcome.Outcome.Fail;
 import org.javai.outcome.Outcome.Ok;
 import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.criterion.Criterion;
+import org.javai.punit.api.criterion.CriterionSampleResult;
 import org.javai.punit.api.criterion.DefaultCriterion;
 
 /**
@@ -246,20 +247,27 @@ public interface Contract<I, O> {
     }
 
     private List<PostconditionResult> evaluateClauses(O value) {
-        // Read through criteria() rather than postconditions() directly.
-        // For the single-criterion default (the K=1 case that recovers
-        // today's behaviour), this is a no-op behavioural change: the
-        // synthesised criterion's postconditions() returns the same
-        // list as the contract's. For contracts that declare explicit
-        // criteria, the evaluation walks each criterion's postcondition
-        // chain in the order the criteria were added. Step 1 evaluates
-        // all criteria's postconditions flatly into a single list; the
-        // per-criterion separation required by the composite verdict
-        // is the subject of a later step.
+        // Walk criteria via per-sample evaluate(value). For each criterion
+        // we get a three-valued CriterionSampleResult; the verdict path
+        // (which consumes a flat List<PostconditionResult>) is fed the
+        // per-postcondition results on PASS / FAIL, and a single synthetic
+        // failed PostconditionResult on INCONCLUSIVE — preserving the
+        // transform Failure's name and message for diagnostics. The
+        // synthetic-result-on-INCONCLUSIVE mapping is the step-2 default
+        // for the denominator policy; a configurable policy is the subject
+        // of a later step.
         List<PostconditionResult> out = new ArrayList<>();
         for (Criterion<O> criterion : criteria()) {
-            for (Postcondition<O> p : criterion.postconditions()) {
-                out.addAll(p.evaluateAll(value));
+            CriterionSampleResult result = criterion.evaluate(value);
+            switch (result.outcome()) {
+                case PASS, FAIL -> out.addAll(result.postconditionResults());
+                case INCONCLUSIVE -> {
+                    Outcome.Fail<?> transformFailure =
+                            result.transformFailure().orElseThrow();
+                    out.add(PostconditionResult.failed(
+                            criterion.id() + " transform",
+                            transformFailure));
+                }
             }
         }
         return out;   // ServiceContractOutcome canonical constructor defensive-copies

--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -31,8 +31,7 @@ import org.javai.punit.api.criterion.DefaultCriterion;
  *       {@link TokenTracker}.</li>
  *   <li>{@link #postconditions(ContractBuilder) postconditions} —
  *       declares the contract's clauses by populating the supplied
- *       builder with {@code ensure(...)} and {@code deriving(...)}
- *       calls.</li>
+ *       builder with {@code ensure(...)} calls.</li>
  * </ul>
  *
  * <p>The three {@code apply} forms are concrete defaults the
@@ -55,7 +54,7 @@ public interface Contract<I, O> {
      * <ul>
      *   <li>{@link Outcome.Ok} — the framework treats the sample as a
      *       candidate for postcondition evaluation. The carried value is
-     *       what each {@code ensure}/{@code deriving} clause sees.</li>
+     *       what each {@code ensure} clause sees.</li>
      *   <li>{@link Outcome.Fail} — the framework treats the sample as an
      *       apply-level failure. Postconditions are not evaluated (no
      *       result was produced). The full {@link org.javai.outcome.Failure}
@@ -88,9 +87,7 @@ public interface Contract<I, O> {
 
     /**
      * Declare this contract's postcondition clauses by calling
-     * {@link ContractBuilder#ensure ensure} and
-     * {@link ContractBuilder#deriving deriving} on the supplied
-     * builder.
+     * {@link ContractBuilder#ensure ensure} on the supplied builder.
      *
      * <p>The framework constructs a fresh builder, calls this method
      * to populate it, and reads the resulting clause list out via the

--- a/punit-core/src/main/java/org/javai/punit/api/ContractBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ContractBuilder.java
@@ -2,21 +2,21 @@ package org.javai.punit.api;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
-import org.javai.outcome.Outcome;
 
 /**
- * Authoring surface for a contract's postcondition clauses. Authors
- * never construct one directly — the framework supplies a fresh builder
- * to the author's {@code postconditions(ContractBuilder<O>)} method and
- * collects the result.
+ * Authoring surface for a postcondition chain. Authors never
+ * construct one directly — the framework supplies a fresh builder to
+ * the author's {@code postconditions(ContractBuilder<O>)} method (or
+ * to the body of a
+ * {@link org.javai.punit.api.criterion.Criteria#direct(String,
+ * java.util.function.Consumer) Criteria.direct} /
+ * {@link org.javai.punit.api.criterion.Criteria#transforming(String,
+ * java.util.function.Function, java.util.function.Consumer)
+ * Criteria.transforming} call) and collects the result.
  *
- * <p>Two methods, both fluent: {@link #ensure ensure} adds a leaf
- * clause, {@link #deriving deriving} adds a derivation whose nested
- * clauses are populated through a sub-builder lambda.
+ * <p>One fluent method: {@link #ensure ensure} adds a leaf clause.
+ * Transformation of the value before a postcondition is the
+ * responsibility of the surrounding criterion, not of the builder.
  *
  * <pre>{@code
  * @Override
@@ -25,17 +25,12 @@ import org.javai.outcome.Outcome;
  *             t.actions().isEmpty()
  *                     ? Outcome.fail("empty-actions", "actions list was empty")
  *                     : Outcome.ok())
- *      .ensure("All actions known", ShoppingBasketServiceContract::allKnown)
- *      .deriving("Resolves to catalog SKUs",
- *             t -> resolveAgainstCatalog(t.actions()),
- *             sub -> sub
- *                     .ensure("Every action mapped to a SKU", ...)
- *                     .ensure("No duplicate SKUs", ...));
+ *      .ensure("All actions known", ShoppingBasketServiceContract::allKnown);
  * }
  * }</pre>
  *
- * @param <O> the value type the contract evaluates against (the use
- *            case's output type)
+ * @param <O> the value type the postcondition chain evaluates
+ *            against
  */
 public final class ContractBuilder<O> {
 
@@ -43,10 +38,10 @@ public final class ContractBuilder<O> {
 
     /**
      * Add a leaf clause. The {@code check} returns
-     * {@link Outcome.Ok} when the aspect holds, or
-     * {@link Outcome.Fail} carrying a stable name and a free-text reason
-     * when it does not. Both name and reason are preserved on the
-     * resulting {@link PostconditionResult}.
+     * {@link org.javai.outcome.Outcome.Ok} when the aspect holds, or
+     * {@link org.javai.outcome.Outcome.Fail} carrying a stable name
+     * and a free-text reason when it does not. Both name and reason
+     * are preserved on the resulting {@link PostconditionResult}.
      *
      * @param description human-readable description of what is checked
      * @param check       the predicate, returning an outcome
@@ -60,40 +55,12 @@ public final class ContractBuilder<O> {
     }
 
     /**
-     * Add a derivation: transform the value via {@code derive}, then
-     * evaluate the clauses populated on the supplied sub-builder
-     * against the derived value. If the derivation fails (returns
-     * {@link Outcome.Fail} or throws), the nested clauses are skipped
-     * and reported as failed with a "skipped: …" reason.
-     *
-     * @param description description of the derivation step
-     * @param derive      the transform, returning an outcome over the
-     *                    derived type
-     * @param nested      consumer that populates the sub-builder
-     * @param <D>         the derived value type
-     * @return this builder
-     * @throws NullPointerException     if any argument is null
-     * @throws IllegalArgumentException if {@code description} is blank
-     */
-    public <D> ContractBuilder<O> deriving(
-            String description,
-            Function<O, Outcome<D>> derive,
-            Consumer<ContractBuilder<D>> nested) {
-        Objects.requireNonNull(nested, "nested");
-        ContractBuilder<D> sub = new ContractBuilder<>();
-        nested.accept(sub);
-        clauses.add(new Postcondition.Derived<>(description, derive, sub.clauses));
-        return this;
-    }
-
-    /**
-     * Returns the accumulated clauses as an immutable list. Called by
-     * the framework after the author's {@code postconditions} method
-     * has populated the builder. Authors do not call this directly;
-     * the method is part of the framework's public surface only so
-     * that types in sibling packages (notably
-     * {@code org.javai.punit.api.criterion.Criterion}) can resolve a
-     * builder they populated.
+     * Returns the accumulated clauses as an immutable list. Called
+     * by the framework after the author's populating method has run.
+     * Authors do not call this directly; the method is part of the
+     * framework's public surface only so that types in sibling
+     * packages (notably {@code org.javai.punit.api.criterion}) can
+     * resolve a builder they populated.
      */
     public List<Postcondition<O>> build() {
         return List.copyOf(clauses);

--- a/punit-core/src/main/java/org/javai/punit/api/Postcondition.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Postcondition.java
@@ -1,26 +1,25 @@
 package org.javai.punit.api;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
 import org.javai.outcome.Outcome;
 
 /**
- * One named acceptance criterion on a {@link ServiceContract}'s output. A use
- * case declares its postconditions via {@link ServiceContract#postconditions()};
- * the framework evaluates each one against every successful sample and
- * surfaces the per-postcondition results in the verdict, the report,
- * and the optimize / explore feedback path.
+ * A named predicate over a single sample's produced value. A
+ * postcondition decides pass or fail for one observable property;
+ * it performs no transformation and carries no statistical
+ * configuration. The {@link Criterion}-level transform (when
+ * present) does any pre-postcondition shaping; the postcondition's
+ * job is strictly the predicate.
  *
  * <h2>Authoring</h2>
  *
  * <p>The {@code ensure} factory is a nod to Eiffel's
  * design-by-contract vocabulary, not a strict replication of it. Each
  * call declares one postcondition that delivers an unopinionated
- * evaluation of an aspect of the output. The check function returns
- * an {@link Outcome.Ok} when the aspect holds, or an
+ * evaluation of an aspect of the value under test. The check
+ * function returns {@link Outcome.Ok} when the aspect holds, or
  * {@link Outcome.Fail} carrying the specific reason — what was
  * observed, which element tripped the check, the diagnostic detail a
  * downstream report or optimize-feedback histogram needs.
@@ -29,13 +28,12 @@ import org.javai.outcome.Outcome;
  * {@code ensure} produces a {@link PostconditionResult}; the
  * framework collects all of them per sample, and the opinion (pass /
  * fail) is taken later when the test or experiment asks for it. A
- * postcondition's {@code Outcome.Fail} only manifests as a JUnit-style
- * assertion failure when the test's {@code assertPasses()} (or
- * equivalent) is invoked.
+ * postcondition's {@code Outcome.Fail} only manifests as a
+ * JUnit-style assertion failure when the test's
+ * {@code assertPasses()} (or equivalent) is invoked.
  *
  * <pre>{@code
  * import static org.javai.punit.api.Postcondition.ensure;
- * import static org.javai.punit.api.Postcondition.deriving;
  *
  * ensure("Response has actions", t -> t.actions().isEmpty()
  *         ? Outcome.fail("empty", "actions list was empty")
@@ -49,78 +47,50 @@ import org.javai.outcome.Outcome;
  * })
  * }</pre>
  *
- * <h2>Derivations</h2>
+ * <h2>Transforming the value before the predicate</h2>
  *
- * <p>Postconditions that need to inspect a transformed view of the
- * output (parsed JSON, normalised text, an extracted sub-record) use
- * the {@link #deriving(String, Function, Postcondition[]) deriving}
- * factory. The derivation runs first; its outcome contributes one
- * postcondition result of its own; its nested {@code ensure}s only
- * evaluate when the derivation succeeds.
- *
- * <pre>{@code
- * deriving("Valid JSON", ChatResponse::parseJson,
- *     ensure("Has operations array", JsonNode::hasOperations),
- *     ensure("All operations valid", JsonNode::operationsValid))
- * }</pre>
+ * <p>To inspect a derived view of the produced value (parsed JSON,
+ * normalised text, an extracted sub-record), declare a transforming
+ * criterion via
+ * {@link org.javai.punit.api.criterion.Criteria#transforming(
+ * String, java.util.function.Function, java.util.function.Consumer)
+ * Criteria.transforming(...)}. The transform is owned by the
+ * criterion; the postcondition's job remains strictly that of a
+ * predicate over whatever value reaches it.
  *
  * @param <T> the type the postcondition evaluates
  */
-public sealed interface Postcondition<T>
-        permits Postcondition.Leaf, Postcondition.Derived {
+public sealed interface Postcondition<T> permits Postcondition.Leaf {
 
     /** Human-readable description; non-blank. */
     String description();
 
     /**
-     * Evaluate this postcondition and return one summary result. For a
-     * derivation, this collapses the derivation's outcome to a single
-     * pass / fail; use {@link #evaluateAll(Object)} when the full
-     * vector (the derivation plus every nested postcondition) is
-     * wanted.
+     * Evaluate this postcondition and return one summary result.
      */
     PostconditionResult evaluate(T value);
 
     /**
-     * Evaluate this postcondition and return every contributing result.
-     * For a {@link Leaf} this is a singleton list; for a
-     * {@link Derived} it is the derivation's own result followed by
-     * the nested postconditions' results.
+     * Evaluate this postcondition and return every contributing
+     * result. For a {@link Leaf} this is a singleton list.
      */
     List<PostconditionResult> evaluateAll(T value);
 
-    // ── Authoring entry points ──────────────────────────────────────
+    // ── Authoring entry point ───────────────────────────────────────
 
     /**
-     * Declare a postcondition. The check function evaluates one aspect
-     * of the output and returns an {@link Outcome.Ok} if the aspect
-     * holds or an {@link Outcome.Fail} carrying the specific reason
-     * if it does not. The framework collects every postcondition's
-     * result per sample; whether a failure becomes an assertion
-     * failure is decided later by the test, not here.
+     * Declare a postcondition. The check function evaluates one
+     * aspect of the value and returns an {@link Outcome.Ok} if the
+     * aspect holds or an {@link Outcome.Fail} carrying the specific
+     * reason if it does not. The framework collects every
+     * postcondition's result per sample; whether a failure becomes
+     * an assertion failure is decided later by the test, not here.
      */
     static <T> Postcondition<T> ensure(String description, PostconditionCheck<T> check) {
         return new Leaf<>(description, check);
     }
 
-    /**
-     * Declare a derivation: transform the output via {@code derive},
-     * then evaluate the {@code nested} postconditions against the
-     * derived value. On derivation failure (the function returns
-     * {@link Outcome.Fail} or throws), the nested postconditions are
-     * skipped and reported as failed with a "skipped: …" reason.
-     */
-    @SafeVarargs
-    static <T, D> Postcondition<T> deriving(
-            String description,
-            Function<T, Outcome<D>> derive,
-            Postcondition<D>... nested) {
-        Objects.requireNonNull(derive, "derive");
-        Objects.requireNonNull(nested, "nested");
-        return new Derived<>(description, derive, List.of(nested));
-    }
-
-    // ── Variants ────────────────────────────────────────────────────
+    // ── Variant ─────────────────────────────────────────────────────
 
     /** A direct postcondition: one description, one check. */
     record Leaf<T>(String description, PostconditionCheck<T> check)
@@ -154,95 +124,6 @@ public sealed interface Postcondition<T>
         @Override
         public List<PostconditionResult> evaluateAll(T value) {
             return List.of(evaluate(value));
-        }
-    }
-
-    /**
-     * A derivation: a transform from {@code T} to {@code D} that gates
-     * a list of nested postconditions over the derived value.
-     */
-    record Derived<T, D>(
-            String description,
-            Function<T, Outcome<D>> derive,
-            List<Postcondition<D>> nested) implements Postcondition<T> {
-
-        public Derived {
-            Objects.requireNonNull(description, "description");
-            Objects.requireNonNull(derive, "derive");
-            Objects.requireNonNull(nested, "nested");
-            if (description.isBlank()) {
-                throw new IllegalArgumentException("description must not be blank");
-            }
-            nested = List.copyOf(nested);
-        }
-
-        @Override
-        public PostconditionResult evaluate(T value) {
-            Outcome<D> derived;
-            try {
-                derived = derive.apply(value);
-            } catch (RuntimeException e) {
-                String reason = e.getMessage() != null
-                        ? e.getMessage()
-                        : e.getClass().getSimpleName();
-                return PostconditionResult.failed(description, reason);
-            }
-            return switch (derived) {
-                case Outcome.Ok<D> ignored -> PostconditionResult.passed(description);
-                case Outcome.Fail<D> f -> PostconditionResult.failed(description, f);
-            };
-        }
-
-        @Override
-        public List<PostconditionResult> evaluateAll(T value) {
-            List<PostconditionResult> out = new ArrayList<>(1 + nested.size());
-            Outcome<D> derived;
-            try {
-                derived = derive.apply(value);
-            } catch (RuntimeException e) {
-                String reason = e.getMessage() != null
-                        ? e.getMessage()
-                        : e.getClass().getSimpleName();
-                out.add(PostconditionResult.failed(description, reason));
-                appendSkipped(out);
-                return out;
-            }
-            switch (derived) {
-                case Outcome.Ok<D> ok -> {
-                    out.add(PostconditionResult.passed(description));
-                    for (Postcondition<D> child : nested) {
-                        out.addAll(child.evaluateAll(ok.value()));
-                    }
-                }
-                case Outcome.Fail<D> f -> {
-                    out.add(PostconditionResult.failed(description, f));
-                    appendSkipped(out);
-                }
-            }
-            return out;
-        }
-
-        private void appendSkipped(List<PostconditionResult> out) {
-            String reason = "skipped: derivation '" + description + "' failed";
-            for (Postcondition<D> child : nested) {
-                appendSkippedRecursive(child, reason, out);
-            }
-        }
-
-        private static <D> void appendSkippedRecursive(
-                Postcondition<D> p, String reason, List<PostconditionResult> out) {
-            switch (p) {
-                case Leaf<D> leaf ->
-                        out.add(PostconditionResult.failed(leaf.description(), reason));
-                case Derived<D, ?> derived -> {
-                    out.add(PostconditionResult.failed(derived.description(), reason));
-                    for (Postcondition<?> grandchild : derived.nested()) {
-                        @SuppressWarnings("unchecked")
-                        Postcondition<Object> g = (Postcondition<Object>) grandchild;
-                        appendSkippedRecursive(g, reason, out);
-                    }
-                }
-            }
         }
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/Covariate.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/Covariate.java
@@ -4,8 +4,6 @@ import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Set;
 
-import org.javai.punit.api.CovariateCategory;
-
 /**
  * A covariate declaration on a service contract.
  *

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/CovariateCategory.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/CovariateCategory.java
@@ -1,4 +1,4 @@
-package org.javai.punit.api;
+package org.javai.punit.api.covariate;
 
 /**
  * Classification of covariates by their nature and matching semantics.

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/CovariateDeclaration.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/CovariateDeclaration.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.javai.punit.api.CovariateCategory;
 import org.javai.punit.api.ServiceContractAttributes;
 import org.javai.punit.internal.util.HashUtils;
 

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/CustomCovariate.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/CustomCovariate.java
@@ -2,8 +2,6 @@ package org.javai.punit.api.covariate;
 
 import java.util.Objects;
 
-import org.javai.punit.api.CovariateCategory;
-
 /**
  * A custom covariate. The framework knows the name and the category;
  * the resolution mechanism (how the value is captured at sample time)

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/DayGroup.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/DayGroup.java
@@ -1,4 +1,4 @@
-package org.javai.punit.api;
+package org.javai.punit.api.covariate;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/DayOfWeekCovariate.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/DayOfWeekCovariate.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import org.javai.punit.api.CovariateCategory;
-
 /**
  * A day-of-week covariate. Days within a single inner set match the
  * same baseline; days falling outside every declared partition form

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/RegionCovariate.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/RegionCovariate.java
@@ -5,8 +5,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
-import org.javai.punit.api.CovariateCategory;
-
 /**
  * A region covariate. Each region is an ISO 3166-1 alpha-2 country
  * code (e.g. {@code "FR"}, {@code "DE"}). Regions within a single

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/RegionGroup.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/RegionGroup.java
@@ -1,4 +1,4 @@
-package org.javai.punit.api;
+package org.javai.punit.api.covariate;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/TimeOfDayCovariate.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/TimeOfDayCovariate.java
@@ -3,8 +3,6 @@ package org.javai.punit.api.covariate;
 import java.util.List;
 import java.util.Objects;
 
-import org.javai.punit.api.CovariateCategory;
-
 /**
  * A time-of-day covariate. Each period string takes the form
  * {@code HH:mm/Nh} (start time, slash, duration in hours).

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/TimezoneCovariate.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/TimezoneCovariate.java
@@ -1,7 +1,5 @@
 package org.javai.punit.api.covariate;
 
-import org.javai.punit.api.CovariateCategory;
-
 /**
  * A timezone covariate. The system timezone (resolved at sample time)
  * is captured as an exact-string identity covariate — no partitioning,

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
@@ -1,0 +1,121 @@
+package org.javai.punit.api.criterion;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.ContractBuilder;
+
+/**
+ * Factory entry points for declaring criteria. Two shapes:
+ *
+ * <ul>
+ *   <li>{@link #direct(String, Consumer) direct(id, body)} — a
+ *       criterion whose postconditions evaluate against the
+ *       contract's output. No transform; per-sample outcome is
+ *       restricted to {@link CriterionSampleOutcome#PASS PASS} or
+ *       {@link CriterionSampleOutcome#FAIL FAIL}.</li>
+ *   <li>{@link #transforming(String, Function, Consumer)
+ *       transforming(id, transform, body)} — a criterion that first
+ *       transforms the contract's output to a derived form, then
+ *       evaluates postconditions against the derived value.
+ *       Transform failure (the function returns
+ *       {@link Outcome.Fail} or throws) classifies the sample
+ *       {@link CriterionSampleOutcome#INCONCLUSIVE INCONCLUSIVE};
+ *       the postcondition chain is not evaluated.</li>
+ * </ul>
+ *
+ * <p>The two factories cover the methodology's two criterion shapes
+ * and structurally enforce the one-transform-per-criterion cap: a
+ * criterion is produced by exactly one factory call, with either
+ * zero or one transform. No API expresses two transforms in one
+ * criterion.
+ *
+ * <pre>{@code
+ * Criterion<ChatResponse> hasContent = Criteria.direct(
+ *         "has-content",
+ *         b -> b.ensure("non-empty", r -> r.content().isEmpty()
+ *                 ? Outcome.fail("empty", "")
+ *                 : Outcome.ok()));
+ *
+ * Criterion<ChatResponse> validJson = Criteria.transforming(
+ *         "valid-json",
+ *         ChatResponse::parseJson,
+ *         b -> b.ensure("has operations", JsonNode::hasOperations)
+ *               .ensure("operations valid", JsonNode::operationsValid));
+ * }</pre>
+ */
+public final class Criteria {
+
+    private Criteria() {
+        // utility class — no instances
+    }
+
+    /**
+     * Declare a criterion whose postcondition chain evaluates
+     * directly against the contract's output. No transform.
+     *
+     * @param id   the criterion's stable identifier; must be non-null
+     *             and non-blank
+     * @param body a consumer that populates a {@link ContractBuilder}
+     *             with the criterion's postcondition chain. The
+     *             builder is fresh; the consumer's calls to
+     *             {@code ensure(...)} populate it.
+     * @param <O>  the contract's per-sample output value type
+     * @return a criterion ready to be added to a {@link CriteriaBuilder}
+     */
+    public static <O> Criterion<O> direct(
+            String id, Consumer<ContractBuilder<O>> body) {
+        validateId(id);
+        Objects.requireNonNull(body, "body");
+        ContractBuilder<O> b = new ContractBuilder<>();
+        body.accept(b);
+        return new DirectCriterion<>(id, b.build());
+    }
+
+    /**
+     * Declare a criterion that first transforms the contract's
+     * output {@code O} to a derived form {@code D}, then evaluates
+     * its postcondition chain against the derived value.
+     *
+     * <p>Transform failure (the function returns
+     * {@link Outcome.Fail} or throws a {@link RuntimeException})
+     * classifies the sample INCONCLUSIVE for this criterion; the
+     * postcondition chain is not evaluated. The transform's failure
+     * — name and message — is preserved on the per-sample result for
+     * diagnostics.
+     *
+     * @param id        the criterion's stable identifier; must be
+     *                  non-null and non-blank
+     * @param transform the pre-postcondition transform; receives the
+     *                  contract's produced output and returns an
+     *                  outcome over the derived type
+     * @param body      a consumer that populates a
+     *                  {@link ContractBuilder} typed over the derived
+     *                  type. The builder is fresh; the consumer's
+     *                  calls to {@code ensure(...)} populate it.
+     * @param <O>       the contract's per-sample output value type
+     * @param <D>       the derived value type the postcondition chain
+     *                  evaluates against
+     * @return a criterion ready to be added to a {@link CriteriaBuilder}
+     */
+    public static <O, D> Criterion<O> transforming(
+            String id,
+            Function<O, Outcome<D>> transform,
+            Consumer<ContractBuilder<D>> body) {
+        validateId(id);
+        Objects.requireNonNull(transform, "transform");
+        Objects.requireNonNull(body, "body");
+        ContractBuilder<D> b = new ContractBuilder<>();
+        body.accept(b);
+        return new TransformingCriterion<>(id, transform, b.build());
+    }
+
+    private static void validateId(String id) {
+        Objects.requireNonNull(id, "id");
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("id must not be blank");
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
@@ -1,43 +1,50 @@
 package org.javai.punit.api.criterion;
 
-import java.util.List;
-
-import org.javai.punit.api.ContractBuilder;
-import org.javai.punit.api.Postcondition;
-
 /**
  * A named, contract-level partition of the functional dimension. A
- * criterion groups a set of postconditions whose pass / fail outcomes
- * form one statistical stream; a {@link org.javai.punit.api.Contract}
- * may carry one criterion (the common case today) or several, each
- * tested independently.
+ * criterion is a unit that judges a single sample's produced value
+ * and yields one of {PASS, FAIL, INCONCLUSIVE}; a
+ * {@link org.javai.punit.api.Contract} may carry one criterion (the
+ * common case today) or several, each evaluated independently.
  *
- * <p>This interface introduces the methodological vocabulary of a
- * criterion without yet adding the rest of the per-criterion
- * configuration the statistical companion eventually requires (mode,
- * procedure direction, denominator policy, confidence level, threshold
- * derivation rule, validation set). Those are the subject of later
- * evolution. For now a criterion is the **identity** and the
- * **postcondition chain**; everything else is inherited from the
- * surrounding contract.
+ * <h2>What lives at this interface</h2>
+ *
+ * <p>The public surface is deliberately minimal: an identifier and a
+ * per-sample evaluation method. Anything else a downstream consumer
+ * (verdict path, report, sentinel) needs about the criterion's
+ * behaviour on a sample rides on the returned
+ * {@link CriterionSampleResult} — per-postcondition pass/fail
+ * details, transform-failure detail when the outcome is
+ * {@link CriterionSampleOutcome#INCONCLUSIVE}, and any other
+ * diagnostic content the implementation chooses to carry.
  *
  * <h2>Authoring</h2>
  *
- * <p>The {@link #postconditions(ContractBuilder)} method mirrors the
- * shape today's {@link org.javai.punit.api.Contract#postconditions(ContractBuilder)}
- * carries: the framework supplies a fresh
- * {@link ContractBuilder}, the author populates it with
- * {@code ensure(...)} / {@code deriving(...)} calls, and the framework
- * collects the result. The default body is empty — a criterion with
- * no postconditions admits every observation.
+ * <p>The idiomatic authoring path is the {@link Criteria} factory:
+ * {@link Criteria#direct(String, java.util.function.Consumer)} for a
+ * criterion whose postconditions evaluate directly against the
+ * contract's output, or
+ * {@link Criteria#transforming(String, java.util.function.Function,
+ * java.util.function.Consumer)} for a criterion that first transforms
+ * the contract's output to a derived form, then evaluates
+ * postconditions against the derived value. The factory produces
+ * implementations that own the per-sample machinery — authors do not
+ * reimplement evaluate-then-classify by hand.
  *
- * <h2>Single-criterion contracts</h2>
+ * <p>Direct implementation of this interface is supported but is
+ * not the expected path; the factory entry points cover the
+ * methodology's two shapes (transform / no-transform) and enforce
+ * the one-transform-per-criterion cap structurally.
+ *
+ * <h2>The single-criterion default</h2>
  *
  * <p>A contract that does not explicitly declare criteria yields a
- * single criterion derived from its existing
- * {@link org.javai.punit.api.Contract#postconditions(ContractBuilder)}.
- * The K=1 case is the same statistical object as today's single-stream
- * contract; the methodology recovers it unchanged.
+ * single-criterion list (the K=1 default) whose postconditions are
+ * the contract's existing
+ * {@link org.javai.punit.api.Contract#postconditions()}. That
+ * default criterion is a {@code direct} criterion under the hood; it
+ * has no transform, and its per-sample outcome is restricted to PASS
+ * or FAIL (INCONCLUSIVE cannot arise without a transform).
  *
  * @param <O> the contract's per-sample output value type
  */
@@ -55,31 +62,22 @@ public interface Criterion<O> {
     String id();
 
     /**
-     * Declare this criterion's postcondition chain by calling
-     * {@link ContractBuilder#ensure ensure} and
-     * {@link ContractBuilder#deriving deriving} on the supplied
-     * builder.
+     * Evaluate this criterion against one sample's produced value.
      *
-     * <p>The default body is empty. A criterion with no postconditions
-     * admits every observation.
+     * <p>The returned {@link CriterionSampleResult} carries the
+     * three-valued per-sample outcome, the per-postcondition results
+     * for the chain that ran (empty on INCONCLUSIVE), and the
+     * transform failure that caused INCONCLUSIVE (empty otherwise).
      *
-     * @param b the builder to populate
+     * <p>Whether this criterion carries an internal transform, and
+     * over what derived type its postcondition chain evaluates, is
+     * an implementation detail not visible at this interface. The
+     * factory-produced implementations supply the per-sample
+     * machinery: transform-fails-into-INCONCLUSIVE,
+     * postcondition-fails-into-FAIL, all-passes-into-PASS.
+     *
+     * @param value the contract's produced output for this sample
+     * @return the criterion's per-sample evaluation record
      */
-    default void postconditions(ContractBuilder<O> b) {
-        // Default: no postconditions. Subclasses override to declare
-        // their chain.
-    }
-
-    /**
-     * Resolves this criterion's clauses to an immutable list. The
-     * framework hook; do not override. The default implementation
-     * builds a fresh {@link ContractBuilder}, calls
-     * {@link #postconditions(ContractBuilder)} to populate it, and
-     * returns the built list.
-     */
-    default List<Postcondition<O>> postconditions() {
-        ContractBuilder<O> b = new ContractBuilder<>();
-        postconditions(b);
-        return b.build();
-    }
+    CriterionSampleResult evaluate(O value);
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionSampleOutcome.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionSampleOutcome.java
@@ -1,0 +1,32 @@
+package org.javai.punit.api.criterion;
+
+/**
+ * The three-valued outcome of evaluating one criterion against one
+ * sample's produced value.
+ *
+ * <p>A criterion partitions the functional dimension into one
+ * independently-evaluated statistical stream. For a single sample,
+ * that evaluation lands in exactly one of:
+ *
+ * <ul>
+ *   <li>{@link #PASS} — the criterion's postcondition chain ran to
+ *       completion and every postcondition passed.</li>
+ *   <li>{@link #FAIL} — the criterion's postcondition chain ran to
+ *       completion and at least one postcondition failed.</li>
+ *   <li>{@link #INCONCLUSIVE} — the criterion's transform (if any)
+ *       returned {@code Outcome.Fail} or threw, so the postcondition
+ *       chain was not evaluated. The sample is undefined under this
+ *       criterion's predicate; the per-trial indicator is neither 0
+ *       nor 1.</li>
+ * </ul>
+ *
+ * <p>The criterion-aggregate verdict (PASS / FAIL / INCONCLUSIVE for
+ * the whole criterion across all samples) is a separate concept built
+ * from a sequence of per-sample outcomes by an aggregation policy.
+ * This enum captures only the per-sample case.
+ */
+public enum CriterionSampleOutcome {
+    PASS,
+    FAIL,
+    INCONCLUSIVE
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionSampleResult.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionSampleResult.java
@@ -10,7 +10,8 @@ import org.javai.punit.api.PostconditionResult;
 /**
  * The full per-sample evaluation record for one criterion: the
  * three-valued outcome, the per-postcondition results when the chain
- * ran, and the transform failure when it did not.
+ * ran, and the reason the chain did not when the sample is
+ * INCONCLUSIVE.
  *
  * <p>Constructed by a {@link Criterion#evaluate(Object)} call. The
  * record is the single contract between a criterion and downstream
@@ -18,41 +19,50 @@ import org.javai.punit.api.PostconditionResult;
  * consumers need about the criterion's behaviour on this sample
  * rides here.
  *
+ * <p>An INCONCLUSIVE sample carries a {@code reason} — an
+ * {@link Outcome.Fail} whose symbolic name names the kind of
+ * undefined-evaluation that occurred. Today's only source is a
+ * transform failure (the criterion's pre-postcondition transform
+ * returned {@code Outcome.Fail} or threw); later steps may
+ * introduce other sources (availability-gate failure, apply-level
+ * failure) without changing this record's shape.
+ *
  * @param criterionId  the criterion's stable identifier, copied onto
  *                     the result for downstream addressing
  * @param outcome      the per-sample outcome
  * @param postconditionResults the per-postcondition results when the
  *                     chain ran (empty when {@code outcome ==
  *                     INCONCLUSIVE} — no postcondition was reached)
- * @param transformFailure the transform's failure when {@code outcome
- *                     == INCONCLUSIVE} (empty otherwise). Preserves
- *                     the failure name and message for diagnostics.
+ * @param reason       the reason the chain did not run when
+ *                     {@code outcome == INCONCLUSIVE} (empty
+ *                     otherwise). Preserves the failure name and
+ *                     message for diagnostics.
  */
 public record CriterionSampleResult(
         String criterionId,
         CriterionSampleOutcome outcome,
         List<PostconditionResult> postconditionResults,
-        Optional<Outcome.Fail<?>> transformFailure) {
+        Optional<Outcome.Fail<?>> reason) {
 
     public CriterionSampleResult {
         Objects.requireNonNull(criterionId, "criterionId");
         Objects.requireNonNull(outcome, "outcome");
         Objects.requireNonNull(postconditionResults, "postconditionResults");
-        Objects.requireNonNull(transformFailure, "transformFailure");
+        Objects.requireNonNull(reason, "reason");
         postconditionResults = List.copyOf(postconditionResults);
 
         if (outcome == CriterionSampleOutcome.INCONCLUSIVE) {
-            if (transformFailure.isEmpty()) {
+            if (reason.isEmpty()) {
                 throw new IllegalArgumentException(
-                        "INCONCLUSIVE result must carry a transformFailure");
+                        "INCONCLUSIVE result must carry a reason");
             }
             if (!postconditionResults.isEmpty()) {
                 throw new IllegalArgumentException(
                         "INCONCLUSIVE result must not carry postcondition results");
             }
-        } else if (transformFailure.isPresent()) {
+        } else if (reason.isPresent()) {
             throw new IllegalArgumentException(
-                    "Non-INCONCLUSIVE result must not carry a transformFailure");
+                    "Non-INCONCLUSIVE result must not carry a reason");
         }
     }
 
@@ -69,12 +79,12 @@ public record CriterionSampleResult(
     }
 
     public static CriterionSampleResult inconclusive(
-            String criterionId, Outcome.Fail<?> transformFailure) {
-        Objects.requireNonNull(transformFailure, "transformFailure");
+            String criterionId, Outcome.Fail<?> reason) {
+        Objects.requireNonNull(reason, "reason");
         return new CriterionSampleResult(
                 criterionId,
                 CriterionSampleOutcome.INCONCLUSIVE,
                 List.of(),
-                Optional.of(transformFailure));
+                Optional.of(reason));
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionSampleResult.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionSampleResult.java
@@ -1,0 +1,80 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionResult;
+
+/**
+ * The full per-sample evaluation record for one criterion: the
+ * three-valued outcome, the per-postcondition results when the chain
+ * ran, and the transform failure when it did not.
+ *
+ * <p>Constructed by a {@link Criterion#evaluate(Object)} call. The
+ * record is the single contract between a criterion and downstream
+ * consumers (verdict path, reports, sentinel) — anything those
+ * consumers need about the criterion's behaviour on this sample
+ * rides here.
+ *
+ * @param criterionId  the criterion's stable identifier, copied onto
+ *                     the result for downstream addressing
+ * @param outcome      the per-sample outcome
+ * @param postconditionResults the per-postcondition results when the
+ *                     chain ran (empty when {@code outcome ==
+ *                     INCONCLUSIVE} — no postcondition was reached)
+ * @param transformFailure the transform's failure when {@code outcome
+ *                     == INCONCLUSIVE} (empty otherwise). Preserves
+ *                     the failure name and message for diagnostics.
+ */
+public record CriterionSampleResult(
+        String criterionId,
+        CriterionSampleOutcome outcome,
+        List<PostconditionResult> postconditionResults,
+        Optional<Outcome.Fail<?>> transformFailure) {
+
+    public CriterionSampleResult {
+        Objects.requireNonNull(criterionId, "criterionId");
+        Objects.requireNonNull(outcome, "outcome");
+        Objects.requireNonNull(postconditionResults, "postconditionResults");
+        Objects.requireNonNull(transformFailure, "transformFailure");
+        postconditionResults = List.copyOf(postconditionResults);
+
+        if (outcome == CriterionSampleOutcome.INCONCLUSIVE) {
+            if (transformFailure.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "INCONCLUSIVE result must carry a transformFailure");
+            }
+            if (!postconditionResults.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "INCONCLUSIVE result must not carry postcondition results");
+            }
+        } else if (transformFailure.isPresent()) {
+            throw new IllegalArgumentException(
+                    "Non-INCONCLUSIVE result must not carry a transformFailure");
+        }
+    }
+
+    public static CriterionSampleResult pass(
+            String criterionId, List<PostconditionResult> results) {
+        return new CriterionSampleResult(
+                criterionId, CriterionSampleOutcome.PASS, results, Optional.empty());
+    }
+
+    public static CriterionSampleResult fail(
+            String criterionId, List<PostconditionResult> results) {
+        return new CriterionSampleResult(
+                criterionId, CriterionSampleOutcome.FAIL, results, Optional.empty());
+    }
+
+    public static CriterionSampleResult inconclusive(
+            String criterionId, Outcome.Fail<?> transformFailure) {
+        Objects.requireNonNull(transformFailure, "transformFailure");
+        return new CriterionSampleResult(
+                criterionId,
+                CriterionSampleOutcome.INCONCLUSIVE,
+                List.of(),
+                Optional.of(transformFailure));
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/DefaultCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/DefaultCriterion.java
@@ -1,29 +1,27 @@
 package org.javai.punit.api.criterion;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.Postcondition;
 
 /**
  * The single-criterion default a {@link Contract} resolves to when
- * the author has not explicitly declared criteria. The default
- * criterion's postconditions are exactly the contract's existing
- * {@link Contract#postconditions()}; its identifier is derived from
- * the contract's class name.
+ * the author has not explicitly declared criteria. Wraps the
+ * contract's existing {@link Contract#postconditions()} as a direct
+ * (no-transform) criterion; its identifier is derived from the
+ * contract's class name.
  *
- * <p>This type exists to make the K=1 isomorphism concrete: a
- * contract written today, with no awareness of the criterion
- * vocabulary, is still a single-criterion contract under the new
- * model. The same postconditions evaluated in the same order produce
- * the same per-trial pass / fail outcomes as before.
+ * <p>This type makes the K=1 isomorphism concrete: a contract
+ * written today, with no awareness of the criterion vocabulary, is
+ * still a single-criterion contract under the model. The same
+ * postconditions evaluated in the same order against the same value
+ * produce the same per-postcondition results as before.
  *
  * <p>The class is final and constructible only via its single public
- * constructor. It is the framework's shim, not an extension point.
- * Authors wanting the multi-criterion authoring surface implement
- * {@link Criterion} directly and supply their criteria via
+ * constructor. It is the framework's K=1 shim, not an extension
+ * point. Authors wanting the multi-criterion authoring surface use
+ * the {@link Criteria} factory and supply their criteria via
  * {@link Contract#criteria(CriteriaBuilder)}; they do not extend or
  * instantiate {@code DefaultCriterion}.
  *
@@ -51,38 +49,21 @@ public final class DefaultCriterion<O> implements Criterion<O> {
         return id;
     }
 
-    /**
-     * Returns the contract's postconditions directly. Bypasses the
-     * default {@link Criterion#postconditions()} materialiser because
-     * the chain already lives on the contract.
-     */
     @Override
-    public List<Postcondition<O>> postconditions() {
-        return contract.postconditions();
+    public CriterionSampleResult evaluate(O value) {
+        return DirectCriterion.evaluateChain(id, contract.postconditions(), value);
     }
 
     /**
      * Lowercase-hyphenated form of the contract class's simple name.
      * Stable for a given concrete contract class; unique within the
      * K=1 criteria list (trivially).
-     *
-     * <p>Examples:
-     * <ul>
-     *   <li>{@code ShoppingBasketContract} → {@code "shopping-basket-contract"}</li>
-     *   <li>{@code PaymentGatewaySLA} → {@code "payment-gateway-sla"}</li>
-     *   <li>An anonymous subclass yields a derived token incorporating
-     *       the enclosing class's simple name; the exact token is an
-     *       implementation detail and is only required to be stable
-     *       and report-readable.</li>
-     * </ul>
      */
     private static String deriveId(Class<?> type) {
         String simple = type.getSimpleName();
         if (simple.isEmpty()) {
             // Anonymous inner class. Fall back to a stable derived
-            // token from the enclosing-class hierarchy. getName() is
-            // unique per concrete class and stable for the life of
-            // the JVM; we trim it to keep the id readable.
+            // token from the enclosing-class hierarchy.
             String full = type.getName();
             int lastDollar = full.lastIndexOf('$');
             simple = lastDollar >= 0 ? full.substring(0, lastDollar) : full;
@@ -90,12 +71,11 @@ public final class DefaultCriterion<O> implements Criterion<O> {
             if (lastDot >= 0) simple = simple.substring(lastDot + 1);
             simple = simple + "-anon";
         }
-        // Camel-case to hyphen-separated lowercase.
         StringBuilder sb = new StringBuilder(simple.length() + 8);
         for (int i = 0; i < simple.length(); i++) {
             char c = simple.charAt(i);
             if (i > 0 && Character.isUpperCase(c)
-                && !Character.isUpperCase(simple.charAt(i - 1))) {
+                    && !Character.isUpperCase(simple.charAt(i - 1))) {
                 sb.append('-');
             }
             sb.append(Character.toLowerCase(c));

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/DirectCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/DirectCriterion.java
@@ -1,0 +1,70 @@
+package org.javai.punit.api.criterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.javai.punit.api.Postcondition;
+import org.javai.punit.api.PostconditionResult;
+
+/**
+ * A criterion whose postconditions evaluate directly against the
+ * contract's output. No transform — the per-sample outcome is
+ * restricted to {@link CriterionSampleOutcome#PASS PASS} or
+ * {@link CriterionSampleOutcome#FAIL FAIL}; INCONCLUSIVE cannot
+ * arise.
+ *
+ * <p>Package-private; constructed by
+ * {@link Criteria#direct(String, java.util.function.Consumer)} and
+ * by the K=1 default {@link DefaultCriterion}. Authors do not
+ * reference this type directly.
+ */
+final class DirectCriterion<O> implements Criterion<O> {
+
+    private final String id;
+    private final List<Postcondition<O>> postconditions;
+
+    DirectCriterion(String id, List<Postcondition<O>> postconditions) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.postconditions = List.copyOf(
+                Objects.requireNonNull(postconditions, "postconditions"));
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public CriterionSampleResult evaluate(O value) {
+        return evaluateChain(id, postconditions, value);
+    }
+
+    /**
+     * Evaluate a postcondition chain over a value. Used by both
+     * {@link DirectCriterion} and {@link TransformingCriterion} once
+     * the transform has produced a derived value.
+     *
+     * <p>The walk does not short-circuit on first failure: every
+     * postcondition is evaluated and its result preserved on the
+     * record, so a downstream consumer can see the full diagnostic
+     * picture for the sample.
+     */
+    static <T> CriterionSampleResult evaluateChain(
+            String id, List<Postcondition<T>> chain, T value) {
+        List<PostconditionResult> results = new ArrayList<>();
+        boolean anyFailed = false;
+        for (Postcondition<T> p : chain) {
+            List<PostconditionResult> pResults = p.evaluateAll(value);
+            results.addAll(pResults);
+            for (PostconditionResult r : pResults) {
+                if (r.failed()) {
+                    anyFailed = true;
+                }
+            }
+        }
+        return anyFailed
+                ? CriterionSampleResult.fail(id, results)
+                : CriterionSampleResult.pass(id, results);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingCriterion.java
@@ -1,0 +1,67 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Postcondition;
+
+/**
+ * A criterion that first transforms the contract's output {@code O}
+ * to a derived form {@code D}, then evaluates its postcondition
+ * chain against the derived value. Transform failure
+ * ({@link Outcome.Fail} or a thrown exception) classifies the sample
+ * as {@link CriterionSampleOutcome#INCONCLUSIVE INCONCLUSIVE}; the
+ * postcondition chain is not evaluated.
+ *
+ * <p>Package-private; constructed by
+ * {@link Criteria#transforming(String, Function, java.util.function.Consumer)}.
+ * Authors do not reference this type directly.
+ *
+ * @param <O> the contract's per-sample output value type
+ * @param <D> the type the postcondition chain evaluates against
+ *            after the transform succeeds
+ */
+final class TransformingCriterion<O, D> implements Criterion<O> {
+
+    private final String id;
+    private final Function<O, Outcome<D>> transform;
+    private final List<Postcondition<D>> postconditions;
+
+    TransformingCriterion(
+            String id,
+            Function<O, Outcome<D>> transform,
+            List<Postcondition<D>> postconditions) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.transform = Objects.requireNonNull(transform, "transform");
+        this.postconditions = List.copyOf(
+                Objects.requireNonNull(postconditions, "postconditions"));
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public CriterionSampleResult evaluate(O value) {
+        Outcome<D> derived;
+        try {
+            derived = transform.apply(value);
+        } catch (RuntimeException e) {
+            String message = e.getMessage() != null
+                    ? e.getMessage()
+                    : e.getClass().getSimpleName();
+            // Outcome.fail returns Outcome<D>; the sealed hierarchy
+            // guarantees it is an Outcome.Fail<D> instance.
+            derived = Outcome.fail("transform-threw", message);
+        }
+        return switch (derived) {
+            case Outcome.Ok<D> ok ->
+                    DirectCriterion.evaluateChain(id, postconditions, ok.value());
+            case Outcome.Fail<D> f ->
+                    CriterionSampleResult.inconclusive(id, f);
+        };
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/package-info.java
+++ b/punit-core/src/main/java/org/javai/punit/api/package-info.java
@@ -41,7 +41,7 @@
  *       evidential) vs SMOKE (sentinel, non-evidential).</li>
  *   <li>{@link org.javai.punit.api.ThresholdOrigin} — provenance of a
  *       criterion's threshold (SLA, SLO, POLICY, EMPIRICAL, …).</li>
- *   <li>{@link org.javai.punit.api.CovariateCategory} — covariate
+ *   <li>{@link org.javai.punit.api.covariate.CovariateCategory} — covariate
  *       classification used by baseline matching.</li>
  *   <li>{@link org.javai.punit.api.BudgetExhaustedBehavior},
  *       {@link org.javai.punit.api.ExceptionHandling},

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSelector.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSelector.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.javai.punit.api.CovariateCategory;
+import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.covariate.Covariate;
 import org.javai.punit.api.covariate.CovariateProfile;
 

--- a/punit-core/src/test/java/org/javai/punit/api/ContractBuilderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/ContractBuilderTest.java
@@ -63,68 +63,6 @@ class ContractBuilderTest {
     }
 
     @Nested
-    @DisplayName("deriving")
-    class Derivations {
-
-        @Test
-        @DisplayName("the nested lambda's clauses are typed at the derived type")
-        void nestedClausesTypedAtDerived() {
-            List<Postcondition<String>> clauses = new ContractBuilder<String>()
-                    .deriving("length",
-                            s -> Outcome.ok(s.length()),
-                            sub -> sub
-                                    .ensure("positive length", (Integer n) -> n > 0
-                                            ? Outcome.ok()
-                                            : Outcome.fail("zero", "n=0"))
-                                    .ensure("at most 10", (Integer n) -> n <= 10
-                                            ? Outcome.ok()
-                                            : Outcome.fail("too-long", "n=" + n)))
-                    .build();
-
-            assertThat(clauses).hasSize(1);
-            Postcondition.Derived<?, ?> d = (Postcondition.Derived<?, ?>) clauses.get(0);
-            assertThat(d.description()).isEqualTo("length");
-            assertThat(d.nested()).extracting(Postcondition::description)
-                    .containsExactly("positive length", "at most 10");
-        }
-
-        @Test
-        @DisplayName("ensure and deriving compose in any order")
-        void mixedComposition() {
-            List<Postcondition<String>> clauses = new ContractBuilder<String>()
-                    .ensure("non-empty", s -> s.isEmpty()
-                            ? Outcome.fail("empty", "")
-                            : Outcome.ok())
-                    .deriving("length",
-                            s -> Outcome.ok(s.length()),
-                            sub -> sub.ensure("positive", (Integer n) -> n > 0
-                                    ? Outcome.ok()
-                                    : Outcome.fail("zero", "")))
-                    .ensure("starts upper", s -> Character.isUpperCase(s.charAt(0))
-                            ? Outcome.ok()
-                            : Outcome.fail("not-upper", ""))
-                    .build();
-
-            assertThat(clauses).extracting(Postcondition::description)
-                    .containsExactly("non-empty", "length", "starts upper");
-        }
-
-        @Test
-        @DisplayName("an empty nested lambda produces a derivation with no children")
-        void emptyNestedAllowed() {
-            List<Postcondition<String>> clauses = new ContractBuilder<String>()
-                    .deriving("length",
-                            s -> Outcome.ok(s.length()),
-                            sub -> { /* no clauses */ })
-                    .build();
-
-            assertThat(clauses).hasSize(1);
-            Postcondition.Derived<?, ?> d = (Postcondition.Derived<?, ?>) clauses.get(0);
-            assertThat(d.nested()).isEmpty();
-        }
-    }
-
-    @Nested
     @DisplayName("build")
     class Build {
 

--- a/punit-core/src/test/java/org/javai/punit/api/PostconditionTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/PostconditionTest.java
@@ -1,7 +1,6 @@
 package org.javai.punit.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.javai.punit.api.Postcondition.deriving;
 import static org.javai.punit.api.Postcondition.ensure;
 
 import java.util.List;
@@ -113,121 +112,6 @@ class PostconditionTest {
 
             assertThat(results).hasSize(1);
             assertThat(results.get(0).passed()).isTrue();
-        }
-    }
-
-    @Nested
-    @DisplayName("deriving(...)")
-    class Derivations {
-
-        @Test
-        @DisplayName("derivation succeeds → derivation pass + nested results")
-        void derivationSucceeds() {
-            Postcondition<String> p = deriving("parsed length",
-                    s -> Outcome.ok(s.length()),
-                    ensure("at least 3", n -> n >= 3
-                            ? Outcome.ok()
-                            : Outcome.fail("too-short", "n=" + n)),
-                    ensure("at most 10", n -> n <= 10
-                            ? Outcome.ok()
-                            : Outcome.fail("too-long", "n=" + n)));
-
-            List<PostconditionResult> results = p.evaluateAll("hello");
-
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0).description()).isEqualTo("parsed length");
-            assertThat(results.get(0).passed()).isTrue();
-            assertThat(results.get(1).description()).isEqualTo("at least 3");
-            assertThat(results.get(1).passed()).isTrue();
-            assertThat(results.get(2).description()).isEqualTo("at most 10");
-            assertThat(results.get(2).passed()).isTrue();
-        }
-
-        @Test
-        @DisplayName("derivation Outcome.fail → nested ensures reported as skipped")
-        void derivationFailsSkipsNested() {
-            Postcondition<String> p = deriving("parsed",
-                    s -> Outcome.<Integer>fail("parse-error", "malformed"),
-                    ensure("inner-1", (Integer n) -> Outcome.ok()),
-                    ensure("inner-2", (Integer n) -> Outcome.ok()));
-
-            List<PostconditionResult> results = p.evaluateAll("garbage");
-
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0).failed()).isTrue();
-            assertThat(results.get(0).failureReason()).contains("malformed");
-            assertThat(results.get(1).failed()).isTrue();
-            assertThat(results.get(1).failureReason())
-                    .hasValueSatisfying(r -> assertThat(r).contains("skipped"));
-            assertThat(results.get(2).failed()).isTrue();
-            assertThat(results.get(2).failureReason())
-                    .hasValueSatisfying(r -> assertThat(r).contains("skipped"));
-        }
-
-        @Test
-        @DisplayName("derivation throws → derivation fails, nested skipped")
-        void derivationThrowsSkipsNested() {
-            Postcondition<String> p = deriving("parsed",
-                    (String s) -> { throw new RuntimeException("kaboom"); },
-                    ensure("inner", (Integer n) -> Outcome.ok()));
-
-            List<PostconditionResult> results = p.evaluateAll("anything");
-
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0).failed()).isTrue();
-            assertThat(results.get(0).failureReason()).contains("kaboom");
-            assertThat(results.get(1).failureReason())
-                    .hasValueSatisfying(r -> assertThat(r).contains("skipped"));
-        }
-
-        @Test
-        @DisplayName("evaluate (singular) collapses to derivation's own outcome")
-        void evaluateSingleCollapsesToDerivation() {
-            Postcondition<String> p = deriving("parsed",
-                    s -> Outcome.ok(s.length()),
-                    ensure("inner", (Integer n) -> Outcome.fail("nope", "x")));
-
-            PostconditionResult r = p.evaluate("hello");
-
-            assertThat(r.passed()).isTrue();
-            assertThat(r.description()).isEqualTo("parsed");
-        }
-
-        @Test
-        @DisplayName("derivation Outcome.fail preserves the failure name (not the description)")
-        void derivationFailPreservesFailureName() {
-            Postcondition<String> p = deriving("parsed",
-                    s -> Outcome.<Integer>fail("parse-error", "malformed"),
-                    ensure("inner", (Integer n) -> Outcome.ok()));
-
-            List<PostconditionResult> results = p.evaluateAll("garbage");
-
-            assertThat(results.get(0).failureName()).contains("parse-error");
-            assertThat(results.get(0).description()).isEqualTo("parsed");
-        }
-
-        @Test
-        @DisplayName("nested derivations propagate skips through every level")
-        void nestedDerivationsSkipChain() {
-            Postcondition<Integer> innerDerived = deriving("doubled",
-                    n -> Outcome.ok(n * 2),
-                    ensure("doubled positive", (Integer d) -> d > 0
-                            ? Outcome.ok()
-                            : Outcome.fail("non-positive", "d=" + d)));
-
-            Postcondition<String> p = deriving("length",
-                    s -> Outcome.<Integer>fail("err", "bad"),
-                    innerDerived);
-
-            List<PostconditionResult> results = p.evaluateAll("anything");
-
-            assertThat(results).hasSize(3);
-            assertThat(results.get(0).description()).isEqualTo("length");
-            assertThat(results.get(0).failed()).isTrue();
-            assertThat(results.get(1).description()).isEqualTo("doubled");
-            assertThat(results.get(1).failed()).isTrue();
-            assertThat(results.get(2).description()).isEqualTo("doubled positive");
-            assertThat(results.get(2).failed()).isTrue();
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/api/covariate/CovariateDeclarationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/covariate/CovariateDeclarationTest.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.javai.punit.api.CovariateCategory;
 import org.javai.punit.api.ServiceContractAttributes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/punit-core/src/test/java/org/javai/punit/api/covariate/CovariateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/covariate/CovariateTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.Set;
 
-import org.javai.punit.api.CovariateCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionSampleResultTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionSampleResultTest.java
@@ -24,7 +24,7 @@ class CriterionSampleResultTest {
 
         assertThat(r.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
         assertThat(r.postconditionResults()).containsExactly(pr);
-        assertThat(r.transformFailure()).isEmpty();
+        assertThat(r.reason()).isEmpty();
     }
 
     @Test
@@ -34,7 +34,7 @@ class CriterionSampleResultTest {
 
         assertThat(r.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
         assertThat(r.postconditionResults()).containsExactly(pr);
-        assertThat(r.transformFailure()).isEmpty();
+        assertThat(r.reason()).isEmpty();
     }
 
     @Test
@@ -44,7 +44,7 @@ class CriterionSampleResultTest {
 
         assertThat(r.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
         assertThat(r.postconditionResults()).isEmpty();
-        assertThat(r.transformFailure()).contains(tf);
+        assertThat(r.reason()).contains(tf);
     }
 
     @Test
@@ -55,7 +55,7 @@ class CriterionSampleResultTest {
                 List.of(),
                 Optional.empty()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("transformFailure");
+                .hasMessageContaining("reason");
     }
 
     @Test
@@ -82,6 +82,6 @@ class CriterionSampleResultTest {
                 List.of(),
                 Optional.of(tf)))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("transformFailure");
+                .hasMessageContaining("reason");
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionSampleResultTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionSampleResultTest.java
@@ -1,0 +1,87 @@
+package org.javai.punit.api.criterion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionResult;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Per-outcome invariants on the {@link CriterionSampleResult}
+ * record. The canonical constructor enforces the shape contracts
+ * each of the three outcomes carries.
+ */
+class CriterionSampleResultTest {
+
+    @Test
+    void passCarriesPostconditionResultsAndNoTransformFailure() {
+        var pr = PostconditionResult.passed("clause");
+        var r = CriterionSampleResult.pass("id", List.of(pr));
+
+        assertThat(r.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+        assertThat(r.postconditionResults()).containsExactly(pr);
+        assertThat(r.transformFailure()).isEmpty();
+    }
+
+    @Test
+    void failCarriesPostconditionResultsAndNoTransformFailure() {
+        var pr = PostconditionResult.failed("clause", "reason");
+        var r = CriterionSampleResult.fail("id", List.of(pr));
+
+        assertThat(r.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
+        assertThat(r.postconditionResults()).containsExactly(pr);
+        assertThat(r.transformFailure()).isEmpty();
+    }
+
+    @Test
+    void inconclusiveCarriesTransformFailureAndEmptyPostconditionResults() {
+        Outcome.Fail<?> tf = (Outcome.Fail<?>) Outcome.fail("err", "msg");
+        var r = CriterionSampleResult.inconclusive("id", tf);
+
+        assertThat(r.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
+        assertThat(r.postconditionResults()).isEmpty();
+        assertThat(r.transformFailure()).contains(tf);
+    }
+
+    @Test
+    void inconclusiveWithoutTransformFailureRejected() {
+        assertThatThrownBy(() -> new CriterionSampleResult(
+                "id",
+                CriterionSampleOutcome.INCONCLUSIVE,
+                List.of(),
+                Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("transformFailure");
+    }
+
+    @Test
+    void inconclusiveWithPostconditionResultsRejected() {
+        Outcome.Fail<?> tf = (Outcome.Fail<?>) Outcome.fail("err", "msg");
+        var pr = PostconditionResult.passed("c");
+
+        assertThatThrownBy(() -> new CriterionSampleResult(
+                "id",
+                CriterionSampleOutcome.INCONCLUSIVE,
+                List.of(pr),
+                Optional.of(tf)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("postcondition");
+    }
+
+    @Test
+    void nonInconclusiveWithTransformFailureRejected() {
+        Outcome.Fail<?> tf = (Outcome.Fail<?>) Outcome.fail("err", "msg");
+
+        assertThatThrownBy(() -> new CriterionSampleResult(
+                "id",
+                CriterionSampleOutcome.PASS,
+                List.of(),
+                Optional.of(tf)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("transformFailure");
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
@@ -14,22 +14,13 @@ import org.javai.punit.api.TokenTracker;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for the vocabulary shim introduced by the first step of the
- * multi-criterion rollout. Asserts that:
- *
- * <ul>
- *   <li>A contract with no explicit criteria yields a single-criterion
- *       list derived from its postconditions, with the same chain in
- *       the same order.</li>
- *   <li>A contract that declares both a non-empty postconditions chain
- *       and a non-empty explicit criteria list throws at first
- *       criteria() access — the framework refuses the structural
- *       ambiguity.</li>
- *   <li>The engine's read-through criteria() produces the same
- *       per-sample postcondition results as the legacy direct read.</li>
- *   <li>The default-criterion identifier is stable across calls and
- *       readable as a report token.</li>
- * </ul>
+ * Tests for the criterion vocabulary as reshaped in step 2 of the
+ * multi-criterion rollout: {@link Criterion} now exposes only
+ * {@code id()} and {@code evaluate(value)}. The K=1 isomorphism is
+ * preserved — a contract written today, with no awareness of the
+ * criterion vocabulary, produces the same per-sample postcondition
+ * results through the criterion-mediated path as through a direct
+ * read of {@link Contract#postconditions()}.
  */
 class CriterionShimTest {
 
@@ -54,7 +45,8 @@ class CriterionShimTest {
         }
     }
 
-    // A contract with explicit criteria (one criterion in this case).
+    // A contract with explicit criteria, declared via the Criteria
+    // factory (the idiomatic authoring path).
     static final class ExplicitCriteriaContract implements Contract<String, String> {
         @Override
         public Outcome<String> invoke(String input, TokenTracker tracker) {
@@ -68,20 +60,11 @@ class CriterionShimTest {
 
         @Override
         public void criteria(CriteriaBuilder<String> b) {
-            b.add(new Criterion<String>() {
-                @Override
-                public String id() {
-                    return "well-formed";
-                }
-
-                @Override
-                public void postconditions(ContractBuilder<String> cb) {
-                    cb.ensure("non-empty", v ->
+            b.add(Criteria.direct("well-formed",
+                    cb -> cb.ensure("non-empty", v ->
                             v.isEmpty()
                                     ? Outcome.fail("empty", "")
-                                    : Outcome.ok());
-                }
-            });
+                                    : Outcome.ok())));
         }
     }
 
@@ -101,38 +84,52 @@ class CriterionShimTest {
 
         @Override
         public void criteria(CriteriaBuilder<String> b) {
-            b.add(new Criterion<String>() {
-                @Override
-                public String id() {
-                    return "other";
-                }
-
-                @Override
-                public void postconditions(ContractBuilder<String> cb) {
-                    cb.ensure("starts-with-h", v ->
+            b.add(Criteria.direct("other",
+                    cb -> cb.ensure("starts-with-h", v ->
                             v.startsWith("h")
                                     ? Outcome.ok()
-                                    : Outcome.fail("no-h", ""));
-                }
-            });
+                                    : Outcome.fail("no-h", ""))));
         }
     }
 
     @Test
-    void singleCriterionDefaultDerivesFromPostconditions() {
+    void singleCriterionDefaultEvaluatesSameAsLegacyPostconditionsWalk() {
+        // The K=1 default's per-sample evaluation must produce the
+        // same postcondition results as a direct walk of the
+        // contract's postconditions(). Step 2's behaviour-preserving
+        // invariant.
         var contract = new SingleStreamContract();
-        List<Criterion<String>> criteria = contract.criteria();
+        String value = "hello world";
 
-        assertThat(criteria).hasSize(1);
-        Criterion<String> sole = criteria.get(0);
+        List<PostconditionResult> legacy = new java.util.ArrayList<>();
+        for (Postcondition<String> p : contract.postconditions()) {
+            legacy.addAll(p.evaluateAll(value));
+        }
 
-        List<Postcondition<String>> fromCriterion = sole.postconditions();
-        List<Postcondition<String>> fromContract = contract.postconditions();
+        Criterion<String> sole = contract.criteria().get(0);
+        CriterionSampleResult result = sole.evaluate(value);
 
-        assertThat(fromCriterion).hasSameSizeAs(fromContract);
-        // Same postconditions in the same order — the synthesised
-        // criterion is a thin pass-through.
-        assertThat(fromCriterion).containsExactlyElementsOf(fromContract);
+        assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+        assertThat(result.transformFailure()).isEmpty();
+        assertThat(result.postconditionResults()).hasSameSizeAs(legacy);
+        for (int i = 0; i < legacy.size(); i++) {
+            PostconditionResult a = legacy.get(i);
+            PostconditionResult b = result.postconditionResults().get(i);
+            assertThat(b.description()).isEqualTo(a.description());
+            assertThat(b.passed()).isEqualTo(a.passed());
+        }
+    }
+
+    @Test
+    void singleCriterionDefaultClassifiesFailWhenAnyPostconditionFails() {
+        var contract = new SingleStreamContract();
+        // "world" passes "non-empty" but fails "starts with greeting".
+        CriterionSampleResult result = contract.criteria().get(0).evaluate("world");
+
+        assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
+        assertThat(result.postconditionResults()).hasSize(2);
+        assertThat(result.postconditionResults().get(0).passed()).isTrue();
+        assertThat(result.postconditionResults().get(1).failed()).isTrue();
     }
 
     @Test
@@ -142,8 +139,15 @@ class CriterionShimTest {
         String second = contract.criteria().get(0).id();
         assertThat(first).isEqualTo(second);
         assertThat(first).isNotBlank();
-        // Should be a reasonable report-friendly token.
         assertThat(first).matches("[a-z0-9-]+");
+    }
+
+    @Test
+    void defaultCriterionIdDerivedFromContractClass() {
+        var contract = new SingleStreamContract();
+        String id = contract.criteria().get(0).id();
+        // SingleStreamContract → single-stream-contract.
+        assertThat(id).isEqualTo("single-stream-contract");
     }
 
     @Test
@@ -153,7 +157,8 @@ class CriterionShimTest {
 
         assertThat(criteria).hasSize(1);
         assertThat(criteria.get(0).id()).isEqualTo("well-formed");
-        assertThat(criteria.get(0).postconditions()).hasSize(1);
+        CriterionSampleResult result = criteria.get(0).evaluate("hello");
+        assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
     }
 
     @Test
@@ -164,45 +169,5 @@ class CriterionShimTest {
                 .hasMessageContaining("postconditions(ContractBuilder)")
                 .hasMessageContaining("criteria(CriteriaBuilder)")
                 .hasMessageContaining(BothOverriddenContract.class.getName());
-    }
-
-    @Test
-    void engineReadThroughCriteriaMatchesLegacyDirectRead() {
-        // The K=1 path's evaluation must produce the same per-sample
-        // postcondition results as a direct evaluation of the legacy
-        // postconditions() list. This is the behaviour-preserving
-        // invariant of step 1.
-        var contract = new SingleStreamContract();
-        String value = "hello world";
-
-        // Legacy path — direct read.
-        var legacyResults = new java.util.ArrayList<PostconditionResult>();
-        for (Postcondition<String> p : contract.postconditions()) {
-            legacyResults.addAll(p.evaluateAll(value));
-        }
-
-        // New path — read through criteria().
-        var newResults = new java.util.ArrayList<PostconditionResult>();
-        for (Criterion<String> c : contract.criteria()) {
-            for (Postcondition<String> p : c.postconditions()) {
-                newResults.addAll(p.evaluateAll(value));
-            }
-        }
-
-        assertThat(newResults).hasSameSizeAs(legacyResults);
-        for (int i = 0; i < legacyResults.size(); i++) {
-            PostconditionResult a = legacyResults.get(i);
-            PostconditionResult b = newResults.get(i);
-            assertThat(b.description()).isEqualTo(a.description());
-            assertThat(b.passed()).isEqualTo(a.passed());
-        }
-    }
-
-    @Test
-    void defaultCriterionIdDerivedFromContractClass() {
-        var contract = new SingleStreamContract();
-        String id = contract.criteria().get(0).id();
-        // SingleStreamContract → single-stream-contract.
-        assertThat(id).isEqualTo("single-stream-contract");
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
@@ -110,7 +110,7 @@ class CriterionShimTest {
         CriterionSampleResult result = sole.evaluate(value);
 
         assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
-        assertThat(result.transformFailure()).isEmpty();
+        assertThat(result.reason()).isEmpty();
         assertThat(result.postconditionResults()).hasSameSizeAs(legacy);
         for (int i = 0; i < legacy.size(); i++) {
             PostconditionResult a = legacy.get(i);

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
@@ -1,0 +1,99 @@
+package org.javai.punit.api.criterion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Contract;
+import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionResult;
+import org.javai.punit.api.ServiceContractOutcome;
+import org.javai.punit.api.TokenTracker;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Step 2's aggregate-mapping default: an INCONCLUSIVE per-sample
+ * criterion result is folded into the verdict path as a single
+ * synthetic failed {@link PostconditionResult} preserving the
+ * transform failure's name and message. Verifies this end-to-end
+ * through the engine's per-sample apply path.
+ */
+class InconclusiveFoldsIntoFailTest {
+
+    static final class TransformingContract implements Contract<String, String> {
+        @Override
+        public Outcome<String> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
+
+        @Override
+        public void postconditions(ContractBuilder<String> b) {
+            // Empty — the explicit criteria carry the postconditions.
+        }
+
+        @Override
+        public void criteria(CriteriaBuilder<String> b) {
+            b.add(Criteria.transforming(
+                    "parsed-positive",
+                    s -> {
+                        try {
+                            return Outcome.ok(Integer.parseInt(s));
+                        } catch (NumberFormatException e) {
+                            return Outcome.fail("parse-error", "not a number: " + s);
+                        }
+                    },
+                    cb -> cb.ensure("positive", (Integer n) -> n > 0
+                            ? Outcome.ok()
+                            : Outcome.fail("non-positive", "n=" + n))));
+        }
+    }
+
+    @Test
+    void inconclusiveFromTransformFailureSurfacesAsSingleSyntheticFailedResult() {
+        var contract = new TransformingContract();
+        TokenTracker tracker = TokenTracker.create();
+
+        ServiceContractOutcome<String, String> outcome =
+                contract.apply("not-a-number", tracker);
+
+        // The engine folds INCONCLUSIVE into a single failed
+        // PostconditionResult that names the criterion's transform
+        // and preserves the transform Failure's name and message.
+        assertThat(outcome.postconditionResults()).hasSize(1);
+        PostconditionResult r = outcome.postconditionResults().get(0);
+        assertThat(r.failed()).isTrue();
+        assertThat(r.description()).contains("parsed-positive");
+        assertThat(r.failureName()).contains("parse-error");
+        assertThat(r.failureReason()).contains("not a number: not-a-number");
+    }
+
+    @Test
+    void transformSucceedsAndPostconditionFailsSurfacesPostconditionResult() {
+        var contract = new TransformingContract();
+        TokenTracker tracker = TokenTracker.create();
+
+        ServiceContractOutcome<String, String> outcome =
+                contract.apply("-3", tracker);
+
+        // Transform succeeded (-3 parses), postcondition failed
+        // (-3 is not positive). The verdict path sees one
+        // PostconditionResult — the failed postcondition — not the
+        // synthetic transform-failure entry.
+        assertThat(outcome.postconditionResults()).hasSize(1);
+        PostconditionResult r = outcome.postconditionResults().get(0);
+        assertThat(r.failed()).isTrue();
+        assertThat(r.description()).isEqualTo("positive");
+        assertThat(r.failureName()).contains("non-positive");
+    }
+
+    @Test
+    void transformAndPostconditionBothSucceedSurfacesPassingResult() {
+        var contract = new TransformingContract();
+        TokenTracker tracker = TokenTracker.create();
+
+        ServiceContractOutcome<String, String> outcome =
+                contract.apply("7", tracker);
+
+        assertThat(outcome.postconditionResults()).hasSize(1);
+        assertThat(outcome.postconditionResults().get(0).passed()).isTrue();
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
  * Step 2's aggregate-mapping default: an INCONCLUSIVE per-sample
  * criterion result is folded into the verdict path as a single
  * synthetic failed {@link PostconditionResult} preserving the
- * transform failure's name and message. Verifies this end-to-end
- * through the engine's per-sample apply path.
+ * reason's name and message. Verifies this end-to-end through the
+ * engine's per-sample apply path.
  */
 class InconclusiveFoldsIntoFailTest {
 
@@ -56,8 +56,8 @@ class InconclusiveFoldsIntoFailTest {
                 contract.apply("not-a-number", tracker);
 
         // The engine folds INCONCLUSIVE into a single failed
-        // PostconditionResult that names the criterion's transform
-        // and preserves the transform Failure's name and message.
+        // PostconditionResult identified by the criterion's id and
+        // carrying the reason's name and message.
         assertThat(outcome.postconditionResults()).hasSize(1);
         PostconditionResult r = outcome.postconditionResults().get(0);
         assertThat(r.failed()).isTrue();

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/TransformingCriterionTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/TransformingCriterionTest.java
@@ -30,7 +30,7 @@ class TransformingCriterionTest {
         assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
         assertThat(result.postconditionResults()).hasSize(1);
         assertThat(result.postconditionResults().get(0).passed()).isTrue();
-        assertThat(result.transformFailure()).isEmpty();
+        assertThat(result.reason()).isEmpty();
     }
 
     @Test
@@ -47,7 +47,7 @@ class TransformingCriterionTest {
         assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
         assertThat(result.postconditionResults()).hasSize(1);
         assertThat(result.postconditionResults().get(0).failed()).isTrue();
-        assertThat(result.transformFailure()).isEmpty();
+        assertThat(result.reason()).isEmpty();
     }
 
     @Test
@@ -61,8 +61,8 @@ class TransformingCriterionTest {
 
         assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
         assertThat(result.postconditionResults()).isEmpty();
-        assertThat(result.transformFailure()).isPresent();
-        Outcome.Fail<?> failure = result.transformFailure().get();
+        assertThat(result.reason()).isPresent();
+        Outcome.Fail<?> failure = result.reason().get();
         assertThat(failure.failure().id().name()).isEqualTo("parse-error");
         assertThat(failure.failure().message()).isEqualTo("expected an integer");
     }
@@ -80,8 +80,8 @@ class TransformingCriterionTest {
 
         assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
         assertThat(result.postconditionResults()).isEmpty();
-        assertThat(result.transformFailure()).isPresent();
-        Outcome.Fail<?> failure = result.transformFailure().get();
+        assertThat(result.reason()).isPresent();
+        Outcome.Fail<?> failure = result.reason().get();
         assertThat(failure.failure().message()).isEqualTo("kaboom");
     }
 

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/TransformingCriterionTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/TransformingCriterionTest.java
@@ -1,0 +1,121 @@
+package org.javai.punit.api.criterion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.javai.outcome.Outcome;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the transform path on {@link Criteria#transforming}: a
+ * criterion that first transforms {@code O} to {@code D}, then
+ * evaluates postconditions against the derived value. Transform
+ * failure (Outcome.Fail or thrown exception) classifies the sample
+ * INCONCLUSIVE with the transform's failure preserved for
+ * diagnostics.
+ */
+class TransformingCriterionTest {
+
+    @Test
+    void transformSucceedsAllPassesYieldsPass() {
+        Criterion<String> c = Criteria.transforming(
+                "parsed-positive",
+                s -> Outcome.ok(Integer.parseInt(s)),
+                b -> b.ensure("positive", (Integer n) -> n > 0
+                        ? Outcome.ok()
+                        : Outcome.fail("non-positive", "n=" + n)));
+
+        CriterionSampleResult result = c.evaluate("42");
+
+        assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+        assertThat(result.postconditionResults()).hasSize(1);
+        assertThat(result.postconditionResults().get(0).passed()).isTrue();
+        assertThat(result.transformFailure()).isEmpty();
+    }
+
+    @Test
+    void transformSucceedsAnyPostconditionFailsYieldsFail() {
+        Criterion<String> c = Criteria.transforming(
+                "parsed-positive",
+                s -> Outcome.ok(Integer.parseInt(s)),
+                b -> b.ensure("positive", (Integer n) -> n > 0
+                        ? Outcome.ok()
+                        : Outcome.fail("non-positive", "n=" + n)));
+
+        CriterionSampleResult result = c.evaluate("-5");
+
+        assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
+        assertThat(result.postconditionResults()).hasSize(1);
+        assertThat(result.postconditionResults().get(0).failed()).isTrue();
+        assertThat(result.transformFailure()).isEmpty();
+    }
+
+    @Test
+    void transformReturnsFailYieldsInconclusiveCarryingTheFailure() {
+        Criterion<String> c = Criteria.transforming(
+                "parsed-positive",
+                s -> Outcome.<Integer>fail("parse-error", "expected an integer"),
+                b -> b.ensure("positive", (Integer n) -> Outcome.ok()));
+
+        CriterionSampleResult result = c.evaluate("not-a-number");
+
+        assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
+        assertThat(result.postconditionResults()).isEmpty();
+        assertThat(result.transformFailure()).isPresent();
+        Outcome.Fail<?> failure = result.transformFailure().get();
+        assertThat(failure.failure().id().name()).isEqualTo("parse-error");
+        assertThat(failure.failure().message()).isEqualTo("expected an integer");
+    }
+
+    @Test
+    void transformThrowsYieldsInconclusiveCarryingTheExceptionMessage() {
+        java.util.function.Function<String, Outcome<Integer>> blowUp =
+                s -> { throw new IllegalStateException("kaboom"); };
+        Criterion<String> c = Criteria.transforming(
+                "parsed-positive",
+                blowUp,
+                b -> b.ensure("positive", (Integer n) -> Outcome.ok()));
+
+        CriterionSampleResult result = c.evaluate("anything");
+
+        assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
+        assertThat(result.postconditionResults()).isEmpty();
+        assertThat(result.transformFailure()).isPresent();
+        Outcome.Fail<?> failure = result.transformFailure().get();
+        assertThat(failure.failure().message()).isEqualTo("kaboom");
+    }
+
+    @Test
+    void directCriterionWithoutTransformOperatesOverContractOutput() {
+        Criterion<String> c = Criteria.direct(
+                "non-empty",
+                b -> b.ensure("non-empty", v -> v.isEmpty()
+                        ? Outcome.fail("empty", "")
+                        : Outcome.ok()));
+
+        CriterionSampleResult pass = c.evaluate("hello");
+        assertThat(pass.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+
+        CriterionSampleResult fail = c.evaluate("");
+        assertThat(fail.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
+    }
+
+    @Test
+    void factoryValidatesIdAndArguments() {
+        assertThatThrownBy(() -> Criteria.direct(null, b -> {}))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Criteria.direct("", b -> {}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("blank");
+        assertThatThrownBy(() -> Criteria.direct("id", null))
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> Criteria.transforming(null, s -> Outcome.ok(s), b -> {}))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Criteria.transforming("id", null, b -> {}))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() ->
+                Criteria.transforming("id", (String s) -> Outcome.ok(s), null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineSelectorTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineSelectorTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.javai.punit.api.CovariateCategory;
+import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.covariate.Covariate;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.BaselineStatistics;

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
@@ -13,7 +13,7 @@ import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ContractBuilder;
-import org.javai.punit.api.CovariateCategory;
+import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/covariate/CovariateResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/covariate/CovariateResolverTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import org.javai.punit.api.CovariateCategory;
+import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.covariate.Covariate;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.junit.jupiter.api.DisplayName;

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.CovariateCategory;
+import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ContractBuilder;


### PR DESCRIPTION
## Summary

Step 2 of the multi-criterion rollout. Splits today's dual-role
derivation — a transform that also reported pass/fail as a
postcondition — into a pure criterion-level transform plus a
postcondition chain. A postcondition reverts to its literal
definition: a named predicate that performs no transformation.

Implements `plan/directives/DIR-CRITERION-STEP-2-DERIVING-AS-TRANSFORM-punit.md`
in the orchestrator repo. Aligns with inventory entries CR01, CR03,
CR05, CR07; companion §1.4.2 and §1.4.5.

## What's new

- **`CriterionSampleOutcome`** — `{PASS, FAIL, INCONCLUSIVE}` enum.
  INCONCLUSIVE captures the per-sample case where a criterion's
  transform failed.
- **`CriterionSampleResult`** — per-sample record carrying the
  outcome, per-postcondition results (PASS/FAIL), or the transform
  `Outcome.Fail` (INCONCLUSIVE).
- **`Criterion<O>`** — reshaped to a minimal interface: `id()` +
  `evaluate(O) → CriterionSampleResult`. Transform and postcondition
  chain are encapsulated inside the implementation; consumers read
  structure off the result, not the criterion.
- **`Criteria`** factory — `direct(id, body)` for no-transform
  criteria; `transforming(id, transform, body)` for criteria that
  derive `D` from `O` before evaluating. The two factories cover the
  methodology's two shapes and structurally enforce the
  one-transform-per-criterion cap (no API expresses two transforms
  in one criterion).
- **`DirectCriterion` / `TransformingCriterion`** — package-private
  implementations owning the per-sample machinery; built by the
  factory.
- **`DefaultCriterion`** rewritten — the K=1 shim now implements
  `evaluate(value)` directly, delegating to a shared chain walker.
  Same K=1 isomorphism as step 1.

## What's gone

- **`Postcondition.Derived`** — removed. Postcondition becomes
  Leaf-only.
- **`ContractBuilder.deriving(...)`** — removed. Builder's only
  authoring method is `ensure(...)`.
- No production source under any module referenced these constructs
  outside the modified files. Two test files dropped their
  deriving-specific test cases; the surviving cases on `ensure(...)`
  and `Postcondition.Leaf` are unchanged.

## Engine behaviour

`Contract.evaluateClauses` walks criteria via `evaluate(value)` and
folds each result into the flat `List<PostconditionResult>` the
verdict path consumes:

- **PASS / FAIL** — per-postcondition results are appended as
  before. K=1 contracts using only `ensure(...)` produce
  byte-identical verdicts and reports.
- **INCONCLUSIVE** — emits one synthetic failed `PostconditionResult`
  that names the criterion's transform and preserves the transform
  `Failure`'s name and message. This is the step-2 default for the
  denominator policy (INCONCLUSIVE folds into fail at aggregation).
  A configurable policy (CONDITIONAL_ON_EVALUABLE vs
  MARGINAL_COUNT_UNEVALUABLE_AS_FAIL) lands in a later CR05 step.

## Design choices explicitly captured in the directive

- `Criterion<O>` exposes only `id()` and `evaluate(value)` — no
  transform or postcondition accessors leak onto the public surface.
  Consumers read criterion structure off the result stream, not the
  criterion type. Cleaner separation of concerns; one virtual call
  per criterion per sample at the engine.
- The one-transform-per-criterion cap is **structural**: each factory
  produces a criterion with either zero or one transform. No runtime
  check needed.
- `deriving(...)` is **removed**, not deprecated. The dual-role
  design is the defect; a deprecation period would leave it callable
  while authors migrated piecemeal.

## Commit decomposition

1. Add `CriterionSampleOutcome` + `CriterionSampleResult`
2. Reshape `Criterion` to `id()` + `evaluate(value)`; migrate engine
3. Add `Criteria` factory
4. Remove `Postcondition.Derived` and `ContractBuilder.deriving`
5. Drop now-dead tests in `PostconditionTest` + `ContractBuilderTest`
6. Update `CriterionShimTest`; add step-2 criterion tests

## What's not yet observable

- **Criterion-aggregate three-valued verdict** (PASS / FAIL /
  INCONCLUSIVE for the whole criterion across samples) — CR07's
  later step.
- **Configurable denominator policy** — step 2 hard-wires
  INCONCLUSIVE → fail at the verdict path. CR05's later step.
- **Composite verdict** over per-criterion verdicts — CR09's later
  step.

## Test plan

- [x] Full `./gradlew test` green (including all ArchUnit guards:
  RequirementCodeIsolationTest, statistics isolation, abstraction
  levels)
- [x] `CriterionShimTest` — K=1 isomorphism preserved via per-sample
  evaluate-stream comparisons
- [x] `TransformingCriterionTest` — transform success/failure/throw
  paths, factory argument validation
- [x] `InconclusiveFoldsIntoFailTest` — end-to-end aggregate
  mapping through `Contract.apply()`
- [x] `CriterionSampleResultTest` — per-outcome record invariants
- [x] No requirement-code leakage (RequirementCodeIsolationTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)