### PR TITLE
Step 1: per-criterion threshold authoring API + ContractBuilder rename

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -29,7 +29,7 @@ import org.javai.punit.api.criterion.DefaultCriterion;
  *       or {@link Outcome.Fail} for an expected business-level
  *       failure. Records cost via the supplied
  *       {@link TokenTracker}.</li>
- *   <li>{@link #postconditions(ContractBuilder) postconditions} —
+ *   <li>{@link #postconditions(PostconditionBuilder) postconditions} —
  *       declares the contract's clauses by populating the supplied
  *       builder with {@code ensure(...)} calls.</li>
  * </ul>
@@ -87,7 +87,7 @@ public interface Contract<I, O> {
 
     /**
      * Declare this contract's postcondition clauses by calling
-     * {@link ContractBuilder#ensure ensure} on the supplied builder.
+     * {@link PostconditionBuilder#ensure ensure} on the supplied builder.
      *
      * <p>The framework constructs a fresh builder, calls this method
      * to populate it, and reads the resulting clause list out via the
@@ -103,7 +103,7 @@ public interface Contract<I, O> {
      *
      * @param b the builder to populate
      */
-    default void postconditions(ContractBuilder<O> b) {
+    default void postconditions(PostconditionBuilder<O> b) {
         // No-op default. Override to declare contract-level
         // postconditions; leave defaulted when the contract uses
         // criteria(CriteriaBuilder) instead.
@@ -112,12 +112,12 @@ public interface Contract<I, O> {
     /**
      * Resolves the contract's clauses to an immutable list. The
      * framework hook; do not override. The default implementation
-     * builds a fresh {@link ContractBuilder}, calls
-     * {@link #postconditions(ContractBuilder)} to populate it, and
+     * builds a fresh {@link PostconditionBuilder}, calls
+     * {@link #postconditions(PostconditionBuilder)} to populate it, and
      * returns the built list.
      */
     default List<Postcondition<O>> postconditions() {
-        ContractBuilder<O> b = new ContractBuilder<>();
+        PostconditionBuilder<O> b = new PostconditionBuilder<>();
         postconditions(b);
         return b.build();
     }
@@ -130,13 +130,13 @@ public interface Contract<I, O> {
      *
      * <p>The default body is empty. A contract that does not
      * explicitly declare criteria yields a single-criterion list
-     * derived from its existing {@link #postconditions(ContractBuilder)}.
+     * derived from its existing {@link #postconditions(PostconditionBuilder)}.
      * Today's contracts therefore satisfy the criterion model
      * without code change: the contract <em>is</em> one criterion.
      *
      * <p>A contract may not override both this method (so that the
      * resulting list is non-empty) and
-     * {@link #postconditions(ContractBuilder)} (so that the resulting
+     * {@link #postconditions(PostconditionBuilder)} (so that the resulting
      * chain is non-empty) at the same time. The two overrides
      * estimate different quantities — one criterion's chain versus
      * the criteria list — and the framework rejects the ambiguity at
@@ -164,7 +164,7 @@ public interface Contract<I, O> {
      * @throws IllegalStateException if the contract declares both an
      *         explicit criteria list (non-empty {@code criteria(CriteriaBuilder)}
      *         override) and a non-empty postcondition chain
-     *         (non-empty {@code postconditions(ContractBuilder)}
+     *         (non-empty {@code postconditions(PostconditionBuilder)}
      *         override). The two are structurally ambiguous; the
      *         framework will not pick one for the author.
      */
@@ -178,7 +178,7 @@ public interface Contract<I, O> {
             throw new IllegalStateException(
                     "Contract " + getClass().getName()
                             + " declares both a non-empty postcondition chain"
-                            + " (via postconditions(ContractBuilder)) and an"
+                            + " (via postconditions(PostconditionBuilder)) and an"
                             + " explicit criteria list (via"
                             + " criteria(CriteriaBuilder)). The two overrides"
                             + " estimate different quantities; the framework"

--- a/punit-core/src/main/java/org/javai/punit/api/PostconditionBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/api/PostconditionBuilder.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  * Authoring surface for a postcondition chain. Authors never
  * construct one directly — the framework supplies a fresh builder to
- * the author's {@code postconditions(ContractBuilder<O>)} method (or
+ * the author's {@code postconditions(PostconditionBuilder<O>)} method (or
  * to the body of a
  * {@link org.javai.punit.api.criterion.Criteria#direct(String,
  * java.util.function.Consumer) Criteria.direct} /
@@ -20,7 +20,7 @@ import java.util.List;
  *
  * <pre>{@code
  * @Override
- * public void postconditions(ContractBuilder<BasketTranslation> b) {
+ * public void postconditions(PostconditionBuilder<BasketTranslation> b) {
  *     b.ensure("Has actions", t ->
  *             t.actions().isEmpty()
  *                     ? Outcome.fail("empty-actions", "actions list was empty")
@@ -32,7 +32,7 @@ import java.util.List;
  * @param <O> the value type the postcondition chain evaluates
  *            against
  */
-public final class ContractBuilder<O> {
+public final class PostconditionBuilder<O> {
 
     private final List<Postcondition<O>> clauses = new ArrayList<>();
 
@@ -49,7 +49,7 @@ public final class ContractBuilder<O> {
      * @throws NullPointerException     if any argument is null
      * @throws IllegalArgumentException if {@code description} is blank
      */
-    public ContractBuilder<O> ensure(String description, PostconditionCheck<O> check) {
+    public PostconditionBuilder<O> ensure(String description, PostconditionCheck<O> check) {
         clauses.add(new Postcondition.Leaf<>(description, check));
         return this;
     }

--- a/punit-core/src/main/java/org/javai/punit/api/ServiceContract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ServiceContract.java
@@ -16,10 +16,10 @@ import org.javai.punit.api.covariate.Covariate;
  *
  * <p>{@code ServiceContract} extends {@link Contract} — the operational layer
  * that carries the service call ({@link Contract#invoke invoke}) and
- * the acceptance criteria ({@link Contract#postconditions(ContractBuilder)
+ * the acceptance criteria ({@link Contract#postconditions(PostconditionBuilder)
  * postconditions}). An author writing one service contract implements one
  * interface and overrides three methods: {@code invoke},
- * {@code postconditions(ContractBuilder)}, and whichever metadata
+ * {@code postconditions(PostconditionBuilder)}, and whichever metadata
  * methods diverge from the framework defaults.
  *
  * <p>{@code FT} is the factor record — the configuration the author has

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 
 /**
  * Factory entry points for declaring criteria. Two shapes:
@@ -58,7 +58,7 @@ public final class Criteria {
      *
      * @param id   the criterion's stable identifier; must be non-null
      *             and non-blank
-     * @param body a consumer that populates a {@link ContractBuilder}
+     * @param body a consumer that populates a {@link PostconditionBuilder}
      *             with the criterion's postcondition chain. The
      *             builder is fresh; the consumer's calls to
      *             {@code ensure(...)} populate it.
@@ -66,10 +66,10 @@ public final class Criteria {
      * @return a criterion ready to be added to a {@link CriteriaBuilder}
      */
     public static <O> Criterion<O> direct(
-            String id, Consumer<ContractBuilder<O>> body) {
+            String id, Consumer<PostconditionBuilder<O>> body) {
         validateId(id);
         Objects.requireNonNull(body, "body");
-        ContractBuilder<O> b = new ContractBuilder<>();
+        PostconditionBuilder<O> b = new PostconditionBuilder<>();
         body.accept(b);
         return new DirectCriterion<>(id, b.build());
     }
@@ -92,7 +92,7 @@ public final class Criteria {
      *                  contract's produced output and returns an
      *                  outcome over the derived type
      * @param body      a consumer that populates a
-     *                  {@link ContractBuilder} typed over the derived
+     *                  {@link PostconditionBuilder} typed over the derived
      *                  type. The builder is fresh; the consumer's
      *                  calls to {@code ensure(...)} populate it.
      * @param <O>       the contract's per-sample output value type
@@ -103,11 +103,11 @@ public final class Criteria {
     public static <O, D> Criterion<O> transforming(
             String id,
             Function<O, Outcome<D>> transform,
-            Consumer<ContractBuilder<D>> body) {
+            Consumer<PostconditionBuilder<D>> body) {
         validateId(id);
         Objects.requireNonNull(transform, "transform");
         Objects.requireNonNull(body, "body");
-        ContractBuilder<D> b = new ContractBuilder<>();
+        PostconditionBuilder<D> b = new PostconditionBuilder<>();
         body.accept(b);
         return new TransformingCriterion<>(id, transform, b.build());
     }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriteriaBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriteriaBuilder.java
@@ -3,6 +3,11 @@ package org.javai.punit.api.criterion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionBuilder;
 
 /**
  * Authoring surface for a contract's criteria list. Authors never
@@ -11,14 +16,31 @@ import java.util.Objects;
  * {@link org.javai.punit.api.Contract#criteria(CriteriaBuilder)}
  * method and collects the result.
  *
- * <p>For now the builder is a simple list collector. A contract that
- * exercises the multi-criterion model adds one criterion per
- * {@link #add(Criterion)} call; the order of {@code add(...)} calls is
- * preserved in the resulting list. The methodology does not yet
- * require any per-criterion configuration beyond the criterion itself
- * (mode, procedure direction, denominator policy, and so on are
- * absent from this step); when those land, the builder grows to
- * carry them.
+ * <p>Three ways to declare a criterion:
+ *
+ * <ul>
+ *   <li>{@link #addCriterion(String, Consumer) addCriterion(id, body)}
+ *       — convenience absorbing the
+ *       {@link Criteria#direct(String, Consumer) Criteria.direct}
+ *       factory call. Returns a {@link CriterionPostureHandle} on
+ *       which {@code .meeting / .empirical / .zeroTolerance /
+ *       .atConfidence} declares the criterion's commitment.</li>
+ *   <li>{@link #addTransformingCriterion(String, Function, Consumer)
+ *       addTransformingCriterion(id, transform, body)} — same shape
+ *       for the transform-then-evaluate kind. Absorbs
+ *       {@link Criteria#transforming(String, Function, Consumer)}.</li>
+ *   <li>{@link #add(Criterion) add(criterion)} — primitive entry
+ *       point for the rare hand-rolled {@link Criterion}. Returns
+ *       the same posture handle, so the posture chain works
+ *       uniformly.</li>
+ * </ul>
+ *
+ * <p>The criterion is committed to the builder at the {@code add*}
+ * call; the returned handle modifies the already-added criterion's
+ * posture. An un-postured criterion is a statement with no terminal
+ * call — there is no {@code .commit()} ceremony, and no way to
+ * forget a terminal that would otherwise turn a criterion into a
+ * no-op.
  *
  * @param <O> the value type the contract evaluates against (the
  *            contract's output type)
@@ -28,15 +50,77 @@ public final class CriteriaBuilder<O> {
     private final List<Criterion<O>> criteria = new ArrayList<>();
 
     /**
-     * Add a criterion. Returns this builder for fluent chaining.
-     *
-     * @param criterion the criterion to add. Must be non-null.
-     * @return this builder
-     * @throws NullPointerException if {@code criterion} is null
+     * Add a criterion whose postconditions evaluate directly against
+     * the contract's output. Returns a posture handle for declaring
+     * the criterion's commitment ({@code .meeting / .empirical /
+     * .zeroTolerance / .atConfidence}); omit the terminal call to
+     * keep the implicit zero-tolerance posture.
      */
-    public CriteriaBuilder<O> add(Criterion<O> criterion) {
-        criteria.add(Objects.requireNonNull(criterion, "criterion"));
-        return this;
+    public CriterionPostureHandle<O> addCriterion(
+            String id, Consumer<PostconditionBuilder<O>> body) {
+        Criterion<O> criterion = Criteria.direct(id, body);
+        return commit(criterion);
+    }
+
+    /**
+     * Add a criterion that first transforms the contract's output to
+     * a derived form, then evaluates its postconditions against the
+     * derived value. Returns a posture handle for declaring the
+     * criterion's commitment.
+     */
+    public <D> CriterionPostureHandle<O> addTransformingCriterion(
+            String id,
+            Function<O, Outcome<D>> transform,
+            Consumer<PostconditionBuilder<D>> body) {
+        Criterion<O> criterion = Criteria.transforming(id, transform, body);
+        return commit(criterion);
+    }
+
+    /**
+     * Add a hand-rolled {@link Criterion}. Returns a posture handle
+     * for declaring the criterion's commitment.
+     *
+     * <p>The {@code Criteria} factory entry points cover the
+     * methodology's two shapes (direct, transforming) and structurally
+     * enforce the one-transform-per-criterion cap. Prefer them. This
+     * primitive is retained for the rare custom case.
+     *
+     * <p>If the supplied criterion already carries a non-implicit
+     * posture, it is replaced when a posture method is called on the
+     * returned handle. To preserve a hand-rolled criterion's existing
+     * posture, do not call any posture method on the handle.
+     */
+    public CriterionPostureHandle<O> add(Criterion<O> criterion) {
+        return commit(Objects.requireNonNull(criterion, "criterion"));
+    }
+
+    private CriterionPostureHandle<O> commit(Criterion<O> criterion) {
+        int index = criteria.size();
+        criteria.add(criterion);
+        return new CriterionPostureHandle<>(this, index);
+    }
+
+    CriterionPosture postureAt(int index) {
+        return criteria.get(index).posture();
+    }
+
+    void setPostureAt(int index, CriterionPosture posture) {
+        Criterion<O> current = criteria.get(index);
+        criteria.set(index, withPosture(current, posture));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <O> Criterion<O> withPosture(Criterion<O> criterion, CriterionPosture posture) {
+        if (criterion instanceof DirectCriterion<O> direct) {
+            return direct.withPosture(posture);
+        }
+        if (criterion instanceof TransformingCriterion<?, ?> transforming) {
+            return (Criterion<O>) ((TransformingCriterion) transforming).withPosture(posture);
+        }
+        // Hand-rolled criterion that doesn't expose withPosture(...).
+        // Wrap with a delegating proxy that returns the new posture
+        // from posture() and forwards everything else.
+        return new PosturedCriterionWrapper<>(criterion, posture);
     }
 
     /**
@@ -58,5 +142,20 @@ public final class CriteriaBuilder<O> {
      */
     public List<Criterion<O>> build() {
         return List.copyOf(criteria);
+    }
+
+    /** Wrapper for hand-rolled {@link Criterion} instances that don't expose a withPosture(...) hook. */
+    private static final class PosturedCriterionWrapper<O> implements Criterion<O> {
+        private final Criterion<O> delegate;
+        private final CriterionPosture posture;
+
+        PosturedCriterionWrapper(Criterion<O> delegate, CriterionPosture posture) {
+            this.delegate = delegate;
+            this.posture = posture;
+        }
+
+        @Override public String id() { return delegate.id(); }
+        @Override public CriterionSampleResult evaluate(O value) { return delegate.evaluate(value); }
+        @Override public CriterionPosture posture() { return posture; }
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
@@ -80,4 +80,21 @@ public interface Criterion<O> {
      * @return the criterion's per-sample evaluation record
      */
     CriterionSampleResult evaluate(O value);
+
+    /**
+     * The criterion's run-time commitment — what counts as acceptable,
+     * and optionally how confidently to evaluate it. Authored via the
+     * {@link CriteriaBuilder} convenience methods
+     * ({@code addCriterion(...).meeting(...)} et al.); read by the
+     * framework's evaluation path when it computes the per-criterion
+     * verdict from the run's sample counts.
+     *
+     * <p>The default is {@link CriterionPosture#implicit()} — used by
+     * criteria constructed without an explicit posture (hand-rolled
+     * {@link Criterion} implementations and the auto-derived K=1
+     * default).
+     */
+    default CriterionPosture posture() {
+        return CriterionPosture.implicit();
+    }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
@@ -1,0 +1,169 @@
+package org.javai.punit.api.criterion;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import org.javai.punit.api.ThresholdOrigin;
+
+/**
+ * The methodology criterion's run-time *commitment*: what counts as
+ * acceptable, optionally how confidently to evaluate it. Authored on
+ * the criterion via the {@link CriteriaBuilder} convenience methods
+ * (see {@code CriteriaBuilder.addCriterion(...).meeting(...)} and
+ * variants); consumed by the framework's evaluation path when it
+ * computes a per-criterion verdict from the run's sample counts.
+ *
+ * <p>Three kinds map to the three posture methods on the criterion-
+ * declaration handle, plus an implicit kind for criteria that
+ * declared no posture at all:
+ *
+ * <ul>
+ *   <li>{@link Kind#STATISTICAL_CONTRACTUAL} — explicit contractual
+ *       threshold via {@code .meeting(rate, origin)}. Carries the
+ *       rate and origin; carries the confidence iff
+ *       {@code .atConfidence(c)} was called.</li>
+ *   <li>{@link Kind#STATISTICAL_EMPIRICAL} — empirical threshold via
+ *       {@code .empirical()}. The threshold is derived from the
+ *       baseline at evaluate time; the {@code origin} is
+ *       {@link ThresholdOrigin#EMPIRICAL}.</li>
+ *   <li>{@link Kind#ZERO_TOLERANCE} — explicit zero-tolerance via
+ *       {@code .zeroTolerance(origin)}. Threshold is implicitly 1.0;
+ *       the run classifies SMOKE per the methodology rule
+ *       (zero-tolerance is not statistically verifiable).
+ *       Composition with {@code .atConfidence(...)} is rejected at
+ *       build time.</li>
+ *   <li>{@link Kind#IMPLICIT_ZERO_TOLERANCE} — no posture method
+ *       called on the criterion declaration. Equivalent in every
+ *       respect to {@code .zeroTolerance(POLICY)} once the implicit
+ *       default is active (directive step 3).</li>
+ * </ul>
+ *
+ * <p>An instance is immutable; the static factory methods produce
+ * the four kinds.
+ */
+public final class CriterionPosture {
+
+    /** The four posture kinds. */
+    public enum Kind {
+        /** {@code .meeting(rate, origin)} — explicit numeric target. */
+        STATISTICAL_CONTRACTUAL,
+        /** {@code .empirical()} — threshold derived from baseline. */
+        STATISTICAL_EMPIRICAL,
+        /** {@code .zeroTolerance(origin)} — explicit binary commitment. */
+        ZERO_TOLERANCE,
+        /** No posture method called — implicit zero-tolerance (step 3 default). */
+        IMPLICIT_ZERO_TOLERANCE
+    }
+
+    private static final CriterionPosture IMPLICIT =
+            new CriterionPosture(Kind.IMPLICIT_ZERO_TOLERANCE,
+                    OptionalDouble.empty(),
+                    Optional.empty(),
+                    OptionalDouble.empty());
+
+    private final Kind kind;
+    private final OptionalDouble threshold;
+    private final Optional<ThresholdOrigin> origin;
+    private final OptionalDouble confidenceFloor;
+
+    private CriterionPosture(
+            Kind kind,
+            OptionalDouble threshold,
+            Optional<ThresholdOrigin> origin,
+            OptionalDouble confidenceFloor) {
+        this.kind = kind;
+        this.threshold = threshold;
+        this.origin = origin;
+        this.confidenceFloor = confidenceFloor;
+    }
+
+    /** The implicit-zero-tolerance posture — the default for any criterion that declared no posture method. */
+    public static CriterionPosture implicit() {
+        return IMPLICIT;
+    }
+
+    /** Statistical, contractual: {@code .meeting(rate, origin)}. */
+    public static CriterionPosture meeting(double rate, ThresholdOrigin origin) {
+        Objects.requireNonNull(origin, "origin");
+        if (Double.isNaN(rate) || rate < 0.0 || rate >= 1.0) {
+            throw new IllegalArgumentException(
+                    "meeting(rate, origin): rate must be in [0, 1), got " + rate);
+        }
+        if (origin == ThresholdOrigin.EMPIRICAL) {
+            throw new IllegalArgumentException(
+                    "meeting(rate, EMPIRICAL) is contradictory — call .empirical() instead");
+        }
+        return new CriterionPosture(Kind.STATISTICAL_CONTRACTUAL,
+                OptionalDouble.of(rate),
+                Optional.of(origin),
+                OptionalDouble.empty());
+    }
+
+    /** Statistical, empirical: {@code .empirical()}. */
+    public static CriterionPosture empirical() {
+        return new CriterionPosture(Kind.STATISTICAL_EMPIRICAL,
+                OptionalDouble.empty(),
+                Optional.of(ThresholdOrigin.EMPIRICAL),
+                OptionalDouble.empty());
+    }
+
+    /** Explicit zero-tolerance: {@code .zeroTolerance(origin)}. */
+    public static CriterionPosture zeroTolerance(ThresholdOrigin origin) {
+        Objects.requireNonNull(origin, "origin");
+        if (origin == ThresholdOrigin.EMPIRICAL) {
+            throw new IllegalArgumentException(
+                    "zeroTolerance(EMPIRICAL) is contradictory — zero-tolerance is a binary commitment, not an empirical one");
+        }
+        return new CriterionPosture(Kind.ZERO_TOLERANCE,
+                OptionalDouble.of(1.0),
+                Optional.of(origin),
+                OptionalDouble.empty());
+    }
+
+    /**
+     * Returns a copy of this posture with the given confidence floor.
+     * Rejects composition with zero-tolerance (explicit or implicit)
+     * — the statistical math is undefined at the threshold boundary.
+     */
+    public CriterionPosture withConfidenceFloor(double confidence) {
+        if (kind == Kind.ZERO_TOLERANCE || kind == Kind.IMPLICIT_ZERO_TOLERANCE) {
+            throw new IllegalStateException(
+                    ".atConfidence(...) cannot compose with zero-tolerance — "
+                            + "statistical confidence is undefined at the threshold boundary");
+        }
+        if (Double.isNaN(confidence) || confidence <= 0.0 || confidence >= 1.0) {
+            throw new IllegalArgumentException(
+                    ".atConfidence(c) requires c in (0, 1), got " + confidence);
+        }
+        return new CriterionPosture(kind, threshold, origin, OptionalDouble.of(confidence));
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    /** The contractual target rate when present (statistical-contractual + zero-tolerance), empty otherwise. */
+    public OptionalDouble threshold() {
+        return threshold;
+    }
+
+    public Optional<ThresholdOrigin> origin() {
+        return origin;
+    }
+
+    /** Per-criterion confidence floor when declared via {@code .atConfidence(...)}, empty otherwise. */
+    public OptionalDouble confidenceFloor() {
+        return confidenceFloor;
+    }
+
+    /** Whether this posture asks for a statistical evaluation. */
+    public boolean isStatistical() {
+        return kind == Kind.STATISTICAL_CONTRACTUAL || kind == Kind.STATISTICAL_EMPIRICAL;
+    }
+
+    /** Whether this posture asks for a binary evaluation (zero-tolerance, explicit or implicit). */
+    public boolean isZeroTolerance() {
+        return kind == Kind.ZERO_TOLERANCE || kind == Kind.IMPLICIT_ZERO_TOLERANCE;
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPostureHandle.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPostureHandle.java
@@ -1,0 +1,87 @@
+package org.javai.punit.api.criterion;
+
+import java.util.Objects;
+
+import org.javai.punit.api.ThresholdOrigin;
+
+/**
+ * Fluent posture-setter returned by
+ * {@link CriteriaBuilder#addCriterion(String, java.util.function.Consumer) addCriterion},
+ * {@link CriteriaBuilder#addTransformingCriterion(String, java.util.function.Function, java.util.function.Consumer)
+ *  addTransformingCriterion}, and {@link CriteriaBuilder#add(Criterion) add}.
+ * Mutates the posture of the just-added criterion in the builder.
+ *
+ * <p>Idiomatic usage:
+ *
+ * <pre>{@code
+ * b.addCriterion("valid-json", pb -> pb.ensure(...))
+ *         .meeting(0.85, ThresholdOrigin.SLA);
+ *
+ * b.addCriterion("pii-redacted", pb -> pb.ensure(...))
+ *         .meeting(0.999, ThresholdOrigin.POLICY)
+ *         .atConfidence(0.99);
+ *
+ * b.addCriterion("response-not-empty", pb -> pb.ensure(...))
+ *         .zeroTolerance(ThresholdOrigin.POLICY);
+ *
+ * // Un-postured — no terminal call. The criterion is committed at
+ * // addCriterion(...) and keeps the implicit zero-tolerance posture.
+ * b.addCriterion("response-time-marker", pb -> pb.ensure(...));
+ * }</pre>
+ *
+ * <p>The criterion is committed to the builder at the {@code add*}
+ * call; the handle modifies the already-added criterion's posture.
+ * There is no {@code .commit()} ceremony, and no way for a forgotten
+ * terminal to turn a criterion into a no-op.
+ *
+ * <p>Order: posture method ({@code .meeting / .empirical /
+ * .zeroTolerance}) first; {@code .atConfidence(...)} after. Calling
+ * a posture method a second time replaces the previously declared
+ * posture (including any confidence floor); the last call wins.
+ */
+public final class CriterionPostureHandle<O> {
+
+    private final CriteriaBuilder<O> builder;
+    private final int criterionIndex;
+
+    CriterionPostureHandle(CriteriaBuilder<O> builder, int criterionIndex) {
+        this.builder = Objects.requireNonNull(builder, "builder");
+        this.criterionIndex = criterionIndex;
+    }
+
+    /** Statistical, contractual: PASS iff observed pass rate ≥ {@code rate}. */
+    public CriterionPostureHandle<O> meeting(double rate, ThresholdOrigin origin) {
+        builder.setPostureAt(criterionIndex, CriterionPosture.meeting(rate, origin));
+        return this;
+    }
+
+    /** Statistical, empirical: threshold derived from the resolved baseline at evaluate time. */
+    public CriterionPostureHandle<O> empirical() {
+        builder.setPostureAt(criterionIndex, CriterionPosture.empirical());
+        return this;
+    }
+
+    /**
+     * Explicit zero-tolerance: any failed sample fails the criterion.
+     * Does not compose with {@link #atConfidence(double)} — the
+     * statistical math is undefined at the threshold boundary.
+     * The run classifies SMOKE per the methodology rule.
+     */
+    public CriterionPostureHandle<O> zeroTolerance(ThresholdOrigin origin) {
+        builder.setPostureAt(criterionIndex, CriterionPosture.zeroTolerance(origin));
+        return this;
+    }
+
+    /**
+     * Set a per-criterion confidence floor that the run cannot
+     * loosen. Must be called after a statistical posture method
+     * ({@code .meeting} or {@code .empirical}); throws
+     * {@link IllegalStateException} on a zero-tolerance posture
+     * (explicit or implicit).
+     */
+    public CriterionPostureHandle<O> atConfidence(double confidence) {
+        CriterionPosture current = builder.postureAt(criterionIndex);
+        builder.setPostureAt(criterionIndex, current.withConfidenceFloor(confidence));
+        return this;
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/DirectCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/DirectCriterion.java
@@ -23,16 +23,31 @@ final class DirectCriterion<O> implements Criterion<O> {
 
     private final String id;
     private final List<Postcondition<O>> postconditions;
+    private final CriterionPosture posture;
 
     DirectCriterion(String id, List<Postcondition<O>> postconditions) {
+        this(id, postconditions, CriterionPosture.implicit());
+    }
+
+    DirectCriterion(String id, List<Postcondition<O>> postconditions, CriterionPosture posture) {
         this.id = Objects.requireNonNull(id, "id");
         this.postconditions = List.copyOf(
                 Objects.requireNonNull(postconditions, "postconditions"));
+        this.posture = Objects.requireNonNull(posture, "posture");
+    }
+
+    DirectCriterion<O> withPosture(CriterionPosture replacement) {
+        return new DirectCriterion<>(id, postconditions, replacement);
     }
 
     @Override
     public String id() {
         return id;
+    }
+
+    @Override
+    public CriterionPosture posture() {
+        return posture;
     }
 
     @Override

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingCriterion.java
@@ -28,20 +28,39 @@ final class TransformingCriterion<O, D> implements Criterion<O> {
     private final String id;
     private final Function<O, Outcome<D>> transform;
     private final List<Postcondition<D>> postconditions;
+    private final CriterionPosture posture;
 
     TransformingCriterion(
             String id,
             Function<O, Outcome<D>> transform,
             List<Postcondition<D>> postconditions) {
+        this(id, transform, postconditions, CriterionPosture.implicit());
+    }
+
+    TransformingCriterion(
+            String id,
+            Function<O, Outcome<D>> transform,
+            List<Postcondition<D>> postconditions,
+            CriterionPosture posture) {
         this.id = Objects.requireNonNull(id, "id");
         this.transform = Objects.requireNonNull(transform, "transform");
         this.postconditions = List.copyOf(
                 Objects.requireNonNull(postconditions, "postconditions"));
+        this.posture = Objects.requireNonNull(posture, "posture");
+    }
+
+    TransformingCriterion<O, D> withPosture(CriterionPosture replacement) {
+        return new TransformingCriterion<>(id, transform, postconditions, replacement);
     }
 
     @Override
     public String id() {
         return id;
+    }
+
+    @Override
+    public CriterionPosture posture() {
+        return posture;
     }
 
     @Override

--- a/punit-core/src/main/java/org/javai/punit/api/spec/EvaluationContext.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/EvaluationContext.java
@@ -1,8 +1,10 @@
 package org.javai.punit.api.spec;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.criterion.CriterionPosture;
 
 /**
  * The typed view a {@link Criterion} receives at evaluate time.
@@ -47,4 +49,22 @@ public interface EvaluationContext<OT, S extends BaselineStatistics> {
      * empty by construction).
      */
     Optional<String> baselineInputsIdentity();
+
+    /**
+     * The contract's per-methodology-criterion postures, keyed by
+     * criterion id. The framework derives this map from the
+     * contract's {@code criteria(CriteriaBuilder)} declarations
+     * (with {@link CriterionPosture#implicit()} for any criterion
+     * that did not declare a posture explicitly).
+     *
+     * <p>Empty when no methodology criteria were declared (the
+     * apply-level-failure path or a hand-built test fixture).
+     *
+     * <p>Default implementation returns an empty map for back-compat
+     * with test fixtures that hand-build their context. Production
+     * code paths in the framework always populate it.
+     */
+    default Map<String, CriterionPosture> criterionPostures() {
+        return Map.of();
+    }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionPassRateStatistics.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionPassRateStatistics.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  * <p>K=1 contracts produce a single-entry map keyed by the
  * methodology criterion's id (typically the auto-derived
  * {@code DefaultCriterion.id()} when the contract uses the legacy
- * {@code postconditions(ContractBuilder)} path). K&gt;1 contracts
+ * {@code postconditions(PostconditionBuilder)} path). K&gt;1 contracts
  * produce one entry per methodology criterion declared via
  * {@code Contract.criteria(CriteriaBuilder)}.
  *
@@ -60,7 +60,7 @@ public record PerCriterionPassRateStatistics(
      * K=1 convenience factory: wraps a single
      * {@link PassRateStatistics} under the supplied methodology
      * criterion id. The common case for tests and for the legacy
-     * {@code postconditions(ContractBuilder)} authoring path.
+     * {@code postconditions(PostconditionBuilder)} authoring path.
      */
     public static PerCriterionPassRateStatistics of(
             String criterionId, PassRateStatistics stats) {

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -177,7 +177,18 @@ public final class ProbabilisticTest implements Spec {
                     ? summary
                     : SampleSummary.from(List.of(), Duration.ZERO);
             FactorBundle factorBundle = FactorBundle.of(factors);
-            String serviceContractId = sampling.serviceContractFactory().apply(factors).id();
+            org.javai.punit.api.ServiceContract<FT, IT, OT> contract =
+                    sampling.serviceContractFactory().apply(factors);
+            String serviceContractId = contract.id();
+            // Per-methodology-criterion postures, keyed by criterion id —
+            // threaded through the EvaluationContext so PassRate (and
+            // future K-aware evaluators) can read each criterion's
+            // commitment without re-resolving the contract.
+            java.util.Map<String, org.javai.punit.api.criterion.CriterionPosture> criterionPostures =
+                    new java.util.LinkedHashMap<>();
+            for (org.javai.punit.api.criterion.Criterion<OT> c : contract.criteria()) {
+                criterionPostures.put(c.id(), c.posture());
+            }
             String testInputsIdentity = sampling.inputsIdentity();
             // Looked up once and reused across criteria — the identity is a
             // property of the baseline file, not of any individual criterion.
@@ -209,7 +220,7 @@ public final class ProbabilisticTest implements Spec {
                 BaselineLookupCapture capture = new BaselineLookupCapture();
                 CriterionResult result = evaluate(
                         entry.criterion(), s, factorBundle, serviceContractId,
-                        testInputsIdentity, baselineInputsIdentity,
+                        testInputsIdentity, baselineInputsIdentity, criterionPostures,
                         provider, warnings, capture);
                 evaluated.add(new EvaluatedCriterion(result, entry.role()));
                 if (baselineProfile.isEmpty() && !capture.profile.isEmpty()) {
@@ -357,6 +368,7 @@ public final class ProbabilisticTest implements Spec {
                 String serviceContractId,
                 String testInputsIdentity,
                 Optional<String> baselineInputsIdentity,
+                java.util.Map<String, org.javai.punit.api.criterion.CriterionPosture> criterionPostures,
                 BaselineProvider provider,
                 java.util.Set<String> warnings,
                 BaselineLookupCapture capture) {
@@ -381,6 +393,10 @@ public final class ProbabilisticTest implements Spec {
                 @Override public String testInputsIdentity() { return testInputsIdentity; }
                 @Override public Optional<String> baselineInputsIdentity() {
                     return baselineInputsIdentity;
+                }
+                @Override
+                public java.util.Map<String, org.javai.punit.api.criterion.CriterionPosture> criterionPostures() {
+                    return criterionPostures;
                 }
             };
             return (CriterionResult) raw.evaluate(ctx);

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.criterion.CriterionPosture;
 import org.javai.punit.api.spec.Criterion;
 import org.javai.punit.api.spec.CriterionResult;
 import org.javai.punit.api.spec.CriterionSampleCounts;
@@ -294,6 +295,65 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                     ? 0.0
                     : (double) counts.pass() / (double) criterionTotal;
             observedByCriterion.put(counts.criterionId(), observed);
+
+            // Resolve the criterion's posture (commitment) — read from
+            // the contract's per-criterion declaration. STATISTICAL_CONTRACTUAL
+            // and ZERO_TOLERANCE shortcut the legacy threshold-on-PassRate
+            // path; STATISTICAL_EMPIRICAL and IMPLICIT_ZERO_TOLERANCE
+            // delegate to the existing logic so step 1 preserves
+            // legacy behaviour for un-postured criteria.
+            CriterionPosture posture = ctx.criterionPostures().getOrDefault(
+                    counts.criterionId(), CriterionPosture.implicit());
+
+            // Confidence-floor ratchet: contract criterion's
+            // .atConfidence(c_criterion) cannot be loosened by the test.
+            if (posture.confidenceFloor().isPresent()
+                    && confidence < posture.confidenceFloor().getAsDouble()) {
+                throw new IllegalStateException(String.format(
+                        "criterion '%s' declares a confidence floor of %.4f but the test runs at %.4f — "
+                                + "the contract's floor cannot be loosened by the test (raise the test's "
+                                + "confidence to %.4f or remove the floor on the criterion)",
+                        counts.criterionId(),
+                        posture.confidenceFloor().getAsDouble(),
+                        confidence,
+                        posture.confidenceFloor().getAsDouble()));
+            }
+
+            // Posture-driven shortcut: STATISTICAL_CONTRACTUAL and
+            // ZERO_TOLERANCE skip the legacy mode handling and use the
+            // criterion's own commitment directly.
+            if (posture.kind() == CriterionPosture.Kind.STATISTICAL_CONTRACTUAL) {
+                double pThreshold = posture.threshold().getAsDouble();
+                ThresholdOrigin pOrigin = posture.origin().orElseThrow();
+                thresholdsByCriterion.put(counts.criterionId(), pThreshold);
+                Verdict pv = criterionTotal == 0
+                        ? Verdict.INCONCLUSIVE
+                        : (observed >= pThreshold ? Verdict.PASS : Verdict.FAIL);
+                perCriterionVerdicts.add(pv);
+                perCriterionExplanations.add(String.format(
+                        "%s: observed=%.4f vs threshold=%.4f (origin=%s) over %d samples → %s",
+                        counts.criterionId(), observed, pThreshold, pOrigin, criterionTotal, pv));
+                continue;
+            }
+            if (posture.kind() == CriterionPosture.Kind.ZERO_TOLERANCE) {
+                // Binary semantics: any failed sample fails the criterion.
+                thresholdsByCriterion.put(counts.criterionId(), 1.0);
+                Verdict pv;
+                if (criterionTotal == 0) {
+                    pv = Verdict.INCONCLUSIVE;
+                } else if (counts.fail() == 0 && counts.inconclusive() == 0) {
+                    pv = Verdict.PASS;
+                } else {
+                    pv = Verdict.FAIL;
+                }
+                perCriterionVerdicts.add(pv);
+                perCriterionExplanations.add(String.format(
+                        "%s: zero-tolerance (origin=%s); failures=%d, inconclusive=%d over %d samples → %s",
+                        counts.criterionId(),
+                        posture.origin().orElseThrow(),
+                        counts.fail(), counts.inconclusive(), criterionTotal, pv));
+                continue;
+            }
 
             double criterionThreshold;
             Double baselineRate = null;

--- a/punit-core/src/test/java/org/javai/punit/api/PostconditionBuilderTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/PostconditionBuilderTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("ContractBuilder — accumulates clauses fluently")
-class ContractBuilderTest {
+@DisplayName("PostconditionBuilder — accumulates clauses fluently")
+class PostconditionBuilderTest {
 
     @Nested
     @DisplayName("ensure")
@@ -20,7 +20,7 @@ class ContractBuilderTest {
         @Test
         @DisplayName("a single ensure call yields one Leaf clause")
         void singleEnsureYieldsOneLeaf() {
-            ContractBuilder<String> b = new ContractBuilder<>();
+            PostconditionBuilder<String> b = new PostconditionBuilder<>();
 
             b.ensure("non-empty", s -> s.isEmpty()
                     ? Outcome.fail("empty", "was empty")
@@ -36,7 +36,7 @@ class ContractBuilderTest {
         @Test
         @DisplayName("multiple ensures chain in order")
         void multipleEnsuresChain() {
-            List<Postcondition<Integer>> clauses = new ContractBuilder<Integer>()
+            List<Postcondition<Integer>> clauses = new PostconditionBuilder<Integer>()
                     .ensure("positive", v -> v > 0 ? Outcome.ok() : Outcome.fail("non-positive", ""))
                     .ensure("even",     v -> v % 2 == 0 ? Outcome.ok() : Outcome.fail("odd", ""))
                     .ensure("small",    v -> v < 100 ? Outcome.ok() : Outcome.fail("too-big", ""))
@@ -49,7 +49,7 @@ class ContractBuilderTest {
         @Test
         @DisplayName("blank description rejected at clause construction")
         void blankDescriptionRejected() {
-            ContractBuilder<Object> b = new ContractBuilder<>();
+            PostconditionBuilder<Object> b = new PostconditionBuilder<>();
 
             assertThatThrownBy(() -> b.ensure("", v -> Outcome.ok()))
                     .isInstanceOf(IllegalArgumentException.class);
@@ -58,7 +58,7 @@ class ContractBuilderTest {
         @Test
         @DisplayName("the empty builder builds an empty clause list")
         void emptyBuilder() {
-            assertThat(new ContractBuilder<String>().build()).isEmpty();
+            assertThat(new PostconditionBuilder<String>().build()).isEmpty();
         }
     }
 
@@ -69,7 +69,7 @@ class ContractBuilderTest {
         @Test
         @DisplayName("the returned list is immutable")
         void buildReturnsImmutable() {
-            List<Postcondition<String>> clauses = new ContractBuilder<String>()
+            List<Postcondition<String>> clauses = new PostconditionBuilder<String>()
                     .ensure("a", s -> Outcome.ok())
                     .build();
 

--- a/punit-core/src/test/java/org/javai/punit/api/SamplingTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/SamplingTest.java
@@ -20,7 +20,7 @@ class SamplingTest {
         EchoServiceContract(Factors factors) {}
 
         @Override
-        public void postconditions(ContractBuilder<String> b) { /* none */ }
+        public void postconditions(PostconditionBuilder<String> b) { /* none */ }
 
         @Override
         public Outcome<String> invoke(String input, TokenTracker tracker) {

--- a/punit-core/src/test/java/org/javai/punit/api/ServiceContractOutcomeTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/ServiceContractOutcomeTest.java
@@ -22,7 +22,7 @@ class ServiceContractOutcomeTest {
         }
 
         @Override
-        public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
     };
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/api/ServiceContractTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/ServiceContractTest.java
@@ -10,28 +10,28 @@ import org.junit.jupiter.api.Test;
 class ServiceContractTest {
 
     private static class SimpleServiceContract implements ServiceContract<Object, String, Integer> {
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
     }
 
     private static class ShoppingBasketServiceContract implements ServiceContract<Object, String, String> {
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
     }
 
     private static class HTTPClientServiceContract implements ServiceContract<Object, String, String> {
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
     }
 
     private static class PaymentGateway implements ServiceContract<Object, String, String> {
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);
         }

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Postcondition;
 import org.javai.punit.api.PostconditionResult;
 import org.javai.punit.api.TokenTracker;
@@ -33,7 +33,7 @@ class CriterionShimTest {
         }
 
         @Override
-        public void postconditions(ContractBuilder<String> b) {
+        public void postconditions(PostconditionBuilder<String> b) {
             b.ensure("non-empty", v ->
                     v == null || v.isEmpty()
                             ? Outcome.fail("empty", "value was empty")
@@ -54,7 +54,7 @@ class CriterionShimTest {
         }
 
         @Override
-        public void postconditions(ContractBuilder<String> b) {
+        public void postconditions(PostconditionBuilder<String> b) {
             // Empty: the explicit criteria carry the postconditions.
         }
 
@@ -77,7 +77,7 @@ class CriterionShimTest {
         }
 
         @Override
-        public void postconditions(ContractBuilder<String> b) {
+        public void postconditions(PostconditionBuilder<String> b) {
             b.ensure("non-empty", v ->
                     v.isEmpty() ? Outcome.fail("empty", "") : Outcome.ok());
         }
@@ -166,7 +166,7 @@ class CriterionShimTest {
         var contract = new BothOverriddenContract();
         assertThatThrownBy(contract::criteria)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("postconditions(ContractBuilder)")
+                .hasMessageContaining("postconditions(PostconditionBuilder)")
                 .hasMessageContaining("criteria(CriteriaBuilder)")
                 .hasMessageContaining(BothOverriddenContract.class.getName());
     }

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.PostconditionResult;
 import org.javai.punit.api.ServiceContractOutcome;
 import org.javai.punit.api.TokenTracker;
@@ -26,7 +26,7 @@ class InconclusiveFoldsIntoFailTest {
         }
 
         @Override
-        public void postconditions(ContractBuilder<String> b) {
+        public void postconditions(PostconditionBuilder<String> b) {
             // Empty — the explicit criteria carry the postconditions.
         }
 

--- a/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.LatencySpec;
@@ -28,7 +28,7 @@ class PercentileLatencyTest {
         @Override public Outcome<String> invoke(Object input, TokenTracker tracker) {
             return Outcome.ok("ok");
         }
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
     };
 
     private static SampleSummary<String> summary(LatencyResult latency, int successes, int failures) {

--- a/punit-core/src/test/java/org/javai/punit/api/spec/ProbabilisticTestIntentTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/ProbabilisticTestIntentTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.TestIntent;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -18,7 +18,7 @@ class ProbabilisticTestIntentTest {
     record Factors(String label) {}
 
     private static final ServiceContract<Factors, String, String> ECHO = new ServiceContract<>() {
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);
         }

--- a/punit-core/src/test/java/org/javai/punit/api/spec/SampleClassificationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/SampleClassificationTest.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.MatchResult;
 import org.javai.punit.api.PostconditionResult;
 import org.javai.punit.api.TokenTracker;
@@ -29,7 +29,7 @@ class SampleClassificationTest {
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
     };
 
     private static ServiceContractOutcome<String, Integer> outcomeOk(int value, Duration duration, long tokens) {
@@ -94,7 +94,7 @@ class SampleClassificationTest {
         void okExceedingMaxLatency() {
             ServiceContract<Factors, String, Integer> bounded = new ServiceContract<>() {
                 @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) { return Outcome.ok(0); }
-                @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+                @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
                 @Override public Optional<Duration> maxLatency() {
                     return Optional.of(Duration.ofMillis(100));
                 }
@@ -115,7 +115,7 @@ class SampleClassificationTest {
         void okAtMaxLatencyExact() {
             ServiceContract<Factors, String, Integer> bounded = new ServiceContract<>() {
                 @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) { return Outcome.ok(0); }
-                @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+                @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
                 @Override public Optional<Duration> maxLatency() {
                     return Optional.of(Duration.ofMillis(100));
                 }

--- a/punit-core/src/test/java/org/javai/punit/api/spec/TrialTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/TrialTest.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContractOutcome;
@@ -27,7 +27,7 @@ class TrialTest {
         }
 
         @Override
-        public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
     };
 
     private static ServiceContractOutcome<String, Integer> ok(int value) {

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
@@ -3,7 +3,7 @@ package org.javai.punit.internal.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -38,7 +38,7 @@ class EarlyTerminationIntegrationTest {
 
     /** Returns Outcome.ok every sample. */
     private static class AlwaysPass implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
         }
@@ -46,7 +46,7 @@ class EarlyTerminationIntegrationTest {
 
     /** Returns Outcome.fail every sample — a clean failure-inevitable shape. */
     private static class AlwaysFail implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure");
         }
@@ -61,7 +61,7 @@ class EarlyTerminationIntegrationTest {
         private final int failsFirst;
         private int seen = 0;
         FailsThenPasses(int failsFirst) { this.failsFirst = failsFirst; }
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return ++seen <= failsFirst
                     ? Outcome.fail("contract_violation", "scripted failure")

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 import java.util.Map;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -38,7 +38,7 @@ class EmpiricalEndToEndIntegrationTest {
     private static final String USE_CASE_ID = "always-passes-use-case";
 
     static class AlwaysPassesServiceContract implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(true);
         }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -13,7 +13,7 @@ import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.ValueMatcher;
 import org.javai.punit.api.spec.TerminationReason;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -43,7 +43,7 @@ class EngineIntegrationTest {
 
     /** Always returns the length of the input. Used as a deterministic sample. */
     private static class LengthServiceContract implements ServiceContract<LlmFactors, String, Integer> {
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
@@ -197,7 +197,7 @@ class EngineIntegrationTest {
     void instanceConformanceDrivesVerdict() {
         // Service contract: mirror the input, but uppercase it (deliberately wrong for half).
         ServiceContract<LlmFactors, String, String> upperCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.toUpperCase());
             }
@@ -226,7 +226,7 @@ class EngineIntegrationTest {
     @DisplayName("expectations: custom matcher overrides equality default")
     void instanceConformanceUsesCustomMatcher() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -269,7 +269,7 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: custom matcher drives the verdict's pass-rate criterion")
     void testPathInstanceConformanceUsesCustomMatcher() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -305,7 +305,7 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: expectedOutputs without explicit matcher defaults to equality")
     void testPathDefaultsToEqualityMatcher() {
         ServiceContract<LlmFactors, String, String> upperCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.toUpperCase());
             }
@@ -335,7 +335,7 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: matcher configured on Sampling.Builder.matching(...) drives the verdict")
     void testPathPropagatesMatcherFromSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -370,7 +370,7 @@ class EngineIntegrationTest {
     @DisplayName("Experiment: matcher configured on Sampling.Builder.matching(...) drives the measure run")
     void measurePathPropagatesMatcherFromSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -399,7 +399,7 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: spec-builder matcher overrides the matcher carried on Sampling")
     void testPathSpecBuilderMatcherOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -436,7 +436,7 @@ class EngineIntegrationTest {
     @DisplayName("Experiment: spec-builder matcher overrides the matcher carried on Sampling")
     void measurePathSpecBuilderMatcherOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -469,7 +469,7 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: spec-builder expectedOutputs overrides the expected list carried on Sampling")
     void testPathSpecBuilderExpectedOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -608,7 +608,7 @@ class EngineIntegrationTest {
 
     private static ServiceContract<LlmFactors, String, String> identityStringServiceContract() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -653,7 +653,7 @@ class EngineIntegrationTest {
     void exploreSpecRunsEachFactorBundle() {
         var observedByModel = new java.util.LinkedHashMap<String, Integer>();
         ServiceContract<LlmFactors, String, Integer> counting = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(0);
             }
@@ -684,7 +684,7 @@ class EngineIntegrationTest {
     @DisplayName("Multi-cell explore: every cell starts its input cursor at zero (no cross-cell bleed)")
     void multiCellExploreStartsEachCellAtInputZero() {
         ServiceContract<LlmFactors, String, Integer> echo = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(0);
             }
@@ -723,7 +723,7 @@ class EngineIntegrationTest {
     @DisplayName("Experiment.optimizing(shape) runs the stepper/scorer loop up to maxIterations")
     void optimizeSpecRunsIterationLoop() {
         ServiceContract<LlmFactors, String, Integer> echo = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.length());
             }
@@ -755,7 +755,7 @@ class EngineIntegrationTest {
     @DisplayName("disableEarlyTermination() runs to maxIterations even when scores are flat")
     void disableEarlyTerminationRunsToMaxIterations() {
         ServiceContract<LlmFactors, String, Integer> echo = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.length());
             }
@@ -786,7 +786,7 @@ class EngineIntegrationTest {
     @DisplayName("NextFactor.stop() ends the optimize loop after the iteration that returned it — no final-iteration sample")
     void nextFactorStopEndsRunCleanly() {
         ServiceContract<LlmFactors, String, Integer> echo = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.length());
             }
@@ -846,7 +846,7 @@ class EngineIntegrationTest {
     private List<String> runAndRecord() {
         List<String> observed = new ArrayList<>();
         ServiceContract<LlmFactors, String, Integer> recording = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 observed.add(input);
                 return Outcome.ok(0);
@@ -866,7 +866,7 @@ class EngineIntegrationTest {
     // ── Test doubles ────────────────────────────────────────────────
 
     private static class AlwaysPassesServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
         }
@@ -874,7 +874,7 @@ class EngineIntegrationTest {
 
     /** Returns business-level Fail outcomes — the "contract didn't hold" signal. */
     private static class AlwaysReturnsFailServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure for input " + input);
         }
@@ -882,7 +882,7 @@ class EngineIntegrationTest {
 
     /** Throws — a defect, not a business-level failure. The engine aborts. */
     private static class DefectiveServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             throw new IllegalStateException("simulated defect — this should abort the run");
         }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Pacing;
 import org.javai.punit.api.Sampling;
@@ -49,7 +49,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
             this.scriptMillis = scriptMillis;
         }
 
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             long millis = scriptMillis[index % scriptMillis.length];
             index++;
@@ -68,7 +68,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
             this.tokens = tokens;
         }
 
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             sleep(sleepMillis);
             tracker.recordTokens(tokens);
@@ -110,7 +110,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
         // per outcome would be accounted post-sample; the *projection*
         // is static, so this scenario uses tokenCharge to model it.
         ServiceContract<Factors, Integer, Integer> zeroOutcomeTokens = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -139,7 +139,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("static token charge is accounted for each sample")
     void staticChargeAccountedEachSample() {
         ServiceContract<Factors, Integer, Integer> zeroCost = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -190,7 +190,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void maxRpsInsertsDelay() {
         // 10 RPS → 100ms min delay between samples.
         ServiceContract<Factors, Integer, Integer> pacingUc = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -219,7 +219,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void mostRestrictiveWinsComposition() {
         // maxRps implies 100ms; min explicit 250ms should dominate.
         ServiceContract<Factors, Integer, Integer> pacingUc = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -253,7 +253,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void failSampleCatchesAndCounts() {
         AtomicInteger n = new AtomicInteger();
         ServiceContract<Factors, Integer, Integer> flaky = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 int i = n.incrementAndGet();
                 if (i % 2 == 0) {
@@ -283,7 +283,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("ABORT_TEST (default) rethrows a thrown defect")
     void abortTestRethrows() {
         ServiceContract<Factors, Integer, Integer> defective = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 throw new IllegalStateException("never mind the exception policy, this is a defect");
             }
@@ -307,7 +307,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("maxExampleFailures caps retained detail but not failure counts")
     void maxExampleFailuresCaps() {
         ServiceContract<Factors, Integer, Integer> failing = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
             @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.fail("scripted", "boom");
             }
@@ -363,7 +363,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void percentileLatencyBreachProducesFail() {
         // 50ms sleeps, assert p50 ≤ 10ms.
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
                 return Outcome.ok(Boolean.TRUE);
@@ -396,7 +396,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("mixed criteria: functional PASS + latency FAIL composes to FAIL when both REQUIRED")
     void mixedCriteriaBothRequiredComposesToFail() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
                 return Outcome.ok(Boolean.TRUE);
@@ -425,7 +425,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("reportOnly latency: functional PASS + latency FAIL(report-only) composes to PASS")
     void reportOnlyLatencyExcludedFromComposition() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
                 return Outcome.ok(Boolean.TRUE);
@@ -458,7 +458,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("reportOnly functional: contract failures reported but excluded → latency criterion determines verdict")
     void reportOnlyFunctionalExcludedFromComposition() {
         ServiceContract<Factors, Integer, Boolean> fastButBroken = new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(5);
                 return Outcome.fail("scripted", "functional fail intentional");

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
@@ -9,7 +9,7 @@ import org.javai.punit.api.spec.FactorsStepper;
 import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -40,7 +40,7 @@ class PostconditionFailureHistogramTest {
         @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
-        @Override public void postconditions(ContractBuilder<Integer> b) {
+        @Override public void postconditions(PostconditionBuilder<Integer> b) {
             b.ensure("alwaysFails", v ->
                     Outcome.fail("alwaysFails-mode", "input was " + v));
             b.ensure("evenFails", v -> v % 2 == 0
@@ -96,7 +96,7 @@ class PostconditionFailureHistogramTest {
     void emptyHistogramWhenNoClauses() {
         ServiceContract<Factors, Integer, Integer> noClauses = new ServiceContract<>() {
             @Override public Outcome<Integer> invoke(Integer i, TokenTracker t) { return Outcome.ok(i); }
-            @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         };
         Sampling<Factors, Integer, Integer> sampling = Sampling
                 .<Factors, Integer, Integer>builder()
@@ -119,7 +119,7 @@ class PostconditionFailureHistogramTest {
             @Override public Outcome<Integer> invoke(Integer i, TokenTracker t) {
                 return Outcome.fail("upstream-error", "always fails at apply");
             }
-            @Override public void postconditions(ContractBuilder<Integer> b) {
+            @Override public void postconditions(PostconditionBuilder<Integer> b) {
                 b.ensure("would-have-checked", v -> Outcome.ok());
             }
         };
@@ -212,7 +212,7 @@ class PostconditionFailureHistogramTest {
         @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
-        @Override public void postconditions(ContractBuilder<Integer> b) {
+        @Override public void postconditions(PostconditionBuilder<Integer> b) {
             b.ensure("alwaysFails", v -> Outcome.fail("alwaysFails", "input " + v));
         }
     }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/SerialSampleExecutorProgressTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/SerialSampleExecutorProgressTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ServiceContractOutcome;
@@ -52,7 +52,7 @@ class SerialSampleExecutorProgressTest {
     /** Service contract whose outcome alternates pass/fail by input parity. */
     private static final class AlternatingServiceContract implements ServiceContract<Void, Integer, String> {
         @Override public String id() { return "Alternating"; }
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
         @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
             return input % 2 == 0
                     ? Outcome.ok("even-" + input)
@@ -98,7 +98,7 @@ class SerialSampleExecutorProgressTest {
     void defectAlsoAdvancesCounter() {
         ServiceContract<Void, Integer, String> alwaysThrows = new ServiceContract<>() {
             @Override public String id() { return "AlwaysThrows"; }
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
                 throw new RuntimeException("synthetic defect");
             }
@@ -116,7 +116,7 @@ class SerialSampleExecutorProgressTest {
     void eachEmissionFlushedImmediately() {
         ServiceContract<Void, Integer, String> counterPeek = new ServiceContract<>() {
             @Override public String id() { return "CounterPeek"; }
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
                 // Sample-internal observable: line count visible inside this
                 // sample's invoke. emitProgress is called *after*

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
@@ -37,7 +37,7 @@ class PowerAnalysisTest {
     private static final String USE_CASE_ID = "echo-use-case";
 
     private static final ServiceContract<Factors, String, String> ECHO = new ServiceContract<>() {
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
@@ -266,7 +266,7 @@ class PowerAnalysisTest {
      */
     private static ServiceContract<Factors, String, String> covariateServiceContract(String resolvedRegion) {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.LatencySpec;
@@ -44,7 +44,7 @@ class CriterionResultDetailTest {
         @Override public Outcome<Integer> invoke(Object input, TokenTracker tracker) {
             return Outcome.ok(0);
         }
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
     };
 
     private static ServiceContractOutcome<Object, Integer> stubOutcome(int value) {

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.Experiment;
@@ -21,7 +21,7 @@ class InlineSamplingFormTest {
     record Factors(String label) {}
 
     private static final ServiceContract<Factors, String, String> ECHO = new ServiceContract<>() {
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);
         }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/PassRateTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/PassRateTest.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.TokenTracker;
@@ -35,7 +35,7 @@ class PassRateTest {
         @Override public Outcome<String> invoke(Object input, TokenTracker tracker) {
             return Outcome.ok("ok");
         }
-        @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
     };
 
     private static SampleSummary<String> summary(int successes, int failures) {

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/explore/ExploreOutputWriterTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -37,7 +37,7 @@ class ExploreOutputWriterTest {
 
     /** Always-passing service contract. Output type is the input length, for trivial sampling. */
     private static class LengthServiceContract implements ServiceContract<LlmFactors, String, Integer> {
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
@@ -232,7 +232,7 @@ class ExploreOutputWriterTest {
         private final String id;
         IdServiceContract(String id) { this.id = id; }
         @Override public String id() { return id; }
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -38,7 +38,7 @@ class OptimizeOutputWriterTest {
         private final String id;
         IdServiceContract(String id) { this.id = id; }
         @Override public String id() { return id; }
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
@@ -138,7 +138,7 @@ class OptimizeOutputWriterTest {
         // give the second criterion a deterministic 1/3 pass rate.
         ServiceContract<LlmFactors, String, String> contract = new ServiceContract<>() {
             @Override public String id() { return "two-criterion-contract"; }
-            @Override public void postconditions(ContractBuilder<String> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public void criteria(CriteriaBuilder<String> b) {
                 b.add(Criteria.direct("always-passes",
                         cb -> cb.ensure("passes", v -> Outcome.ok())));

--- a/punit-core/src/test/java/org/javai/punit/internal/runtime/BaselineEmitterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/runtime/BaselineEmitterTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -27,7 +27,7 @@ class BaselineEmitterTest {
 
     private static final ServiceContract<NoFactors, Integer, Boolean> ALWAYS_PASSES = new ServiceContract<>() {
         @Override public String id() { return "AlwaysPassesServiceContract"; }
-        @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(true);
         }
@@ -82,7 +82,7 @@ class BaselineEmitterTest {
 
     private static final ServiceContract<NoFactors, Integer, String> EVENS_PASS = new ServiceContract<>() {
         @Override public String id() { return "EvensPassServiceContract"; }
-        @Override public void postconditions(ContractBuilder<String> b) {
+        @Override public void postconditions(PostconditionBuilder<String> b) {
             b.ensure("non-blank", s -> s.isBlank()
                     ? Outcome.fail("blank", "value was blank")
                     : Outcome.ok(null));

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -8,7 +8,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -41,7 +41,7 @@ public final class CovariateSubjects {
      */
     private static ServiceContract<NoFactors, Integer, Boolean> covariateServiceContract() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -4,7 +4,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -28,7 +28,7 @@ public final class FeasibilitySubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> alwaysPasses() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -4,7 +4,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -36,7 +36,7 @@ public final class PUnitSubjects {
 
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPasses() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }
@@ -48,7 +48,7 @@ public final class PUnitSubjects {
 
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFails() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.fail("nope", "always fails");
             }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -36,7 +36,7 @@ public final class PreflightInvariantSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> countingAlwaysPasses() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
@@ -6,7 +6,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -32,7 +32,7 @@ public final class PreflightSubjects {
     /** Always-passing service contract that records every invocation. */
     private static ServiceContract<NoFactors, Integer, Boolean> countingServiceContract() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -3,7 +3,7 @@ package org.javai.punit.junit5.testsubjects;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -28,7 +28,7 @@ public final class RoundTripSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> serviceContract() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/SoundnessFloorSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/SoundnessFloorSubjects.java
@@ -6,7 +6,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -33,7 +33,7 @@ public final class SoundnessFloorSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> countingAlwaysPasses() {
         return new ServiceContract<>() {
-            @Override public void postconditions(ContractBuilder<Boolean> b) { /* none */ }
+            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/runtime/ArtefactEmissionRegressionTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/ArtefactEmissionRegressionTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -47,7 +47,7 @@ class ArtefactEmissionRegressionTest {
 
     private static class TrivialServiceContract implements ServiceContract<F, String, Integer> {
         @Override public String id() { return "regression-guard"; }
-        @Override public void postconditions(ContractBuilder<Integer> b) { /* none */ }
+        @Override public void postconditions(PostconditionBuilder<Integer> b) { /* none */ }
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }

--- a/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -55,7 +55,7 @@ class LatencyEverywhereIntegrationTest {
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
-        @Override public void postconditions(ContractBuilder<Integer> b) {
+        @Override public void postconditions(PostconditionBuilder<Integer> b) {
             b.ensure("length is even", n ->
                     n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "length=" + n));
         }
@@ -214,7 +214,7 @@ class LatencyEverywhereIntegrationTest {
             @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.length());
             }
-            @Override public void postconditions(ContractBuilder<Integer> b) {
+            @Override public void postconditions(PostconditionBuilder<Integer> b) {
                 b.ensure("never satisfies", n -> Outcome.fail("nope", "always fails"));
             }
         };

--- a/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.ContractBuilder;
+import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
@@ -66,7 +66,7 @@ class MultiDimensionVerdictIntegrationTest {
             sleep(SLEEP_MS);
             return Outcome.ok(input.length());
         }
-        @Override public void postconditions(ContractBuilder<Integer> b) {
+        @Override public void postconditions(PostconditionBuilder<Integer> b) {
             b.ensure("non-null length", n -> Outcome.ok());
         }
     }
@@ -83,7 +83,7 @@ class MultiDimensionVerdictIntegrationTest {
             sleep(SLEEP_MS);
             return Outcome.ok(input.length());
         }
-        @Override public void postconditions(ContractBuilder<Integer> b) {
+        @Override public void postconditions(PostconditionBuilder<Integer> b) {
             b.ensure("length is even", n ->
                     n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "n=" + n));
         }


### PR DESCRIPTION
First of three PRs implementing [DIR-CONTRACT-THRESHOLDS-punit](../plan/directives/DIR-CONTRACT-THRESHOLDS-punit.md). Adds the new authoring surface for per-criterion threshold / confidence declarations on service contracts. **No behaviour change for existing tests** — un-postured criteria still pick up the threshold-on-\`PassRate\` the test builder declares. Step 3 will activate the implicit-zero-tolerance default and retire the test-builder API.

## What's in this PR

### New types in \`org.javai.punit.api.criterion\`

- **\`CriterionPosture\`** — the methodology criterion's run-time commitment. Four kinds:
  - \`STATISTICAL_CONTRACTUAL\` (\`.meeting(rate, origin)\`)
  - \`STATISTICAL_EMPIRICAL\` (\`.empirical()\`)
  - \`ZERO_TOLERANCE\` (\`.zeroTolerance(origin)\`)
  - \`IMPLICIT_ZERO_TOLERANCE\` (default; no posture method called)
  - Optional confidence floor via \`.atConfidence(c)\`; composition with zero-tolerance rejected at construction time.
- **\`CriterionPostureHandle<O>\`** — fluent posture-setter returned by \`addCriterion / add / addTransformingCriterion\`. Mutates the just-added criterion's posture in the builder. No \`.commit()\` ceremony.

### \`CriteriaBuilder<O>\` grows convenience methods

\`\`\`java
b.addCriterion(\"valid-json\", pb -> pb.ensure(...))
        .meeting(0.85, ThresholdOrigin.SLA);

b.addCriterion(\"pii-redacted\", pb -> pb.ensure(...))
        .meeting(0.999, ThresholdOrigin.POLICY)
        .atConfidence(0.99);

b.addTransformingCriterion(\"normalised-actions\", transform, pb -> ...)
        .empirical();
\`\`\`

The primitive \`b.add(Criterion)\` is retained for hand-rolled criteria and now also returns a \`CriterionPostureHandle\` so the posture chain works uniformly.

### Rename: \`ContractBuilder<O>\` → \`PostconditionBuilder<O>\`

Mechanical rename (38 files). The class only ever built a postcondition list (\`.ensure(...)\` + \`.build()\`); the old name overpromised. \`CriteriaBuilder<O>\` keeps its name — it builds a criteria list, which is what its name already says, and each \`Contract\` method's parameter type now matches its method name.

### \`PassRate.evaluate\` is posture-aware

Per-criterion loop reads each criterion's posture from \`EvaluationContext.criterionPostures()\`:

- \`STATISTICAL_CONTRACTUAL\` — uses the posture's threshold / origin directly.
- \`ZERO_TOLERANCE\` — binary semantics; failures > 0 ⇒ FAIL.
- \`STATISTICAL_EMPIRICAL\` and \`IMPLICIT_ZERO_TOLERANCE\` — fall through to the existing logic so step 1 preserves legacy behaviour for un-postured criteria.

Confidence-floor ratchet: a criterion's \`.atConfidence(c_criterion)\` floor cannot be loosened by the test. \`PassRate\` rejects the run with a diagnostic naming both numbers and the criterion id when \`c_run < c_criterion\`.

## Test plan

- [x] \`./gradlew :punit-core:test\` — green
- [x] No test migrations yet; the test-builder \`.criterion(PassRate.meeting/.empirical)\` API still works.
- [ ] Step 2 (per-contract test migration in \`punit-core\`) and step 3 (activate implicit zero-tolerance; remove test-builder API) follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)