### PR TITLE
Bump baseline schema to punit-baseline-3 (per-methodology-criterion shape)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (MEASURE baseline schema — per-methodology-criterion shape)
+
+- **Baseline YAML schema bumps from `punit-baseline-2` to
+  `punit-baseline-3`.** The `statistics.bernoulli-pass-rate`
+  block now nests a `criteria:` sub-map keyed by methodology
+  criterion id; each entry carries its own `observedPassRate`
+  and `sampleCount`. K=1 contracts (the common case, via the
+  legacy `postconditions(ContractBuilder)` path) produce a
+  single-entry map keyed by the auto-derived
+  `DefaultCriterion.id()`. K&gt;1 contracts (those declaring
+  `criteria(CriteriaBuilder)` explicitly) produce one entry
+  per methodology criterion in contract declaration order. The
+  top-level `latency:` block is unchanged — latency stays at the
+  run level, not partitioned by criterion.
+
+- **`BaselineReader` rejects `punit-baseline-2` files with a
+  re-MEASURE migration message.** No silent read-time adapter
+  — files on disk in the older shape must be regenerated.
+
+- **`PerCriterionPassRateStatistics` is a new `BaselineStatistics`
+  variant** wrapping `Map<String, PassRateStatistics>`. It is
+  what the baseline file's `bernoulli-pass-rate` block
+  deserialises to. The `BaselineResolver` unwraps it for callers
+  that request `PassRateStatistics.class` (the empirical
+  `PassRate` evaluator): single-entry maps yield their lone
+  entry; multi-entry maps fast-fail with an
+  `IllegalStateException` naming the criteria — multi-criterion
+  empirical evaluation awaits the evaluator-inference machinery
+  (deferred to a later directive).
+
+- **`BaselineEmitter` composes the per-criterion structure from
+  the engine's `SampleSummary.criterionSampleCounts()`**, one
+  entry per methodology criterion the engine recorded. No new
+  arithmetic — the per-criterion pass / total counts come
+  straight from the engine's already-recorded data.
+
 ### Added (HTML report — per-criterion breakdown)
 
 - **HTML report renders the methodology-level per-criterion

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionPassRateStatistics.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionPassRateStatistics.java
@@ -1,0 +1,82 @@
+package org.javai.punit.api.spec;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Per-methodology-criterion pass-rate basis. The on-disk shape of
+ * the {@code bernoulli-pass-rate} statistics entry from
+ * {@code punit-baseline-3} and later: one nested
+ * {@link PassRateStatistics} per methodology criterion the MEASURE
+ * run recorded, keyed by the criterion's identifier.
+ *
+ * <p>K=1 contracts produce a single-entry map keyed by the
+ * methodology criterion's id (typically the auto-derived
+ * {@code DefaultCriterion.id()} when the contract uses the legacy
+ * {@code postconditions(ContractBuilder)} path). K&gt;1 contracts
+ * produce one entry per methodology criterion declared via
+ * {@code Contract.criteria(CriteriaBuilder)}.
+ *
+ * <p>The framework's {@code BaselineProvider} unwraps this structure
+ * for callers that request {@link PassRateStatistics} directly: a
+ * single-entry map yields its lone entry; a multi-entry map fails
+ * fast because the empirical {@code PassRate} evaluator does not yet
+ * know which methodology criterion to target. The producer side
+ * carries the K&gt;1 data faithfully even though the K&gt;1 consumer
+ * path is not yet wired — re-running an empirical TEST against a
+ * K&gt;1 baseline surfaces the deliberate gate, not a regression.
+ *
+ * @param byCriterion ordered map of methodology criterion id to its
+ *                    per-criterion pass-rate basis; must be non-null
+ */
+public record PerCriterionPassRateStatistics(
+        Map<String, PassRateStatistics> byCriterion) implements BaselineStatistics {
+
+    public PerCriterionPassRateStatistics {
+        Objects.requireNonNull(byCriterion, "byCriterion");
+        byCriterion = Collections.unmodifiableMap(new LinkedHashMap<>(byCriterion));
+    }
+
+    /**
+     * @return the sum of per-criterion sample counts. Note: this is
+     *         only meaningful as the "denominator total" for
+     *         {@link EmpiricalChecks} when the methodology's
+     *         marginal-denominator semantics align with that
+     *         summation — for K=1 it equals the single criterion's
+     *         sampleCount.
+     */
+    @Override
+    public int sampleCount() {
+        int sum = 0;
+        for (PassRateStatistics entry : byCriterion.values()) {
+            sum += entry.sampleCount();
+        }
+        return sum;
+    }
+
+    /**
+     * K=1 convenience factory: wraps a single
+     * {@link PassRateStatistics} under the supplied methodology
+     * criterion id. The common case for tests and for the legacy
+     * {@code postconditions(ContractBuilder)} authoring path.
+     */
+    public static PerCriterionPassRateStatistics of(
+            String criterionId, PassRateStatistics stats) {
+        Objects.requireNonNull(criterionId, "criterionId");
+        Objects.requireNonNull(stats, "stats");
+        return new PerCriterionPassRateStatistics(Map.of(criterionId, stats));
+    }
+
+    /**
+     * K=1 convenience factory: builds a single-entry map keyed by
+     * the supplied criterion id, with one
+     * {@link PassRateStatistics} record built from the supplied
+     * observed rate and sample count.
+     */
+    public static PerCriterionPassRateStatistics of(
+            String criterionId, double observedPassRate, int sampleCount) {
+        return of(criterionId, new PassRateStatistics(observedPassRate, sampleCount));
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineReader.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineReader.java
@@ -1,6 +1,7 @@
 package org.javai.punit.internal.engine.baseline;
 
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_COVARIATES;
+import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_CRITERIA;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_FACTORS_FINGERPRINT;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_GENERATED_AT;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_INPUTS_IDENTITY;
@@ -15,6 +16,7 @@ import static org.javai.punit.internal.engine.baseline.BaselineSchema.PERCENTILE
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.PERCENTILE_KEY_P90;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.PERCENTILE_KEY_P95;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.PERCENTILE_KEY_P99;
+import static org.javai.punit.internal.engine.baseline.BaselineSchema.SCHEMA_VERSION_PREVIOUS;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.SCHEMA_VERSION_VALUE;
 
 import java.io.IOException;
@@ -33,6 +35,7 @@ import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -98,6 +101,15 @@ public final class BaselineReader {
 
         String version = requireString(root, FIELD_SCHEMA_VERSION);
         if (!SCHEMA_VERSION_VALUE.equals(version)) {
+            if (SCHEMA_VERSION_PREVIOUS.equals(version)) {
+                throw new IllegalArgumentException(
+                        "Baseline file is at schema '" + SCHEMA_VERSION_PREVIOUS
+                                + "', which predates the per-methodology-criterion shape"
+                                + " introduced in '" + SCHEMA_VERSION_VALUE + "'."
+                                + " Re-run the MEASURE experiment to regenerate the baseline"
+                                + " in the current shape; the reader does not adapt across"
+                                + " this schema break.");
+            }
             throw new IllegalArgumentException(
                     "Unsupported schema version '" + version + "' (expected '"
                             + SCHEMA_VERSION_VALUE + "')");
@@ -205,10 +217,26 @@ public final class BaselineReader {
         }
         Map<String, Object> entry = asStringKeyedMap(mapRaw, "statistics." + criterionName);
 
-        if (entry.containsKey(FIELD_OBSERVED_PASS_RATE)) {
-            double observed = requireDouble(entry, FIELD_OBSERVED_PASS_RATE);
-            int sampleCount = requireInt(entry, FIELD_SAMPLE_COUNT);
-            return new PassRateStatistics(observed, sampleCount);
+        if (entry.containsKey(FIELD_CRITERIA)) {
+            Map<String, Object> criteriaMap = requireMap(entry, FIELD_CRITERIA);
+            Map<String, PassRateStatistics> byCriterion = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> c : criteriaMap.entrySet()) {
+                if (!(c.getValue() instanceof Map<?, ?> rowRaw)) {
+                    throw new IllegalArgumentException(
+                            "statistics." + criterionName + ".criteria." + c.getKey()
+                                    + " must be a mapping, got "
+                                    + (c.getValue() == null
+                                            ? "null"
+                                            : c.getValue().getClass().getSimpleName()));
+                }
+                Map<String, Object> row = asStringKeyedMap(rowRaw,
+                        "statistics." + criterionName + ".criteria." + c.getKey());
+                double observed = requireDouble(row, FIELD_OBSERVED_PASS_RATE);
+                int rowSampleCount = requireInt(row, FIELD_SAMPLE_COUNT);
+                byCriterion.put(c.getKey(),
+                        new PassRateStatistics(observed, rowSampleCount));
+            }
+            return new PerCriterionPassRateStatistics(byCriterion);
         }
         if (entry.containsKey(FIELD_PERCENTILES)) {
             Map<String, Object> percentiles = requireMap(entry, FIELD_PERCENTILES);
@@ -224,7 +252,7 @@ public final class BaselineReader {
         throw new IllegalArgumentException(
                 "Unrecognised statistics entry shape for criterion '" + criterionName
                         + "' — expected a known discriminator field ('"
-                        + FIELD_OBSERVED_PASS_RATE + "' or '" + FIELD_PERCENTILES + "')");
+                        + FIELD_CRITERIA + "' or '" + FIELD_PERCENTILES + "')");
     }
 
     @SuppressWarnings("unchecked")

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
@@ -16,6 +16,8 @@ import org.javai.punit.api.covariate.Covariate;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.BaselineLookup;
 import org.javai.punit.api.spec.BaselineStatistics;
+import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 
 /**
@@ -166,6 +168,34 @@ public final class BaselineResolver {
         if (entry == null) {
             return new BaselineLookup<>(
                     Optional.empty(), baselineProfile, notes, sourceFile);
+        }
+        // Unwrap per-methodology-criterion pass-rate basis when the
+        // caller is a single-criterion empirical evaluator (PassRate).
+        // K=1: the lone entry is the evaluator's basis. K>1: fast-fail
+        // with a clear message — the K>1 empirical TEST path requires
+        // the evaluator-inference machinery that hasn't landed yet.
+        if (entry instanceof PerCriterionPassRateStatistics perCriterion
+                && statisticsType == PassRateStatistics.class) {
+            Map<String, PassRateStatistics> byCriterion = perCriterion.byCriterion();
+            if (byCriterion.isEmpty()) {
+                return new BaselineLookup<>(
+                        Optional.empty(), baselineProfile, notes, sourceFile);
+            }
+            if (byCriterion.size() > 1) {
+                throw new IllegalStateException(
+                        "Baseline for service contract '" + serviceContractId
+                                + "' carries " + byCriterion.size()
+                                + " methodology criteria under '" + criterionName + "': "
+                                + byCriterion.keySet()
+                                + ". The empirical PassRate evaluator can only target one"
+                                + " criterion today; multi-criterion empirical evaluation"
+                                + " awaits the evaluator-inference machinery (deferred"
+                                + " from this stage). Until then, K>1 contracts can MEASURE"
+                                + " but cannot run an empirical TEST.");
+            }
+            PassRateStatistics only = byCriterion.values().iterator().next();
+            return new BaselineLookup<>(
+                    Optional.of(statisticsType.cast(only)), baselineProfile, notes, sourceFile);
         }
         if (!statisticsType.isInstance(entry)) {
             throw new IllegalStateException(

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSchema.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSchema.java
@@ -13,7 +13,22 @@ final class BaselineSchema {
     private BaselineSchema() { }
 
     /** The structural-version discriminator for the baseline YAML schema. */
-    static final String SCHEMA_VERSION_VALUE = "punit-baseline-2";
+    static final String SCHEMA_VERSION_VALUE = "punit-baseline-3";
+
+    /**
+     * Previous schema version retained as a literal so the reader can
+     * give a precise migration message when it encounters an
+     * out-of-date file.
+     */
+    static final String SCHEMA_VERSION_PREVIOUS = "punit-baseline-2";
+
+    /**
+     * The per-methodology-criterion nesting key under
+     * {@code statistics.bernoulli-pass-rate}. From punit-baseline-3
+     * onward, the bernoulli stats are always nested per methodology
+     * criterion (uniformly, including K=1).
+     */
+    static final String FIELD_CRITERIA = "criteria";
 
     static final String FIELD_SCHEMA_VERSION = "schemaVersion";
     static final String FIELD_USE_CASE_ID = "useCaseId";

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineWriter.java
@@ -33,6 +33,7 @@ import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -140,8 +141,8 @@ public final class BaselineWriter {
 
     private Map<String, Object> serialiseStatisticsEntry(
             String criterionName, BaselineStatistics statistics) {
-        if (statistics instanceof PassRateStatistics passRate) {
-            return serialisePassRate(passRate);
+        if (statistics instanceof PerCriterionPassRateStatistics perCriterion) {
+            return serialisePerCriterionPassRate(perCriterion);
         }
         if (statistics instanceof LatencyStatistics latency) {
             return serialiseLatency(latency);
@@ -152,11 +153,18 @@ public final class BaselineWriter {
                         + " — extend BaselineWriter and BaselineReader together to add support.");
     }
 
-    private Map<String, Object> serialisePassRate(PassRateStatistics stats) {
-        Map<String, Object> entry = new LinkedHashMap<>();
-        entry.put(FIELD_OBSERVED_PASS_RATE, stats.observedPassRate());
-        entry.put(FIELD_SAMPLE_COUNT, stats.sampleCount());
-        return entry;
+    private Map<String, Object> serialisePerCriterionPassRate(
+            PerCriterionPassRateStatistics stats) {
+        Map<String, Object> criteriaBlock = new LinkedHashMap<>();
+        for (Map.Entry<String, PassRateStatistics> e : stats.byCriterion().entrySet()) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put(FIELD_OBSERVED_PASS_RATE, e.getValue().observedPassRate());
+            entry.put(FIELD_SAMPLE_COUNT, e.getValue().sampleCount());
+            criteriaBlock.put(e.getKey(), entry);
+        }
+        Map<String, Object> outer = new LinkedHashMap<>();
+        outer.put(BaselineSchema.FIELD_CRITERIA, criteriaBlock);
+        return outer;
     }
 
     private Map<String, Object> serialiseLatency(LatencyStatistics stats) {

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
@@ -21,9 +21,11 @@ import org.javai.punit.api.covariate.Covariate;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.Configuration;
+import org.javai.punit.api.spec.CriterionSampleCounts;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.Spec;
 import org.javai.punit.api.spec.TypedSpec;
@@ -139,8 +141,7 @@ public final class BaselineEmitter {
         SampleSummary<OT> summary = (SampleSummary<OT>) rawSummary;
         int total = summary.total();
         Map<String, BaselineStatistics> stats = new LinkedHashMap<>();
-        stats.put("bernoulli-pass-rate",
-                new PassRateStatistics((double) summary.successes() / (double) total, total));
+        stats.put("bernoulli-pass-rate", buildPerCriterionPassRate(summary));
         // LatencyStatistics retained on the in-memory record under
         // the criterion-name "percentile-latency" so the
         // PercentileLatency criterion's lookup path keeps working.
@@ -186,6 +187,28 @@ public final class BaselineEmitter {
                 stats,
                 profile,
                 latencyIndicator);
+    }
+
+    /**
+     * Build the per-methodology-criterion pass-rate basis from the
+     * engine's recorded {@code criterionSampleCounts}. One entry per
+     * criterion the contract declared, in contract declaration order.
+     * For K=1 (the common case via {@code DefaultCriterion}) this
+     * yields a single-entry map keyed by the auto-derived criterion
+     * id.
+     */
+    private static PerCriterionPassRateStatistics buildPerCriterionPassRate(
+            SampleSummary<?> summary) {
+        Map<String, PassRateStatistics> byCriterion = new LinkedHashMap<>();
+        for (CriterionSampleCounts c : summary.criterionSampleCounts()) {
+            int criterionTotal = c.pass() + c.fail() + c.inconclusive();
+            double observed = criterionTotal == 0
+                    ? 0.0
+                    : (double) c.pass() / (double) criterionTotal;
+            byCriterion.put(c.criterionId(),
+                    new PassRateStatistics(observed, criterionTotal));
+        }
+        return new PerCriterionPassRateStatistics(byCriterion);
     }
 
 }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -17,6 +17,7 @@ import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.internal.engine.criteria.PassRate;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
@@ -85,7 +86,7 @@ class EmpiricalEndToEndIntegrationTest {
                 Instant.parse("2026-04-26T15:30:00Z"),
                 Map.<String, BaselineStatistics>of(
                         "bernoulli-pass-rate",
-                        new PassRateStatistics(passRate, sampleCount)));
+                        PerCriterionPassRateStatistics.of("contract", passRate, sampleCount)));
         new BaselineWriter().write(record, baselineDir);
     }
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineIntegrityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineIntegrityTest.java
@@ -18,7 +18,7 @@ class BaselineIntegrityTest {
     @DisplayName("appendFingerprint adds a final contentFingerprint: line whose digest is "
             + "SHA-256 of the body that precedes it")
     void appendsFingerprintMatchingBodyDigest() {
-        String body = "schemaVersion: punit-baseline-2\nuseCaseId: X\n";
+        String body = "schemaVersion: punit-baseline-3\nuseCaseId: X\n";
         String fingerprinted = BaselineIntegrity.appendFingerprint(body);
 
         assertThat(fingerprinted)
@@ -34,19 +34,19 @@ class BaselineIntegrityTest {
     @DisplayName("appendFingerprint normalises a body without trailing newline so the "
             + "fingerprint line stays on its own line")
     void appendsTrailingNewlineWhenAbsent() {
-        String body = "schemaVersion: punit-baseline-2"; // no trailing newline
+        String body = "schemaVersion: punit-baseline-3"; // no trailing newline
         String fingerprinted = BaselineIntegrity.appendFingerprint(body);
 
         assertThat(fingerprinted.lines().toList())
                 .containsExactly(
-                        "schemaVersion: punit-baseline-2",
+                        "schemaVersion: punit-baseline-3",
                         "contentFingerprint: " + HashUtils.sha256(body + "\n"));
     }
 
     @Test
     @DisplayName("verify returns empty when stored digest matches recomputed body digest")
     void verifyOkOnMatchingDigest() {
-        String body = "schemaVersion: punit-baseline-2\n";
+        String body = "schemaVersion: punit-baseline-3\n";
         String yaml = BaselineIntegrity.appendFingerprint(body);
 
         Optional<String> warning = BaselineIntegrity.verify(yaml, FAKE_FILE);
@@ -59,7 +59,7 @@ class BaselineIntegrityTest {
             + "computed digests — when the body has been edited after the fingerprint "
             + "was appended")
     void verifyMismatchOnEditedBody() {
-        String body = "schemaVersion: punit-baseline-2\nminPassRate: 0.95\n";
+        String body = "schemaVersion: punit-baseline-3\nminPassRate: 0.95\n";
         String yaml = BaselineIntegrity.appendFingerprint(body);
         // Tamper: lower the threshold without re-fingerprinting.
         String tampered = yaml.replace("minPassRate: 0.95", "minPassRate: 0.50");
@@ -79,7 +79,7 @@ class BaselineIntegrityTest {
     @DisplayName("verify returns the softer missing warning when no contentFingerprint: "
             + "field is present (legacy baseline pre-dating the integrity feature)")
     void verifyMissingOnLegacyBaseline() {
-        String legacy = "schemaVersion: punit-baseline-2\nuseCaseId: X\n";
+        String legacy = "schemaVersion: punit-baseline-3\nuseCaseId: X\n";
 
         Optional<String> warning = BaselineIntegrity.verify(legacy, FAKE_FILE);
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineReaderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineReaderTest.java
@@ -16,6 +16,7 @@ import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -43,10 +44,10 @@ class BaselineReaderTest {
     }
 
     @Test
-    @DisplayName("round-trips a PassRateStatistics record without loss")
+    @DisplayName("round-trips a PerCriterionPassRateStatistics record without loss")
     void roundTripPassRate() {
         BaselineRecord parsed = roundTrip(Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)));
 
         assertThat(parsed.serviceContractId()).isEqualTo("ShoppingBasket");
         assertThat(parsed.methodName()).isEqualTo("measureBaseline");
@@ -56,8 +57,10 @@ class BaselineReaderTest {
         assertThat(parsed.generatedAt()).isEqualTo(Instant.parse("2026-04-26T15:30:00Z"));
 
         BaselineStatistics entry = parsed.statisticsByCriterionName().get("bernoulli-pass-rate");
-        assertThat(entry).isInstanceOf(PassRateStatistics.class);
-        PassRateStatistics passRate = (PassRateStatistics) entry;
+        assertThat(entry).isInstanceOf(PerCriterionPassRateStatistics.class);
+        PerCriterionPassRateStatistics perCriterion = (PerCriterionPassRateStatistics) entry;
+        PassRateStatistics passRate = perCriterion.byCriterion().get("contract");
+        assertThat(passRate).isNotNull();
         assertThat(passRate.observedPassRate()).isEqualTo(0.94);
         assertThat(passRate.sampleCount()).isEqualTo(1000);
     }
@@ -77,7 +80,7 @@ class BaselineReaderTest {
         // non-empty per BaselineRecord's invariant); latency rides on
         // the indicator.
         BaselineRecord parsed = roundTrip(
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)),
                 indicator);
 
         // Reader synthesises the LatencyStatistics map entry from
@@ -102,7 +105,7 @@ class BaselineReaderTest {
     @DisplayName("round-trips both criteria — pass-rate via statistics:, latency via top-level block")
     void roundTripBothCriteria() {
         Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
-        entries.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+        entries.put("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000));
         LatencyIndicator indicator = new LatencyIndicator(
                 new LatencyResult(Duration.ofMillis(250), Duration.ofMillis(500),
                         Duration.ofMillis(800), Duration.ofMillis(1200), 1000),
@@ -118,7 +121,7 @@ class BaselineReaderTest {
     @DisplayName("read(Path) wraps parse failure with the file path in the diagnostic")
     void readWrapsErrorWithPath(@TempDir Path tempDir) throws IOException {
         Path file = tempDir.resolve("malformed.yaml");
-        Files.writeString(file, "schemaVersion: punit-baseline-2\n");
+        Files.writeString(file, "schemaVersion: punit-baseline-3\n");
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> reader.read(file))
@@ -134,7 +137,7 @@ class BaselineReaderTest {
                 "ShoppingBasket", "measureBaseline", "a1b2c3d4",
                 "sha256:abc", 100,
                 Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.9, 100)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.9, 100)),
                 CovariateProfile.empty(),
                 LatencyIndicator.empty());
         Path file = writer.write(original, tempDir);
@@ -155,7 +158,7 @@ class BaselineReaderTest {
                 "ShoppingBasket", "measureBaseline", "a1b2c3d4",
                 "sha256:abc", 100,
                 Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.95, 100)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.95, 100)),
                 CovariateProfile.empty(),
                 LatencyIndicator.empty());
         Path file = writer.write(original, tempDir);
@@ -182,7 +185,7 @@ class BaselineReaderTest {
                 "Legacy", "measureBaseline", "a1b2c3d4",
                 "sha256:abc", 50,
                 Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.8, 50)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.8, 50)),
                 CovariateProfile.empty(),
                 LatencyIndicator.empty());
         Path file = writer.write(original, tempDir);
@@ -210,13 +213,15 @@ class BaselineReaderTest {
                 + "generatedAt: 2026-04-26T15:30:00Z\n"
                 + "statistics:\n"
                 + "  bernoulli-pass-rate:\n"
-                + "    observedPassRate: 0.5\n"
-                + "    sampleCount: 1\n";
+                + "    criteria:\n"
+                + "      contract:\n"
+                + "        observedPassRate: 0.5\n"
+                + "        sampleCount: 1\n";
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> reader.parse(yaml))
                 .withMessageContaining("punit-baseline-99")
-                .withMessageContaining("punit-baseline-2");
+                .withMessageContaining("punit-baseline-3");
     }
 
     @Test
@@ -230,7 +235,7 @@ class BaselineReaderTest {
     @Test
     @DisplayName("rejects a missing required field with the field name in the diagnostic")
     void rejectsMissingField() {
-        String yaml = "schemaVersion: punit-baseline-2\n"
+        String yaml = "schemaVersion: punit-baseline-3\n"
                 + "useCaseId: x\n";
 
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -241,7 +246,7 @@ class BaselineReaderTest {
     @Test
     @DisplayName("rejects a statistics entry whose shape matches no known statistics kind")
     void rejectsUnknownStatisticsShape() {
-        String yaml = "schemaVersion: punit-baseline-2\n"
+        String yaml = "schemaVersion: punit-baseline-3\n"
                 + "useCaseId: x\n"
                 + "methodName: m\n"
                 + "factorsFingerprint: f\n"
@@ -271,7 +276,7 @@ class BaselineReaderTest {
                 "ShoppingBasket", "measureBaseline", "a1b2c3d4",
                 "sha256:abc123", 1000,
                 Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)),
                 CovariateProfile.of(profile));
 
         BaselineRecord parsed = reader.parse(writer.toYaml(original));
@@ -289,7 +294,7 @@ class BaselineReaderTest {
         // Older YAML predates the covariates: block. The reader must
         // accept it and assign the empty profile so old baselines on
         // disk continue to work after the upgrade.
-        String yaml = "schemaVersion: punit-baseline-2\n"
+        String yaml = "schemaVersion: punit-baseline-3\n"
                 + "useCaseId: x\n"
                 + "methodName: m\n"
                 + "factorsFingerprint: f\n"
@@ -298,8 +303,10 @@ class BaselineReaderTest {
                 + "generatedAt: 2026-04-26T15:30:00Z\n"
                 + "statistics:\n"
                 + "  bernoulli-pass-rate:\n"
-                + "    observedPassRate: 0.5\n"
-                + "    sampleCount: 1\n";
+                + "    criteria:\n"
+                + "      contract:\n"
+                + "        observedPassRate: 0.5\n"
+                + "        sampleCount: 1\n";
 
         BaselineRecord parsed = reader.parse(yaml);
         assertThat(parsed.covariateProfile().isEmpty()).isTrue();
@@ -308,7 +315,7 @@ class BaselineReaderTest {
     @Test
     @DisplayName("rejects a non-string covariate value")
     void rejectsNonStringCovariate() {
-        String yaml = "schemaVersion: punit-baseline-2\n"
+        String yaml = "schemaVersion: punit-baseline-3\n"
                 + "useCaseId: x\n"
                 + "methodName: m\n"
                 + "factorsFingerprint: f\n"
@@ -317,8 +324,10 @@ class BaselineReaderTest {
                 + "generatedAt: 2026-04-26T15:30:00Z\n"
                 + "statistics:\n"
                 + "  bernoulli-pass-rate:\n"
-                + "    observedPassRate: 0.5\n"
-                + "    sampleCount: 1\n"
+                + "    criteria:\n"
+                + "      contract:\n"
+                + "        observedPassRate: 0.5\n"
+                + "        sampleCount: 1\n"
                 + "covariates:\n"
                 + "  region: 42\n";
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineRecordTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineRecordTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ import org.junit.jupiter.api.Test;
 class BaselineRecordTest {
 
     private static final Map<String, BaselineStatistics> ONE_ENTRY =
-            Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+            Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000));
 
     @Test
     @DisplayName("filename is {serviceContractId}.{methodName}-{factorsFingerprint}.yaml")
@@ -82,7 +83,7 @@ class BaselineRecordTest {
     @DisplayName("statistics map is defensively copied — caller mutations don't leak in")
     void defensiveCopy() {
         java.util.HashMap<String, BaselineStatistics> mutable = new java.util.HashMap<>();
-        mutable.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+        mutable.put("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000));
 
         BaselineRecord record = new BaselineRecord(
                 "u", "m", "f", "sha256:x", 1, Instant.now(), mutable);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineResolverTest.java
@@ -14,6 +14,7 @@ import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,7 +45,7 @@ class BaselineResolverTest {
     @DisplayName("resolves a present PassRateStatistics entry")
     void resolvesPresentEntry(@TempDir Path dir) throws IOException {
         writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)));
 
         var resolver = new BaselineResolver(dir);
 
@@ -70,7 +71,7 @@ class BaselineResolverTest {
     @DisplayName("returns empty when no file matches the (serviceContractId, fingerprint) pair")
     void emptyForNonMatchingFile(@TempDir Path dir) throws IOException {
         writeBaseline(dir, "Other", "a1b2c3d4", Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.5, 100)));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.5, 100)));
 
         var resolver = new BaselineResolver(dir);
 
@@ -84,7 +85,7 @@ class BaselineResolverTest {
     @DisplayName("returns empty when the file matches but the criterion name does not")
     void emptyForUnknownCriterion(@TempDir Path dir) throws IOException {
         writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)));
 
         var resolver = new BaselineResolver(dir);
 
@@ -98,7 +99,7 @@ class BaselineResolverTest {
     @DisplayName("rejects mismatch between recorded statistics flavour and requested type")
     void rejectsStatisticsTypeMismatch(@TempDir Path dir) throws IOException {
         writeBaseline(dir, "ShoppingBasket", "a1b2c3d4", Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)));
 
         var resolver = new BaselineResolver(dir);
 
@@ -117,7 +118,7 @@ class BaselineResolverTest {
                 "ShoppingBasket", "measureBaseline", "a1b2c3d4",
                 "sha256:specific-identity", 1000,
                 Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)));
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)));
         writer.write(record, dir);
 
         var resolver = new BaselineResolver(dir);
@@ -145,7 +146,7 @@ class BaselineResolverTest {
                 1000, 1000);
         writeBaseline(dir, "ShoppingBasket", "a1b2c3d4",
                 new java.util.LinkedHashMap<>(Map.of(
-                        "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))),
+                        "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000))),
                 indicator);
 
         var resolver = new BaselineResolver(dir);
@@ -171,7 +172,7 @@ class BaselineResolverTest {
         BaselineRecord record = new BaselineRecord(
                 "ShoppingBasket", "measureBaseline", "a1b2c3d4",
                 "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)),
                 CovariateProfile.of(profile));
         writer.write(record, dir);
 
@@ -189,7 +190,7 @@ class BaselineResolverTest {
         // if the resolver only checked startsWith — which it doesn't,
         // because the segment must be terminated by '-' or '.yaml'.
         writeBaseline(dir, "ShoppingBasket", "aabbccddee", Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.5, 100)));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.5, 100)));
 
         var resolver = new BaselineResolver(dir);
 
@@ -261,7 +262,8 @@ class BaselineResolverTest {
         BaselineRecord record = new BaselineRecord(
                 "ShoppingBasket", "measureBaseline", "a1b2c3d4",
                 "sha256:abc", 1000, Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", stats),
+                Map.of("bernoulli-pass-rate",
+                        PerCriterionPassRateStatistics.of("contract", stats)),
                 profile);
         writer.write(record, dir);
     }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineSelectorTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineSelectorTest.java
@@ -13,6 +13,7 @@ import org.javai.punit.api.covariate.Covariate;
 import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ import org.junit.jupiter.api.Test;
 class BaselineSelectorTest {
 
     private static final Map<String, BaselineStatistics> STATS =
-            Map.of("bernoulli-pass-rate", new PassRateStatistics(0.9, 100));
+            Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.9, 100));
 
     private static BaselineRecord baseline(String fingerprintTag, CovariateProfile profile) {
         return new BaselineRecord(

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/BaselineWriterTest.java
@@ -16,6 +16,7 @@ import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,12 +42,12 @@ class BaselineWriterTest {
     @DisplayName("emits the schema discriminator and identity keys")
     void emitsHeader() {
         String yaml = writer.toYaml(recordWith(Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000))));
 
         Map<String, Object> root = new Yaml().load(yaml);
 
         assertThat(root)
-                .containsEntry("schemaVersion", "punit-baseline-2")
+                .containsEntry("schemaVersion", "punit-baseline-3")
                 .containsEntry("useCaseId", "ShoppingBasketServiceContract")
                 .containsEntry("methodName", "measureBaseline")
                 .containsEntry("factorsFingerprint", "a1b2c3d4")
@@ -56,16 +57,18 @@ class BaselineWriterTest {
     }
 
     @Test
-    @DisplayName("serialises a PassRateStatistics entry with observedPassRate + sampleCount")
+    @DisplayName("serialises a PerCriterionPassRateStatistics entry under criteria.<id> with observedPassRate + sampleCount")
     void serialisesPassRate() {
         String yaml = writer.toYaml(recordWith(Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000))));
 
         Map<String, Object> root = new Yaml().load(yaml);
         Map<String, Object> stats = (Map<String, Object>) root.get("statistics");
         Map<String, Object> entry = (Map<String, Object>) stats.get("bernoulli-pass-rate");
+        Map<String, Object> criteria = (Map<String, Object>) entry.get("criteria");
+        Map<String, Object> contract = (Map<String, Object>) criteria.get("contract");
 
-        assertThat(entry)
+        assertThat(contract)
                 .containsEntry("observedPassRate", 0.94)
                 .containsEntry("sampleCount", 1000);
     }
@@ -82,7 +85,7 @@ class BaselineWriterTest {
         LatencyIndicator indicator = new LatencyIndicator(percentiles, 1000, 1000);
 
         String yaml = writer.toYaml(recordWithLatency(
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)),
                 indicator));
 
         Map<String, Object> root = new Yaml().load(yaml);
