### PR TITLE
Sweep SampleSummary back-compat constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed (`SampleSummary` back-compat constructors)
+
+- **`SampleSummary` 9-arg, 10-arg, and 11-arg back-compat
+  constructors** withdrawn. Introduced over the step-3 / step-4 /
+  step-5 rollout, they have served their migration purpose; every
+  caller now passes the full canonical 12-arg form (outcomes,
+  elapsed, successes, failures, tokensConsumed, failuresDropped,
+  latencyResult, terminationReason, trials, failuresByPostcondition,
+  passingLatencyResult, criterionSampleCounts). A follow-on directive
+  will revisit the shape of `SampleSummary` itself — the canonical
+  arity is the right thing to sweep first, then the shape.
+
 ### Removed (legacy-aggregate deprecation close-out)
 
 - **`ProbabilisticTestResult.legacyAggregateVerdict`** —

--- a/punit-core/src/main/java/org/javai/punit/api/spec/SampleSummary.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/SampleSummary.java
@@ -101,73 +101,6 @@ public record SampleSummary<OT>(
     }
 
     /**
-     * Backward-compatible 11-arg constructor that defaults
-     * {@link #criterionSampleCounts()} to an empty list. Test fixtures
-     * and call sites that don't carry per-criterion sample counts
-     * construct via this overload; the engine constructs summaries via
-     * the canonical constructor with the per-criterion counts populated
-     * from per-sample {@link org.javai.punit.api.criterion.CriterionSampleResult}s.
-     */
-    public SampleSummary(
-            List<ServiceContractOutcome<?, OT>> outcomes,
-            Duration elapsed,
-            int successes,
-            int failures,
-            long tokensConsumed,
-            int failuresDropped,
-            LatencyResult latencyResult,
-            TerminationReason terminationReason,
-            List<Trial<?, OT>> trials,
-            Map<String, FailureCount> failuresByPostcondition,
-            LatencyResult passingLatencyResult) {
-        this(outcomes, elapsed, successes, failures, tokensConsumed,
-                failuresDropped, latencyResult, terminationReason, trials,
-                failuresByPostcondition, passingLatencyResult, List.of());
-    }
-
-    /**
-     * Backward-compatible 10-arg constructor that defaults
-     * {@link #passingLatencyResult()} to {@link LatencyResult#empty()}
-     * and {@link #criterionSampleCounts()} to an empty list.
-     */
-    public SampleSummary(
-            List<ServiceContractOutcome<?, OT>> outcomes,
-            Duration elapsed,
-            int successes,
-            int failures,
-            long tokensConsumed,
-            int failuresDropped,
-            LatencyResult latencyResult,
-            TerminationReason terminationReason,
-            List<Trial<?, OT>> trials,
-            Map<String, FailureCount> failuresByPostcondition) {
-        this(outcomes, elapsed, successes, failures, tokensConsumed,
-                failuresDropped, latencyResult, terminationReason, trials,
-                failuresByPostcondition, LatencyResult.empty(), List.of());
-    }
-
-    /**
-     * Backward-compatible 9-arg constructor that defaults
-     * {@link #failuresByPostcondition()} to an empty map,
-     * {@link #passingLatencyResult()} to {@link LatencyResult#empty()},
-     * and {@link #criterionSampleCounts()} to an empty list.
-     */
-    public SampleSummary(
-            List<ServiceContractOutcome<?, OT>> outcomes,
-            Duration elapsed,
-            int successes,
-            int failures,
-            long tokensConsumed,
-            int failuresDropped,
-            LatencyResult latencyResult,
-            TerminationReason terminationReason,
-            List<Trial<?, OT>> trials) {
-        this(outcomes, elapsed, successes, failures, tokensConsumed,
-                failuresDropped, latencyResult, terminationReason, trials,
-                Map.of(), LatencyResult.empty(), List.of());
-    }
-
-    /**
      * Tally successes, failures and tokens from an uncapped outcome
      * list; attach the supplied latency and termination metadata.
      *
@@ -189,7 +122,8 @@ public record SampleSummary<OT>(
             tokens += o.tokens();
         }
         return new SampleSummary<>(outcomes, elapsed, s, f, tokens, 0,
-                latencyResult, terminationReason, List.of());
+                latencyResult, terminationReason, List.of(),
+                Map.of(), LatencyResult.empty(), List.of());
     }
 
     /**

--- a/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
@@ -42,7 +42,8 @@ class PercentileLatencyTest {
                 successes, failures, 0L, 0,
                 latency,
                 TerminationReason.COMPLETED,
-                List.of());
+                List.of(),
+                java.util.Map.of(), LatencyResult.empty(), List.of());
     }
 
     private static ServiceContractOutcome<Object, String> stubOutcome(Outcome<String> result) {

--- a/punit-core/src/test/java/org/javai/punit/api/spec/TrialTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/TrialTest.java
@@ -86,7 +86,8 @@ class TrialTest {
                 2, 0, 0L, 0,
                 LatencyResult.empty(),
                 TerminationReason.COMPLETED,
-                trials);
+                trials,
+                java.util.Map.of(), LatencyResult.empty(), List.of());
 
         assertThat(summary.trials()).hasSize(2);
         assertThat(summary.trials().get(0).input()).isEqualTo("a");
@@ -108,12 +109,13 @@ class TrialTest {
                         2, 0, 0L, 0,
                         LatencyResult.empty(),
                         TerminationReason.COMPLETED,
-                        oneTrial))
+                        oneTrial,
+                        java.util.Map.of(), LatencyResult.empty(), List.of()))
                 .withMessageContaining("trials");
     }
 
     @Test
-    @DisplayName("SampleSummary accepts an empty trials list (back-compat path)")
+    @DisplayName("SampleSummary accepts an empty trials list")
     void summaryAcceptsEmptyTrials() {
         ServiceContractOutcome<String, Integer> okOutcome = ok(1);
         SampleSummary<Integer> summary = new SampleSummary<>(
@@ -122,7 +124,8 @@ class TrialTest {
                 1, 0, 0L, 0,
                 LatencyResult.empty(),
                 TerminationReason.COMPLETED,
-                List.of());
+                List.of(),
+                java.util.Map.of(), LatencyResult.empty(), List.of());
 
         assertThat(summary.trials()).isEmpty();
     }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
@@ -60,7 +60,8 @@ class CriterionResultDetailTest {
                 2, 0, 0L, 0,
                 latency,
                 TerminationReason.COMPLETED,
-                List.of());
+                List.of(),
+                java.util.Map.of(), LatencyResult.empty(), List.of());
     }
 
     private static final String DEFAULT_IDENTITY = "sha256:test-default-identity";

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/PassRateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/PassRateTest.java
@@ -48,7 +48,8 @@ class PassRateTest {
                 successes, failures, 0L, 0,
                 LatencyResult.empty(),
                 TerminationReason.COMPLETED,
-                List.of());
+                List.of(),
+                java.util.Map.of(), LatencyResult.empty(), List.of());
     }
 
     private static ServiceContractOutcome<Object, String> stubOutcome(Outcome<String> result) {


### PR DESCRIPTION
## Summary

Withdraws the three back-compat constructors on `SampleSummary` (9-arg, 10-arg, 11-arg) introduced over the step-3 / step-4 / step-5 rollout. Every call site now passes the canonical 12-arg form.

This PR initially proposed bundling per-criterion observations under a new `CriterionRunStats` type. That approach was abandoned: the bundle carried only one field today (`CriterionSampleCounts`), and the future-trajectory justification rested in part on the false premise that "per-criterion latency" is a per-functional-criterion observation. Latency is a peer criterion in its own right; its inputs are run-level, already on `SampleSummary` as `latencyResult` / `passingLatencyResult`. With that justification removed, the wrapper added complexity without earning its keep. A follow-on directive will revisit the shape of `SampleSummary` itself — its canonical arity remains too large.

## What changed

- Deleted the 9-arg / 10-arg / 11-arg back-compat constructors on `SampleSummary`.
- Updated `SampleSummary.from(...)` factory and 5 test fixtures (`CriterionResultDetailTest`, `PassRateTest`, `TrialTest` ×3, `PercentileLatencyTest`) to the canonical 12-arg form with explicit `Map.of()` / `LatencyResult.empty()` / `List.of()` trailing.
- Renamed the `TrialTest` case previously labelled \"back-compat path\" — that path no longer exists.

No behaviour change.

## Test plan

- [x] `./gradlew test` green
- [x] Architecture rules green

🤖 Generated with [Claude Code](https://claude.com/claude-code)