### PR TITLE
HTML report: render per-criterion breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added (HTML report — per-criterion breakdown)
+
+- **HTML report renders the methodology-level per-criterion
+  decomposition** at the deepest expansion level of each test row.
+  When the verdict carries a `<per-criterion>` structure (verdict
+  XML 1.2, or in-memory results that produced one), the new
+  `Per-criterion breakdown` `<details>` block lists one block per
+  criterion, headed by the criterion's identifier. Each block
+  shows the three-valued verdict (PASS / FAIL / INCONCLUSIVE) with
+  the existing verdict-CSS colouring, the per-outcome sample
+  counts (pass / fail / inconclusive / total), the observed
+  marginal pass-rate, and the threshold the row was judged
+  against. `NaN` observed-rates and thresholds render as a dash.
+  The block is omitted entirely for runs that produced no
+  per-criterion structure (legacy 1.0 XML, apply-level-failure
+  runs).
+- **Composite verdict is not duplicated as a separate line.** The
+  level-1 verdict column already carries the composite under the
+  step-4 cutover (the composite *is* the test's verdict); the new
+  block surfaces the rows the composite was composed from.
+- **Latency is not added as a per-criterion row.** It remains
+  surfaced once, in the dedicated p50 / p95 / p99 columns at
+  level 1 and the Statistical Analysis block at level 3.
+
 ### Removed (`ProbabilisticTestResult` back-compat constructors)
 
 - **`ProbabilisticTestResult` 5-arg, 6-arg, 7-arg, 8-arg, and 9-arg

--- a/punit-core/build.gradle.kts
+++ b/punit-core/build.gradle.kts
@@ -10,6 +10,16 @@ signing {
     useGpgCmd()
 }
 
+// Targeted `exports ... to org.javai.punit.report / .sentinel` in
+// module-info.java reference sibling modules that depend on this one,
+// so they are not on the module path when punit-core compiles. javac
+// emits a benign "module not found" warning per target. Suppress the
+// `module` lint category for punit-core to keep the build output clean;
+// downstream modules still resolve the exports at their own compile time.
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-module")
+}
+
 tasks.test {
     // Test subjects under testsubjects/ are JUnit-driven inputs to the
     // TestKit-based integration tests; running them directly would trip

--- a/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
@@ -9,7 +9,10 @@ import java.util.Map;
 import java.util.Optional;
 import org.javai.punit.api.spec.FailureCount;
 import org.javai.punit.api.spec.FailureExemplar;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.internal.engine.emit.LatencySection;
+import org.javai.punit.verdict.CriterionRow;
+import org.javai.punit.verdict.PerCriterionStructure;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.ExecutionSummary;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.FunctionalDimension;
@@ -169,6 +172,9 @@ final class HtmlReportWriter {
         html.append("<pre class=\"level3\">").append(VerdictTextRenderer.renderStatisticalAnalysisHtml(verdict)).append("</pre>\n");
         html.append("</details>\n");
 
+        // Level 3: methodology-level per-criterion breakdown (sibling to Statistical Analysis)
+        appendPerCriterionBreakdown(html, verdict);
+
         // Per-clause failure histogram (only when non-empty)
         appendPostconditionFailures(html, verdict.postconditionFailures());
 
@@ -300,6 +306,62 @@ final class HtmlReportWriter {
         };
     }
 
+    private static String verdictCssClass(Verdict verdict) {
+        return switch (verdict) {
+            case PASS -> "punit-pass";
+            case FAIL -> "punit-fail";
+            case INCONCLUSIVE -> "punit-inconclusive";
+        };
+    }
+
+    private static String formatRate(double value) {
+        if (Double.isNaN(value)) {
+            return "&mdash;";
+        }
+        return String.format(java.util.Locale.ROOT, "%.4f", value);
+    }
+
+    /**
+     * Renders the methodology-level per-criterion breakdown as a
+     * nested {@code <details>} block at the deepest expansion level.
+     * Each row appears as its own group, headed by the criterion's
+     * identifier (no separate "Criterion" label — the id is the
+     * heading). The latency criterion is intentionally absent here:
+     * latency is surfaced once, in the dedicated p50 / p95 / p99
+     * columns at level 1 and the Statistical Analysis block at level
+     * 3. The block is omitted entirely when no per-criterion
+     * structure is present (legacy 1.0 XML, apply-level-failure
+     * runs).
+     */
+    private static void appendPerCriterionBreakdown(
+            StringBuilder html, ProbabilisticTestVerdict verdict) {
+        Optional<PerCriterionStructure> opt = verdict.perCriterion();
+        if (opt.isEmpty() || opt.get().criteria().isEmpty()) {
+            return;
+        }
+        PerCriterionStructure pc = opt.get();
+        html.append("<details>\n");
+        html.append("<summary>Per-criterion breakdown</summary>\n");
+        html.append("<div class=\"per-criterion\">\n");
+        for (CriterionRow row : pc.criteria()) {
+            html.append("<div class=\"criterion-block\">\n");
+            html.append("<h4>").append(escape(row.criterionId()))
+                    .append(" <span class=\"").append(verdictCssClass(row.verdict()))
+                    .append("\">").append(row.verdict().name()).append("</span></h4>\n");
+            html.append("<dl>\n");
+            html.append("<dt>Pass</dt><dd>").append(row.pass()).append("</dd>\n");
+            html.append("<dt>Fail</dt><dd>").append(row.fail()).append("</dd>\n");
+            html.append("<dt>Inconclusive</dt><dd>").append(row.inconclusive()).append("</dd>\n");
+            html.append("<dt>Total</dt><dd>").append(row.total()).append("</dd>\n");
+            html.append("<dt>Observed rate</dt><dd>").append(formatRate(row.observedRate())).append("</dd>\n");
+            html.append("<dt>Threshold</dt><dd>").append(formatRate(row.threshold())).append("</dd>\n");
+            html.append("</dl>\n");
+            html.append("</div>\n");
+        }
+        html.append("</div>\n");
+        html.append("</details>\n");
+    }
+
     private static String escape(String text) {
         if (text == null) return "";
         return text.replace("&", "&amp;")
@@ -410,6 +472,23 @@ final class HtmlReportWriter {
                 .punit-pass { color: var(--pass-color); font-weight: 600; }
                 .punit-fail { color: var(--fail-color); font-weight: 600; }
                 .punit-inconclusive { color: var(--inconclusive-color); font-weight: 600; }
+                .per-criterion { padding: 0.5rem 0 0.25rem 0.5rem; }
+                .criterion-block { margin: 0.25rem 0 0.75rem 0; }
+                .criterion-block h4 {
+                    font-size: 0.875rem;
+                    font-family: monospace;
+                    margin-bottom: 0.25rem;
+                }
+                .criterion-block dl {
+                    display: grid;
+                    grid-template-columns: max-content 1fr;
+                    column-gap: 1rem;
+                    row-gap: 0.1rem;
+                    font-size: 0.8125rem;
+                    margin-left: 0.5rem;
+                }
+                .criterion-block dt { color: var(--text-muted); }
+                .criterion-block dd { font-family: monospace; }
                 .latency-observed { color: #adb5bd; }
                 .latency-pass { color: var(--pass-color); font-weight: 600; }
                 .latency-fail { color: var(--fail-color); font-weight: 600; }

--- a/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/javai/punit/report/HtmlReportWriterTest.java
@@ -13,6 +13,8 @@ import org.javai.punit.verdict.TokenMode;
 import org.javai.punit.internal.engine.emit.LatencySection;
 import org.javai.punit.verdict.TerminationReason;
 import org.javai.punit.api.ServiceContractAttributes;
+import org.javai.punit.verdict.CriterionRow;
+import org.javai.punit.verdict.PerCriterionStructure;
 import org.javai.punit.verdict.ProbabilisticTestVerdict;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.CostSummary;
 import org.javai.punit.verdict.ProbabilisticTestVerdict.CovariateStatus;
@@ -534,7 +536,82 @@ class HtmlReportWriterTest {
         }
     }
 
+    @Nested
+    @DisplayName("Per-criterion breakdown")
+    class PerCriterionBreakdown {
+
+        @Test
+        @DisplayName("renders a Per-criterion breakdown <details> block when perCriterion is present")
+        void rendersBlockWhenPresent() {
+            PerCriterionStructure pc = new PerCriterionStructure(
+                    List.of(new CriterionRow(
+                            "bernoulli-pass-rate",
+                            org.javai.punit.api.spec.Verdict.PASS,
+                            95, 5, 0, 0.95, 0.9)),
+                    org.javai.punit.api.spec.Verdict.PASS);
+
+            String html = HtmlReportWriter.generate(List.of(verdictWithPerCriterion(pc)));
+
+            assertThat(html).contains("<summary>Per-criterion breakdown</summary>");
+            assertThat(html).contains("bernoulli-pass-rate");
+            assertThat(html).contains("0.9500");
+            assertThat(html).contains("0.9000");
+        }
+
+        @Test
+        @DisplayName("omits the block entirely when perCriterion is empty")
+        void omitsBlockWhenAbsent() {
+            String html = HtmlReportWriter.generate(List.of(passingVerdict()));
+
+            assertThat(html).doesNotContain("Per-criterion breakdown");
+        }
+
+        @Test
+        @DisplayName("renders NaN observed-rate and threshold as a dash, not the literal NaN")
+        void rendersNaNAsDash() {
+            PerCriterionStructure pc = new PerCriterionStructure(
+                    List.of(new CriterionRow(
+                            "bernoulli-pass-rate",
+                            org.javai.punit.api.spec.Verdict.INCONCLUSIVE,
+                            0, 0, 0, Double.NaN, Double.NaN)),
+                    org.javai.punit.api.spec.Verdict.INCONCLUSIVE);
+
+            String html = HtmlReportWriter.generate(List.of(verdictWithPerCriterion(pc)));
+
+            assertThat(html).contains("<summary>Per-criterion breakdown</summary>");
+            assertThat(html).contains("&mdash;");
+            assertThat(html).doesNotContain(">NaN<");
+        }
+
+        @Test
+        @DisplayName("each row's verdict carries the matching three-valued CSS class")
+        void verdictBadgeCarriesCssClass() {
+            PerCriterionStructure failingPc = new PerCriterionStructure(
+                    List.of(new CriterionRow(
+                            "bernoulli-pass-rate",
+                            org.javai.punit.api.spec.Verdict.FAIL,
+                            65, 35, 0, 0.65, 0.9)),
+                    org.javai.punit.api.spec.Verdict.FAIL);
+
+            String html = HtmlReportWriter.generate(List.of(verdictWithPerCriterion(failingPc)));
+
+            // The verdict badge inside the per-criterion block is wrapped in
+            // a span carrying the verdict's CSS class.
+            assertThat(html).contains("<span class=\"punit-fail\">FAIL</span>");
+        }
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    private ProbabilisticTestVerdict verdictWithPerCriterion(PerCriterionStructure pc) {
+        ProbabilisticTestVerdict base = passingVerdict();
+        return new ProbabilisticTestVerdict(
+                base.correlationId(), base.timestamp(), base.identity(), base.execution(),
+                base.functional(), base.latency(), base.statistics(), base.covariates(),
+                base.cost(), base.pacing(), base.provenance(), base.termination(),
+                base.environmentMetadata(), base.junitPassed(), base.punitVerdict(),
+                base.verdictReason(), base.postconditionFailures(), Optional.of(pc));
+    }
 
     private ProbabilisticTestVerdict passingVerdict() {
         return minimalVerdict("shouldPass", true, PUnitVerdict.PASS);


### PR DESCRIPTION
## Summary

Renders the multi-criterion methodology block at the deepest expansion level of the HTML report. No model or XML changes — the data was already plumbed end-to-end via `VerdictXmlReader`, `VerdictXmlWriter`, and the in-memory `PerCriterionEvaluation` → `PerCriterionStructure` translation. The HTML writer was the only consumer not reading it.

Implements `plan/directives/DIR-HTML-REPORT-PER-CRITERION-punit.md` (orchestrator).

## Design decisions

- **Composite verdict is not shown as a separate line at level 2.** The level-1 verdict column already carries the composite (under the step-4 cutover, the composite *is* the test's verdict). Surfacing it again with a label would be redundant.
- **Each criterion's identifier is its heading at level 3.** Natural grouping; no "Criterion: …" label needed.
- **Latency is not added as a per-criterion row.** Latency is a peer criterion methodologically, but the dedicated p50/p95/p99 columns at level 1 and the Statistical Analysis block at level 3 already surface it. Duplicating would only confuse readers. Today `PerCriterionStructure` carries only the functional criteria (the bernoulli pass-rate row); when future directives extend the per-criterion table to include latency, that directive will revisit this exclusion explicitly.
- **NaN observed-rate and threshold render as a dash**, not the literal `NaN`. Matches the level-1 dash convention for unavailable values.

## What changed

- `HtmlReportWriter`: new `appendPerCriterionBreakdown(...)` helper + `verdictCssClass(Verdict)` mapping + `formatRate(double)` formatter. CSS: small `.criterion-block` / `.per-criterion` styling.
- `HtmlReportWriterTest`: new `PerCriterionBreakdown` nested class with four cases — present, absent, NaN→dash, verdict-CSS-class.
- `CHANGELOG.md`: `[Unreleased]` `Added` entry.

For K=1 today the per-criterion block has one row. For K>1 (future per-postcondition criteria) the same block just grows rows without renderer changes.

## Test plan

- [x] `./gradlew test` green
- [x] `./gradlew :punit-report:test --tests "*PerCriterionBreakdown*"` green
- [x] No new requirement-code leaks; no new statistics outside `org.javai.punit.statistics`
- [ ] Manual visual check: re-run `punitexamples` and confirm the new block appears under "Statistical Analysis" with PASS/FAIL/INCONCLUSIVE colouring

🤖 Generated with [Claude Code](https://claude.com/claude-code)