@@ -107,7 +110,7 @@ class BaselineWriterTest {
     @DisplayName("serialises pass-rate under statistics: and latency at the top level alongside")
     void serialisesBothCriteria() {
         Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
-        entries.put("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000));
+        entries.put("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000));
         LatencyIndicator indicator = new LatencyIndicator(
                 new LatencyResult(Duration.ofMillis(250), Duration.ofMillis(500),
                         Duration.ofMillis(800), Duration.ofMillis(1200), 1000),
@@ -141,7 +144,7 @@ class BaselineWriterTest {
         Path baselineDir = tempDir.resolve("baselines");
 
         Path file = writer.write(
-                recordWith(Map.of("bernoulli-pass-rate", new PassRateStatistics(0.5, 100))),
+                recordWith(Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.5, 100))),
                 baselineDir);
 
         assertThat(Files.exists(baselineDir)).isTrue();
@@ -151,7 +154,7 @@ class BaselineWriterTest {
                         "ShoppingBasketServiceContract.measureBaseline-a1b2c3d4.yaml"));
 
         String content = Files.readString(file);
-        assertThat(content).contains("schemaVersion: punit-baseline-2");
+        assertThat(content).contains("schemaVersion: punit-baseline-3");
     }
 
     @Test
@@ -159,7 +162,7 @@ class BaselineWriterTest {
             + "preceding it (integrity check)")
     void emitsContentFingerprintAsLastField() {
         String yaml = writer.toYaml(recordWith(Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000))));
 
         // Last non-empty line carries the fingerprint key.
         java.util.List<String> nonEmpty = yaml.lines()
@@ -191,7 +194,7 @@ class BaselineWriterTest {
     @DisplayName("omits the covariates section when the profile is empty (default constructor)")
     void omitsCovariatesWhenEmpty() {
         String yaml = writer.toYaml(recordWith(Map.of(
-                "bernoulli-pass-rate", new PassRateStatistics(0.94, 1000))));
+                "bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000))));
 
         assertThat(yaml).doesNotContain("covariates:");
     }
@@ -211,7 +214,7 @@ class BaselineWriterTest {
                 "sha256:7d3a8c1e9b2f",
                 1000,
                 Instant.parse("2026-04-26T15:30:00Z"),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.94, 1000)),
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.94, 1000)),
                 CovariateProfile.of(profile));
 
         String yaml = writer.toYaml(record);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
