### PR TITLE
PR #2 slice 3: silent-uplift sample-count resolution at engine start

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
@@ -96,7 +96,27 @@ public final class Engine {
         while (it.hasNext()) {
             Configuration<FT, IT, OT> cfg = it.next();
             ServiceContract<FT, IT, OT> uc = spec.serviceContractFactory().apply(cfg.factors());
-            SampleSummary<OT> summary = runConfig(spec, uc, cfg, 0);
+            // Silent uplift: when the contract carries a
+            // confidence-first criterion, the framework computes its
+            // PowerAnalysis-required sample count from the baseline
+            // and uplifts the configuration's declared count to the
+            // maximum. The author's .samples(N) is a floor; the
+            // contract's commitment is the source of truth.
+            org.javai.punit.internal.engine.baseline.SampleSizeResolver.Resolution resolution =
+                    org.javai.punit.internal.engine.baseline.SampleSizeResolver.resolve(
+                            uc,
+                            org.javai.punit.api.FactorBundle.of(cfg.factors()),
+                            baselineProvider,
+                            cfg.samples());
+            if (resolution.wasUplifted()) {
+                System.out.println(String.format(
+                        "[PUNIT-UPLIFT] criterion '%s' demands %d samples (PowerAnalysis); "
+                                + "uplifting declared count of %d.",
+                        resolution.drivenBy().get(),
+                        resolution.effective(),
+                        resolution.declared()));
+            }
+            SampleSummary<OT> summary = runConfig(spec, uc, cfg, 0, resolution.effective());
             spec.consume(cfg, summary);
         }
         return spec.conclude(baselineProvider);
@@ -106,7 +126,8 @@ public final class Engine {
             TypedSpec<FT, IT, OT> spec,
             ServiceContract<FT, IT, OT> serviceContract,
             Configuration<FT, IT, OT> cfg,
-            int cycleStart) {
+            int cycleStart,
+            int effectiveSamples) {
 
         BudgetTracker tracker = new BudgetTracker(
                 spec.timeBudget(), spec.tokenBudget(), spec.tokenCharge());
@@ -118,7 +139,7 @@ public final class Engine {
                 spec.maxExampleFailures(),
                 tracker,
                 spec.earlyTermination(),
-                cfg.samples());
+                effectiveSamples);
 
         long t0 = System.nanoTime();
         executor.runSamples(
@@ -126,7 +147,7 @@ public final class Engine {
                 cfg.inputs(),
                 cfg.expected(),
                 spec.matcher(),
-                cfg.samples(),
+                effectiveSamples,
                 cycleStart,
                 agg,
                 tracker::shouldStopBeforeNextSample);

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/SampleSizeResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/SampleSizeResolver.java
@@ -1,0 +1,140 @@
+package org.javai.punit.internal.engine.baseline;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.ServiceContract;
+import org.javai.punit.api.covariate.Covariate;
+import org.javai.punit.api.covariate.CovariateProfile;
+import org.javai.punit.api.criterion.Criterion;
+import org.javai.punit.api.criterion.CriterionPosture;
+import org.javai.punit.api.spec.BaselineProvider;
+import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
+import org.javai.punit.internal.engine.covariate.CovariateResolver;
+import org.javai.punit.statistics.SampleSizeCalculator;
+
+/**
+ * Resolves the *effective* sample count for a run by composing the
+ * author-declared sample count with any confidence-first criterion's
+ * power-analysis floor. The directive's silent-uplift rule:
+ *
+ * <pre>
+ * N_effective = max(
+ *     declared,
+ *     max over confidence-first criteria of PowerAnalysis(baseline, mde, power)
+ * )
+ * </pre>
+ *
+ * <p>Called by the engine before sampling starts. The resolution is
+ * captured on the returned {@link Resolution} record so the verdict
+ * path can report which criterion drove any uplift.
+ */
+public final class SampleSizeResolver {
+
+    private static final double DEFAULT_CONFIDENCE = 0.95;
+    private static final SampleSizeCalculator CALCULATOR = new SampleSizeCalculator();
+
+    private SampleSizeResolver() { }
+
+    /**
+     * The result of {@link #resolve}: the effective sample count plus
+     * provenance.
+     *
+     * @param declared the author's {@code Sampling.samples(N)} value
+     * @param effective the post-uplift sample count that will actually run
+     * @param drivenBy when uplifted: the id of the criterion whose
+     *                 PowerAnalysis floor pinned {@code effective};
+     *                 empty when {@code effective == declared}
+     */
+    public record Resolution(int declared, int effective, Optional<String> drivenBy) {
+
+        /** Whether the framework silently uplifted the declared count. */
+        public boolean wasUplifted() {
+            return effective > declared && drivenBy.isPresent();
+        }
+    }
+
+    /**
+     * Compute the effective sample count for a configuration.
+     *
+     * @param contract       the service contract instance for this configuration
+     *                       (already constructed via the spec's factory)
+     * @param factors        the configuration's factor bundle
+     * @param baselineProvider the framework's baseline provider
+     * @param declaredSamples the author's declared sample count
+     *                        (typically {@code Configuration.samples()})
+     * @return the {@link Resolution}: effective count + provenance
+     */
+    public static <FT, IT, OT> Resolution resolve(
+            ServiceContract<FT, IT, OT> contract,
+            FactorBundle factors,
+            BaselineProvider baselineProvider,
+            int declaredSamples) {
+
+        List<? extends Criterion<OT>> criteria = contract.criteria();
+        List<? extends Criterion<OT>> confidenceFirst = criteria.stream()
+                .filter(c -> c.posture().isConfidenceFirst())
+                .toList();
+        if (confidenceFirst.isEmpty()) {
+            return new Resolution(declaredSamples, declaredSamples, Optional.empty());
+        }
+
+        // Resolve the baseline once for the contract's id + factor
+        // bundle. PerCriterionPassRateStatistics is the K-aware shape;
+        // we read the per-criterion rate when present.
+        String serviceContractId = contract.id();
+        List<Covariate> declarations = contract.covariates();
+        CovariateProfile profile = declarations.isEmpty()
+                ? CovariateProfile.empty()
+                : CovariateResolver.defaults().resolve(
+                        declarations, contract.customCovariateResolvers());
+        Optional<PerCriterionPassRateStatistics> baseline = baselineProvider.baselineFor(
+                serviceContractId, factors, "bernoulli-pass-rate",
+                PerCriterionPassRateStatistics.class, profile, declarations);
+        if (baseline.isEmpty()) {
+            // No baseline yet — the criterion's empirical evaluation
+            // will produce a no-baseline INCONCLUSIVE at conclude
+            // time. Don't uplift; let the verdict path handle the
+            // missing baseline as its own diagnostic.
+            return new Resolution(declaredSamples, declaredSamples, Optional.empty());
+        }
+
+        int maxRequired = declaredSamples;
+        String drivenBy = null;
+        for (Criterion<OT> c : confidenceFirst) {
+            CriterionPosture posture = c.posture();
+            double mde = posture.mde().getAsDouble();
+            double power = posture.power().getAsDouble();
+            double confidence = posture.confidenceFloor().orElse(DEFAULT_CONFIDENCE);
+            PassRateStatistics stats = baseline.get().byCriterion().get(c.id());
+            if (stats == null && baseline.get().byCriterion().size() == 1) {
+                // K=1 isomorphism: a single-entry baseline matches the
+                // criterion even when the ids disagree (the legacy
+                // "contract" id versus the auto-derived class name).
+                stats = baseline.get().byCriterion().values().iterator().next();
+            }
+            if (stats == null) {
+                continue;
+            }
+            double baselineRate = stats.observedPassRate();
+            if (baselineRate - mde <= 0.0) {
+                // Defer to the verdict path's own diagnostic on
+                // alternative-hypothesis-rate ≤ 0.
+                continue;
+            }
+            int required = CALCULATOR
+                    .calculateForPower(baselineRate, mde, confidence, power)
+                    .requiredSamples();
+            if (required > maxRequired) {
+                maxRequired = required;
+                drivenBy = c.id();
+            }
+        }
+        if (drivenBy == null) {
+            return new Resolution(declaredSamples, declaredSamples, Optional.empty());
+        }
+        return new Resolution(declaredSamples, maxRequired, Optional.of(drivenBy));
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
@@ -1,0 +1,180 @@
+package org.javai.punit.internal.engine.baseline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.ServiceContract;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.spec.BaselineStatistics;
+import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("SampleSizeResolver — silent uplift from contract postures")
+class SampleSizeResolverTest {
+
+    record Factors(String label) { }
+
+    private static final Factors FACTORS = new Factors("m");
+    private static final String CONTRACT_ID = "echo-contract";
+
+    private static Path writeBaseline(Path dir, double rate, int n) throws IOException {
+        BaselineRecord record = new BaselineRecord(
+                CONTRACT_ID, "measure", FactorsFingerprint.of(FactorBundle.of(FACTORS)),
+                "sha256:any", n, Instant.parse("2026-05-16T00:00:00Z"),
+                Map.<String, BaselineStatistics>of(
+                        "bernoulli-pass-rate",
+                        PerCriterionPassRateStatistics.of("the-criterion", rate, n)));
+        new BaselineWriter().write(record, dir);
+        return dir;
+    }
+
+    private static ServiceContract<Factors, String, String> contractWithConfidenceFirst(
+            double mde, double power) {
+        return new ServiceContract<>() {
+            @Override public String id() { return CONTRACT_ID; }
+            @Override public Outcome<String> invoke(String input, TokenTracker t) {
+                return Outcome.ok(input);
+            }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("the-criterion", pb -> pb.ensure("always", v -> Outcome.ok()))
+                        .empirical()
+                        .detectingMde(mde)
+                        .atPower(power);
+            }
+        };
+    }
+
+    private static ServiceContract<Factors, String, String> contractNoConfidenceFirst() {
+        return new ServiceContract<>() {
+            @Override public String id() { return CONTRACT_ID; }
+            @Override public Outcome<String> invoke(String input, TokenTracker t) {
+                return Outcome.ok(input);
+            }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("threshold-criterion", pb -> pb.ensure("always", v -> Outcome.ok()))
+                        .meeting(0.90, ThresholdOrigin.SLA);
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("uplifts the declared count when a confidence-first criterion demands more")
+    void upliftsWhenConfidenceFirstDemandsMore(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, 0.90, 1000);
+        var provider = new org.javai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        // MDE 0.05, power 0.80, rate 0.90 → ~470 samples per the
+        // SampleSizeCalculator; declare only 100.
+        var resolution = SampleSizeResolver.resolve(
+                contractWithConfidenceFirst(0.05, 0.80),
+                FactorBundle.of(FACTORS),
+                provider,
+                100);
+
+        assertThat(resolution.declared()).isEqualTo(100);
+        assertThat(resolution.effective()).isGreaterThan(100);
+        assertThat(resolution.drivenBy()).contains("the-criterion");
+        assertThat(resolution.wasUplifted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("keeps the declared count when it already meets the criterion's demand")
+    void noUpliftWhenDeclaredAlreadyMeetsDemand(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, 0.90, 1000);
+        var provider = new org.javai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        var resolution = SampleSizeResolver.resolve(
+                contractWithConfidenceFirst(0.05, 0.80),
+                FactorBundle.of(FACTORS),
+                provider,
+                10000);
+
+        assertThat(resolution.declared()).isEqualTo(10000);
+        assertThat(resolution.effective()).isEqualTo(10000);
+        assertThat(resolution.drivenBy()).isEmpty();
+        assertThat(resolution.wasUplifted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("no uplift when the contract has no confidence-first criterion")
+    void noUpliftForNonConfidenceFirstContract(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, 0.90, 1000);
+        var provider = new org.javai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        var resolution = SampleSizeResolver.resolve(
+                contractNoConfidenceFirst(),
+                FactorBundle.of(FACTORS),
+                provider,
+                100);
+
+        assertThat(resolution.declared()).isEqualTo(100);
+        assertThat(resolution.effective()).isEqualTo(100);
+        assertThat(resolution.drivenBy()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("no uplift when the baseline is missing — verdict-path INCONCLUSIVE will handle it")
+    void noUpliftWhenBaselineAbsent(@TempDir Path emptyDir) {
+        var provider = new org.javai.punit.internal.engine.baseline.YamlBaselineProvider(emptyDir);
+
+        var resolution = SampleSizeResolver.resolve(
+                contractWithConfidenceFirst(0.05, 0.80),
+                FactorBundle.of(FACTORS),
+                provider,
+                100);
+
+        assertThat(resolution.declared()).isEqualTo(100);
+        assertThat(resolution.effective()).isEqualTo(100);
+        assertThat(resolution.drivenBy()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("multi-criterion: max across confidence-first criteria wins; drivenBy names that criterion")
+    void multiCriterionMaxWins(@TempDir Path dir) throws IOException {
+        // Two-criterion baseline: 'loose' at 0.95 (easy), 'tight' at 0.95.
+        BaselineRecord record = new BaselineRecord(
+                CONTRACT_ID, "measure", FactorsFingerprint.of(FactorBundle.of(FACTORS)),
+                "sha256:any", 1000, Instant.parse("2026-05-16T00:00:00Z"),
+                Map.<String, BaselineStatistics>of(
+                        "bernoulli-pass-rate",
+                        new PerCriterionPassRateStatistics(Map.of(
+                                "loose", new org.javai.punit.api.spec.PassRateStatistics(0.95, 1000),
+                                "tight", new org.javai.punit.api.spec.PassRateStatistics(0.95, 1000)))));
+        new BaselineWriter().write(record, dir);
+        var provider = new org.javai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        ServiceContract<Factors, String, String> contract = new ServiceContract<>() {
+            @Override public String id() { return CONTRACT_ID; }
+            @Override public Outcome<String> invoke(String input, TokenTracker t) {
+                return Outcome.ok(input);
+            }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("loose", pb -> pb.ensure("always", v -> Outcome.ok()))
+                        .empirical().detectingMde(0.10).atPower(0.50);
+                b.addCriterion("tight", pb -> pb.ensure("always", v -> Outcome.ok()))
+                        .empirical().detectingMde(0.02).atPower(0.95);
+            }
+        };
+
+        var resolution = SampleSizeResolver.resolve(
+                contract,
+                FactorBundle.of(FACTORS),
+                provider,
+                10);
+
+        // 'tight' (small MDE + high power) needs many more samples.
+        assertThat(resolution.drivenBy()).contains("tight");
+        assertThat(resolution.effective()).isGreaterThan(100);
+    }
+}


### PR DESCRIPTION
Third slice of [DIR-CONTRACT-THRESHOLDS-punit PR #2](https://github.com/javai-org/punit/blob/main/../plan/directives/DIR-CONTRACT-THRESHOLDS-punit.md). The engine now asks the new \`SampleSizeResolver\` before each configuration runs whether the contract's confidence-first criteria demand more samples than declared. When they do, the run is silently uplifted to the max.

## The behaviour

\`\`\`java
// Contract — confidence-first criterion
b.addCriterion(\"valid-json\", pb -> pb.ensure(...))
        .empirical()
        .detectingMde(0.05)
        .atPower(0.80);

// Test — declares 100, but the contract demands ~470 at baseline rate 0.90
PUnit.testing(sampling)
        .samples(100)               // floor
        .assertPasses();
\`\`\`

Output:

\`\`\`
[PUNIT-UPLIFT] criterion 'valid-json' demands 470 samples (PowerAnalysis); uplifting declared count of 100.
\`\`\`

The author's \`.samples(N)\` becomes a *floor*: when a confidence-first criterion's PowerAnalysis(baseline, mde, power) yields a higher required count, the framework uses that. The contract's commitment is the source of truth.

## What \`SampleSizeResolver\` does

For each Configuration the engine is about to run:

1. Reads the contract's criteria; filters for confidence-first (\`posture.isConfidenceFirst()\`).
2. No confidence-first criterion → no uplift; returns \`(declared, declared, empty)\`.
3. Resolves the baseline once for the contract id + factor bundle. Missing baseline → no uplift (the verdict path's no-baseline diagnostic takes over).
4. For each confidence-first criterion, looks up the per-criterion baseline rate (K=1 isomorphism preserved), computes \`SampleSizeCalculator.calculateForPower(rate, mde, conf, power).requiredSamples()\`.
5. Returns the max; records the driving criterion id.

## What's still ahead

- **Verdict XML \`<sampling>\` block** — additive metadata; follows next. The \`Resolution\` data needs to flow through \`SampleSummary\` or a side-channel to reach the verdict-render path. Routine plumbing.
- **\`.samples(N)\` becoming optional on \`Sampling\`** — authors still declare a floor today.
- **punit-core test migration** (\`.criterion(PassRate...)\` → contract-side \`.meeting(...)\`).
- **PR #3** — activate implicit zero-tolerance + retire test-builder API.

## Test plan

- [x] \`./gradlew :punit-core:test\` — green
- [x] Five regression tests in \`SampleSizeResolverTest\`: uplift case, no-uplift-when-declared-sufficient, non-confidence-first contract, missing-baseline path, multi-criterion max-drives-by.
- [x] All existing engine / baseline / criterion tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)