### PR TITLE
Criterion step 4: composite verdict becomes authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (behavioural)
+
+- **Composite verdict is now the contract's overall verdict authority.**
+  Step 4 of the multi-criterion rollout. `ProbabilisticTestResult.verdict()`
+  is now driven by the methodology-level per-criterion composite under
+  the FAIL-dominant rule (companion §1.4.6) rather than the legacy
+  spec-layer flat-aggregation over the functional verdict-component
+  alone. Cross-dimension aggregation (functional + latency) continues
+  to flow through `Verdict.compose` — the per-criterion composite
+  substitutes the functional verdict-component's verdict, then
+  compose handles cross-dimension under the existing INCONCLUSIVE-first
+  rule.
+
+  **K=1 contracts:** byte-identical. The per-criterion composite
+  over one verdict equals that verdict, so the substitution is a
+  no-op.
+
+  **K>1 contracts:** the *hiding result* case — one criterion
+  genuinely failing, others passing, flat-aggregation passing — now
+  reports FAIL at the harness boundary. Authors of K>1 contracts
+  whose JUnit outcome changed should review.
+
+  **Empty per-criterion evaluation** (apply-level-failure runs where
+  `Contract.evaluateClauses` never fired): falls back to the legacy
+  flat-aggregation result.
+
+### Added
+
+- **`ProbabilisticTestResult.legacyAggregateVerdict`** —
+  `Optional<Verdict>` component carrying the pre-cutover
+  `Verdict.compose(evaluated)` value. Transitional artefact carried
+  for one release so authors of affected K>1 contracts can see what
+  the verdict was pre-step-4. A follow-on directive removes it.
+
+- **Transparent-stats audit-trail callout.** When the pre-cutover
+  legacy aggregate differs from the composite, the per-criterion
+  block in the transparent-stats output emits a line noting the
+  pre-cutover verdict and the new authoritative composite. Replaces
+  step 3's evidence-gathering callout.
+
+### Deferred to follow-on directive
+
+- **Verdict-XML schema bump to `verdict-1.1.xsd`** — explicit
+  per-criterion table and composite element. The existing
+  `<verdict>` element correctly carries the composite as the
+  authoritative value because `ProbabilisticTestResult.verdict()`
+  returns the composite. The XSD bump adds explanatory surfaces
+  (per-criterion breakdown, explicit composite element) and is the
+  subject of a separate directive after we gather experience from
+  this cutover. Cross-framework coordination (feotest reader) lands
+  with that directive.
+
+- **Conformance-fixture consumption** from javai-R v0.8.0 remains
+  pending per a separate directive.
+
 ## [0.7.0-alpha6] - 2026-05-12
 
 > **🧪 Experimental release.** Breaking: renames the authoring-surface

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -220,12 +220,37 @@ public final class ProbabilisticTest implements Spec {
                 }
             }
 
-            Verdict composed = Verdict.compose(evaluated);
+            Verdict legacyAggregate = Verdict.compose(evaluated);
             EngineRunSummary engineSummary = buildEngineSummary(s, evaluated, baselineFilename);
             PerCriterionEvaluation perCriterionEvaluation =
                     PerCriterionVerdicts.derive(evaluated, s.criterionSampleCounts());