@@ -23,6 +23,7 @@ import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -68,7 +69,7 @@ class PowerAnalysisTest {
                 "sha256:any", sampleCount, Instant.parse("2026-04-26T15:30:00Z"),
                 Map.<String, BaselineStatistics>of(
                         "bernoulli-pass-rate",
-                        new PassRateStatistics(passRate, sampleCount)));
+                        PerCriterionPassRateStatistics.of("contract", passRate, sampleCount)));
         new BaselineWriter().write(record, dir);
         return dir;
     }
@@ -307,7 +308,7 @@ class PowerAnalysisTest {
                 "sha256:any", sampleCount, Instant.parse("2026-04-26T15:30:00Z"),
                 Map.<String, BaselineStatistics>of(
                         "bernoulli-pass-rate",
-                        new PassRateStatistics(passRate, sampleCount)),
+                        PerCriterionPassRateStatistics.of("contract", passRate, sampleCount)),
                 CovariateProfile.of(profileValues));
         new BaselineWriter().write(record, dir);
     }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/YamlBaselineProviderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/YamlBaselineProviderTest.java
@@ -12,6 +12,7 @@ import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.spec.BaselineLookup;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,7 +29,7 @@ class YamlBaselineProviderTest {
     void resolvesPresent(@TempDir Path dir) throws IOException {
         FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
         BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.92, 1000)));
         writer.write(record, dir);
 
         var provider = new YamlBaselineProvider(dir);
