### PR TITLE
Reset input cursor to zero at the start of each configuration

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
@@ -85,14 +85,19 @@ public final class Engine {
     }
 
     private <FT, IT, OT> EngineResult runTyped(TypedSpec<FT, IT, OT> spec) {
+        // Each configuration starts its input cursor at 0. In an
+        // explore / optimize grid, cells must be compared on the same
+        // inputs so that the factor change is the only variable; an
+        // accumulating cursor across cells confounded the factor with
+        // whichever portion of the input list happened to land in
+        // each cell. Intra-cell semantics are unchanged: sample i of
+        // a cell still uses inputs[i mod inputs.size()].
         Iterator<Configuration<FT, IT, OT>> it = spec.configurations();
-        int cycleStart = 0;
         while (it.hasNext()) {
             Configuration<FT, IT, OT> cfg = it.next();
             ServiceContract<FT, IT, OT> uc = spec.serviceContractFactory().apply(cfg.factors());
-            SampleSummary<OT> summary = runConfig(spec, uc, cfg, cycleStart);
+            SampleSummary<OT> summary = runConfig(spec, uc, cfg, 0);
             spec.consume(cfg, summary);
-            cycleStart = (cycleStart + summary.total()) % cfg.inputs().size();
         }
         return spec.conclude(baselineProvider);
     }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -681,6 +681,45 @@ class EngineIntegrationTest {
     }
 
     @Test
+    @DisplayName("Multi-cell explore: every cell starts its input cursor at zero (no cross-cell bleed)")
+    void multiCellExploreStartsEachCellAtInputZero() {
+        ServiceContract<LlmFactors, String, Integer> echo = new ServiceContract<>() {
+            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(0);
+            }
+        };
+        // Five inputs, three samples per cell — fewer samples than
+        // inputs so the legacy cumulative cursor would skip the first
+        // two inputs of the second cell.
+        Sampling<LlmFactors, String, Integer> shape = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .serviceContractFactory(f -> echo)
+                .inputs("i0", "i1", "i2", "i3", "i4")
+                .samples(3)
+                .build();
+        Experiment spec = Experiment.exploring(shape)
+                .grid(
+                        new LlmFactors("gpt-4o", 0.0),
+                        new LlmFactors("claude-3-sonnet", 0.0))
+                .build();
+
+        new Engine().run(spec);
+
+        var perCellTrials = spec.perConfigSummaries();
+        assertThat(perCellTrials).hasSize(2);
+        for (var perCell : perCellTrials) {
+            // Every cell must start at input 0 and walk forward.
+            // Pre-fix: cell 1 started at input 3 because cell 0
+            // consumed 3 samples, so the factor effect was confounded
+            // with input difficulty.
+            assertThat(perCell.summary().trials())
+                    .extracting(t -> t.inputIndex())
+                    .containsExactly(0, 1, 2);
+        }
+    }
+
+    @Test
     @DisplayName("Experiment.optimizing(shape) runs the stepper/scorer loop up to maxIterations")
     void optimizeSpecRunsIterationLoop() {
         ServiceContract<LlmFactors, String, Integer> echo = new ServiceContract<>() {


### PR DESCRIPTION
## Summary

Engine.runTyped carried a single \`cycleStart\` accumulator across every configuration in a multi-cell spec, so each cell began on a different slice of the input list. For explore / optimize grids this confounded the factor change with input position — cells of the grid were judged on different inputs, silently. Fix: reset to 0 at the top of each configuration. Intra-cell semantics unchanged.

Resolves \`DIR-BUG-EXPLORE-INPUT-CURSOR-BLEED-punit\`.

## Before / after — \`ShoppingBasketExplore.compareModels\` (10 inputs, 5 samples/cell, 4 cells)

| Cell | Model            | Before — inputIndex | After — inputIndex |
|------|------------------|---------------------|--------------------|
| 0    | gpt-4o-mini      | 0..4                | 0..4               |
| 1    | gpt-4o           | 5..9                | 0..4               |
| 2    | claude-haiku-4-5 | 0..4                | 0..4               |
| 3    | claude-sonnet    | 5..9                | 0..4               |

The cell-to-cell comparison is now over the same inputs, which is what an explore experiment exists to do.

## Test plan

- [x] New regression test in \`EngineIntegrationTest\`: two-cell explore over five inputs with three samples per cell — a shape where the pre-fix code started cell 1 at \`inputIndex=3\`. Asserts both cells walk \`inputIndex\` 0, 1, 2.
- [x] \`./gradlew :punit-core:test\` — green
- [x] Single-configuration paths (probabilistic-test, measure) unaffected — \`cycleStart\` started at 0 in those paths anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)