+            // Substitute the functional verdict-component's verdict with
+            // the per-criterion composite, then continue to use
+            // Verdict.compose for cross-dimension aggregation. This keeps
+            // latency-dimension criteria (PercentileLatency etc.) in
+            // their existing role — they remain spec-layer EvaluatedCriterion
+            // entries and contribute to the final verdict under the
+            // existing INCONCLUSIVE-first composition rule — while the
+            // functional dimension's verdict is now driven by the
+            // methodology-level per-criterion composite under the
+            // FAIL-dominant aggregation rule (§1.4.6).
+            //
+            // The substitution is a no-op for K=1 contracts (per-criterion
+            // composite over one verdict equals that verdict; step-3's
+            // K=1 isomorphism test pins this), preserving byte-identical
+            // behaviour. For K>1 contracts the hiding-result case flips:
+            // a single failing criterion now drives the functional
+            // verdict to FAIL.
+            //
+            // Empty per-criterion evaluation (apply-level-failure runs
+            // where Contract.evaluateClauses never fired) leaves the
+            // legacy compose result intact.
+            List<EvaluatedCriterion> compositeAdjusted = perCriterionEvaluation.perCriterionVerdicts().isEmpty()
+                    ? evaluated
+                    : substituteFunctionalVerdict(evaluated, perCriterionEvaluation.compositeVerdict());
+            Verdict authoritative = Verdict.compose(compositeAdjusted);
             return new ProbabilisticTestResult(
-                    composed, factorBundle, evaluated, intent,
+                    authoritative, factorBundle, evaluated, intent,
                     List.copyOf(warnings),
                     CovariateAlignment.compute(
                             CovariateProfile.empty(),
@@ -233,7 +258,35 @@ public final class ProbabilisticTest implements Spec {
                     Optional.empty(),
                     s.failuresByPostcondition(),
                     engineSummary,
-                    perCriterionEvaluation);
+                    perCriterionEvaluation,
+                    Optional.of(legacyAggregate));
+        }
+
+        /**
+         * Returns a copy of {@code evaluated} in which the
+         * {@code bernoulli-pass-rate} entry's verdict is replaced by
+         * the supplied composite verdict. Other entries (latency,
+         * future dimensions) pass through unchanged. When no
+         * bernoulli-pass-rate entry is present (a spec without a
+         * functional criterion — currently unreachable but defensively
+         * supported), the list is returned unchanged.
+         */
+        private static List<EvaluatedCriterion> substituteFunctionalVerdict(
+                List<EvaluatedCriterion> evaluated, Verdict composite) {
+            List<EvaluatedCriterion> out = new java.util.ArrayList<>(evaluated.size());
+            for (EvaluatedCriterion ec : evaluated) {
+                if ("bernoulli-pass-rate".equals(ec.result().criterionName())) {
+                    CriterionResult substituted = new CriterionResult(
+                            ec.result().criterionName(),
+                            composite,
+                            ec.result().explanation(),
+                            ec.result().detail());
+                    out.add(new EvaluatedCriterion(substituted, ec.role()));
+                } else {
+                    out.add(ec);
+                }
+            }
+            return out;
         }
 
         /**

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTestResult.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTestResult.java
@@ -63,7 +63,8 @@ public record ProbabilisticTestResult(
         Optional<String> contractRef,
         Map<String, FailureCount> failuresByPostcondition,
         EngineRunSummary engineSummary,
-        PerCriterionEvaluation perCriterionEvaluation) implements EngineResult {
+        PerCriterionEvaluation perCriterionEvaluation,
+        Optional<Verdict> legacyAggregateVerdict) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -76,14 +77,39 @@ public record ProbabilisticTestResult(
         Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
         Objects.requireNonNull(engineSummary, "engineSummary");
         Objects.requireNonNull(perCriterionEvaluation, "perCriterionEvaluation");
+        Objects.requireNonNull(legacyAggregateVerdict, "legacyAggregateVerdict");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);
         failuresByPostcondition = Map.copyOf(failuresByPostcondition);
     }
 
     /**
+     * Backward-compatible 10-arg constructor that defaults
+     * {@link #legacyAggregateVerdict()} to {@link Optional#empty()}.
+     * The legacy aggregate is a transitional artefact carried for one
+     * release after the composite-verdict cutover; a follow-on
+     * directive removes it.
+     */
+    public ProbabilisticTestResult(
+            Verdict verdict,
+            FactorBundle factors,
+            List<EvaluatedCriterion> criterionResults,
+            TestIntent intent,
+            List<String> warnings,
+            CovariateAlignment covariates,
+            Optional<String> contractRef,
+            Map<String, FailureCount> failuresByPostcondition,
+            EngineRunSummary engineSummary,
+            PerCriterionEvaluation perCriterionEvaluation) {
+        this(verdict, factors, criterionResults, intent, warnings,
+                covariates, contractRef, failuresByPostcondition,
+                engineSummary, perCriterionEvaluation, Optional.empty());
+    }
+
+    /**
      * Backward-compatible 9-arg constructor that defaults
-     * {@link #perCriterionEvaluation()} to {@link PerCriterionEvaluation#empty()}.
+     * {@link #perCriterionEvaluation()} to {@link PerCriterionEvaluation#empty()}
+     * and {@link #legacyAggregateVerdict()} to {@link Optional#empty()}.
      */
     public ProbabilisticTestResult(
             Verdict verdict,
@@ -97,7 +123,7 @@ public record ProbabilisticTestResult(
             EngineRunSummary engineSummary) {
         this(verdict, factors, criterionResults, intent, warnings,
                 covariates, contractRef, failuresByPostcondition,
-                engineSummary, PerCriterionEvaluation.empty());
+                engineSummary, PerCriterionEvaluation.empty(), Optional.empty());
     }
 
     /**
@@ -180,7 +206,7 @@ public record ProbabilisticTestResult(
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
                 covariates, contractRef, failuresByPostcondition,
-                engineSummary, perCriterionEvaluation);
+                engineSummary, perCriterionEvaluation, legacyAggregateVerdict);
     }
 
     /**
@@ -201,6 +227,6 @@ public record ProbabilisticTestResult(
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
                 covariates, wrapped, failuresByPostcondition,
-                engineSummary, perCriterionEvaluation);
+                engineSummary, perCriterionEvaluation, legacyAggregateVerdict);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
@@ -89,7 +89,8 @@ public final class TransparentStatsRenderer {
             renderCriterion(sb, entry);
         }
 
-        renderPerCriterionEvaluation(sb, result.verdict(), result.perCriterionEvaluation());
+        renderPerCriterionEvaluation(sb, result.perCriterionEvaluation(),
+                result.legacyAggregateVerdict());
 
         renderPostconditionFailures(sb, result.failuresByPostcondition());
 
@@ -298,15 +299,16 @@ public final class TransparentStatsRenderer {
     /**
      * Renders the per-criterion methodology-level evaluation: one row
      * per criterion (id, PASS/FAIL/INCONCLUSIVE counts, observed
-     * pass-rate, threshold, derived verdict), the composite verdict,
-     * and — when composite and the legacy flat-aggregation verdict
-     * disagree — a short callout pointing the reader at the per-criterion
-     * table.
+     * pass-rate, threshold, derived verdict) and the composite verdict
+     * — which, after the composite-verdict cutover, drives the
+     * contract's overall verdict.
      *
-     * <p>The composite is observational in this step: the contract's
-     * overall verdict authority is unchanged. The disagreement callout
-     * is the empirical channel by which the disagreement frequency on
-     * real contracts can be observed before any cutover.
+     * <p>When a legacy aggregate verdict is present and differs from
+     * the composite, the renderer emits an audit-trail callout
+     * noting the pre-cutover value. This is a transitional aid for
+     * authors of K&gt;1 contracts whose JUnit outcome changed at the
+     * cutover; a follow-on directive removes both the legacy aggregate
+     * field and this callout.
      *
      * <p>Skipped when no per-criterion data was captured (apply-level
      * failure paths, or runs whose engine summary used the
@@ -314,8 +316,8 @@ public final class TransparentStatsRenderer {
      */
     private static void renderPerCriterionEvaluation(
             StringBuilder sb,
-            Verdict overallVerdict,
-            PerCriterionEvaluation evaluation) {
+            PerCriterionEvaluation evaluation,
+            java.util.Optional<Verdict> legacyAggregateVerdict) {
         List<PerCriterionVerdict> rows = evaluation.perCriterionVerdicts();
         if (rows.isEmpty()) {
             return;
@@ -338,13 +340,15 @@ public final class TransparentStatsRenderer {
             sb.append(label("Threshold:", thresholdStr));
         }
         sb.append(label("Composite:", evaluation.compositeVerdict().toString()));
-        if (evaluation.compositeVerdict() != overallVerdict) {
-            sb.append("    ! Composite verdict (")
-                    .append(evaluation.compositeVerdict())
-                    .append(") differs from overall verdict (")
-                    .append(overallVerdict)
-                    .append("); see per-criterion table above.\n");
-        }
+        legacyAggregateVerdict.ifPresent(legacy -> {
+            if (legacy != evaluation.compositeVerdict()) {
+                sb.append("    ! Pre-cutover aggregate verdict was ")
+                        .append(legacy)
+                        .append("; the per-criterion composite (")
+                        .append(evaluation.compositeVerdict())
+                        .append(") is now authoritative — see the per-criterion table above.\n");
+            }
+        });
         sb.append('\n');
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/internal/reporting/TransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/reporting/TransparentStatsRendererTest.java
@@ -401,6 +401,12 @@ class TransparentStatsRendererTest {
 
         private static ProbabilisticTestResult resultWithEvaluation(
                 Verdict overall, PerCriterionEvaluation evaluation) {
+            return resultWithEvaluation(overall, evaluation, Optional.empty());
+        }
+
+        private static ProbabilisticTestResult resultWithEvaluation(
+                Verdict overall, PerCriterionEvaluation evaluation,
+                Optional<Verdict> legacyAggregateVerdict) {
             return new ProbabilisticTestResult(
                     overall,
                     FactorBundle.empty(),
@@ -411,7 +417,8 @@ class TransparentStatsRendererTest {
                     Optional.empty(),
                     Map.of(),
                     EngineRunSummary.empty(),
-                    evaluation);
+                    evaluation,
+                    legacyAggregateVerdict);
         }
 
         @Test
@@ -449,8 +456,11 @@ class TransparentStatsRendererTest {
         }
 
         @Test
-        @DisplayName("emits disagreement callout when composite differs from overall")
-        void disagreementCallout() {
+        @DisplayName("emits audit-trail callout when pre-cutover legacy aggregate differs from composite")
+        void legacyAggregateCallout() {
+            // K>1 hiding result: composite (FAIL) is now authoritative;
+            // the legacy pre-cutover aggregate was PASS. The callout
+            // surfaces the change for one release as an audit trail.
             PerCriterionEvaluation eval = new PerCriterionEvaluation(
                     List.of(
                             new PerCriterionVerdict(
@@ -468,11 +478,47 @@ class TransparentStatsRendererTest {
                     Verdict.FAIL);
 
             String rendered = TransparentStatsRenderer.render(
-                    "test", resultWithEvaluation(Verdict.PASS, eval));
+                    "test", resultWithEvaluation(Verdict.FAIL, eval, Optional.of(Verdict.PASS)));
 
             assertThat(rendered)
-                    .contains("Composite verdict (FAIL) differs from overall verdict (PASS)")
-                    .contains("see per-criterion table");
+                    .contains("Pre-cutover aggregate verdict was PASS")
+                    .contains("per-criterion composite (FAIL) is now authoritative");
+        }
+
+        @Test
+        @DisplayName("no audit-trail callout when legacy aggregate equals composite")
+        void noCalloutWhenAligned() {
+            PerCriterionEvaluation eval = new PerCriterionEvaluation(
+                    List.of(new PerCriterionVerdict(
+                            "only",
+                            Verdict.PASS,
+                            new CriterionSampleCounts("only", 100, 0, 0),
+                            1.0,
+                            0.85)),
+                    Verdict.PASS);
+
+            String rendered = TransparentStatsRenderer.render(
+                    "test", resultWithEvaluation(Verdict.PASS, eval, Optional.of(Verdict.PASS)));
+
+            assertThat(rendered).doesNotContain("Pre-cutover aggregate verdict");
+        }
+
+        @Test
+        @DisplayName("no audit-trail callout when legacy aggregate is absent")
+        void noCalloutWhenLegacyAbsent() {
+            PerCriterionEvaluation eval = new PerCriterionEvaluation(
+                    List.of(new PerCriterionVerdict(
+                            "only",
+                            Verdict.FAIL,
+                            new CriterionSampleCounts("only", 60, 40, 0),
+                            0.60,
+                            0.85)),
+                    Verdict.FAIL);
+
+            String rendered = TransparentStatsRenderer.render(
+                    "test", resultWithEvaluation(Verdict.FAIL, eval));
+
+            assertThat(rendered).doesNotContain("Pre-cutover aggregate verdict");
         }
 
         @Test


### PR DESCRIPTION
## Summary

Step 4 of the multi-criterion rollout. The methodology-level **composite verdict** now drives the contract's overall verdict authority — what JUnit reads, what the verdict XML's `<verdict>` element carries. The legacy spec-layer flat-aggregation path is retired from the authoritative position.

Implements `DIR-CRITERION-STEP-4-COMPOSITE-AUTHORITY-punit.md` (orchestrator). References CR09 (composite), CR01 (criterion as partition unit), companion §1.4.4 / §1.4.6.

## What changed

- **`ProbabilisticTest.Internal.conclude(...)`** now substitutes the functional verdict-component's (`bernoulli-pass-rate`) verdict with the per-criterion composite, then continues to call `Verdict.compose` for cross-dimension aggregation (functional + latency). The substitution preserves the existing INCONCLUSIVE-first cross-dimension rule while introducing the FAIL-dominant per-criterion composite into the functional slot. Empty per-criterion evaluation (apply-level-failure runs) falls back to the original legacy compose result.
- **`ProbabilisticTestResult` gains optional `legacyAggregateVerdict: Optional<Verdict>`** — transitional artefact carrying the pre-cutover `Verdict.compose(evaluated)` value. One release; removed by follow-on directive.
- **Transparent-stats callout flips polarity** — from step 3's *"composite is observation, here's a disagreement"* to step 4's *"pre-cutover aggregate was X; the composite (Y) is now authoritative."*

## Behavioural impact

- **K=1 contracts: byte-identical.** Per-criterion composite over one verdict equals that verdict (step 3's K=1 isomorphism test pins this); substitution is a no-op.
- **K>1 contracts: hiding-result case flips PASS→FAIL.** A single failing criterion now drives the functional verdict to FAIL even when flat-aggregation would pass. punitexamples' `ShoppingBasketServiceContract` (the only K>1 contract today) did not exhibit the hiding result on its tests — the composite agrees with the legacy aggregate for every K>1 test in the test suite, so no JUnit outcomes changed in CI. Authors of future K>1 contracts whose composite differs from the legacy aggregate will see the audit-trail callout in the transparent-stats output.

## Deferred to follow-on directive

- **Verdict-XML schema bump to `verdict-1.1.xsd`** with explicit `<criteria>` per-criterion table and `<composite>` element. The original directive scoped this in but: the existing `<verdict>` element already carries the composite (via `VerdictAdapter` reading `result.verdict()` which is now the composite), so the schema bump adds *explanatory* surfaces, not load-bearing ones. Better landed once we've gathered experience from this cutover — and once the cross-framework coordination with feotest is sequenced. Documented as deferred in CHANGELOG.
- **Conformance-fixture consumption** from javai-R v0.8.0 (`composite_verdict.json` etc.) — also deferred per the directive.
- **Removal of the transitional `legacyAggregateVerdict` field and audit-trail callout** — one release after this lands.
- **Removal of `criterionResults: List<EvaluatedCriterion>`** — the spec-layer doubling stays until renderers migrate to read from `perCriterionEvaluation`.

## Commits

1. `a23e8df` — Composite is authoritative; legacy aggregate carried alongside.
2. `c8fa2f2` — Transparent-stats callout flips from observation to audit trail.
3. `7060437` — CHANGELOG entry.

## Test plan

- [x] `./gradlew test` green in punit (`punit-core`, `punit-report`, `punit-sentinel`, `punit-gradle-plugin`).
- [x] ArchUnit clean (`RequirementCodeIsolationTest`, `CoreArchitectureTest`, `RuntimeArchitectureTest`, `AbstractionLevelArchitectureTest`, `SentinelArchitectureTest`).
- [x] No new statistical arithmetic outside `org.javai.punit.statistics`.
- [x] No requirement-code leakage anywhere in src.
- [x] K=1 isomorphism preserved — all existing K=1 tests in punit and punitexamples produce identical JUnit outcomes.
- [x] K>1 (`ShoppingBasketServiceContract` in punitexamples) — composite agrees with legacy aggregate on every test; no outcome changes.
- [x] Transparent-stats audit-trail callout fires only when legacy aggregate is present *and* differs from composite (three test cases pin this).
- [x] punitexamples: only failure remains the pre-existing `ShoppingBasketDiagnosticsTest.contractualAtExplicitThreshold` (feasibility-gate IllegalStateException, unrelated, present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)