### PR TITLE
Remove legacy-aggregate transitional surfaces; schema 1.1 → 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed (legacy-aggregate deprecation close-out)
+
+- **`ProbabilisticTestResult.legacyAggregateVerdict`** —
+  the transitional `Optional<Verdict>` field introduced at the
+  step-4 cutover for one release as an audit-trail aid for K>1
+  contracts whose JUnit outcome changed. The one-release window has
+  closed; the field is gone. `ProbabilisticTest.conclude(...)` no
+  longer computes the pre-cutover legacy aggregate.
+
+- **`ProbabilisticTestVerdict.legacyAggregateVerdict`** and the
+  matching builder setter — same field at the persistence layer, also
+  gone.
+
+- **`<legacy-aggregate>` XML element** — the transitional one-release
+  child of `<per-criterion>` is withdrawn. The schema bumps from
+  `verdict-1.1.xsd` to `verdict-1.2.xsd`; the new schema's
+  `PerCriterionType` carries `<criterion>*` and `<composite>` only.
+  Both `verdict-1.0.xsd` and `verdict-1.1.xsd` are retained for one
+  release each as references. The `VerdictXmlReader` remains
+  permissive — a stray `<legacy-aggregate>` element from a 1.1
+  emitter still in service is silently ignored at parse, not
+  rejected.
+
+- **Transparent-stats audit-trail callout** — the per-criterion block
+  no longer emits the "pre-cutover aggregate verdict was X; the
+  composite is now authoritative" callout. The block renders the
+  per-criterion table and the composite line only.
+
 ### Added (verdict-XML 1.1 schema)
 
 - **`verdict-1.1.xsd`** — additive schema bump under the existing

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -220,7 +220,6 @@ public final class ProbabilisticTest implements Spec {
                 }
             }
 
-            Verdict legacyAggregate = Verdict.compose(evaluated);
             EngineRunSummary engineSummary = buildEngineSummary(s, evaluated, baselineFilename);
             PerCriterionEvaluation perCriterionEvaluation =
                     PerCriterionVerdicts.derive(evaluated, s.criterionSampleCounts());
