### PR TITLE
PR #2 slice 2: PowerAnalysis.sampleSize(baseline) reads MDE/power from contract

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/PowerAnalysis.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/PowerAnalysis.java
@@ -84,6 +84,74 @@ public final class PowerAnalysis {
     }
 
     /**
+     * Single-argument overload that reads minimum detectable effect
+     * and statistical power from the contract's *confidence-first*
+     * criteria — those declared as
+     * {@code .empirical().detectingMde(m).atPower(p)}. Returns the
+     * maximum sample count any such criterion demands; the contract's
+     * own commitment dictates the run's sample size without the
+     * author re-stating MDE / power at the call site.
+     *
+     * <p>Resolves the baseline directory via
+     * {@link BaselineResolver#defaultDir()} like the no-args
+     * overload pair.
+     *
+     * @param baseline a supplier yielding the {@code MEASURE}
+     *                 experiment whose baseline is the comparison
+     *                 reference
+     * @return the maximum required sample count across the contract's
+     *         confidence-first criteria; ceiling-rounded
+     * @throws IllegalStateException if the contract declares no
+     *         confidence-first criterion (no MDE / power on any
+     *         criterion's posture) — there is nothing for the
+     *         single-arg call to size against
+     */
+    public static int sampleSize(Supplier<Experiment> baseline) {
+        return sampleSize(BaselineResolver.defaultDir(), baseline);
+    }
+
+    /**
+     * Single-argument-plus-baseline-dir variant of
+     * {@link #sampleSize(Supplier)}. See that method for the contract-
+     * driven semantics.
+     */
+    public static int sampleSize(Path baselineDir, Supplier<Experiment> baseline) {
+        Objects.requireNonNull(baselineDir, "baselineDir");
+        Objects.requireNonNull(baseline, "baseline");
+        Experiment experiment = Objects.requireNonNull(
+                baseline.get(), "baseline supplier returned null");
+        if (experiment.kind() != Experiment.Kind.MEASURE) {
+            throw new IllegalArgumentException(
+                    "PowerAnalysis.sampleSize requires a MEASURE-flavour Experiment "
+                            + "(one that produces a baseline); got " + experiment.kind()
+                            + ". Pass a method reference to an @PUnitExperiment method "
+                            + "whose body returns Experiment.measuring(...).build().");
+        }
+        BaselineLookup lookup = experiment.dispatch(LOOKUP_DISPATCHER);
+        java.util.List<org.javai.punit.api.criterion.Criterion<?>> confidenceFirst = lookup.contractCriteria().stream()
+                .filter(c -> c.posture().isConfidenceFirst())
+                .toList();
+        if (confidenceFirst.isEmpty()) {
+            throw new IllegalStateException(
+                    "PowerAnalysis.sampleSize(baseline) requires the contract to declare "
+                            + "at least one confidence-first criterion "
+                            + "(.empirical().detectingMde(m).atPower(p)); none found. "
+                            + "Either add MDE+power to a criterion or call the three-argument "
+                            + "overload with explicit values.");
+        }
+        int maxRequired = 0;
+        for (org.javai.punit.api.criterion.Criterion<?> c : confidenceFirst) {
+            org.javai.punit.api.criterion.CriterionPosture p = c.posture();
+            int n = sampleSize(baselineDir, baseline,
+                    p.mde().getAsDouble(), p.power().getAsDouble());
+            if (n > maxRequired) {
+                maxRequired = n;
+            }
+        }
+        return maxRequired;
+    }
+
+    /**
      * Computes the sample size required to detect a difference of at
      * least {@code mde} from the baseline's recorded pass rate at the
      * given statistical power, using the default confidence
@@ -213,7 +281,8 @@ public final class PowerAnalysis {
             String serviceContractId,
             String factorsFingerprint,
             CovariateProfile profile,
-            List<Covariate> declarations) { }
+            List<Covariate> declarations,
+            List<org.javai.punit.api.criterion.Criterion<?>> contractCriteria) { }
 
     /**
      * Dispatcher that captures the {@code <FT>} type parameter from the
@@ -242,7 +311,9 @@ public final class PowerAnalysis {
                             ? CovariateProfile.empty()
                             : CovariateResolver.defaults().resolve(
                                     declarations, serviceContract.customCovariateResolvers());
-                    return new BaselineLookup(serviceContractId, fingerprint, profile, declarations);
+                    List<org.javai.punit.api.criterion.Criterion<?>> contractCriteria =
+                            new java.util.ArrayList<>(serviceContract.criteria());
+                    return new BaselineLookup(serviceContractId, fingerprint, profile, declarations, contractCriteria);
                 }
             };
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
@@ -354,4 +354,95 @@ class PowerAnalysisTest {
 
         assertThat(n).isPositive();
     }
+
+    // ── Single-argument overload: reads MDE / power from the contract's
+    //    confidence-first criteria. ─────────────────────────────────────
+
+    private static Supplier<Experiment> confidenceFirstBaseline(
+            double mde, double power) {
+        return () -> {
+            ServiceContract<Factors, String, String> contract = new ServiceContract<>() {
+                @Override public String id() { return USE_CASE_ID; }
+                @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                    return Outcome.ok(input);
+                }
+                @Override public void criteria(
+                        org.javai.punit.api.criterion.CriteriaBuilder<String> b) {
+                    b.addCriterion("the-criterion",
+                                    pb -> pb.ensure("always",
+                                            v -> Outcome.ok()))
+                            .empirical()
+                            .detectingMde(mde)
+                            .atPower(power);
+                }
+            };
+            Sampling<Factors, String, String> sampling = Sampling
+                    .<Factors, String, String>builder()
+                    .serviceContractFactory(f -> contract)
+                    .inputs("a")
+                    .samples(100)
+                    .build();
+            return Experiment.measuring(sampling, FACTORS).build();
+        };
+    }
+
+    @Test
+    @DisplayName("single-arg overload reads MDE / power from the contract's confidence-first criterion")
+    void singleArgReadsFromContractCriterion(@TempDir Path dir) throws IOException {
+        writeBaselineWithRate(dir, 0.90, 1000);
+
+        int viaContract = PowerAnalysis.sampleSize(dir, confidenceFirstBaseline(0.05, 0.80));
+        int viaExplicit = PowerAnalysis.sampleSize(dir, baseline(), 0.05, 0.80);
+
+        assertThat(viaContract).isEqualTo(viaExplicit);
+    }
+
+    @Test
+    @DisplayName("single-arg overload returns the max sample count across confidence-first criteria")
+    void singleArgReturnsMaxAcrossCriteria(@TempDir Path dir) throws IOException {
+        writeBaselineWithRate(dir, 0.90, 1000);
+        Supplier<Experiment> twoCriteria = () -> {
+            ServiceContract<Factors, String, String> contract = new ServiceContract<>() {
+                @Override public String id() { return USE_CASE_ID; }
+                @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                    return Outcome.ok(input);
+                }
+                @Override public void criteria(
+                        org.javai.punit.api.criterion.CriteriaBuilder<String> b) {
+                    // Looser: MDE 0.10 / power 0.50  → smaller N
+                    b.addCriterion("loose",
+                                    pb -> pb.ensure("always", v -> Outcome.ok()))
+                            .empirical().detectingMde(0.10).atPower(0.50);
+                    // Tighter: MDE 0.02 / power 0.95 → larger N
+                    b.addCriterion("tight",
+                                    pb -> pb.ensure("always", v -> Outcome.ok()))
+                            .empirical().detectingMde(0.02).atPower(0.95);
+                }
+            };
+            Sampling<Factors, String, String> sampling = Sampling
+                    .<Factors, String, String>builder()
+                    .serviceContractFactory(f -> contract)
+                    .inputs("a")
+                    .samples(100)
+                    .build();
+            return Experiment.measuring(sampling, FACTORS).build();
+        };
+
+        int viaContract = PowerAnalysis.sampleSize(dir, twoCriteria);
+        int viaTight = PowerAnalysis.sampleSize(dir, baseline(), 0.02, 0.95);
+
+        assertThat(viaContract).isEqualTo(viaTight);
+    }
+
+    @Test
+    @DisplayName("single-arg overload throws when no criterion declares MDE + power")
+    void singleArgThrowsWhenNoConfidenceFirstCriterion(@TempDir Path dir) throws IOException {
+        writeBaselineWithRate(dir, 0.90, 1000);
+
+        // The base `baseline()` uses ECHO — a no-criteria contract.
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> PowerAnalysis.sampleSize(dir, baseline()))
+                .withMessageContaining("confidence-first")
+                .withMessageContaining(".detectingMde");
+    }
 }


### PR DESCRIPTION
Second slice of [DIR-CONTRACT-THRESHOLDS-punit PR #2](https://github.com/javai-org/punit/blob/main/../plan/directives/DIR-CONTRACT-THRESHOLDS-punit.md). Adds the single-argument entry point that the authoring docs now point at for the confidence-first approach.

## What changes

\`PowerAnalysis.sampleSize(baseline)\` now exists. It reads each contract criterion's posture (plumbed in PR #172), filters for confidence-first criteria (\`STATISTICAL_EMPIRICAL\` + both MDE and power), and returns the maximum required sample count across them.

### Before

\`\`\`java
PUnit.testing(this::baseline)
        .samples(PowerAnalysis.sampleSize(this::baseline, 0.05, 0.80))  // MDE/power restated
        .criterion(PassRate.empirical().atConfidence(0.95))
        .assertPasses();
\`\`\`

### After (the confidence-first authoring shape)

\`\`\`java
// Contract
b.addCriterion(\"valid-json\", pb -> pb.ensure(...))
        .empirical()
        .detectingMde(0.05)
        .atPower(0.80)
        .atConfidence(0.95);

// Test
PUnit.testing(this::baseline)
        .samples(PowerAnalysis.sampleSize(this::baseline))  // MDE/power come from contract
        .assertPasses();
\`\`\`

The three-arg \`sampleSize(baseline, mde, power)\` is retained for ad-hoc consultation (CI scripts, exploratory analysis) but is no longer the documented entry point for confidence-first tests.

## Multi-criterion rule

Max across confidence-first criteria: the worst-case requirement dictates N. A criterion declaring tighter MDE / higher power demands more samples; running fewer would leave that criterion under-sized.

## What's still ahead

- **Silent uplift in the engine**: the author writing only \`.assertPasses()\` (no \`.samples\` call at all) requires baseline resolution before sampling starts. That's the next slice.
- **Verdict XML \`<sampling>\` block** with provenance for the derived N.
- **punit-core test migration**: move every \`.criterion(PassRate.meeting/.empirical)\` call to the contract's criterion declaration.

## Test plan

- [x] \`./gradlew :punit-core:test\` — green
- [x] Three new regression tests in \`PowerAnalysisTest\`:
  - single-arg matches three-arg with identical inputs
  - max across two confidence-first criteria (loose + tight)
  - clear rejection when no confidence-first criterion declared

🤖 Generated with [Claude Code](https://claude.com/claude-code)