### PR TITLE
Criterion step 3: per-criterion verdicts + composite (observable)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -226,9 +226,9 @@ public interface Contract<I, O> {
         Duration duration = Duration.ofNanos(System.nanoTime() - start);
         long sampleTokens = Math.max(0L, tracker.totalTokens() - startTokens);
 
-        List<PostconditionResult> clauseResults = result instanceof Ok<O> ok
+        ClauseEvaluation clauseEvaluation = result instanceof Ok<O> ok
                 ? evaluateClauses(ok.value())
-                : List.of();   // postcondition evaluation skipped on apply-level failure
+                : ClauseEvaluation.empty();   // postcondition evaluation skipped on apply-level failure
 
         Optional<MatchResult> match = result instanceof Ok<O> ok2
                 ? matchStep.map(step -> step.apply(ok2.value()))
@@ -237,13 +237,14 @@ public interface Contract<I, O> {
         return new ServiceContractOutcome<>(
                 result,
                 this,
-                clauseResults,
+                clauseEvaluation.postconditionResults(),
                 match,
                 sampleTokens,
-                duration);
+                duration,
+                clauseEvaluation.criterionSampleResults());
     }
 
-    private List<PostconditionResult> evaluateClauses(O value) {
+    private ClauseEvaluation evaluateClauses(O value) {
         // Walk criteria via per-sample evaluate(value). For each criterion
         // we get a three-valued CriterionSampleResult; the verdict path
         // (which consumes a flat List<PostconditionResult>) is fed the
@@ -252,20 +253,34 @@ public interface Contract<I, O> {
         // reason's name and message for diagnostics. The
         // synthetic-result-on-INCONCLUSIVE mapping is the step-2 default
         // for the denominator policy; a configurable policy is the subject
-        // of a later step.
-        List<PostconditionResult> out = new ArrayList<>();
+        // of a later step. The per-criterion sample results are retained
+        // verbatim alongside the flat list so downstream consumers — the
+        // per-criterion accumulator, the per-criterion verdict computation
+        // — can read the methodology-level partition unit's behaviour
+        // without re-walking the criteria.
+        List<PostconditionResult> flat = new ArrayList<>();
+        List<CriterionSampleResult> perCriterion = new ArrayList<>();
         for (Criterion<O> criterion : criteria()) {
             CriterionSampleResult result = criterion.evaluate(value);
+            perCriterion.add(result);
             switch (result.outcome()) {
-                case PASS, FAIL -> out.addAll(result.postconditionResults());
+                case PASS, FAIL -> flat.addAll(result.postconditionResults());
                 case INCONCLUSIVE -> {
                     Outcome.Fail<?> reason = result.reason().orElseThrow();
-                    out.add(PostconditionResult.failed(
+                    flat.add(PostconditionResult.failed(
                             criterion.id(),
                             reason));
                 }
             }
         }
-        return out;   // ServiceContractOutcome canonical constructor defensive-copies
+        return new ClauseEvaluation(flat, perCriterion);
+    }
+
+    record ClauseEvaluation(
+            List<PostconditionResult> postconditionResults,
+            List<CriterionSampleResult> criterionSampleResults) {
+        static ClauseEvaluation empty() {
+            return new ClauseEvaluation(List.of(), List.of());
+        }
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/ServiceContractOutcome.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ServiceContractOutcome.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.javai.outcome.Outcome;
+import org.javai.punit.api.criterion.CriterionSampleResult;
 
 /**
  * The artefact assembled by {@link Contract#apply(Object, TokenTracker)}
@@ -57,7 +58,8 @@ public record ServiceContractOutcome<I, O>(
         List<PostconditionResult> postconditionResults,
         Optional<MatchResult> match,
         long tokens,
-        Duration duration) {
+        Duration duration,
+        List<CriterionSampleResult> criterionSampleResults) {
 
     public ServiceContractOutcome {
         Objects.requireNonNull(result, "result");
@@ -65,6 +67,7 @@ public record ServiceContractOutcome<I, O>(
         Objects.requireNonNull(postconditionResults, "postconditionResults");
         Objects.requireNonNull(match, "match");
         Objects.requireNonNull(duration, "duration");
+        Objects.requireNonNull(criterionSampleResults, "criterionSampleResults");
         if (tokens < 0) {
             throw new IllegalArgumentException("tokens must be non-negative, got " + tokens);
         }
@@ -72,6 +75,24 @@ public record ServiceContractOutcome<I, O>(
             throw new IllegalArgumentException("duration must be non-negative, got " + duration);
         }
         postconditionResults = List.copyOf(postconditionResults);
+        criterionSampleResults = List.copyOf(criterionSampleResults);
+    }
+
+    /**
+     * Backward-compatible 6-arg constructor that defaults
+     * {@link #criterionSampleResults()} to an empty list. Test fixtures
+     * and call sites that don't carry per-criterion sample detail
+     * construct via this overload; the framework's contract-apply path
+     * constructs via the canonical 7-arg form.
+     */
+    public ServiceContractOutcome(
+            Outcome<O> result,
+            Contract<I, O> contract,
+            List<PostconditionResult> postconditionResults,
+            Optional<MatchResult> match,
+            long tokens,
+            Duration duration) {
+        this(result, contract, postconditionResults, match, tokens, duration, List.of());
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/spec/CriterionSampleCounts.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/CriterionSampleCounts.java
@@ -1,0 +1,59 @@
+package org.javai.punit.api.spec;
+
+import java.util.Objects;
+
+/**
+ * Per-criterion sample-outcome counts across a run, keyed by the
+ * criterion's stable identifier. One record per
+ * {@link org.javai.punit.api.criterion.Criterion} the
+ * {@link org.javai.punit.api.Contract} declares.
+ *
+ * <p>The denominator under today's marginal-totals policy is
+ * {@link #total()} = {@link #pass()} + {@link #fail()} +
+ * {@link #inconclusive()}; the per-criterion observed pass rate is
+ * {@link #pass()} / {@link #total()}, with INCONCLUSIVE samples
+ * contributing zero to the numerator. The methodology's "n_c = 0 →
+ * INCONCLUSIVE" rule applies only when {@link #total()} is zero,
+ * which under the marginal policy means the entire run had zero
+ * samples and the feasibility gate has independently refused the
+ * test.
+ *
+ * @param criterionId the criterion's stable identifier
+ * @param pass count of samples whose per-criterion outcome was PASS
+ * @param fail count of samples whose per-criterion outcome was FAIL
+ * @param inconclusive count of samples whose per-criterion outcome
+ *                     was INCONCLUSIVE (transform failure or other
+ *                     evaluation gap)
+ */
+public record CriterionSampleCounts(
+        String criterionId,
+        int pass,
+        int fail,
+        int inconclusive) {
+
+    public CriterionSampleCounts {
+        Objects.requireNonNull(criterionId, "criterionId");
+        if (pass < 0 || fail < 0 || inconclusive < 0) {
+            throw new IllegalArgumentException(
+                    "counts must be non-negative; got pass=" + pass
+                            + ", fail=" + fail
+                            + ", inconclusive=" + inconclusive);
+        }
+    }
+
+    /** Sum of all per-criterion sample outcomes — the marginal denominator. */
+    public int total() {
+        return pass + fail + inconclusive;
+    }
+
+    /**
+     * Observed pass rate under the marginal denominator policy:
+     * {@link #pass()} / {@link #total()}. Returns {@code NaN} when
+     * {@link #total()} is zero — callers should treat that as
+     * INCONCLUSIVE per the methodology's $n_c = 0$ rule.
+     */
+    public double observedPassRate() {
+        int t = total();
+        return t == 0 ? Double.NaN : (double) pass / (double) t;
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionEvaluation.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionEvaluation.java
@@ -1,0 +1,44 @@
+package org.javai.punit.api.spec;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The per-criterion evaluation bundle attached to a
+ * {@link ProbabilisticTestResult}: one verdict per methodology-level
+ * criterion the contract declares, plus the composite verdict over
+ * those per-criterion verdicts under the methodology's worst-case
+ * rule ({@link Verdict#aggregate(List)}).
+ *
+ * <p>The composite is computed and surfaced but is <em>not</em> the
+ * contract's overall verdict authority in this step. When the
+ * composite disagrees with the legacy
+ * {@link ProbabilisticTestResult#verdict() flat-aggregation verdict},
+ * the transparent-stats output flags the disagreement explicitly —
+ * that surfaced disagreement is the empirical evidence the cutover
+ * step relies on.
+ *
+ * @param perCriterionVerdicts the verdict per declared criterion, in
+ *                             contract declaration order; empty for
+ *                             apply-level-failed runs that produced
+ *                             no per-criterion sample evaluations
+ * @param compositeVerdict     {@link Verdict#aggregate(List)} over the
+ *                             per-criterion verdicts; defaults to
+ *                             {@link Verdict#PASS} on an empty list
+ *                             per the rule's empty-case semantics
+ */
+public record PerCriterionEvaluation(
+        List<PerCriterionVerdict> perCriterionVerdicts,
+        Verdict compositeVerdict) {
+
+    public PerCriterionEvaluation {
+        Objects.requireNonNull(perCriterionVerdicts, "perCriterionVerdicts");
+        Objects.requireNonNull(compositeVerdict, "compositeVerdict");
+        perCriterionVerdicts = List.copyOf(perCriterionVerdicts);
+    }
+
+    /** Empty evaluation — no per-criterion data; composite defaults to PASS. */
+    public static PerCriterionEvaluation empty() {
+        return new PerCriterionEvaluation(List.of(), Verdict.PASS);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdict.java
@@ -1,0 +1,41 @@
+package org.javai.punit.api.spec;
+
+import java.util.Objects;
+
+/**
+ * The per-criterion three-valued verdict for one methodology-level
+ * criterion across a run, plus the supporting counts, observed
+ * pass-rate, and the threshold the verdict was judged against.
+ *
+ * <p>Per the step-3 design the threshold is contract-inherited: every
+ * criterion is judged against the same threshold the contract's
+ * legacy verdict path resolves. The {@link #threshold()} field is
+ * therefore the same value for every per-criterion verdict in one
+ * run — it is carried per-criterion so that downstream renderers can
+ * surface it inline with each criterion's row without reaching back
+ * across the result.
+ *
+ * @param criterionId the criterion's stable identifier
+ * @param verdict     PASS / FAIL / INCONCLUSIVE under the
+ *                    contract-inherited threshold
+ * @param counts      per-sample-outcome counts that produced this verdict
+ * @param observed    the criterion's observed pass-rate
+ *                    ({@link CriterionSampleCounts#observedPassRate()})
+ *                    or {@code NaN} when {@link CriterionSampleCounts#total()}
+ *                    is zero
+ * @param threshold   the contract-inherited threshold the verdict was
+ *                    judged against
+ */
+public record PerCriterionVerdict(
+        String criterionId,
+        Verdict verdict,
+        CriterionSampleCounts counts,
+        double observed,
+        double threshold) {
+
+    public PerCriterionVerdict {
+        Objects.requireNonNull(criterionId, "criterionId");
+        Objects.requireNonNull(verdict, "verdict");
+        Objects.requireNonNull(counts, "counts");
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdicts.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdicts.java
@@ -1,0 +1,93 @@
+package org.javai.punit.api.spec;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Derives a per-criterion three-valued verdict for every methodology-
+ * level criterion the contract declared on a run.
+ *
+ * <p>This is glue, not statistics: it reuses the threshold the
+ * legacy verdict path already resolved (via {@code PassRate.evaluate})
+ * and applies the same {@code observed >= threshold} decision rule to
+ * each criterion's marginal-policy observed pass-rate. Any new
+ * statistical arithmetic belongs in
+ * {@code org.javai.punit.statistics}; this helper performs no such
+ * arithmetic.
+ *
+ * <p>Step-3 behavioural contract:
+ *
+ * <ul>
+ *   <li>The legacy spec-layer evaluation (the list of
+ *       {@link EvaluatedCriterion}) is the source of truth for the
+ *       resolved threshold and for the gate-fired INCONCLUSIVE state.
+ *       When the legacy composite is INCONCLUSIVE — e.g. no baseline,
+ *       sample-size constraint violated, identity mismatch — every
+ *       per-criterion verdict is INCONCLUSIVE too. The framework has
+ *       judged the entire run statistically inconclusive; a
+ *       per-criterion verdict cannot meaningfully be PASS or FAIL.</li>
+ *   <li>Otherwise: per-criterion verdict =
+ *       {@code observed >= threshold ? PASS : FAIL}, where
+ *       {@code observed} is the criterion's marginal-policy observed
+ *       pass-rate (PASS count over PASS+FAIL+INCONCLUSIVE) and
+ *       {@code threshold} is the contract-inherited resolved
+ *       threshold. A criterion with zero samples (only reachable on a
+ *       zero-sample run, in which case the feasibility gate has
+ *       independently refused the test) maps to INCONCLUSIVE.</li>
+ *   <li>The composite is {@link Verdict#aggregate(List)} over the
+ *       per-criterion verdicts.</li>
+ * </ul>
+ */
+public final class PerCriterionVerdicts {
+
+    private PerCriterionVerdicts() {}
+
+    public static PerCriterionEvaluation derive(
+            List<EvaluatedCriterion> legacyEvaluated,
+            List<CriterionSampleCounts> perCriterionCounts) {
+        if (perCriterionCounts.isEmpty()) {
+            return PerCriterionEvaluation.empty();
+        }
+        Optional<Double> threshold = scanThreshold(legacyEvaluated);
+        Verdict legacyComposed = Verdict.compose(legacyEvaluated);
+        boolean propagateInconclusive =
+                legacyComposed == Verdict.INCONCLUSIVE || threshold.isEmpty();
+
+        double resolvedThreshold = threshold.orElse(Double.NaN);
+        List<PerCriterionVerdict> derived = new ArrayList<>(perCriterionCounts.size());
+        List<Verdict> verdicts = new ArrayList<>(perCriterionCounts.size());
+        for (CriterionSampleCounts counts : perCriterionCounts) {
+            Verdict v;
+            double observed = counts.observedPassRate();
+            if (propagateInconclusive || counts.total() == 0) {
+                v = Verdict.INCONCLUSIVE;
+            } else {
+                v = observed >= resolvedThreshold ? Verdict.PASS : Verdict.FAIL;
+            }
+            derived.add(new PerCriterionVerdict(
+                    counts.criterionId(), v, counts, observed, resolvedThreshold));
+            verdicts.add(v);
+        }
+        return new PerCriterionEvaluation(derived, Verdict.aggregate(verdicts));
+    }
+
+    /**
+     * Lifts the resolved threshold from the legacy
+     * {@link EvaluatedCriterion} list. The legacy
+     * {@code PassRate.evaluate} writes {@code threshold} into its
+     * result detail map; the first criterion whose detail carries a
+     * numeric threshold wins. Returns empty when no criterion has
+     * resolved a threshold yet (e.g. all are INCONCLUSIVE before
+     * derivation).
+     */
+    private static Optional<Double> scanThreshold(List<EvaluatedCriterion> evaluated) {
+        for (EvaluatedCriterion ec : evaluated) {
+            Object v = ec.result().detail().get("threshold");
+            if (v instanceof Number n) {
+                return Optional.of(n.doubleValue());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -222,6 +222,8 @@ public final class ProbabilisticTest implements Spec {
 
             Verdict composed = Verdict.compose(evaluated);
             EngineRunSummary engineSummary = buildEngineSummary(s, evaluated, baselineFilename);
+            PerCriterionEvaluation perCriterionEvaluation =
+                    PerCriterionVerdicts.derive(evaluated, s.criterionSampleCounts());
             return new ProbabilisticTestResult(
                     composed, factorBundle, evaluated, intent,
                     List.copyOf(warnings),
@@ -230,7 +232,8 @@ public final class ProbabilisticTest implements Spec {
                             baselineProfile),
                     Optional.empty(),
                     s.failuresByPostcondition(),
-                    engineSummary);
+                    engineSummary,
+                    perCriterionEvaluation);
         }
 
         /**

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTestResult.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTestResult.java
@@ -62,7 +62,8 @@ public record ProbabilisticTestResult(
         CovariateAlignment covariates,
         Optional<String> contractRef,
         Map<String, FailureCount> failuresByPostcondition,
-        EngineRunSummary engineSummary) implements EngineResult {
+        EngineRunSummary engineSummary,
+        PerCriterionEvaluation perCriterionEvaluation) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -74,9 +75,29 @@ public record ProbabilisticTestResult(
         Objects.requireNonNull(contractRef, "contractRef");
         Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
         Objects.requireNonNull(engineSummary, "engineSummary");
+        Objects.requireNonNull(perCriterionEvaluation, "perCriterionEvaluation");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);
         failuresByPostcondition = Map.copyOf(failuresByPostcondition);
+    }
+
+    /**
+     * Backward-compatible 9-arg constructor that defaults
+     * {@link #perCriterionEvaluation()} to {@link PerCriterionEvaluation#empty()}.
+     */
+    public ProbabilisticTestResult(
+            Verdict verdict,
+            FactorBundle factors,
+            List<EvaluatedCriterion> criterionResults,
+            TestIntent intent,
+            List<String> warnings,
+            CovariateAlignment covariates,
+            Optional<String> contractRef,
+            Map<String, FailureCount> failuresByPostcondition,
+            EngineRunSummary engineSummary) {
+        this(verdict, factors, criterionResults, intent, warnings,
+                covariates, contractRef, failuresByPostcondition,
+                engineSummary, PerCriterionEvaluation.empty());
     }
 
     /**
@@ -158,7 +179,8 @@ public record ProbabilisticTestResult(
     public ProbabilisticTestResult withCovariates(CovariateAlignment covariates) {
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
-                covariates, contractRef, failuresByPostcondition, engineSummary);
+                covariates, contractRef, failuresByPostcondition,
+                engineSummary, perCriterionEvaluation);
     }
 
     /**
@@ -178,6 +200,7 @@ public record ProbabilisticTestResult(
                 : Optional.of(contractRef);
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
-                covariates, wrapped, failuresByPostcondition, engineSummary);
+                covariates, wrapped, failuresByPostcondition,
+                engineSummary, perCriterionEvaluation);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/SampleSummary.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/SampleSummary.java
@@ -60,7 +60,8 @@ public record SampleSummary<OT>(
         TerminationReason terminationReason,
         List<Trial<?, OT>> trials,
         Map<String, FailureCount> failuresByPostcondition,
-        LatencyResult passingLatencyResult) {
+        LatencyResult passingLatencyResult,
+        List<CriterionSampleCounts> criterionSampleCounts) {
 
     public SampleSummary {
         Objects.requireNonNull(outcomes, "outcomes");
@@ -70,6 +71,7 @@ public record SampleSummary<OT>(
         Objects.requireNonNull(trials, "trials");
         Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
         Objects.requireNonNull(passingLatencyResult, "passingLatencyResult");
+        Objects.requireNonNull(criterionSampleCounts, "criterionSampleCounts");
         if (successes < 0 || failures < 0) {
             throw new IllegalArgumentException("counts must be non-negative");
         }
@@ -95,15 +97,38 @@ public record SampleSummary<OT>(
         outcomes = List.copyOf(outcomes);
         trials = List.copyOf(trials);
         failuresByPostcondition = Map.copyOf(failuresByPostcondition);
+        criterionSampleCounts = List.copyOf(criterionSampleCounts);
+    }
+
+    /**
+     * Backward-compatible 11-arg constructor that defaults
+     * {@link #criterionSampleCounts()} to an empty list. Test fixtures
+     * and call sites that don't carry per-criterion sample counts
+     * construct via this overload; the engine constructs summaries via
+     * the canonical constructor with the per-criterion counts populated
+     * from per-sample {@link org.javai.punit.api.criterion.CriterionSampleResult}s.
+     */
+    public SampleSummary(
+            List<ServiceContractOutcome<?, OT>> outcomes,
+            Duration elapsed,
+            int successes,
+            int failures,
+            long tokensConsumed,
+            int failuresDropped,
+            LatencyResult latencyResult,
+            TerminationReason terminationReason,
+            List<Trial<?, OT>> trials,
+            Map<String, FailureCount> failuresByPostcondition,
+            LatencyResult passingLatencyResult) {
+        this(outcomes, elapsed, successes, failures, tokensConsumed,
+                failuresDropped, latencyResult, terminationReason, trials,
+                failuresByPostcondition, passingLatencyResult, List.of());
     }
 
     /**
      * Backward-compatible 10-arg constructor that defaults
-     * {@link #passingLatencyResult()} to {@link LatencyResult#empty()}.
-     * Test fixtures and call sites that haven't yet migrated to the
-     * canonical 11-field shape can construct via this overload; the
-     * engine constructs summaries via the canonical constructor with
-     * the passing-only latency result populated.
+     * {@link #passingLatencyResult()} to {@link LatencyResult#empty()}
+     * and {@link #criterionSampleCounts()} to an empty list.
      */
     public SampleSummary(
             List<ServiceContractOutcome<?, OT>> outcomes,
@@ -118,13 +143,14 @@ public record SampleSummary<OT>(
             Map<String, FailureCount> failuresByPostcondition) {
         this(outcomes, elapsed, successes, failures, tokensConsumed,
                 failuresDropped, latencyResult, terminationReason, trials,
-                failuresByPostcondition, LatencyResult.empty());
+                failuresByPostcondition, LatencyResult.empty(), List.of());
     }
 
     /**
      * Backward-compatible 9-arg constructor that defaults
-     * {@link #failuresByPostcondition()} to an empty map and
-     * {@link #passingLatencyResult()} to {@link LatencyResult#empty()}.
+     * {@link #failuresByPostcondition()} to an empty map,
+     * {@link #passingLatencyResult()} to {@link LatencyResult#empty()},
+     * and {@link #criterionSampleCounts()} to an empty list.
      */
     public SampleSummary(
             List<ServiceContractOutcome<?, OT>> outcomes,
@@ -138,7 +164,7 @@ public record SampleSummary<OT>(
             List<Trial<?, OT>> trials) {
         this(outcomes, elapsed, successes, failures, tokensConsumed,
                 failuresDropped, latencyResult, terminationReason, trials,
-                Map.of(), LatencyResult.empty());
+                Map.of(), LatencyResult.empty(), List.of());
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/spec/Verdict.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Verdict.java
@@ -36,6 +36,46 @@ public enum Verdict {
      *
      * Pure function: same inputs, same output; order-independent.
      */
+    /**
+     * Aggregate a list of three-valued verdicts under the methodology's
+     * worst-case rule for the composite over per-criterion verdicts:
+     *
+     * <ul>
+     *   <li>Empty list → {@link #PASS}.</li>
+     *   <li>Any entry is {@link #FAIL} → {@link #FAIL}.</li>
+     *   <li>Else any entry is {@link #INCONCLUSIVE} → {@link #INCONCLUSIVE}.</li>
+     *   <li>Else → {@link #PASS}.</li>
+     * </ul>
+     *
+     * <p>This is the composite-verdict rule per the methodology's
+     * §1.4.6: a failing criterion dominates an inconclusive one, on
+     * the principle that an inconclusive criterion may yet pass with
+     * more evidence while a failing criterion has demonstrated
+     * incompatibility with the threshold. The rule differs from
+     * {@link #compose(List)}, which dominates with INCONCLUSIVE — that
+     * method covers spec-layer verdict-component composition where an
+     * inconclusive component blocks any verdict claim. Both rules
+     * coexist; per-criterion composition over methodology-level
+     * partition units uses {@code aggregate}, spec-layer
+     * verdict-component composition continues to use {@code compose}.
+     *
+     * <p>Pure function: same inputs, same output; order-independent.
+     */
+    public static Verdict aggregate(List<Verdict> verdicts) {
+        Objects.requireNonNull(verdicts, "verdicts");
+        boolean sawInconclusive = false;
+        for (Verdict v : verdicts) {
+            Objects.requireNonNull(v, "verdict");
+            if (v == FAIL) {
+                return FAIL;
+            }
+            if (v == INCONCLUSIVE) {
+                sawInconclusive = true;
+            }
+        }
+        return sawInconclusive ? INCONCLUSIVE : PASS;
+    }
+
     public static Verdict compose(List<EvaluatedCriterion> evaluated) {
         Objects.requireNonNull(evaluated, "evaluated");
         boolean sawFail = false;

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
@@ -16,6 +16,7 @@ import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ServiceContractOutcome;
 import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.Configuration;
+import org.javai.punit.api.spec.CriterionSampleCounts;
 import org.javai.punit.api.spec.EarlyTerminationContext;
 import org.javai.punit.api.spec.EngineResult;
 import org.javai.punit.api.spec.ExceptionPolicy;
@@ -162,6 +163,13 @@ public final class Engine {
         private final List<Trial<?, OT>> trials = new ArrayList<>();
         private final LinkedHashMap<String, MutableFailureBucket> failuresByPostcondition =
                 new LinkedHashMap<>();
+        // Per-criterion sample-outcome counts, keyed by criterion id and
+        // populated from each sample's CriterionSampleResult stream.
+        // LinkedHashMap preserves the criterion declaration order so
+        // reporters render criteria in the order the contract declared
+        // them.
+        private final LinkedHashMap<String, MutableCriterionCounts> criterionCounts =
+                new LinkedHashMap<>();
         private static final int EXEMPLAR_CAP_PER_CLAUSE = 3;
         private int successes = 0;
         private int failures = 0;
@@ -263,6 +271,7 @@ public final class Engine {
                 }
             }
             recordPostconditionFailures(index, classification);
+            recordCriterionSampleOutcomes(stamped);
             FailureLineEmitter.emit(index, classification);
             tokensConsumed += classification.tokens() + tracker.tokenCharge();
             checkStatisticalEarlyTermination();
@@ -326,6 +335,28 @@ public final class Engine {
             final List<FailureExemplar> exemplars = new ArrayList<>();
         }
 
+        private static final class MutableCriterionCounts {
+            int pass = 0;
+            int fail = 0;
+            int inconclusive = 0;
+        }
+
+        private void recordCriterionSampleOutcomes(ServiceContractOutcome<?, OT> stamped) {
+            // Empty list when the contract had nothing to evaluate (apply-level
+            // failure, synthesised defect outcome) or when this sample's
+            // outcome was constructed without per-criterion detail (test
+            // fixtures using the back-compat constructor).
+            for (var entry : stamped.criterionSampleResults()) {
+                MutableCriterionCounts counts = criterionCounts.computeIfAbsent(
+                        entry.criterionId(), k -> new MutableCriterionCounts());
+                switch (entry.outcome()) {
+                    case PASS -> counts.pass++;
+                    case FAIL -> counts.fail++;
+                    case INCONCLUSIVE -> counts.inconclusive++;
+                }
+            }
+        }
+
         private <I> Trial<IT, OT> trialFor(int index, ServiceContractOutcome<I, OT> stamped) {
             // Trial<IT, OT> requires ServiceContractOutcome<IT, OT>; the wildcard
             // carrier in onSample loses that I; we know the executor only
@@ -359,7 +390,17 @@ public final class Engine {
                     tracker.terminationReason(),
                     trials,
                     immutableFailuresByPostcondition(),
-                    passingLatencyResult);
+                    passingLatencyResult,
+                    immutableCriterionSampleCounts());
+        }
+
+        private List<CriterionSampleCounts> immutableCriterionSampleCounts() {
+            List<CriterionSampleCounts> out = new ArrayList<>(criterionCounts.size());
+            for (var e : criterionCounts.entrySet()) {
+                MutableCriterionCounts c = e.getValue();
+                out.add(new CriterionSampleCounts(e.getKey(), c.pass, c.fail, c.inconclusive));
+            }
+            return List.copyOf(out);
         }
 
         private Map<String, FailureCount> immutableFailuresByPostcondition() {

--- a/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
@@ -8,9 +8,12 @@ import java.util.Map;
 import org.javai.punit.api.covariate.CovariateAlignment;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.CriterionResult;
+import org.javai.punit.api.spec.CriterionSampleCounts;
 import org.javai.punit.api.spec.EvaluatedCriterion;
 import org.javai.punit.api.spec.FailureCount;
 import org.javai.punit.api.spec.FailureExemplar;
+import org.javai.punit.api.spec.PerCriterionEvaluation;
+import org.javai.punit.api.spec.PerCriterionVerdict;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
 
@@ -85,6 +88,8 @@ public final class TransparentStatsRenderer {
         for (EvaluatedCriterion entry : result.criterionResults()) {
             renderCriterion(sb, entry);
         }
+
+        renderPerCriterionEvaluation(sb, result.verdict(), result.perCriterionEvaluation());
 
         renderPostconditionFailures(sb, result.failuresByPostcondition());
 
@@ -286,6 +291,59 @@ public final class TransparentStatsRenderer {
                 sb.append("      • ").append(ex.input())
                         .append(" → ").append(ex.reason()).append('\n');
             }
+        }
+        sb.append('\n');
+    }
+
+    /**
+     * Renders the per-criterion methodology-level evaluation: one row
+     * per criterion (id, PASS/FAIL/INCONCLUSIVE counts, observed
+     * pass-rate, threshold, derived verdict), the composite verdict,
+     * and — when composite and the legacy flat-aggregation verdict
+     * disagree — a short callout pointing the reader at the per-criterion
+     * table.
+     *
+     * <p>The composite is observational in this step: the contract's
+     * overall verdict authority is unchanged. The disagreement callout
+     * is the empirical channel by which the disagreement frequency on
+     * real contracts can be observed before any cutover.
+     *
+     * <p>Skipped when no per-criterion data was captured (apply-level
+     * failure paths, or runs whose engine summary used the
+     * back-compat constructor without populating per-criterion counts).
+     */
+    private static void renderPerCriterionEvaluation(
+            StringBuilder sb,
+            Verdict overallVerdict,
+            PerCriterionEvaluation evaluation) {
+        List<PerCriterionVerdict> rows = evaluation.perCriterionVerdicts();
+        if (rows.isEmpty()) {
+            return;
+        }
+        sb.append("  Per-criterion verdicts\n");
+        for (PerCriterionVerdict row : rows) {
+            CriterionSampleCounts c = row.counts();
+            String observedStr = Double.isNaN(row.observed())
+                    ? "n/a"
+                    : formatRate(row.observed());
+            String thresholdStr = Double.isNaN(row.threshold())
+                    ? "n/a"
+                    : formatRate(row.threshold());
+            sb.append("    ").append(row.criterionId())
+                    .append(" → ").append(row.verdict()).append('\n');
+            sb.append(label("Counts:", String.format(Locale.ROOT,
+                    "pass=%d, fail=%d, inconclusive=%d, total=%d",
+                    c.pass(), c.fail(), c.inconclusive(), c.total())));
+            sb.append(label("Observed rate:", observedStr));
+            sb.append(label("Threshold:", thresholdStr));
+        }
+        sb.append(label("Composite:", evaluation.compositeVerdict().toString()));
+        if (evaluation.compositeVerdict() != overallVerdict) {
+            sb.append("    ! Composite verdict (")
+                    .append(evaluation.compositeVerdict())
+                    .append(") differs from overall verdict (")
+                    .append(overallVerdict)
+                    .append("); see per-criterion table above.\n");
         }
         sb.append('\n');
     }

--- a/punit-core/src/test/java/org/javai/punit/api/spec/PerCriterionVerdictsTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/PerCriterionVerdictsTest.java
@@ -1,0 +1,123 @@
+package org.javai.punit.api.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PerCriterionVerdicts derivation")
+class PerCriterionVerdictsTest {
+
+    private static EvaluatedCriterion legacyPass(double threshold) {
+        return new EvaluatedCriterion(
+                new CriterionResult(
+                        "bernoulli-pass-rate",
+                        Verdict.PASS,
+                        "ok",
+                        Map.of("threshold", threshold)),
+                CriterionRole.REQUIRED);
+    }
+
+    private static EvaluatedCriterion legacyInconclusive() {
+        return new EvaluatedCriterion(
+                new CriterionResult(
+                        "bernoulli-pass-rate",
+                        Verdict.INCONCLUSIVE,
+                        "no baseline",
+                        Map.of()),
+                CriterionRole.REQUIRED);
+    }
+
+    @Test
+    @DisplayName("empty per-criterion counts yields empty evaluation, composite PASS")
+    void emptyCountsIsEmpty() {
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.80)), List.of());
+        assertThat(eval.perCriterionVerdicts()).isEmpty();
+        assertThat(eval.compositeVerdict()).isEqualTo(Verdict.PASS);
+    }
+
+    @Test
+    @DisplayName("K=1 isomorphism — sole per-criterion verdict matches legacy verdict (PASS)")
+    void k1IsomorphismPass() {
+        // 90 of 100 passed, threshold 0.80 → 0.90 >= 0.80 → PASS, mirrors legacy.
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.80)),
+                List.of(new CriterionSampleCounts("only", 90, 10, 0)));
+        assertThat(eval.perCriterionVerdicts()).hasSize(1);
+        PerCriterionVerdict row = eval.perCriterionVerdicts().get(0);
+        assertThat(row.criterionId()).isEqualTo("only");
+        assertThat(row.verdict()).isEqualTo(Verdict.PASS);
+        assertThat(row.observed()).isEqualTo(0.9);
+        assertThat(row.threshold()).isEqualTo(0.80);
+        assertThat(eval.compositeVerdict()).isEqualTo(Verdict.PASS);
+    }
+
+    @Test
+    @DisplayName("K=1 isomorphism — observed below threshold yields FAIL")
+    void k1IsomorphismFail() {
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.95)),
+                List.of(new CriterionSampleCounts("only", 80, 20, 0)));
+        assertThat(eval.perCriterionVerdicts().get(0).verdict()).isEqualTo(Verdict.FAIL);
+        assertThat(eval.compositeVerdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("inconclusive samples lower the marginal observed rate")
+    void inconclusiveLowersObservedRate() {
+        // 80 PASS, 10 FAIL, 10 INCONCLUSIVE — marginal denominator 100, observed 0.80.
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.85)),
+                List.of(new CriterionSampleCounts("crit", 80, 10, 10)));
+        PerCriterionVerdict row = eval.perCriterionVerdicts().get(0);
+        assertThat(row.observed()).isEqualTo(0.80);
+        assertThat(row.verdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("legacy INCONCLUSIVE propagates to every per-criterion verdict")
+    void legacyInconclusivePropagates() {
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyInconclusive()),
+                List.of(
+                        new CriterionSampleCounts("a", 100, 0, 0),
+                        new CriterionSampleCounts("b", 100, 0, 0)));
+        assertThat(eval.perCriterionVerdicts())
+                .allMatch(r -> r.verdict() == Verdict.INCONCLUSIVE);
+        assertThat(eval.compositeVerdict()).isEqualTo(Verdict.INCONCLUSIVE);
+    }
+
+    @Test
+    @DisplayName("K>1 hiding result — one criterion fails, others pass, composite FAILs")
+    void hidingResultExposed() {
+        // The "hiding result" the methodology warns against: a single
+        // criterion is genuinely failing but flat-aggregation would
+        // pass because the other criteria push the overall pass-rate
+        // above threshold. The composite — being FAIL-dominant —
+        // surfaces the failure.
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.85)),
+                List.of(
+                        new CriterionSampleCounts("good-1", 100, 0, 0),
+                        new CriterionSampleCounts("bad", 60, 40, 0),
+                        new CriterionSampleCounts("good-2", 100, 0, 0)));
+        List<Verdict> verdicts = eval.perCriterionVerdicts().stream()
+                .map(PerCriterionVerdict::verdict).toList();
+        assertThat(verdicts).containsExactly(Verdict.PASS, Verdict.FAIL, Verdict.PASS);
+        assertThat(eval.compositeVerdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("zero-sample criterion yields INCONCLUSIVE")
+    void zeroSampleCriterionInconclusive() {
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.80)),
+                List.of(new CriterionSampleCounts("empty", 0, 0, 0)));
+        assertThat(eval.perCriterionVerdicts().get(0).verdict())
+                .isEqualTo(Verdict.INCONCLUSIVE);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/api/spec/VerdictAggregateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/VerdictAggregateTest.java
@@ -1,0 +1,54 @@
+package org.javai.punit.api.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Verdict.aggregate worst-case rule")
+class VerdictAggregateTest {
+
+    @Test
+    @DisplayName("empty list aggregates to PASS")
+    void emptyListPasses() {
+        assertThat(Verdict.aggregate(List.of())).isEqualTo(Verdict.PASS);
+    }
+
+    @Test
+    @DisplayName("all PASS aggregates to PASS")
+    void allPass() {
+        assertThat(Verdict.aggregate(List.of(Verdict.PASS, Verdict.PASS)))
+                .isEqualTo(Verdict.PASS);
+    }
+
+    @Test
+    @DisplayName("any FAIL dominates — FAIL among PASSes aggregates to FAIL")
+    void failDominatesPasses() {
+        assertThat(Verdict.aggregate(List.of(Verdict.PASS, Verdict.FAIL, Verdict.PASS)))
+                .isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("FAIL beats INCONCLUSIVE — disagrees with compose which is INCONCLUSIVE-first")
+    void failDominatesInconclusive() {
+        assertThat(Verdict.aggregate(List.of(Verdict.INCONCLUSIVE, Verdict.FAIL)))
+                .isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE among PASSes aggregates to INCONCLUSIVE")
+    void inconclusiveAmongPasses() {
+        assertThat(Verdict.aggregate(List.of(Verdict.PASS, Verdict.INCONCLUSIVE, Verdict.PASS)))
+                .isEqualTo(Verdict.INCONCLUSIVE);
+    }
+
+    @Test
+    @DisplayName("order-independent — same multiset same answer")
+    void orderIndependent() {
+        assertThat(Verdict.aggregate(List.of(Verdict.PASS, Verdict.FAIL, Verdict.INCONCLUSIVE)))
+                .isEqualTo(Verdict.aggregate(
+                        List.of(Verdict.INCONCLUSIVE, Verdict.FAIL, Verdict.PASS)));
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/internal/reporting/TransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/reporting/TransparentStatsRendererTest.java
@@ -15,9 +15,15 @@ import org.javai.punit.api.covariate.CovariateAlignment;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.CriterionResult;
 import org.javai.punit.api.spec.CriterionRole;
+import org.javai.punit.api.spec.CriterionSampleCounts;
+import org.javai.punit.api.spec.EngineRunSummary;
 import org.javai.punit.api.spec.EvaluatedCriterion;
+import org.javai.punit.api.spec.PerCriterionEvaluation;
+import org.javai.punit.api.spec.PerCriterionVerdict;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
+
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -386,6 +392,97 @@ class TransparentStatsRendererTest {
 
             assertThat(rendered).contains("Single trip — 1 failure\n");
             assertThat(rendered).contains("Multi trip — 5 failures\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("Per-criterion methodology block")
+    class PerCriterionBlock {
+
+        private static ProbabilisticTestResult resultWithEvaluation(
+                Verdict overall, PerCriterionEvaluation evaluation) {
+            return new ProbabilisticTestResult(
+                    overall,
+                    FactorBundle.empty(),
+                    List.of(),
+                    TestIntent.VERIFICATION,
+                    List.of(),
+                    CovariateAlignment.none(),
+                    Optional.empty(),
+                    Map.of(),
+                    EngineRunSummary.empty(),
+                    evaluation);
+        }
+
+        @Test
+        @DisplayName("renders per-criterion rows with counts, observed rate, threshold")
+        void rendersPerCriterionRows() {
+            PerCriterionEvaluation eval = new PerCriterionEvaluation(
+                    List.of(
+                            new PerCriterionVerdict(
+                                    "response-not-empty",
+                                    Verdict.PASS,
+                                    new CriterionSampleCounts("response-not-empty", 100, 0, 0),
+                                    1.0,
+                                    0.85),
+                            new PerCriterionVerdict(
+                                    "valid-json",
+                                    Verdict.PASS,
+                                    new CriterionSampleCounts("valid-json", 90, 5, 5),
+                                    0.90,
+                                    0.85)),
+                    Verdict.PASS);
+
+            String rendered = TransparentStatsRenderer.render(
+                    "shopping-basket.test", resultWithEvaluation(Verdict.PASS, eval));
+
+            assertThat(rendered)
+                    .contains("Per-criterion verdicts")
+                    .contains("response-not-empty → PASS")
+                    .contains("valid-json → PASS")
+                    .contains("pass=100, fail=0, inconclusive=0, total=100")
+                    .contains("pass=90, fail=5, inconclusive=5, total=100")
+                    .contains("Threshold:")
+                    .contains("0.8500")
+                    .contains("Composite:")
+                    .contains("PASS");
+        }
+
+        @Test
+        @DisplayName("emits disagreement callout when composite differs from overall")
+        void disagreementCallout() {
+            PerCriterionEvaluation eval = new PerCriterionEvaluation(
+                    List.of(
+                            new PerCriterionVerdict(
+                                    "good",
+                                    Verdict.PASS,
+                                    new CriterionSampleCounts("good", 100, 0, 0),
+                                    1.0,
+                                    0.85),
+                            new PerCriterionVerdict(
+                                    "bad",
+                                    Verdict.FAIL,
+                                    new CriterionSampleCounts("bad", 60, 40, 0),
+                                    0.60,
+                                    0.85)),
+                    Verdict.FAIL);
+
+            String rendered = TransparentStatsRenderer.render(
+                    "test", resultWithEvaluation(Verdict.PASS, eval));
+
+            assertThat(rendered)
+                    .contains("Composite verdict (FAIL) differs from overall verdict (PASS)")
+                    .contains("see per-criterion table");
+        }
+
+        @Test
+        @DisplayName("no per-criterion block when evaluation is empty (back-compat path)")
+        void emptyEvaluationOmitsBlock() {
+            String rendered = TransparentStatsRenderer.render(
+                    "test", resultWithEvaluation(Verdict.PASS, PerCriterionEvaluation.empty()));
+
+            assertThat(rendered).doesNotContain("Per-criterion verdicts");
+            assertThat(rendered).doesNotContain("Composite:");
         }
     }
 }


### PR DESCRIPTION
## Summary

Step 3 of the multi-criterion rollout. Lands the per-criterion three-valued verdict for every methodology-level criterion the contract declares, the composite verdict over those per-criterion verdicts under the methodology's worst-case rule, and surfaces both — plus a disagreement callout — through the transparent-stats output.

Implements `DIR-CRITERION-STEP-3-PER-CRITERION-VERDICTS-punit.md` from the orchestrator. References CR07 (three-valued criterion verdict — aggregate piece), CR09 (composite verdict — first-class concept), CR01 (criterion as partition unit). Aligns with Statistical Companion §1.4.3, §1.4.5, §1.4.6.

## What is new

- **`api.criterion.CriterionSampleResult`s are retained.** `ServiceContractOutcome` gains an optional 7th component `criterionSampleResults` populated by `Contract.evaluateClauses`. Until now those evaluations were folded into the flat `List<PostconditionResult>` and discarded.
- **Per-criterion sample-count accumulator.** `Engine.Aggregator` accumulates per-criterion PASS / FAIL / INCONCLUSIVE counts (keyed by criterion id, order-preserving). Surfaced via the new optional `SampleSummary.criterionSampleCounts` field.
- **`Verdict.aggregate(List<Verdict>)`** — new method implementing the methodology's FAIL-dominant composite rule (empty → PASS; any FAIL → FAIL; else any INCONCLUSIVE → INCONCLUSIVE; else PASS). Distinct from the existing `Verdict.compose(List<EvaluatedCriterion>)` which is INCONCLUSIVE-first and operates over spec-layer evaluated criteria with role filtering — both methods coexist for their respective scopes.
- **Per-criterion verdict derivation.** `api.spec.PerCriterionVerdicts.derive(...)` reuses the threshold the legacy verdict path already resolved (via `PassRate.evaluate`) and applies the same `observed >= threshold` rule once per methodology criterion, then aggregates into a composite. When the legacy composite is INCONCLUSIVE (gate fired, no baseline, sample-size violation, identity mismatch) every per-criterion verdict propagates as INCONCLUSIVE. No new statistical arithmetic — the helper is glue, the statistics live in `org.javai.punit.statistics` and `PassRate`.
- **`ProbabilisticTestResult.perCriterionEvaluation`** — new optional component carrying both the per-criterion verdicts and the composite. Existing call sites construct via a back-compat 9-arg constructor that defaults the component to `PerCriterionEvaluation.empty()`.
- **Transparent-stats output.** `TransparentStatsRenderer` renders a `Per-criterion verdicts` block (id, counts, observed rate, threshold, verdict per criterion) followed by the `Composite:` line, and emits a disagreement callout when the composite differs from the legacy overall verdict.

## What is explicitly NOT changed

- **The contract's overall verdict authority is unchanged.** `ProbabilisticTest.conclude` continues to use `Verdict.compose(evaluated)` over the spec-layer evaluated criteria as the authoritative verdict. The composite is observational in this step. Replacing the legacy authority is the subject of step 4 — this step supplies the empirical evidence (disagreement frequency on real contracts) the cutover relies on.
- **`punit-report/src/main/resources/.../verdict-1.0.xsd` is unchanged.** Per-criterion + composite surface through the punit-internal transparent-stats channel only. The cross-framework verdict XML schema bump (which feotest also reads) lands in step 4 when the composite becomes authoritative.
- **Conformance-fixture consumption is deferred to step 4.** The javai-R v0.8.0 `criterion_verdict_*.json` / `composite_verdict.json` fixtures are eligible consumers; wiring them into a conformance test is cleaner when the composite is the verdict authority.
- **Each criterion inherits the contract's threshold / alpha / mode.** No per-criterion threshold authoring surface (a later directive). No criterion mode toggle (CR08 out of scope). No procedure direction (CR04 out of scope). No configurable denominator policy (CR05 out of scope — marginal default persists).
- **`Contract.postconditions()` is not removed.**

## Test plan

- [x] `./gradlew test` green in punit (`punit-core`, `punit-report`, `punit-sentinel`, `punit-gradle-plugin`).
- [x] ArchUnit clean: `RequirementCodeIsolationTest`, `CoreArchitectureTest`, `RuntimeArchitectureTest`, `AbstractionLevelArchitectureTest`, `SentinelArchitectureTest`.
- [x] Statistics isolation preserved — no new arithmetic outside `org.javai.punit.statistics`.
- [x] No requirement-code leakage anywhere in `src/main` or `src/test`.
- [x] K=1 isomorphism test: sole per-criterion verdict equals the legacy flat-aggregation verdict on multiple pass-rate / threshold triples.
- [x] K>1 disagreement scenario test: contract whose composite is FAIL but flat-aggregation would PASS (the "hiding result"); both verdicts surface, callout appears.
- [x] Renderer test: per-criterion block and disagreement callout render with the expected text; empty evaluation suppresses the block (back-compat path).
- [x] Byte-identical legacy verdicts on all existing punit tests; the new fields are additive and default to empty via back-compat constructors.
- [x] punitexamples: the only failing test (`ShoppingBasketDiagnosticsTest.contractualAtExplicitThreshold`) fails identically on `main` — pre-existing feasibility-gate IllegalStateException, unrelated to this PR.

## Commit map

1. Retain per-criterion sample results on `ServiceContractOutcome` (plumbing).
2. Accumulate per-criterion sample counts; add `Verdict.aggregate`.
3. Derive per-criterion verdicts + composite on `ProbabilisticTestResult`.
4. Surface per-criterion verdicts + composite in transparent-stats output.
5. Tests for `Verdict.aggregate`, `PerCriterionVerdicts`, and the renderer's per-criterion block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)