### PR TITLE
PassRate evaluator: K-aware per-criterion empirical evaluation

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Experiment.java
@@ -47,11 +47,24 @@ import org.junit.jupiter.api.Test;
  * method body's verb ({@code measuring} / {@code exploring} /
  * {@code optimizing}).
  *
- * <p>Tagged {@code "punit-experiment"} so the standard test run
- * (filtered by Gradle / Maven configuration) excludes them by
- * default. Experiments run only when explicitly invoked, typically
- * via the {@code experiment} / {@code exp} Gradle tasks the punit
- * plugin registers.
+ * <p>An experiment runs through the same JUnit Platform engine as a
+ * {@link ProbabilisticTest} — both annotations are meta-annotated with
+ * {@code @Test} and the method body drives sampling via the {@code PUnit}
+ * entry point. What makes an experiment different is its runtime
+ * contract: it is typically slow and expensive (e.g. an LLM-calling
+ * 1000-sample MEASURE), it is side-effecting (writes baseline spec,
+ * exploration, or optimization YAML to disk), and an INCONCLUSIVE
+ * outcome is normal rather than a failure.
+ *
+ * <p>For that reason the annotation carries the
+ * {@code "punit-experiment"} tag, and the punit Gradle plugin
+ * configures {@code ./gradlew test} to exclude it. Without that
+ * exclusion, a routine test run (or CI) would re-execute every
+ * baseline experiment in the project and clobber the committed spec
+ * files those experiments produce. Experiments run only when
+ * explicitly invoked, via the {@code experiment} / {@code exp} Gradle
+ * tasks the plugin registers — those tasks carry the cache, failure,
+ * and output-dir defaults experiments need.
  */
 @Test
 @Tag("punit-experiment")

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdicts.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdicts.java
@@ -49,18 +49,28 @@ public final class PerCriterionVerdicts {
         if (perCriterionCounts.isEmpty()) {
             return PerCriterionEvaluation.empty();
         }
-        Optional<Double> threshold = scanThreshold(legacyEvaluated);
+        java.util.Map<String, Double> perCriterionThresholds =
+                scanPerCriterionThresholds(legacyEvaluated);
+        Optional<Double> sharedThreshold = scanThreshold(legacyEvaluated);
         Verdict legacyComposed = Verdict.compose(legacyEvaluated);
-        boolean propagateInconclusive =
-                legacyComposed == Verdict.INCONCLUSIVE || threshold.isEmpty();
+        boolean propagateInconclusive = legacyComposed == Verdict.INCONCLUSIVE;
 
-        double resolvedThreshold = threshold.orElse(Double.NaN);
         List<PerCriterionVerdict> derived = new ArrayList<>(perCriterionCounts.size());
         List<Verdict> verdicts = new ArrayList<>(perCriterionCounts.size());
         for (CriterionSampleCounts counts : perCriterionCounts) {
+            // Per-criterion threshold takes precedence over the shared
+            // single-threshold fallback. The PassRate evaluator publishes
+            // a thresholdsByCriterion map in its result detail when K>1;
+            // for K=1 it publishes the flat `threshold` field which the
+            // shared-threshold fallback picks up.
+            double resolvedThreshold = perCriterionThresholds.containsKey(counts.criterionId())
+                    ? perCriterionThresholds.get(counts.criterionId())
+                    : sharedThreshold.orElse(Double.NaN);
             Verdict v;
             double observed = counts.observedPassRate();
-            if (propagateInconclusive || counts.total() == 0) {
+            if (propagateInconclusive
+                    || Double.isNaN(resolvedThreshold)
+                    || counts.total() == 0) {
                 v = Verdict.INCONCLUSIVE;
             } else {
                 v = observed >= resolvedThreshold ? Verdict.PASS : Verdict.FAIL;
@@ -74,12 +84,13 @@ public final class PerCriterionVerdicts {
 
     /**
      * Lifts the resolved threshold from the legacy
-     * {@link EvaluatedCriterion} list. The legacy
-     * {@code PassRate.evaluate} writes {@code threshold} into its
-     * result detail map; the first criterion whose detail carries a
-     * numeric threshold wins. Returns empty when no criterion has
-     * resolved a threshold yet (e.g. all are INCONCLUSIVE before
-     * derivation).
+     * {@link EvaluatedCriterion} list — the single-threshold path
+     * used for K=1 runs. The legacy {@code PassRate.evaluate} writes
+     * {@code threshold} into its result detail map; the first
+     * criterion whose detail carries a numeric threshold wins.
+     * Returns empty when no criterion has resolved a threshold yet
+     * (all INCONCLUSIVE before derivation, or K&gt;1 where
+     * thresholds are per-criterion only).
      */
     private static Optional<Double> scanThreshold(List<EvaluatedCriterion> evaluated) {
         for (EvaluatedCriterion ec : evaluated) {
@@ -89,5 +100,31 @@ public final class PerCriterionVerdicts {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Lifts per-methodology-criterion thresholds from the legacy
+     * {@link EvaluatedCriterion} list — the K&gt;1 path used since
+     * the PassRate evaluator gained per-criterion empirical
+     * evaluation. {@code thresholdsByCriterion} on the result detail
+     * is a {@code Map<String, Double>} keyed by methodology criterion
+     * id. Returns an empty map when no criterion publishes that key
+     * (K=1 runs use the shared-threshold path instead).
+     */
+    private static java.util.Map<String, Double> scanPerCriterionThresholds(
+            List<EvaluatedCriterion> evaluated) {
+        java.util.LinkedHashMap<String, Double> out = new java.util.LinkedHashMap<>();
+        for (EvaluatedCriterion ec : evaluated) {
+            Object v = ec.result().detail().get("thresholdsByCriterion");
+            if (v instanceof java.util.Map<?, ?> raw) {
+                for (java.util.Map.Entry<?, ?> e : raw.entrySet()) {
+                    if (e.getKey() instanceof String key
+                            && e.getValue() instanceof Number n) {
+                        out.put(key, n.doubleValue());
+                    }
+                }
+            }
+        }
+        return out;
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
@@ -169,11 +169,13 @@ public final class BaselineResolver {
             return new BaselineLookup<>(
                     Optional.empty(), baselineProfile, notes, sourceFile);
         }
-        // Unwrap per-methodology-criterion pass-rate basis when the
-        // caller is a single-criterion empirical evaluator (PassRate).
-        // K=1: the lone entry is the evaluator's basis. K>1: fast-fail
-        // with a clear message — the K>1 empirical TEST path requires
-        // the evaluator-inference machinery that hasn't landed yet.
+        // Backward-compat unwrap: callers that still request
+        // PassRateStatistics directly (legacy tests, pinned-baseline
+        // paths) get the single entry for K=1 baselines. K>1
+        // baselines no longer throw — PassRate now declares
+        // PerCriterionPassRateStatistics as its baseline shape and
+        // does its own per-criterion iteration. The unwrap below is
+        // retained for callers that haven't migrated.
         if (entry instanceof PerCriterionPassRateStatistics perCriterion
                 && statisticsType == PassRateStatistics.class) {
             Map<String, PassRateStatistics> byCriterion = perCriterion.byCriterion();
@@ -181,21 +183,20 @@ public final class BaselineResolver {
                 return new BaselineLookup<>(
                         Optional.empty(), baselineProfile, notes, sourceFile);
             }
-            if (byCriterion.size() > 1) {
-                throw new IllegalStateException(
-                        "Baseline for service contract '" + serviceContractId
-                                + "' carries " + byCriterion.size()
-                                + " methodology criteria under '" + criterionName + "': "
-                                + byCriterion.keySet()
-                                + ". The empirical PassRate evaluator can only target one"
-                                + " criterion today; multi-criterion empirical evaluation"
-                                + " awaits the evaluator-inference machinery (deferred"
-                                + " from this stage). Until then, K>1 contracts can MEASURE"
-                                + " but cannot run an empirical TEST.");
+            if (byCriterion.size() == 1) {
+                PassRateStatistics only = byCriterion.values().iterator().next();
+                return new BaselineLookup<>(
+                        Optional.of(statisticsType.cast(only)), baselineProfile, notes, sourceFile);
             }
-            PassRateStatistics only = byCriterion.values().iterator().next();
+            // K>1 + legacy PassRateStatistics request — return empty
+            // with a note. Production callers now request
+            // PerCriterionPassRateStatistics and skip this branch.
+            List<String> notesWithNote = new ArrayList<>(notes);
+            notesWithNote.add("K>1 baseline (criteria=" + byCriterion.keySet()
+                    + ") cannot be unwrapped to a single PassRateStatistics — "
+                    + "callers should request PerCriterionPassRateStatistics");
             return new BaselineLookup<>(
-                    Optional.of(statisticsType.cast(only)), baselineProfile, notes, sourceFile);
+                    Optional.empty(), baselineProfile, notesWithNote, sourceFile);
         }
         if (!statisticsType.isInstance(entry)) {
             throw new IllegalStateException(

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/PowerAnalysis.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/PowerAnalysis.java
@@ -15,6 +15,7 @@ import org.javai.punit.api.covariate.CovariateProfile;
 import org.javai.punit.api.spec.Configuration;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.Spec;
 import org.javai.punit.api.spec.TypedSpec;
 import org.javai.punit.internal.engine.covariate.CovariateResolver;
@@ -136,11 +137,11 @@ public final class PowerAnalysis {
 
         BaselineLookup lookup = experiment.dispatch(LOOKUP_DISPATCHER);
         BaselineResolver resolver = new BaselineResolver(baselineDir);
-        PassRateStatistics stats = resolver.resolve(
+        PerCriterionPassRateStatistics stats = resolver.resolve(
                 lookup.serviceContractId(),
                 lookup.factorsFingerprint(),
                 PASS_RATE_CRITERION,
-                PassRateStatistics.class,
+                PerCriterionPassRateStatistics.class,
                 lookup.profile(),
                 lookup.declarations())
                 .orElseThrow(() -> new IllegalStateException(
@@ -151,7 +152,21 @@ public final class PowerAnalysis {
                                 + ") under " + baselineDir
                                 + " — run the baseline measure before planning a test against it."));
 
-        double observedRate = stats.observedPassRate();
+        // K>1 worst-case: when the contract carries multiple
+        // methodology criteria, the sample-size dictating criterion
+        // is the one with the lowest baseline rate — its degradation
+        // is hardest to detect, so its sample-size requirement
+        // dominates. For K=1 this collapses to the lone criterion's
+        // rate, preserving legacy behaviour.
+        if (stats.byCriterion().isEmpty()) {
+            throw new IllegalStateException(
+                    "baseline carries no per-criterion pass-rate entries — "
+                            + "the baseline file is malformed");
+        }
+        double observedRate = stats.byCriterion().values().stream()
+                .mapToDouble(PassRateStatistics::observedPassRate)
+                .min()
+                .getAsDouble();
         // One-sided check: degradation testing only cares about the
         // lower side, so the alternative-hypothesis rate p1 = rate − mde
         // must be strictly positive. The upper side (rate + mde) is

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -7,13 +7,18 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.function.Supplier;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.spec.Criterion;
 import org.javai.punit.api.spec.CriterionResult;
+import org.javai.punit.api.spec.CriterionSampleCounts;
 import org.javai.punit.api.spec.EmpiricalChecks;
 import org.javai.punit.api.spec.EvaluationContext;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.statistics.BinomialProportionEstimator;
@@ -57,7 +62,7 @@ import org.javai.punit.statistics.ThresholdDeriver;
  * dependencies. The {@link Criterion} interface itself stays in
  * {@code api package}; only this implementation moved.
  */
-public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
+public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateStatistics> {
 
     private static final String NAME = "bernoulli-pass-rate";
     private static final double DEFAULT_CONFIDENCE = 0.95;
@@ -170,8 +175,8 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
     }
 
     @Override
-    public Class<PassRateStatistics> statisticsType() {
-        return PassRateStatistics.class;
+    public Class<PerCriterionPassRateStatistics> statisticsType() {
+        return PerCriterionPassRateStatistics.class;
     }
 
     @Override
@@ -193,31 +198,64 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
     }
 
     @Override
-    public CriterionResult evaluate(EvaluationContext<OT, PassRateStatistics> ctx) {
+    public CriterionResult evaluate(EvaluationContext<OT, PerCriterionPassRateStatistics> ctx) {
         Objects.requireNonNull(ctx, "ctx");
         SampleSummary<OT> summary = ctx.summary();
         int total = summary.total();
         if (total == 0) {
             return inconclusive("zero samples taken", Map.of());
         }
-
-        double resolvedThreshold;
-        ThresholdOrigin resolvedOrigin;
-        Integer baselineSampleCount = null;
-        Double baselineRate = null;
-
-        if (mode == Mode.CONTRACTUAL) {
-            resolvedThreshold = threshold;
-            resolvedOrigin = origin;
-        } else {
-            PassRateStatistics stats = ctx.baseline().orElse(null);
-            if (stats == null) {
+        // Resolve the per-criterion baseline map up-front (empirical
+        // paths only). Identity / sample-size gates also fire once at
+        // the run level — identity is a property of the matched
+        // baseline file, not of any one criterion.
+        PerCriterionPassRateStatistics baselineMap = null;
+        List<CriterionSampleCounts> methodologyCriteria = summary.criterionSampleCounts();
+        // K=1 path uses run-level counts (summary.successes/failures),
+        // not the auto-derived methodology criterion's counts. The
+        // run-level numbers reflect framework-side concerns
+        // (expectedOutputs mismatches, value-matcher failures) that
+        // the contract-level postcondition counter does not see; the
+        // legacy K=1 behaviour read these run-level numbers, and
+        // K=1 tests are pinned against them. K>1 must use per-criterion
+        // counts so each methodology criterion is evaluated against
+        // its own pass/fail tally.
+        if (methodologyCriteria.size() == 1) {
+            CriterionSampleCounts auto = methodologyCriteria.get(0);
+            methodologyCriteria = List.of(
+                    new CriterionSampleCounts(
+                            auto.criterionId(),
+                            summary.successes(),
+                            summary.failures(),
+                            auto.inconclusive()));
+        }
+        if (methodologyCriteria.isEmpty()) {
+            // Run produced no methodology-criterion sample counts
+            // (apply-level-failure run, or a hand-built test fixture).
+            // Fall back to run-level pass / fail counts. The criterion
+            // id is borrowed from the baseline map's lone entry when
+            // available (so the lookup below finds it); otherwise the
+            // criterion's own name is used as a stable placeholder
+            // — there's no baseline entry to match in that case
+            // (contractual mode) so the placeholder is never queried.
+            String fallbackId = NAME;
+            if (mode != Mode.CONTRACTUAL) {
+                PerCriterionPassRateStatistics b = ctx.baseline().orElse(null);
+                if (b != null && b.byCriterion().size() == 1) {
+                    fallbackId = b.byCriterion().keySet().iterator().next();
+                }
+            }
+            methodologyCriteria = List.of(
+                    new CriterionSampleCounts(
+                            fallbackId, summary.successes(), summary.failures(), 0));
+        }
+        // Resolve the baseline map up-front (empirical mode only).
+        if (mode != Mode.CONTRACTUAL) {
+            baselineMap = ctx.baseline().orElse(null);
+            if (baselineMap == null || baselineMap.byCriterion().isEmpty()) {
                 return EmpiricalChecks.noBaseline(NAME, empiricalDetail());
             }
             Map<String, Object> empiricalDetail = Map.of("confidence", confidence);
-            // Inputs-identity rule precedes the sample-size rule: an identity
-            // mismatch is a more fundamental violation, so its diagnostic
-            // wins when both would fire.
             String baselineIdentity = ctx.baselineInputsIdentity().orElseThrow(() ->
                     new IllegalStateException(
                             "baseline statistics were resolved but baselineInputsIdentity is empty — "
@@ -227,52 +265,174 @@ public final class PassRate<OT> implements Criterion<OT, PassRateStatistics> {
             if (identityViolation.isPresent()) {
                 return identityViolation.get();
             }
-            Optional<CriterionResult> sizeViolation = EmpiricalChecks.sampleSizeConstraint(
-                    NAME, total, stats.sampleCount(), empiricalDetail);
-            if (sizeViolation.isPresent()) {
-                return sizeViolation.get();
+        }
+
+        // Evaluate each methodology criterion against its own basis
+        // (empirical: per-criterion Wilson threshold; contractual:
+        // shared external threshold). Compose per the FAIL-dominant
+        // rule (companion §1.4.6).
+        List<Verdict> perCriterionVerdicts = new ArrayList<>(methodologyCriteria.size());
+        Map<String, Double> thresholdsByCriterion = new LinkedHashMap<>();
+        Map<String, Double> observedByCriterion = new LinkedHashMap<>();
+        Map<String, PassRateStatistics> resolvedBaselineByCriterion = new LinkedHashMap<>();
+        List<String> perCriterionExplanations = new ArrayList<>();
+        ThresholdOrigin resolvedOrigin = mode == Mode.CONTRACTUAL
+                ? origin
+                : ThresholdOrigin.EMPIRICAL;
+
+        // K=1 short-circuit: when there's a single criterion and an
+        // empirical-check violation fires (sample-size constraint), the
+        // result is the violation's full CriterionResult — preserving
+        // the legacy detail keys (testSampleCount, baselineSampleCount)
+        // and explanation phrasing that downstream consumers depend on.
+        // Identity violations already returned above.
+        boolean isK1 = methodologyCriteria.size() == 1;
+
+        for (CriterionSampleCounts counts : methodologyCriteria) {
+            int criterionTotal = counts.pass() + counts.fail() + counts.inconclusive();
+            double observed = criterionTotal == 0
+                    ? 0.0
+                    : (double) counts.pass() / (double) criterionTotal;
+            observedByCriterion.put(counts.criterionId(), observed);
+
+            double criterionThreshold;
+            Double baselineRate = null;
+            Integer baselineSampleCount = null;
+            if (mode == Mode.CONTRACTUAL) {
+                criterionThreshold = threshold;
+            } else {
+                PassRateStatistics criterionBaseline =
+                        baselineMap.byCriterion().get(counts.criterionId());
+                if (criterionBaseline == null
+                        && isK1 && baselineMap.byCriterion().size() == 1) {
+                    // K=1 isomorphism: when there's exactly one
+                    // methodology criterion on both the run side and
+                    // the baseline side, treat them as the same
+                    // criterion even when their ids differ. Older
+                    // baselines were written with the legacy default
+                    // id "contract"; newer runs auto-derive an id
+                    // from the service contract class name.
+                    criterionBaseline = baselineMap.byCriterion().values().iterator().next();
+                }
+                if (criterionBaseline == null) {
+                    if (isK1) {
+                        return EmpiricalChecks.noBaseline(NAME, empiricalDetail());
+                    }
+                    perCriterionVerdicts.add(Verdict.INCONCLUSIVE);
+                    perCriterionExplanations.add(String.format(
+                            "%s: INCONCLUSIVE (no baseline entry for this criterion)",
+                            counts.criterionId()));
+                    thresholdsByCriterion.put(counts.criterionId(), Double.NaN);
+                    continue;
+                }
+                Optional<CriterionResult> sizeViolation =
+                        EmpiricalChecks.sampleSizeConstraint(
+                                NAME, criterionTotal, criterionBaseline.sampleCount(),
+                                Map.of("confidence", confidence));
+                if (sizeViolation.isPresent()) {
+                    if (isK1) {
+                        return sizeViolation.get();
+                    }
+                    perCriterionVerdicts.add(sizeViolation.get().verdict());
+                    perCriterionExplanations.add(
+                            counts.criterionId() + ": " + sizeViolation.get().explanation());
+                    thresholdsByCriterion.put(counts.criterionId(), Double.NaN);
+                    continue;
+                }
+                resolvedBaselineByCriterion.put(counts.criterionId(), criterionBaseline);
+                int baselineSuccesses = (int) Math.round(
+                        criterionBaseline.observedPassRate() * criterionBaseline.sampleCount());
+                DerivedThreshold derived = DERIVER.deriveSampleSizeFirst(
+                        criterionBaseline.sampleCount(), baselineSuccesses, criterionTotal, confidence);
+                criterionThreshold = derived.value();
+                baselineRate = criterionBaseline.observedPassRate();
+                baselineSampleCount = criterionBaseline.sampleCount();
             }
-            // Empirical: derive the threshold via the sample-size-first
-            // construction at the test sample size (statistical companion
-            // §3.4 / §4.3.2). The decision rule (§5.1) compares the raw
-            // observed pass rate against this derived threshold.
-            int baselineSuccesses = (int) Math.round(
-                    stats.observedPassRate() * stats.sampleCount());
-            DerivedThreshold derived = DERIVER.deriveSampleSizeFirst(
-                    stats.sampleCount(), baselineSuccesses, total, confidence);
-            resolvedThreshold = derived.value();
-            resolvedOrigin = ThresholdOrigin.EMPIRICAL;
-            baselineSampleCount = stats.sampleCount();
-            baselineRate = stats.observedPassRate();
+            thresholdsByCriterion.put(counts.criterionId(), criterionThreshold);
+
+            Verdict v;
+            if (criterionTotal == 0) {
+                v = Verdict.INCONCLUSIVE;
+            } else {
+                v = observed >= criterionThreshold ? Verdict.PASS : Verdict.FAIL;
+            }
+            perCriterionVerdicts.add(v);
+            if (mode == Mode.CONTRACTUAL) {
+                perCriterionExplanations.add(String.format(
+                        "%s: observed=%.4f vs threshold=%.4f over %d samples → %s",
+                        counts.criterionId(), observed, criterionThreshold, criterionTotal, v));
+            } else {
+                perCriterionExplanations.add(String.format(
+                        "%s: observed=%.4f vs threshold=%.4f "
+                                + "(Wilson-%.0f%% lower of baseline rate %.4f at n=%d) → %s",
+                        counts.criterionId(), observed, criterionThreshold,
+                        confidence * 100.0, baselineRate, criterionTotal, v));
+            }
         }
 
-        double observed = (double) summary.successes() / (double) total;
-        Verdict verdict = observed >= resolvedThreshold ? Verdict.PASS : Verdict.FAIL;
+        Verdict composite = Verdict.aggregate(perCriterionVerdicts);
 
+        // Build the result detail map. For K=1 the legacy flat shape
+        // (observed/threshold/successes/failures/total) is preserved
+        // so downstream renderers and tests that read it continue to
+        // work. For K>1 the same keys carry the lone criterion's
+        // values when applicable, and a perCriterion-keyed sub-map
+        // carries the K-row breakdown.
         Map<String, Object> detail = new LinkedHashMap<>();
-        detail.put("observed", observed);
-        detail.put("threshold", resolvedThreshold);
-        detail.put("origin", resolvedOrigin.name());
-        detail.put("successes", summary.successes());
-        detail.put("failures", summary.failures());
-        detail.put("total", total);
-        if (mode != Mode.CONTRACTUAL) {
-            detail.put("confidence", confidence);
-            detail.put("baselineSampleCount", baselineSampleCount);
-            detail.put("baselineRate", baselineRate);
+        if (methodologyCriteria.size() == 1) {
+            CriterionSampleCounts only = methodologyCriteria.get(0);
+            int onlyTotal = only.pass() + only.fail() + only.inconclusive();
+            double observed = observedByCriterion.get(only.criterionId());
+            double t = thresholdsByCriterion.get(only.criterionId());
+            detail.put("observed", observed);
+            detail.put("threshold", t);
+            detail.put("origin", resolvedOrigin.name());
+            detail.put("successes", only.pass());
+            detail.put("failures", only.fail());
+            detail.put("total", onlyTotal);
+            if (mode != Mode.CONTRACTUAL) {
+                PassRateStatistics b = resolvedBaselineByCriterion.get(only.criterionId());
+                detail.put("confidence", confidence);
+                detail.put("baselineSampleCount", b == null ? null : b.sampleCount());
+                detail.put("baselineRate", b == null ? null : b.observedPassRate());
+            }
+        } else {
+            detail.put("origin", resolvedOrigin.name());
+            detail.put("total", total);
+            detail.put("successes", summary.successes());
+            detail.put("failures", summary.failures());
+            if (mode != Mode.CONTRACTUAL) {
+                detail.put("confidence", confidence);
+            }
+            detail.put("thresholdsByCriterion", Map.copyOf(thresholdsByCriterion));
+            detail.put("observedByCriterion", Map.copyOf(observedByCriterion));
         }
 
-        String explanation = mode == Mode.CONTRACTUAL
-                ? String.format(
+        String explanation;
+        if (methodologyCriteria.size() == 1) {
+            CriterionSampleCounts only = methodologyCriteria.get(0);
+            int onlyTotal = only.pass() + only.fail() + only.inconclusive();
+            double observed = observedByCriterion.get(only.criterionId());
+            double t = thresholdsByCriterion.get(only.criterionId());
+            if (mode == Mode.CONTRACTUAL) {
+                explanation = String.format(
                         "observed=%.4f, threshold=%.4f (origin=%s) over %d samples",
-                        observed, resolvedThreshold, resolvedOrigin, total)
-                : String.format(
+                        observed, t, resolvedOrigin, onlyTotal);
+            } else {
+                PassRateStatistics b = resolvedBaselineByCriterion.get(only.criterionId());
+                explanation = String.format(
                         "observed=%.4f vs threshold=%.4f (Wilson-%.0f%% lower of "
                                 + "baseline rate %.4f at n_test=%d; origin=%s) over %d samples",
-                        observed, resolvedThreshold, confidence * 100.0,
-                        baselineRate, total, resolvedOrigin, total);
+                        observed, t, confidence * 100.0,
+                        b == null ? Double.NaN : b.observedPassRate(),
+                        onlyTotal, resolvedOrigin, onlyTotal);
+            }
+        } else {
+            explanation = "composite verdict over " + methodologyCriteria.size()
+                    + " criteria: " + String.join("; ", perCriterionExplanations);
+        }
 
-        return new CriterionResult(NAME, verdict, explanation, detail);
+        return new CriterionResult(NAME, composite, explanation, detail);
     }
 
     private CriterionResult inconclusive(String reason, Map<String, Object> detail) {

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -136,6 +136,25 @@ public final class ExploreOutputWriter {
             failureDistribution.put(entry.getKey(), entry.getValue().count());
         }
         block.put("failureDistribution", failureDistribution);
+        // Per-criterion decomposition (only when the run produced
+        // methodology-level criterion counts — empty for contracts
+        // that declared no explicit criteria(CriteriaBuilder) list).
+        // Mirrors the per-criterion shape that MEASURE writes into
+        // baselines so a reader can compare explore vs measure
+        // emissions of the same contract criterion-by-criterion.
+        if (!summary.criterionSampleCounts().isEmpty()) {
+            Map<String, Object> criteria = new LinkedHashMap<>();
+            for (org.javai.punit.api.spec.CriterionSampleCounts counts
+                    : summary.criterionSampleCounts()) {
+                Map<String, Object> row = new LinkedHashMap<>();
+                row.put("observedPassRate", counts.observedPassRate());
+                row.put("pass", counts.pass());
+                row.put("fail", counts.fail());
+                row.put("inconclusive", counts.inconclusive());
+                criteria.put(counts.criterionId(), row);
+            }
+            block.put("criteria", criteria);
+        }
         return block;
     }
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
@@ -20,6 +20,7 @@ import org.javai.punit.api.spec.CriterionResult;
 import org.javai.punit.api.spec.EvaluationContext;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.PercentileKey;
 import org.javai.punit.api.spec.PercentileLatency;
 import org.javai.punit.api.spec.SampleSummary;
@@ -105,7 +106,7 @@ class CriterionResultDetailTest {
     void baselineSampleCountKeyIsStable() {
         var passRate = PassRate.<Integer>empirical().evaluate(
                 ctx(summaryWithLatency(LatencyResult.empty()),
-                        Optional.of(new PassRateStatistics(0.9, 1234))));
+                        Optional.of(PerCriterionPassRateStatistics.of("contract", 0.9, 1234))));
         var latency = PercentileLatency.<Integer>empirical(PercentileKey.P95).evaluate(
                 ctx(summaryWithLatency(observed(10, 20, 30, 40, 2)),
                         Optional.of(new LatencyStatistics(observed(10, 20, 50, 60, 1234), 1234))));
@@ -132,7 +133,7 @@ class CriterionResultDetailTest {
     void bernoulliEmpiricalDetailKeys() {
         var result = PassRate.<Integer>empirical().evaluate(
                 ctx(summaryWithLatency(LatencyResult.empty()),
-                        Optional.of(new PassRateStatistics(0.9, 1234))));
+                        Optional.of(PerCriterionPassRateStatistics.of("contract", 0.9, 1234))));
 
         assertThat(result.detail()).containsKeys("confidence", "baselineSampleCount");
         assertThat(result.detail()).containsEntry("origin", "EMPIRICAL");

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/PassRateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/PassRateTest.java
@@ -19,6 +19,7 @@ import org.javai.punit.api.spec.CriterionResult;
 import org.javai.punit.api.spec.EvaluationContext;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.TerminationReason;
 import org.javai.punit.api.spec.Verdict;
@@ -61,20 +62,25 @@ class PassRateTest {
 
     private static final String DEFAULT_IDENTITY = "sha256:test-default-identity";
 
-    private static <OT> EvaluationContext<OT, PassRateStatistics> ctx(
+    private static <OT> EvaluationContext<OT, PerCriterionPassRateStatistics> ctx(
             SampleSummary<OT> summary, Optional<PassRateStatistics> baseline) {
         return ctx(summary, baseline, DEFAULT_IDENTITY,
                 baseline.isPresent() ? Optional.of(DEFAULT_IDENTITY) : Optional.empty());
     }
 
-    private static <OT> EvaluationContext<OT, PassRateStatistics> ctx(
+    private static <OT> EvaluationContext<OT, PerCriterionPassRateStatistics> ctx(
             SampleSummary<OT> summary,
             Optional<PassRateStatistics> baseline,
             String testIdentity,
             Optional<String> baselineIdentity) {
-        return new EvaluationContext<OT, PassRateStatistics>() {
+        // Wrap the hand-constructed PassRateStatistics into a
+        // single-entry PerCriterionPassRateStatistics so the K-aware
+        // PassRate evaluator can read its lone criterion's basis.
+        Optional<PerCriterionPassRateStatistics> wrapped = baseline.map(
+                b -> PerCriterionPassRateStatistics.of("contract", b));
+        return new EvaluationContext<OT, PerCriterionPassRateStatistics>() {
             @Override public SampleSummary<OT> summary() { return summary; }
-            @Override public Optional<PassRateStatistics> baseline() { return baseline; }
+            @Override public Optional<PerCriterionPassRateStatistics> baseline() { return wrapped; }
             @Override public FactorBundle factors() { return FactorBundle.of(new Factors("x")); }
             @Override public String testInputsIdentity() { return testIdentity; }
             @Override public Optional<String> baselineInputsIdentity() { return baselineIdentity; }
@@ -437,10 +443,10 @@ class PassRateTest {
     // ── plumbing ─────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("criterion exposes PassRateStatistics.class as its statistics type")
-    void statisticsTypeIsPassRateStatistics() {
+    @DisplayName("criterion exposes PerCriterionPassRateStatistics.class as its statistics type")
+    void statisticsTypeIsPerCriterionPassRateStatistics() {
         PassRate<String> criterion = PassRate.empirical();
-        assertThat(criterion.statisticsType()).isEqualTo(PassRateStatistics.class);
+        assertThat(criterion.statisticsType()).isEqualTo(PerCriterionPassRateStatistics.class);
     }
 
     @Test

--- a/punit-gradle-plugin/src/functionalTest/kotlin/org/javai/punit/gradle/PUnitPluginFunctionalTest.kt
+++ b/punit-gradle-plugin/src/functionalTest/kotlin/org/javai/punit/gradle/PUnitPluginFunctionalTest.kt
@@ -72,7 +72,7 @@ class PUnitPluginFunctionalTest {
 
             val result = runner("tasks", "--all").build()
 
-            assertTrue(result.output.contains("experiment - Runs experiments"))
+            assertTrue(result.output.contains("experiment - Runs @Experiment-tagged methods"))
             assertTrue(result.output.contains("exp - Shorthand for 'experiment' task"))
         }
     }

--- a/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/javai/punit/gradle/PUnitPlugin.kt
@@ -19,10 +19,20 @@ import java.net.URLClassLoader
  * Gradle plugin that configures PUnit probabilistic testing tasks.
  *
  * Applies to any project using PUnit:
- * - Configures the `test` task to exclude experiment-tagged tests
- * - Registers `experiment` and `exp` tasks for running experiments
+ * - Configures the `test` task to exclude experiment-tagged methods
+ *   so `./gradlew test` and CI never accidentally re-run an
+ *   expensive, side-effecting experiment (e.g. an LLM-calling MEASURE
+ *   that would clobber committed baseline spec files)
+ * - Registers `experiment` and `exp` tasks for the inverse run —
+ *   experiment-tagged methods only, with the cache/failure/output-dir
+ *   defaults experiments need (uncacheable, INCONCLUSIVE-tolerant,
+ *   spec/exploration/optimization output dirs wired through)
  * - Registers `createSentinel` task to build an executable sentinel JAR
  * - Forwards `punit.*` system properties and supports `-Prun=` filter syntax
+ *
+ * `test` and `experiment` share the same JUnit Platform engine — the
+ * split between them is about runtime contract (cost, idempotence,
+ * artefact production), not about distinct execution machinery.
  */
 class PUnitPlugin : Plugin<Project> {
 
@@ -68,7 +78,10 @@ class PUnitPlugin : Plugin<Project> {
             }
 
             registerExperimentTask(project, extension, "experiment",
-                "Runs experiments (mode determined from @Experiment annotation)")
+                "Runs @Experiment-tagged methods with experiment-appropriate " +
+                "defaults: uncacheable, INCONCLUSIVE-tolerant, and wired to " +
+                "the spec/exploration/optimization output dirs. Excluded from " +
+                "'test' so CI never accidentally re-runs them.")
             registerExperimentTask(project, extension, "exp",
                 "Shorthand for 'experiment' task")
 


### PR DESCRIPTION
## Summary

- Lands per-criterion empirical evaluation in PassRate so K>1 contracts (those declaring a methodology `criteria(CriteriaBuilder)` list) can be evaluated against per-criterion baseline statistics.
- PassRate now requests `PerCriterionPassRateStatistics` from the baseline and iterates `summary.criterionSampleCounts()` internally — Wilson lower-bound threshold per criterion, FAIL-dominant composite (companion §1.4.6).
- K=1 preserves the legacy flat detail shape and uses run-level success/failure counters so framework-level concerns (`expectedOutputs` mismatches, value-matcher failures) still register as failures.
- K=1 isomorphism: when both run and baseline carry exactly one criterion but ids differ, the lone baseline entry is adopted — preserves interop with baselines written under the legacy `\"contract\"` default id.
- K>1 detail adds `thresholdsByCriterion` and `observedByCriterion` maps; `PerCriterionVerdicts` now reads `thresholdsByCriterion` as the per-criterion threshold source.
- `BaselineResolver` no longer throws when a K>1 entry is requested as `PassRateStatistics`; legacy callers get `Optional.empty()` + a note.

## Background

Pre-#167 the baseline producer silently collapsed K>1 to K=1. #167 made emission honest, which surfaced an evaluator gap: `PassRate` read a single `PassRateStatistics` and compared against `summary.successes()/total()`. For a K=2 contract such as `ShoppingBasketServiceContract` that drove an `IllegalStateException` from `BaselineResolver`. This PR closes the evaluator side.

## Test plan

- [x] `./gradlew :punit-core:test` — green
- [x] `./gradlew :punit-report:test :punit-sentinel:test` — green
- [x] `punitexamples` `ShoppingBasketDiagnosticsTest.empiricalAtHigherSampleCount` — green (was the original failure that triggered Option B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)