@@ -46,7 +47,7 @@ class YamlBaselineProviderTest {
         FactorBundle measured = FactorBundle.of(new Factors("gpt-4o", 0.0));
         FactorBundle queried = FactorBundle.of(new Factors("gpt-4o", 0.7));
         BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(measured),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.92, 1000)));
         writer.write(record, dir);
 
         var provider = new YamlBaselineProvider(dir);
@@ -77,7 +78,7 @@ class YamlBaselineProviderTest {
     void lookupCleanWhenFingerprintMatches(@TempDir Path dir) throws IOException {
         FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
         BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.92, 1000)));
         writer.write(record, dir);
 
         var provider = new YamlBaselineProvider(dir);
@@ -96,7 +97,7 @@ class YamlBaselineProviderTest {
     void lookupSurfacesMismatchWarning(@TempDir Path dir) throws IOException {
         FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
         BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.92, 1000)));
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.92, 1000)));
         Path file = writer.write(record, dir);
         // Tamper: lower observedPassRate without re-fingerprinting.
         String tampered = Files.readString(file).replace(
@@ -121,7 +122,7 @@ class YamlBaselineProviderTest {
     void lookupSurfacesMissingWarning(@TempDir Path dir) throws IOException {
         FactorBundle bundle = FactorBundle.of(new Factors("gpt-4o", 0.0));
         BaselineRecord record = baseline("ShoppingBasket", FactorsFingerprint.of(bundle),
-                Map.of("bernoulli-pass-rate", new PassRateStatistics(0.88, 500)));
+                Map.of("bernoulli-pass-rate", PerCriterionPassRateStatistics.of("contract", 0.88, 500)));
         Path file = writer.write(record, dir);
         // Strip the trailing fingerprint line — synthesises a pre-integrity baseline.
         String stripped = Files.readString(file)

--- a/punit-core/src/test/java/org/javai/punit/junit5/FeasibilityIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/FeasibilityIntegrationTest.java
@@ -13,6 +13,7 @@ import org.javai.punit.api.InputSupplier;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.internal.engine.baseline.BaselineRecord;
 import org.javai.punit.internal.engine.baseline.BaselineWriter;
 import org.javai.punit.internal.engine.baseline.FactorsFingerprint;
@@ -159,7 +160,7 @@ class FeasibilityIntegrationTest {
                 Instant.parse("2026-04-28T15:00:00Z"),
                 Map.<String, BaselineStatistics>of(
                         "bernoulli-pass-rate",
-                        new PassRateStatistics(rate, sampleCount)));
+                        PerCriterionPassRateStatistics.of("contract", rate, sampleCount)));
         new BaselineWriter().write(record, baselineDir);
     }
 