@@ -244,7 +243,7 @@ public final class ProbabilisticTest implements Spec {
             //
             // Empty per-criterion evaluation (apply-level-failure runs
             // where Contract.evaluateClauses never fired) leaves the
-            // legacy compose result intact.
+            // unsubstituted compose result intact.
             List<EvaluatedCriterion> compositeAdjusted = perCriterionEvaluation.perCriterionVerdicts().isEmpty()
                     ? evaluated
                     : substituteFunctionalVerdict(evaluated, perCriterionEvaluation.compositeVerdict());
@@ -258,8 +257,7 @@ public final class ProbabilisticTest implements Spec {
                     Optional.empty(),
                     s.failuresByPostcondition(),
                     engineSummary,
-                    perCriterionEvaluation,
-                    Optional.of(legacyAggregate));
+                    perCriterionEvaluation);
         }
 
         /**

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTestResult.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTestResult.java
@@ -63,8 +63,7 @@ public record ProbabilisticTestResult(
         Optional<String> contractRef,
         Map<String, FailureCount> failuresByPostcondition,
         EngineRunSummary engineSummary,
-        PerCriterionEvaluation perCriterionEvaluation,
-        Optional<Verdict> legacyAggregateVerdict) implements EngineResult {
+        PerCriterionEvaluation perCriterionEvaluation) implements EngineResult {
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -77,39 +76,14 @@ public record ProbabilisticTestResult(
         Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
         Objects.requireNonNull(engineSummary, "engineSummary");
         Objects.requireNonNull(perCriterionEvaluation, "perCriterionEvaluation");
-        Objects.requireNonNull(legacyAggregateVerdict, "legacyAggregateVerdict");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);
         failuresByPostcondition = Map.copyOf(failuresByPostcondition);
     }
 
     /**
-     * Backward-compatible 10-arg constructor that defaults
-     * {@link #legacyAggregateVerdict()} to {@link Optional#empty()}.
-     * The legacy aggregate is a transitional artefact carried for one
-     * release after the composite-verdict cutover; a follow-on
-     * directive removes it.
-     */
-    public ProbabilisticTestResult(
-            Verdict verdict,
-            FactorBundle factors,
-            List<EvaluatedCriterion> criterionResults,
-            TestIntent intent,
-            List<String> warnings,
-            CovariateAlignment covariates,
-            Optional<String> contractRef,
-            Map<String, FailureCount> failuresByPostcondition,
-            EngineRunSummary engineSummary,
-            PerCriterionEvaluation perCriterionEvaluation) {
-        this(verdict, factors, criterionResults, intent, warnings,
-                covariates, contractRef, failuresByPostcondition,
-                engineSummary, perCriterionEvaluation, Optional.empty());
-    }
-
-    /**
      * Backward-compatible 9-arg constructor that defaults
-     * {@link #perCriterionEvaluation()} to {@link PerCriterionEvaluation#empty()}
-     * and {@link #legacyAggregateVerdict()} to {@link Optional#empty()}.
+     * {@link #perCriterionEvaluation()} to {@link PerCriterionEvaluation#empty()}.
      */
     public ProbabilisticTestResult(
             Verdict verdict,
@@ -123,7 +97,7 @@ public record ProbabilisticTestResult(
             EngineRunSummary engineSummary) {
         this(verdict, factors, criterionResults, intent, warnings,
                 covariates, contractRef, failuresByPostcondition,
-                engineSummary, PerCriterionEvaluation.empty(), Optional.empty());
+                engineSummary, PerCriterionEvaluation.empty());
     }
 
     /**
@@ -206,7 +180,7 @@ public record ProbabilisticTestResult(
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
                 covariates, contractRef, failuresByPostcondition,
-                engineSummary, perCriterionEvaluation, legacyAggregateVerdict);
+                engineSummary, perCriterionEvaluation);
     }
 
     /**
@@ -227,6 +201,6 @@ public record ProbabilisticTestResult(
         return new ProbabilisticTestResult(
                 verdict, factors, criterionResults, intent, warnings,
                 covariates, wrapped, failuresByPostcondition,
-                engineSummary, perCriterionEvaluation, legacyAggregateVerdict);
+                engineSummary, perCriterionEvaluation);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
@@ -89,8 +89,7 @@ public final class TransparentStatsRenderer {
             renderCriterion(sb, entry);
         }
 
-        renderPerCriterionEvaluation(sb, result.perCriterionEvaluation(),
-                result.legacyAggregateVerdict());
+        renderPerCriterionEvaluation(sb, result.perCriterionEvaluation());
 
         renderPostconditionFailures(sb, result.failuresByPostcondition());
 
@@ -300,15 +299,8 @@ public final class TransparentStatsRenderer {
      * Renders the per-criterion methodology-level evaluation: one row
      * per criterion (id, PASS/FAIL/INCONCLUSIVE counts, observed
      * pass-rate, threshold, derived verdict) and the composite verdict
-     * — which, after the composite-verdict cutover, drives the
+     * — which, since the composite-verdict cutover, drives the
      * contract's overall verdict.
-     *
-     * <p>When a legacy aggregate verdict is present and differs from
-     * the composite, the renderer emits an audit-trail callout
-     * noting the pre-cutover value. This is a transitional aid for
-     * authors of K&gt;1 contracts whose JUnit outcome changed at the
-     * cutover; a follow-on directive removes both the legacy aggregate
-     * field and this callout.
      *
      * <p>Skipped when no per-criterion data was captured (apply-level
      * failure paths, or runs whose engine summary used the
@@ -316,8 +308,7 @@ public final class TransparentStatsRenderer {
      */
     private static void renderPerCriterionEvaluation(
             StringBuilder sb,
-            PerCriterionEvaluation evaluation,
-            java.util.Optional<Verdict> legacyAggregateVerdict) {
+            PerCriterionEvaluation evaluation) {
         List<PerCriterionVerdict> rows = evaluation.perCriterionVerdicts();
         if (rows.isEmpty()) {
             return;
@@ -340,15 +331,6 @@ public final class TransparentStatsRenderer {
             sb.append(label("Threshold:", thresholdStr));
         }
         sb.append(label("Composite:", evaluation.compositeVerdict().toString()));
-        legacyAggregateVerdict.ifPresent(legacy -> {
-            if (legacy != evaluation.compositeVerdict()) {
-                sb.append("    ! Pre-cutover aggregate verdict was ")
-                        .append(legacy)
-                        .append("; the per-criterion composite (")
-                        .append(evaluation.compositeVerdict())
-                        .append(") is now authoritative — see the per-criterion table above.\n");
-            }
-        });
         sb.append('\n');
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/VerdictAdapter.java
@@ -180,11 +180,6 @@ public final class VerdictAdapter {
         // evaluations leave the field absent.
         b.perCriterion(translatePerCriterion(result.perCriterionEvaluation()));
 
-        // Transitional one-release audit-trail field. Mirrors
-        // ProbabilisticTestResult.legacyAggregateVerdict's Optional;
-        // null leaves the field absent.
-        result.legacyAggregateVerdict().ifPresent(b::legacyAggregateVerdict);
-
         return b.build();
     }
 

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
@@ -42,8 +42,7 @@ public record ProbabilisticTestVerdict(
         PUnitVerdict punitVerdict,
         String verdictReason,
         Map<String, FailureCount> postconditionFailures,
-        Optional<PerCriterionStructure> perCriterion,
-        Optional<org.javai.punit.api.spec.Verdict> legacyAggregateVerdict
+        Optional<PerCriterionStructure> perCriterion
 ) {
 
     public ProbabilisticTestVerdict {
@@ -54,17 +53,12 @@ public record ProbabilisticTestVerdict(
                 ? Collections.unmodifiableMap(new LinkedHashMap<>(postconditionFailures))
                 : Map.of();
         perCriterion = perCriterion != null ? perCriterion : Optional.empty();
-        legacyAggregateVerdict = legacyAggregateVerdict != null
-                ? legacyAggregateVerdict
-                : Optional.empty();
     }
 
     /**
      * Backward-compatible constructor for the 17-component shape that
      * predates the per-criterion structural surface (CR09 / CR01 in
-     * the verdict XML). Defaults both new components to empty. Used
-     * by test fixtures and any producer that doesn't yet thread the
-     * per-criterion structure through.
+     * the verdict XML). Defaults the per-criterion component to empty.
      */
     public ProbabilisticTestVerdict(
             String correlationId,
@@ -87,14 +81,13 @@ public record ProbabilisticTestVerdict(
         this(correlationId, timestamp, identity, execution, functional, latency,
                 statistics, covariates, cost, pacing, provenance, termination,
                 environmentMetadata, junitPassed, punitVerdict, verdictReason,
-                postconditionFailures, Optional.empty(), Optional.empty());
+                postconditionFailures, Optional.empty());
     }
 
     /**
      * Backward-compatible constructor for the 16-component shape that
      * predates the per-postcondition failure histogram. Defaults the
-     * histogram to an empty map and the per-criterion structure /
-     * legacy aggregate to empty.
+     * histogram to an empty map and the per-criterion structure to empty.
      */
     public ProbabilisticTestVerdict(
             String correlationId,
@@ -116,7 +109,7 @@ public record ProbabilisticTestVerdict(
         this(correlationId, timestamp, identity, execution, functional, latency,
                 statistics, covariates, cost, pacing, provenance, termination,
                 environmentMetadata, junitPassed, punitVerdict, verdictReason,
-                Map.of(), Optional.empty(), Optional.empty());
+                Map.of(), Optional.empty());
     }
 
     // ── TestIdentity ──────────────────────────────────────────────────────

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -120,7 +120,6 @@ public class ProbabilisticTestVerdictBuilder {
     // ProbabilisticTestResult.perCriterionEvaluation() on every normal
     // run; empty for apply-level-failure paths.
     private Optional<PerCriterionStructure> perCriterion = Optional.empty();
-    private Optional<Verdict> legacyAggregateVerdict = Optional.empty();
 
     // ── Builder methods ───────────────────────────────────────────────────
 
@@ -325,17 +324,6 @@ public class ProbabilisticTestVerdictBuilder {
         return this;
     }
 
-    /**
-     * The pre-cutover legacy aggregate verdict, transitional one-release
-     * audit-trail field mirroring
-     * {@code ProbabilisticTestResult.legacyAggregateVerdict()}.
-     * {@code null} leaves the field empty.
-     */
-    public ProbabilisticTestVerdictBuilder legacyAggregateVerdict(Verdict legacyAggregateVerdict) {
-        this.legacyAggregateVerdict = Optional.ofNullable(legacyAggregateVerdict);
-        return this;
-    }
-
     // ── Build ─────────────────────────────────────────────────────────────
 
     public ProbabilisticTestVerdict build() {
@@ -359,8 +347,7 @@ public class ProbabilisticTestVerdictBuilder {
                 covariates, cost, pacing, provenance, termination,
                 environmentMetadata, junitPassed, punitVerdict, verdictReason,
                 postconditionFailures,
-                perCriterion,
-                legacyAggregateVerdict
+                perCriterion
         );
     }
 

--- a/punit-core/src/test/java/org/javai/punit/internal/reporting/TransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/reporting/TransparentStatsRendererTest.java
@@ -401,12 +401,6 @@ class TransparentStatsRendererTest {
 
         private static ProbabilisticTestResult resultWithEvaluation(
                 Verdict overall, PerCriterionEvaluation evaluation) {
-            return resultWithEvaluation(overall, evaluation, Optional.empty());
-        }
-
-        private static ProbabilisticTestResult resultWithEvaluation(
-                Verdict overall, PerCriterionEvaluation evaluation,
-                Optional<Verdict> legacyAggregateVerdict) {
             return new ProbabilisticTestResult(
                     overall,
                     FactorBundle.empty(),
@@ -417,8 +411,7 @@ class TransparentStatsRendererTest {
                     Optional.empty(),
                     Map.of(),
                     EngineRunSummary.empty(),
-                    evaluation,
-                    legacyAggregateVerdict);
+                    evaluation);
         }
 
         @Test
@@ -453,72 +446,6 @@ class TransparentStatsRendererTest {
                     .contains("0.8500")
                     .contains("Composite:")
                     .contains("PASS");
-        }
-
-        @Test
-        @DisplayName("emits audit-trail callout when pre-cutover legacy aggregate differs from composite")
-        void legacyAggregateCallout() {
-            // K>1 hiding result: composite (FAIL) is now authoritative;
-            // the legacy pre-cutover aggregate was PASS. The callout
-            // surfaces the change for one release as an audit trail.
-            PerCriterionEvaluation eval = new PerCriterionEvaluation(
-                    List.of(
-                            new PerCriterionVerdict(
-                                    "good",
-                                    Verdict.PASS,
-                                    new CriterionSampleCounts("good", 100, 0, 0),
-                                    1.0,
-                                    0.85),
-                            new PerCriterionVerdict(
-                                    "bad",
-                                    Verdict.FAIL,
-                                    new CriterionSampleCounts("bad", 60, 40, 0),
-                                    0.60,
-                                    0.85)),
-                    Verdict.FAIL);
-
-            String rendered = TransparentStatsRenderer.render(
-                    "test", resultWithEvaluation(Verdict.FAIL, eval, Optional.of(Verdict.PASS)));
-
-            assertThat(rendered)
-                    .contains("Pre-cutover aggregate verdict was PASS")
-                    .contains("per-criterion composite (FAIL) is now authoritative");
-        }
-
-        @Test
-        @DisplayName("no audit-trail callout when legacy aggregate equals composite")
-        void noCalloutWhenAligned() {
-            PerCriterionEvaluation eval = new PerCriterionEvaluation(
-                    List.of(new PerCriterionVerdict(
-                            "only",
-                            Verdict.PASS,
-                            new CriterionSampleCounts("only", 100, 0, 0),
-                            1.0,
-                            0.85)),
-                    Verdict.PASS);
-
-            String rendered = TransparentStatsRenderer.render(
-                    "test", resultWithEvaluation(Verdict.PASS, eval, Optional.of(Verdict.PASS)));
-
-            assertThat(rendered).doesNotContain("Pre-cutover aggregate verdict");
-        }
-
-        @Test
-        @DisplayName("no audit-trail callout when legacy aggregate is absent")
-        void noCalloutWhenLegacyAbsent() {
-            PerCriterionEvaluation eval = new PerCriterionEvaluation(
-                    List.of(new PerCriterionVerdict(
-                            "only",
-                            Verdict.FAIL,
-                            new CriterionSampleCounts("only", 60, 40, 0),
-                            0.60,
-                            0.85)),
-                    Verdict.FAIL);
-
-            String rendered = TransparentStatsRenderer.render(
-                    "test", resultWithEvaluation(Verdict.FAIL, eval));
-
-            assertThat(rendered).doesNotContain("Pre-cutover aggregate verdict");
         }
 
         @Test

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictXmlReader.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictXmlReader.java
@@ -79,11 +79,14 @@ public final class VerdictXmlReader {
         String verdictReason = optionalAttribute(verdictEl, "reason").orElse("");
         boolean junitPassed = punitVerdict != PUnitVerdict.FAIL;
 
-        Optional<Element> perCriterionEl = optionalElement(root, "per-criterion");
+        // The reader is permissive: a <legacy-aggregate> element that
+        // appears inside <per-criterion> (from a 1.1 emitter still in
+        // service) is silently ignored. The transitional surface was
+        // removed in verdict-1.2.xsd; older emitters' output continues
+        // to parse without surprise.
         Optional<org.javai.punit.verdict.PerCriterionStructure> perCriterion =
-                perCriterionEl.flatMap(this::readPerCriterionStructure);
-        Optional<org.javai.punit.api.spec.Verdict> legacyAggregateVerdict =
-                perCriterionEl.flatMap(this::readLegacyAggregate);
+                optionalElement(root, "per-criterion")
+                        .flatMap(this::readPerCriterionStructure);
 
         return new ProbabilisticTestVerdict(
                 correlationId, timestamp, identity, execution,
@@ -95,8 +98,7 @@ public final class VerdictXmlReader {
                 environment,
                 junitPassed, punitVerdict, verdictReason,
                 Map.of(),
-                perCriterion,
-                legacyAggregateVerdict
+                perCriterion
         );
     }
 
@@ -105,9 +107,6 @@ public final class VerdictXmlReader {
         NodeList rows = perCriterionEl.getElementsByTagNameNS(
                 VerdictXmlWriter.NAMESPACE, "criterion");
         Optional<Element> compositeEl = optionalElement(perCriterionEl, "composite");
-        // No criterion rows AND no composite element → no methodology-level
-        // decomposition was emitted (the element exists only to carry a
-        // <legacy-aggregate>). Treat as absent.
         if (rows.getLength() == 0 && compositeEl.isEmpty()) {
             return Optional.empty();
         }
@@ -140,12 +139,6 @@ public final class VerdictXmlReader {
                 });
         return Optional.of(new org.javai.punit.verdict.PerCriterionStructure(
                 criteria, composite));
-    }
-
-    private Optional<org.javai.punit.api.spec.Verdict> readLegacyAggregate(
-            Element perCriterionEl) {
-        return optionalElement(perCriterionEl, "legacy-aggregate")
-                .map(e -> org.javai.punit.api.spec.Verdict.valueOf(e.getAttribute("value")));
     }
 
     private TestIdentity readIdentity(Element el) {

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
@@ -33,7 +33,7 @@ public final class VerdictXmlWriter {
      */
     static final String NAMESPACE = "http://javai.org/verdict/1.0";
     static final String VERSION_1_0 = "1.0";
-    static final String VERSION_1_1 = "1.1";
+    static final String VERSION_1_2 = "1.2";
 
     private static final XMLOutputFactory OUTPUT_FACTORY = XMLOutputFactory.newFactory();
 
@@ -65,12 +65,11 @@ public final class VerdictXmlWriter {
     private void writeVerdictRecord(XMLStreamWriter w, ProbabilisticTestVerdict v) throws XMLStreamException {
         w.writeStartElement("verdict-record");
         w.writeDefaultNamespace(NAMESPACE);
-        // version="1.1" when <per-criterion> content is populated;
+        // version="1.2" when <per-criterion> content is populated;
         // "1.0" otherwise. Consumers inspecting the attribute remain
         // correctly informed about which optional elements may appear.
-        boolean emit11Surface = v.perCriterion().isPresent()
-                || v.legacyAggregateVerdict().isPresent();
-        w.writeAttribute("version", emit11Surface ? VERSION_1_1 : VERSION_1_0);
+        w.writeAttribute("version",
+                v.perCriterion().isPresent() ? VERSION_1_2 : VERSION_1_0);
         w.writeAttribute("timestamp", v.timestamp().toString());
         w.writeAttribute("generator", resolveGenerator());
         if (v.correlationId() != null && !v.correlationId().isEmpty()) {
@@ -99,37 +98,30 @@ public final class VerdictXmlWriter {
 
     private void writePerCriterion(XMLStreamWriter w, ProbabilisticTestVerdict v)
             throws XMLStreamException {
-        if (v.perCriterion().isEmpty() && v.legacyAggregateVerdict().isEmpty()) {
+        if (v.perCriterion().isEmpty()) {
             return;
         }
+        org.javai.punit.verdict.PerCriterionStructure pc = v.perCriterion().get();
         w.writeStartElement("per-criterion");
-        if (v.perCriterion().isPresent()) {
-            org.javai.punit.verdict.PerCriterionStructure pc = v.perCriterion().get();
-            for (org.javai.punit.verdict.CriterionRow row : pc.criteria()) {
-                w.writeStartElement("criterion");
-                w.writeAttribute("id", row.criterionId());
-                w.writeAttribute("verdict", row.verdict().name());
-                w.writeAttribute("pass", Integer.toString(row.pass()));
-                w.writeAttribute("fail", Integer.toString(row.fail()));
-                w.writeAttribute("inconclusive", Integer.toString(row.inconclusive()));
-                w.writeAttribute("total", Integer.toString(row.total()));
-                if (!Double.isNaN(row.observedRate())) {
-                    w.writeAttribute("observed-rate", formatDouble(row.observedRate()));
-                }
-                if (!Double.isNaN(row.threshold())) {
-                    w.writeAttribute("threshold", formatDouble(row.threshold()));
-                }
-                w.writeEndElement();
+        for (org.javai.punit.verdict.CriterionRow row : pc.criteria()) {
+            w.writeStartElement("criterion");
+            w.writeAttribute("id", row.criterionId());
+            w.writeAttribute("verdict", row.verdict().name());
+            w.writeAttribute("pass", Integer.toString(row.pass()));
+            w.writeAttribute("fail", Integer.toString(row.fail()));
+            w.writeAttribute("inconclusive", Integer.toString(row.inconclusive()));
+            w.writeAttribute("total", Integer.toString(row.total()));
+            if (!Double.isNaN(row.observedRate())) {
+                w.writeAttribute("observed-rate", formatDouble(row.observedRate()));
             }
-            w.writeStartElement("composite");
-            w.writeAttribute("value", pc.composite().name());
+            if (!Double.isNaN(row.threshold())) {
+                w.writeAttribute("threshold", formatDouble(row.threshold()));
+            }
             w.writeEndElement();
         }
-        if (v.legacyAggregateVerdict().isPresent()) {
-            w.writeStartElement("legacy-aggregate");
-            w.writeAttribute("value", v.legacyAggregateVerdict().get().name());
-            w.writeEndElement();
-        }
+        w.writeStartElement("composite");
+        w.writeAttribute("value", pc.composite().name());
+        w.writeEndElement();
         w.writeEndElement();
     }
 

--- a/punit-report/src/main/resources/org/javai/punit/report/verdict-1.2.xsd
+++ b/punit-report/src/main/resources/org/javai/punit/report/verdict-1.2.xsd
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://javai.org/verdict/1.0"
+           targetNamespace="http://javai.org/verdict/1.0"
+           elementFormDefault="qualified">
+
+  <!-- ===================================================================
+       Root elements
+       =================================================================== -->
+
+  <xs:element name="verdict-record" type="tns:VerdictRecordType"/>
+  <xs:element name="verdict-suite"  type="tns:VerdictSuiteType"/>
+
+  <!-- ===================================================================
+       Suite envelope (for batch processing / XSLT input)
+       =================================================================== -->
+
+  <xs:complexType name="VerdictSuiteType">
+    <xs:sequence>
+      <xs:element ref="tns:verdict-record" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="timestamp" type="xs:dateTime" use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Verdict record (one per test execution)
+       =================================================================== -->
+
+  <xs:complexType name="VerdictRecordType">
+    <xs:all>
+      <xs:element name="identity"     type="tns:IdentityType"/>
+      <xs:element name="execution"    type="tns:ExecutionType"/>
+      <xs:element name="factors"      type="tns:FactorsType"      minOccurs="0"/>
+      <xs:element name="functional"   type="tns:FunctionalType"   minOccurs="0"/>
+      <xs:element name="latency"      type="tns:LatencyType"      minOccurs="0"/>
+      <xs:element name="statistics"   type="tns:StatisticsType"   minOccurs="0"/>
+      <xs:element name="covariates"   type="tns:CovariatesType"/>
+      <xs:element name="provenance"   type="tns:ProvenanceType"   minOccurs="0"/>
+      <xs:element name="baseline"     type="tns:BaselineType"     minOccurs="0"/>
+      <xs:element name="termination"  type="tns:TerminationType"/>
+      <xs:element name="cost"         type="tns:CostType"         minOccurs="0"/>
+      <xs:element name="warnings"     type="tns:WarningsType"     minOccurs="0"/>
+      <xs:element name="pacing"       type="tns:PacingType"       minOccurs="0"/>
+      <xs:element name="environment"  type="tns:EnvironmentType"  minOccurs="0"/>
+      <xs:element name="postcondition-failures" type="tns:PostconditionFailuresType" minOccurs="0"/>
+      <xs:element name="per-criterion" type="tns:PerCriterionType" minOccurs="0"/>
+      <xs:element name="verdict"      type="tns:VerdictType"/>
+    </xs:all>
+    <!-- version: "1.0" or "1.2". 1.2 emitters set version="1.2"
+         when <per-criterion> content is populated; otherwise stay
+         at "1.0" so consumers inspecting the version attribute
+         remain correctly informed. -->
+    <!-- 1.2 withdrawal: the <legacy-aggregate> child of <per-criterion>,
+         present in 1.1 as a one-release audit-trail element, is gone.
+         Producers emitting 1.2-shaped content do not write the
+         element; permissive readers may continue to ignore it when
+         encountered in 1.1-shaped content from older emitters in
+         service. See plan/directives/DIR-LEGACY-AGGREGATE-VERDICT-REMOVAL-punit.md
+         for the deprecation close-out. -->
+    <xs:attribute name="version"        type="xs:string"   use="required"/>
+    <xs:attribute name="timestamp"      type="xs:dateTime"  use="required"/>
+    <xs:attribute name="generator"      type="xs:string"    use="required"/>
+    <xs:attribute name="correlation-id" type="xs:string"    use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Identity
+       =================================================================== -->
+
+  <xs:complexType name="IdentityType">
+    <xs:attribute name="use-case-id" type="xs:string" use="required"/>
+    <xs:attribute name="test-name"   type="xs:string" use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Execution
+       =================================================================== -->
+
+  <xs:complexType name="ExecutionType">
+    <xs:attribute name="planned-samples"  type="xs:int"    use="required"/>
+    <xs:attribute name="samples-executed" type="xs:int"    use="required"/>
+    <xs:attribute name="successes"        type="xs:int"    use="required"/>
+    <xs:attribute name="failures"         type="xs:int"    use="required"/>
+    <xs:attribute name="elapsed-ms"       type="xs:long"   use="required"/>
+    <xs:attribute name="intent"           type="tns:IntentEnum" use="required"/>
+    <xs:attribute name="confidence"       type="xs:double" use="required"/>
+    <xs:attribute name="warmup"           type="xs:int"    use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="IntentEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="VERIFICATION"/>
+      <xs:enumeration value="SMOKE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Factor bundle (FT instance the test ran under; shape-symmetric
+       with EX04 baseline factors:)
+       =================================================================== -->
+
+  <xs:complexType name="FactorsType">
+    <xs:sequence>
+      <xs:element name="entry" type="tns:FactorEntryType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="FactorEntryType">
+    <xs:attribute name="key"   type="xs:string"           use="required"/>
+    <xs:attribute name="value" type="xs:string"           use="required"/>
+    <xs:attribute name="type"  type="tns:FactorTypeEnum"  use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="FactorTypeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="number"/>
+      <xs:enumeration value="boolean"/>
+      <xs:enumeration value="enum"/>
+      <xs:enumeration value="duration"/>
+      <xs:enumeration value="instant"/>
+      <xs:enumeration value="uri"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Functional dimension
+       =================================================================== -->
+
+  <xs:complexType name="FunctionalType">
+    <xs:sequence>
+      <xs:element name="failure-distribution" type="tns:FailureDistributionType"
+                  minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="successes" type="xs:int"    use="required"/>
+    <xs:attribute name="failures"  type="xs:int"    use="required"/>
+    <xs:attribute name="pass-rate" type="xs:double" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="FailureDistributionType">
+    <xs:sequence>
+      <xs:element name="check" type="tns:CheckType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CheckType">
+    <xs:attribute name="name"  type="xs:string" use="required"/>
+    <xs:attribute name="count" type="xs:int"    use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Latency dimension
+       =================================================================== -->
+
+  <xs:complexType name="LatencyType">
+    <xs:sequence>
+      <xs:element name="observed"    type="tns:ObservedPercentilesType" minOccurs="0"/>
+      <xs:element name="evaluations" type="tns:EvaluationsType"        minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="successful-samples"  type="xs:int" use="required"/>
+    <xs:attribute name="strict-violations"   type="xs:int" use="required"/>
+    <xs:attribute name="advisory-violations" type="xs:int" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="ObservedPercentilesType">
+    <xs:sequence>
+      <xs:element name="percentile" type="tns:ObservedPercentileType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="ObservedPercentileType">
+    <xs:attribute name="label"    type="tns:PercentileLabelEnum" use="required"/>
+    <xs:attribute name="value-ms" type="xs:long"                 use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="EvaluationsType">
+    <xs:sequence>
+      <xs:element name="evaluation" type="tns:EvaluationType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EvaluationType">
+    <xs:attribute name="percentile"          type="tns:PercentileLabelEnum"   use="required"/>
+    <xs:attribute name="observed-ms"         type="xs:long"                   use="optional"/>
+    <xs:attribute name="threshold-ms"        type="xs:long"                   use="required"/>
+    <xs:attribute name="provenance"          type="tns:LatencyProvenanceEnum" use="required"/>
+    <xs:attribute name="mode"                type="tns:EnforcementModeEnum"   use="required"/>
+    <xs:attribute name="status"              type="tns:EvaluationStatusEnum"  use="required"/>
+    <!-- Present only when provenance="baseline-derived" -->
+    <xs:attribute name="baseline-confidence" type="xs:double"                 use="optional"/>
+    <xs:attribute name="baseline-rank"       type="xs:int"                    use="optional"/>
+    <xs:attribute name="baseline-n"          type="xs:int"                    use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="PercentileLabelEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="p50"/>
+      <xs:enumeration value="p90"/>
+      <xs:enumeration value="p95"/>
+      <xs:enumeration value="p99"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="LatencyProvenanceEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="explicit"/>
+      <xs:enumeration value="baseline-derived"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EnforcementModeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="strict"/>
+      <xs:enumeration value="advisory"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EvaluationStatusEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PASS"/>
+      <xs:enumeration value="STRICT_FAIL"/>
+      <xs:enumeration value="ADVISORY_WARN"/>
+      <xs:enumeration value="INFEASIBLE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Statistical analysis
+       =================================================================== -->
+
+  <xs:complexType name="StatisticsType">
+    <xs:attribute name="confidence-level" type="xs:double"               use="required"/>
+    <xs:attribute name="standard-error"   type="xs:double"               use="required"/>
+    <xs:attribute name="wilson-lower"     type="xs:double"               use="required"/>
+    <xs:attribute name="threshold"        type="xs:double"               use="required"/>
+    <xs:attribute name="threshold-origin" type="tns:ThresholdOriginEnum" use="required"/>
+    <xs:attribute name="test-statistic"   type="xs:double"               use="optional"/>
+    <xs:attribute name="p-value"          type="xs:double"               use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ThresholdOriginEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SLA"/>
+      <xs:enumeration value="SLO"/>
+      <xs:enumeration value="POLICY"/>
+      <xs:enumeration value="EMPIRICAL"/>
+      <xs:enumeration value="UNSPECIFIED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Covariates
+       =================================================================== -->
+
+  <xs:complexType name="CovariatesType">
+    <xs:sequence>
+      <xs:element name="misalignment" type="tns:MisalignmentType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="aligned" type="xs:boolean" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="MisalignmentType">
+    <xs:attribute name="key"            type="xs:string" use="required"/>
+    <xs:attribute name="baseline-value" type="xs:string" use="required"/>
+    <xs:attribute name="observed-value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Provenance (policy context)
+       =================================================================== -->
+
+  <xs:complexType name="ProvenanceType">
+    <xs:sequence>
+      <xs:element name="expiration" type="tns:ExpirationType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="origin"        type="tns:ThresholdOriginEnum" use="required"/>
+    <xs:attribute name="spec-filename" type="xs:string"               use="optional"/>
+    <xs:attribute name="contract-ref"  type="xs:string"               use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="ExpirationType">
+    <xs:attribute name="status"           type="tns:ExpirationStatusEnum" use="required"/>
+    <xs:attribute name="expires-at"       type="xs:dateTime"              use="optional"/>
+    <xs:attribute name="requires-warning" type="xs:boolean"               use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ExpirationStatusEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NO_EXPIRATION"/>
+      <xs:enumeration value="VALID"/>
+      <xs:enumeration value="EXPIRING_SOON"/>
+      <xs:enumeration value="EXPIRING_IMMINENTLY"/>
+      <xs:enumeration value="EXPIRED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Baseline (measurement context)
+       =================================================================== -->
+
+  <xs:complexType name="BaselineType">
+    <xs:attribute name="source-file"       type="xs:string"   use="required"/>
+    <xs:attribute name="generated-at"      type="xs:dateTime" use="required"/>
+    <xs:attribute name="samples"           type="xs:int"      use="required"/>
+    <xs:attribute name="baseline-rate"     type="xs:double"   use="required"/>
+    <xs:attribute name="derived-threshold" type="xs:double"   use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Termination
+       =================================================================== -->
+
+  <xs:complexType name="TerminationType">
+    <xs:attribute name="reason" type="tns:TerminationReasonEnum" use="required"/>
+    <xs:attribute name="detail" type="xs:string"                 use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="TerminationReasonEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="COMPLETED"/>
+      <xs:enumeration value="FAILURE_INEVITABLE"/>
+      <xs:enumeration value="SUCCESS_GUARANTEED"/>
+      <xs:enumeration value="TIME_BUDGET_EXHAUSTED"/>
+      <xs:enumeration value="TOKEN_BUDGET_EXHAUSTED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Cost
+       =================================================================== -->
+
+  <xs:complexType name="CostType">
+    <xs:attribute name="total-time-ms"         type="xs:long" use="required"/>
+    <xs:attribute name="total-tokens"          type="xs:long" use="required"/>
+    <xs:attribute name="avg-time-per-sample-ms" type="xs:long" use="required"/>
+    <xs:attribute name="avg-tokens-per-sample" type="xs:long" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Warnings
+       =================================================================== -->
+
+  <xs:complexType name="WarningsType">
+    <xs:sequence>
+      <xs:element name="warning" type="tns:WarningType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="WarningType" mixed="true">
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Postcondition failures (per-clause histogram with bounded exemplars)
+       =================================================================== -->
+
+  <xs:complexType name="PostconditionFailuresType">
+    <xs:sequence>
+      <xs:element name="clause" type="tns:PostconditionClauseFailureType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="PostconditionClauseFailureType">
+    <xs:sequence>
+      <xs:element name="exemplar" type="tns:PostconditionExemplarType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="description" type="xs:string" use="required"/>
+    <xs:attribute name="count"       type="xs:int"    use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="PostconditionExemplarType">
+    <xs:attribute name="input"  type="xs:string" use="required"/>
+    <xs:attribute name="reason" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Pacing
+       =================================================================== -->
+
+  <xs:complexType name="PacingType">
+    <xs:attribute name="max-rps"                type="xs:double" use="required"/>
+    <xs:attribute name="max-rpm"                type="xs:double" use="required"/>
+    <xs:attribute name="max-concurrent"         type="xs:int"    use="required"/>
+    <xs:attribute name="effective-min-delay-ms" type="xs:long"   use="required"/>
+    <xs:attribute name="effective-concurrency"  type="xs:int"    use="required"/>
+    <xs:attribute name="effective-rps"          type="xs:double" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Environment metadata
+       =================================================================== -->
+
+  <xs:complexType name="EnvironmentType">
+    <xs:sequence>
+      <xs:element name="entry" type="tns:EnvironmentEntryType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EnvironmentEntryType">
+    <xs:attribute name="key"   type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Verdict
+       =================================================================== -->
+
+  <xs:complexType name="VerdictType">
+    <xs:attribute name="value"  type="tns:VerdictEnum" use="required"/>
+    <xs:attribute name="reason" type="xs:string"       use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="VerdictEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PASS"/>
+      <xs:enumeration value="FAIL"/>
+      <xs:enumeration value="INCONCLUSIVE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Per-criterion methodology-level decomposition (1.1 addition,
+       1.2 refinement)
+
+       Carries the per-criterion three-valued aggregate verdicts (CR07)
+       and the composite verdict over them (CR09).
+
+       The bundle is optional under <verdict-record>. Present when the
+       producing run had per-criterion data (every normal run on every
+       contract post-step-4); absent for apply-level-failure runs where
+       the per-criterion evaluation never fired.
+
+       1.2 refinement: the <legacy-aggregate> child element of 1.1
+       (one-release audit-trail of the pre-cutover Verdict.compose
+       result) is withdrawn. Producers do not emit it; permissive
+       readers ignore it when encountered in 1.1-shaped content from
+       older emitters in service.
+       =================================================================== -->
+
+  <xs:complexType name="PerCriterionType">
+    <xs:sequence>
+      <xs:element name="criterion" type="tns:CriterionRowType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="composite" type="tns:CompositeType"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CriterionRowType">
+    <xs:attribute name="id"            type="xs:string"       use="required"/>
+    <xs:attribute name="verdict"       type="tns:VerdictEnum" use="required"/>
+    <xs:attribute name="pass"          type="xs:int"          use="required"/>
+    <xs:attribute name="fail"          type="xs:int"          use="required"/>
+    <xs:attribute name="inconclusive"  type="xs:int"          use="required"/>
+    <xs:attribute name="total"         type="xs:int"          use="required"/>
+    <!-- observed-rate and threshold are optional because the in-memory
+         values may be NaN (zero-sample criterion; threshold not yet
+         resolved). Emitters omit the attribute when the value is NaN. -->
+    <xs:attribute name="observed-rate" type="xs:double"       use="optional"/>
+    <xs:attribute name="threshold"     type="xs:double"       use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="CompositeType">
+    <xs:attribute name="value" type="tns:VerdictEnum" use="required"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictXmlReaderTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictXmlReaderTest.java
@@ -356,11 +356,11 @@ class VerdictXmlReaderTest {
     }
 
     @Nested
-    @DisplayName("per-criterion 1.1 surface round-trip")
+    @DisplayName("per-criterion 1.2 surface round-trip")
     class PerCriterionRoundTrip {
 
         @Test
-        @DisplayName("K=1 per-criterion bundle round-trips with preserved row, composite, absent legacy-aggregate")
+        @DisplayName("K=1 per-criterion bundle round-trips with preserved row, composite")
         void k1RoundTrip() throws Exception {
             org.javai.punit.verdict.PerCriterionStructure pc =
                     new org.javai.punit.verdict.PerCriterionStructure(
@@ -369,8 +369,7 @@ class VerdictXmlReaderTest {
                                     org.javai.punit.api.spec.Verdict.PASS,
                                     100, 0, 0, 1.0, 0.85)),
                             org.javai.punit.api.spec.Verdict.PASS);
-            ProbabilisticTestVerdict original = verdictWithPerCriterion(
-                    pc, Optional.empty(), PUnitVerdict.PASS);
+            ProbabilisticTestVerdict original = verdictWithPerCriterion(pc, PUnitVerdict.PASS);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -380,12 +379,11 @@ class VerdictXmlReaderTest {
                     .isEqualTo("only");
             assertThat(result.perCriterion().get().composite())
                     .isEqualTo(org.javai.punit.api.spec.Verdict.PASS);
-            assertThat(result.legacyAggregateVerdict()).isEmpty();
         }
 
         @Test
-        @DisplayName("K>1 hiding result: rows in order, composite FAIL, legacy-aggregate PASS")
-        void k2WithLegacyAggregateRoundTrip() throws Exception {
+        @DisplayName("K>1 hiding result: rows in order, composite FAIL")
+        void k2RoundTrip() throws Exception {
             org.javai.punit.verdict.PerCriterionStructure pc =
                     new org.javai.punit.verdict.PerCriterionStructure(
                             List.of(
@@ -398,10 +396,7 @@ class VerdictXmlReaderTest {
                                             org.javai.punit.api.spec.Verdict.FAIL,
                                             60, 40, 0, 0.60, 0.85)),
                             org.javai.punit.api.spec.Verdict.FAIL);
-            ProbabilisticTestVerdict original = verdictWithPerCriterion(
-                    pc,
-                    Optional.of(org.javai.punit.api.spec.Verdict.PASS),
-                    PUnitVerdict.FAIL);
+            ProbabilisticTestVerdict original = verdictWithPerCriterion(pc, PUnitVerdict.FAIL);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -416,8 +411,6 @@ class VerdictXmlReaderTest {
             assertThat(criteria.get(1).threshold()).isEqualTo(0.85);
             assertThat(result.perCriterion().get().composite())
                     .isEqualTo(org.javai.punit.api.spec.Verdict.FAIL);
-            assertThat(result.legacyAggregateVerdict())
-                    .contains(org.javai.punit.api.spec.Verdict.PASS);
         }
 
         @Test
@@ -431,8 +424,7 @@ class VerdictXmlReaderTest {
                                     0, 0, 0,
                                     Double.NaN, Double.NaN)),
                             org.javai.punit.api.spec.Verdict.INCONCLUSIVE);
-            ProbabilisticTestVerdict original = verdictWithPerCriterion(
-                    pc, Optional.empty(), PUnitVerdict.INCONCLUSIVE);
+            ProbabilisticTestVerdict original = verdictWithPerCriterion(pc, PUnitVerdict.INCONCLUSIVE);
 
             ProbabilisticTestVerdict result = roundTrip(original);
 
@@ -449,7 +441,47 @@ class VerdictXmlReaderTest {
             ProbabilisticTestVerdict result = roundTrip(original);
 
             assertThat(result.perCriterion()).isEmpty();
-            assertThat(result.legacyAggregateVerdict()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("stray <legacy-aggregate> from a 1.1 emitter is ignored at parse")
+        void legacyAggregateIgnored() throws Exception {
+            // Hand-rolled 1.1-shaped XML carrying a <legacy-aggregate>
+            // child. The permissive reader parses the <per-criterion>
+            // bundle without surprise; the legacy element is silently
+            // discarded.
+            String xml = """
+                    <verdict-record xmlns="http://javai.org/verdict/1.0"
+                                    version="1.1"
+                                    timestamp="2026-03-11T14:30:00Z"
+                                    generator="test">
+                      <identity use-case-id="com.example.Test" test-name="t"/>
+                      <execution planned-samples="1" samples-executed="1"
+                                 successes="1" failures="0" elapsed-ms="0"
+                                 intent="VERIFICATION" confidence="0.95"/>
+                      <statistics confidence-level="0.95" standard-error="0"
+                                  wilson-lower="0" threshold="0.5"
+                                  threshold-origin="SLA"/>
+                      <covariates aligned="true"/>
+                      <termination reason="COMPLETED"/>
+                      <per-criterion>
+                        <criterion id="only" verdict="FAIL"
+                                   pass="60" fail="40" inconclusive="0" total="100"
+                                   observed-rate="0.60" threshold="0.85"/>
+                        <composite value="FAIL"/>
+                        <legacy-aggregate value="PASS"/>
+                      </per-criterion>
+                      <verdict value="FAIL"/>
+                    </verdict-record>
+                    """;
+            ProbabilisticTestVerdict result = reader.read(
+                    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+            assertThat(result.perCriterion()).isPresent();
+            assertThat(result.perCriterion().get().composite())
+                    .isEqualTo(org.javai.punit.api.spec.Verdict.FAIL);
+            // The <legacy-aggregate> element exists no more — no field
+            // on the parsed verdict record surfaces it.
         }
     }
 
@@ -457,7 +489,6 @@ class VerdictXmlReaderTest {
 
     private ProbabilisticTestVerdict verdictWithPerCriterion(
             org.javai.punit.verdict.PerCriterionStructure perCriterion,
-            Optional<org.javai.punit.api.spec.Verdict> legacyAggregate,
             PUnitVerdict punitVerdict) {
         ProbabilisticTestVerdict base = minimalVerdict(
                 punitVerdict != PUnitVerdict.FAIL, punitVerdict);
@@ -470,8 +501,7 @@ class VerdictXmlReaderTest {
                 base.environmentMetadata(), base.junitPassed(),
                 base.punitVerdict(), base.verdictReason(),
                 base.postconditionFailures(),
-                Optional.of(perCriterion),
-                legacyAggregate);
+                Optional.of(perCriterion));
     }
 
     private ProbabilisticTestVerdict roundTrip(ProbabilisticTestVerdict verdict) throws XMLStreamException {

--- a/punit-report/src/test/java/org/javai/punit/report/VerdictXmlWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/VerdictXmlWriterTest.java
@@ -560,11 +560,11 @@ class VerdictXmlWriterTest {
     }
 
     @Nested
-    @DisplayName("per-criterion XML surface (1.1)")
+    @DisplayName("per-criterion XML surface (1.2)")
     class PerCriterionXmlTests {
 
         @Test
-        @DisplayName("K=1: emits single criterion row, composite matches verdict, no legacy-aggregate")
+        @DisplayName("K=1: emits single criterion row, composite matches verdict")
         void k1Emission() throws Exception {
             org.javai.punit.verdict.PerCriterionStructure pc =
                     new org.javai.punit.verdict.PerCriterionStructure(
@@ -575,13 +575,13 @@ class VerdictXmlWriterTest {
                                     1.0, 0.85)),
                             org.javai.punit.api.spec.Verdict.PASS);
             ProbabilisticTestVerdict verdict = verdictWithPerCriterion(
-                    pc, Optional.empty(), PUnitVerdict.PASS);
+                    pc, PUnitVerdict.PASS);
 
             Document doc = writeAndParse(verdict);
             Element root = doc.getDocumentElement();
             Element perCriterion = firstElement(doc, "per-criterion");
 
-            assertThat(root.getAttribute("version")).isEqualTo("1.1");
+            assertThat(root.getAttribute("version")).isEqualTo("1.2");
             NodeList rows = perCriterion.getElementsByTagNameNS(
                     VerdictXmlWriter.NAMESPACE, "criterion");
             assertThat(rows.getLength()).isEqualTo(1);
@@ -596,14 +596,11 @@ class VerdictXmlWriterTest {
             Element composite = (Element) perCriterion.getElementsByTagNameNS(
                     VerdictXmlWriter.NAMESPACE, "composite").item(0);
             assertThat(composite.getAttribute("value")).isEqualTo("PASS");
-            assertThat(perCriterion.getElementsByTagNameNS(
-                    VerdictXmlWriter.NAMESPACE, "legacy-aggregate").getLength())
-                    .isZero();
         }
 
         @Test
-        @DisplayName("K>1 hiding result: composite FAIL, criteria rows in order, audit-trail legacy-aggregate")
-        void k2WithLegacyAggregate() throws Exception {
+        @DisplayName("K>1 hiding result: composite FAIL, criteria rows in declaration order")
+        void k2Emission() throws Exception {
             org.javai.punit.verdict.PerCriterionStructure pc =
                     new org.javai.punit.verdict.PerCriterionStructure(
                             List.of(
@@ -617,9 +614,7 @@ class VerdictXmlWriterTest {
                                             60, 40, 0, 0.60, 0.85)),
                             org.javai.punit.api.spec.Verdict.FAIL);
             ProbabilisticTestVerdict verdict = verdictWithPerCriterion(
-                    pc,
-                    Optional.of(org.javai.punit.api.spec.Verdict.PASS),
-                    PUnitVerdict.FAIL);
+                    pc, PUnitVerdict.FAIL);
 
             Document doc = writeAndParse(verdict);
             Element perCriterion = firstElement(doc, "per-criterion");
@@ -635,9 +630,11 @@ class VerdictXmlWriterTest {
                     VerdictXmlWriter.NAMESPACE, "composite").item(0);
             assertThat(composite.getAttribute("value")).isEqualTo("FAIL");
 
-            Element legacy = (Element) perCriterion.getElementsByTagNameNS(
-                    VerdictXmlWriter.NAMESPACE, "legacy-aggregate").item(0);
-            assertThat(legacy.getAttribute("value")).isEqualTo("PASS");
+            // <legacy-aggregate> was the 1.1 transitional element;
+            // 1.2 emitters do not write it.
+            assertThat(perCriterion.getElementsByTagNameNS(
+                    VerdictXmlWriter.NAMESPACE, "legacy-aggregate").getLength())
+                    .isZero();
         }
 
         @Test
@@ -652,7 +649,7 @@ class VerdictXmlWriterTest {
                                     Double.NaN, Double.NaN)),
                             org.javai.punit.api.spec.Verdict.INCONCLUSIVE);
             ProbabilisticTestVerdict verdict = verdictWithPerCriterion(
-                    pc, Optional.empty(), PUnitVerdict.INCONCLUSIVE);
+                    pc, PUnitVerdict.INCONCLUSIVE);
 
             Document doc = writeAndParse(verdict);
             Element perCriterion = firstElement(doc, "per-criterion");
@@ -679,8 +676,8 @@ class VerdictXmlWriterTest {
         }
 
         @Test
-        @DisplayName("emitter output validates against verdict-1.1 schema")
-        void validatesAgainst11Schema() throws Exception {
+        @DisplayName("emitter output validates against verdict-1.2 schema")
+        void validatesAgainst12Schema() throws Exception {
             org.javai.punit.verdict.PerCriterionStructure pc =
                     new org.javai.punit.verdict.PerCriterionStructure(
                             List.of(
@@ -694,46 +691,21 @@ class VerdictXmlWriterTest {
                                             60, 40, 0, 0.60, 0.85)),
                             org.javai.punit.api.spec.Verdict.FAIL);
             ProbabilisticTestVerdict verdict = verdictWithPerCriterion(
-                    pc,
-                    Optional.of(org.javai.punit.api.spec.Verdict.PASS),
-                    PUnitVerdict.FAIL);
+                    pc, PUnitVerdict.FAIL);
 
             String xml = writeToString(verdict);
 
-            validateAgainstSchema11(xml);
+            validateAgainstSchema12(xml);
         }
 
         @Test
-        @DisplayName("1.0-only emission still validates against verdict-1.1 schema (additive)")
-        void absentPerCriterionValidatesAgainst11Schema() throws Exception {
+        @DisplayName("1.0-only emission still validates against verdict-1.2 schema (additive)")
+        void absentPerCriterionValidatesAgainst12Schema() throws Exception {
             ProbabilisticTestVerdict verdict = minimalVerdict(true, PUnitVerdict.PASS);
 
             String xml = writeToString(verdict);
 
-            validateAgainstSchema11(xml);
-        }
-
-        @Test
-        @DisplayName("1.1 emission's existing 1.0 elements still validate against verdict-1.0 schema")
-        void existing10ElementsTolerateOldSchema() throws Exception {
-            org.javai.punit.verdict.PerCriterionStructure pc =
-                    new org.javai.punit.verdict.PerCriterionStructure(
-                            List.of(new org.javai.punit.verdict.CriterionRow(
-                                    "only",
-                                    org.javai.punit.api.spec.Verdict.PASS,
-                                    100, 0, 0, 1.0, 0.85)),
-                            org.javai.punit.api.spec.Verdict.PASS);
-            ProbabilisticTestVerdict verdict = verdictWithPerCriterion(
-                    pc, Optional.empty(), PUnitVerdict.PASS);
-
-            // Strict 1.0 validation rejects unknown <per-criterion> content
-            // — that's the documented break. The looser invariant is that
-            // a consumer reading only the 1.0 elements (ignoring unknown
-            // children at parse time) parses them without surprise. The
-            // round-trip test below covers the practical case.
-            String xml = writeToString(verdict);
-            assertThat(xml).contains("<verdict");
-            assertThat(xml).contains("<execution");
+            validateAgainstSchema12(xml);
         }
     }
 
@@ -1009,7 +981,6 @@ class VerdictXmlWriterTest {
 
     private ProbabilisticTestVerdict verdictWithPerCriterion(
             org.javai.punit.verdict.PerCriterionStructure perCriterion,
-            Optional<org.javai.punit.api.spec.Verdict> legacyAggregate,
             PUnitVerdict punitVerdict) {
         ProbabilisticTestVerdict base = minimalVerdict(
                 punitVerdict != PUnitVerdict.FAIL, punitVerdict);
@@ -1022,8 +993,7 @@ class VerdictXmlWriterTest {
                 base.environmentMetadata(), base.junitPassed(),
                 base.punitVerdict(), base.verdictReason(),
                 base.postconditionFailures(),
-                Optional.of(perCriterion),
-                legacyAggregate);
+                Optional.of(perCriterion));
     }
 
     private void validateAgainstSchema(String xml) throws Exception {
@@ -1036,10 +1006,10 @@ class VerdictXmlWriterTest {
         }
     }
 
-    private void validateAgainstSchema11(String xml) throws Exception {
+    private void validateAgainstSchema12(String xml) throws Exception {
         SchemaFactory schemaFactory = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        try (InputStream xsdStream = getClass().getResourceAsStream("/org/javai/punit/report/verdict-1.1.xsd")) {
-            assertThat(xsdStream).as("XSD 1.1 resource must be available").isNotNull();
+        try (InputStream xsdStream = getClass().getResourceAsStream("/org/javai/punit/report/verdict-1.2.xsd")) {
+            assertThat(xsdStream).as("XSD 1.2 resource must be available").isNotNull();
             Schema schema = schemaFactory.newSchema(new StreamSource(xsdStream));
             Validator validator = schema.newValidator();
             validator.validate(new StreamSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));


### PR DESCRIPTION
## Summary

Discharges the deprecation close-out scheduled by step 4. Removes the transitional `legacyAggregateVerdict` audit-trail across **all three** homes it carries today:

1. **In-memory** — `ProbabilisticTestResult.legacyAggregateVerdict` field + the `Verdict.compose(evaluated)` line in `ProbabilisticTest.conclude(...)` that existed solely to populate it.
2. **Persistence-layer** — `ProbabilisticTestVerdict.legacyAggregateVerdict` field + the builder setter + the `VerdictAdapter` propagation.
3. **Wire format** — `<legacy-aggregate>` XML element. Schema bumps from `verdict-1.1.xsd` to `verdict-1.2.xsd`.

Plus the matching audit-trail callout in `TransparentStatsRenderer`.

This is the **first subtractive directive** in the multi-criterion rollout — every prior step has been additive. The directive (`DIR-LEGACY-AGGREGATE-VERDICT-REMOVAL-punit.md`) is explicit that subtractive evolution does not get the back-compat-ctor treatment additive evolution has been getting: the field has only existed for one release, the call-site count is bounded, every site migrates.

## What changed

**Schema** (`punit-report/src/main/resources/org/javai/punit/report/verdict-1.2.xsd`):

```xml
<verdict-record version="1.2" ...>
  ...
  <per-criterion>
    <criterion id="..." verdict="..." pass="..." fail="..." inconclusive="..." total="..."
               observed-rate="..." threshold="..."/>
    ...
    <composite value="..."/>   <!-- no <legacy-aggregate> any more -->
  </per-criterion>
  <verdict value="..."/>
</verdict-record>
```

Namespace stays at `http://javai.org/verdict/1.0`. Filename and root `version` attribute bump. `verdict-1.0.xsd` and `verdict-1.1.xsd` retained for one release each as references.

**Reader stays permissive**: a stray `<legacy-aggregate>` from a 1.1 emitter still in service is silently *ignored*, not rejected. Pinned by a new `legacyAggregateIgnored` round-trip test using hand-rolled 1.1-shaped XML.

**In-memory & persistence types**:

- `ProbabilisticTestResult`: 11 components → 10. The 10-arg back-compat ctor that defaulted the transitional field is gone; the 9-arg back-compat ctor remains for callers that don't carry per-criterion data.
- `ProbabilisticTestVerdict`: 19 components → 18. The 17-arg back-compat ctor (pre-per-criterion) and 16-arg back-compat ctor (pre-postcondition-histogram) both remain.
- `ProbabilisticTestVerdictBuilder.legacyAggregateVerdict(Verdict)` setter and field removed.

**Renderer**: `TransparentStatsRenderer.renderPerCriterionEvaluation(...)` loses its `Optional<Verdict>` parameter; the audit-trail callout block is gone. The per-criterion block renders the table and the composite line only.

## Behavioural impact

- **Zero.** This is a structural cleanup. The composite verdict has been authoritative since step 4 (PR #161). The transitional surfaces were transparency aids; their removal changes nothing about which tests pass or fail.
- **K=1 and K>1 verdicts**: byte-identical.
- **Verdict XML**: 1.2-shaped messages no longer carry `<legacy-aggregate>`. 1.0 and 1.1 consumers reading 1.2 messages continue to parse the 1.0 elements; strict 1.1 validation of 1.2 content sees no `<legacy-aggregate>`, which is what 1.1 declared as optional anyway.

## Test plan

- [x] `./gradlew test` green in punit (`punit-core`, `punit-report`, `punit-sentinel`, `punit-gradle-plugin`).
- [x] ArchUnit clean.
- [x] Writer / reader tests for the transitional callout, `<legacy-aggregate>` emission, and round-trip removed. The new `legacyAggregateIgnored` test pins that the reader silently discards stray 1.1-shaped `<legacy-aggregate>` content.
- [x] `validateAgainstSchema12` test asserts emitter output validates against the new schema.
- [x] No new statistical arithmetic outside `org.javai.punit.statistics` — removals only.
- [x] No requirement-code leakage.
- [x] punitexamples: only the pre-existing `ShoppingBasketDiagnosticsTest.contractualAtExplicitThreshold` failure remains (feasibility-gate IllegalStateException; unrelated; present on `main`).

## Commits

1. `10bf317` — Remove in-memory field + audit-trail callout.
2. `bf0e047` — Remove persistence field + builder setter + XML element + schema bump to 1.2.
3. `afa3e36` — CHANGELOG. (`CLAUDE.md` is gitignored locally; doc home is the orchestrator directive.)

## Followup

Feotest never adopted the transitional surface (its `verdict-1.1.xsd` reader/emitter is still pending). When it adopts the cross-framework schema it adopts `verdict-1.2.xsd` directly — no coordination required for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)