--- a/punit-core/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/MeasureToTestRoundTripTest.java
@@ -15,6 +15,7 @@ import org.javai.punit.api.InputSupplier;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.internal.engine.baseline.BaselineRecord;
 import org.javai.punit.internal.engine.baseline.BaselineWriter;
 import org.javai.punit.internal.engine.baseline.FactorsFingerprint;
@@ -125,7 +126,7 @@ class MeasureToTestRoundTripTest {
                 Instant.parse("2026-04-28T12:00:00Z"),
                 Map.<String, BaselineStatistics>of(
                         "bernoulli-pass-rate",
-                        new PassRateStatistics(passRate, sampleCount)));
+                        PerCriterionPassRateStatistics.of("contract", passRate, sampleCount)));
         new BaselineWriter().write(record, dir);
     }
 

--- a/punit-core/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/PreflightInvariantsTest.java
@@ -13,6 +13,7 @@ import org.javai.punit.api.InputSupplier;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.internal.engine.baseline.BaselineRecord;
 import org.javai.punit.internal.engine.baseline.BaselineResolver;
 import org.javai.punit.internal.engine.baseline.BaselineWriter;
@@ -183,7 +184,7 @@ class PreflightInvariantsTest {
                 Instant.parse("2026-05-10T00:00:00Z"),
                 Map.<String, BaselineStatistics>of(
                         "bernoulli-pass-rate",
-                        new PassRateStatistics(rate, sampleCount)));
+                        PerCriterionPassRateStatistics.of("contract", rate, sampleCount)));
         new BaselineWriter().write(record, baselineDir);
     }
 


### PR DESCRIPTION
## Summary

Stage 1 of the experiment-side alignment with the multi-criterion methodology. MEASURE baselines now carry per-methodology-criterion empirical bases.

Implements `plan/directives/DIR-MEASURE-PER-CRITERION-punit.md` (orchestrator).

## Schema

`punit-baseline-2` → `punit-baseline-3`. The `statistics.bernoulli-pass-rate` block now nests a `criteria:` sub-map keyed by methodology criterion id:

```yaml
statistics:
  bernoulli-pass-rate:
    criteria:
      shopping-basket-service-contract:    # methodology criterion id
        observedPassRate: 1.0
        sampleCount: 30
```

Latency stays at the run level (`latency:` top-level block, unchanged).

## What changed

- **Producer**: `BaselineEmitter` composes `PerCriterionPassRateStatistics` from `SampleSummary.criterionSampleCounts()`; `BaselineWriter` emits the nested YAML; new `PerCriterionPassRateStatistics` is the BaselineStatistics variant.
- **Consumer (reader)**: `BaselineReader` parses the new shape; rejects `punit-baseline-2` files with a re-MEASURE migration message (no silent adapter — user choice).
- **Consumer (evaluator)**: `BaselineResolver` unwraps for callers requesting `PassRateStatistics.class`: single-entry → lone entry; multi-entry → `IllegalStateException` naming the criteria (K>1 empirical TEST awaits Stage C-flavoured evaluator-inference).
- **Tests**: 25+ test fixtures migrated from `new PassRateStatistics(...)` to `PerCriterionPassRateStatistics.of("contract", ...)` for the K=1 default. Embedded YAML literals updated to the new shape.

## Test plan

- [x] `./gradlew test --rerun-tasks` green
- [x] Architecture rules green (no requirement-code leaks; statistics isolation; sentinel JUnit isolation)
- [x] K=1 empirical TEST end-to-end works byte-identical with the new shape
- [x] K>1 path fast-fails at resolver time with a clear diagnostic

## Pair-PR

`punitexamples` re-runs MEASURE on the two example contracts and commits the regenerated baselines — depends on this PR landing and an alpha containing it.

## Follow-on

- K>1 empirical TEST evaluator inference (Stage C — separate directive)
- EXPLORE / OPTIMIZE alignment (Stages 2 and 3 — separate directive pairs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)