### PR TITLE
Migrate punit-core tests to declare posture on the contract

### DIFF
--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
@@ -3,7 +3,7 @@ package org.javai.punit.internal.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -36,9 +36,31 @@ class EarlyTerminationIntegrationTest {
 
     record Factors() {}
 
-    /** Returns Outcome.ok every sample. */
+    /** Returns Outcome.ok every sample. Contract posture: meeting(0.5, SLA). */
     private static class AlwaysPass implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.5, ThresholdOrigin.SLA);
+        }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(Boolean.TRUE);
+        }
+    }
+
+    /** Always-pass variant whose contract posture is meeting(0.20, SLA). */
+    private static class AlwaysPassLowThreshold implements ServiceContract<Factors, Integer, Boolean> {
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.20, ThresholdOrigin.SLA);
+        }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(Boolean.TRUE);
+        }
+    }
+
+    /** Always-pass variant whose contract posture is empirical. */
+    private static class AlwaysPassEmpirical implements ServiceContract<Factors, Integer, Boolean> {
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).empirical();
+        }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
         }
@@ -46,7 +68,9 @@ class EarlyTerminationIntegrationTest {
 
     /** Returns Outcome.fail every sample — a clean failure-inevitable shape. */
     private static class AlwaysFail implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+        }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure");
         }
@@ -61,7 +85,9 @@ class EarlyTerminationIntegrationTest {
         private final int failsFirst;
         private int seen = 0;
         FailsThenPasses(int failsFirst) { this.failsFirst = failsFirst; }
-        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.80, ThresholdOrigin.SLA);
+        }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return ++seen <= failsFirst
                     ? Outcome.fail("contract_violation", "scripted failure")
@@ -149,7 +175,7 @@ class EarlyTerminationIntegrationTest {
         // required at sample 20 but total < floor; the run continues to
         // sample 25 where the floor is met and the short-circuit fires.
         ProbabilisticTest spec = ProbabilisticTest
-                .testing(sampling(f -> new AlwaysPass(), 100), new Factors())
+                .testing(sampling(f -> new AlwaysPassLowThreshold(), 100), new Factors())
                 .criterion(PassRate.<Boolean>meeting(0.20, ThresholdOrigin.SLA))
                 .build();
 
@@ -188,7 +214,7 @@ class EarlyTerminationIntegrationTest {
         // available to the engine; the spec returns Optional.empty()
         // from earlyTermination() and the run is not short-circuited.
         ProbabilisticTest spec = ProbabilisticTest
-                .testing(sampling(f -> new AlwaysPass(), 30), new Factors())
+                .testing(sampling(f -> new AlwaysPassEmpirical(), 30), new Factors())
                 .criterion(PassRate.<Boolean>empirical())
                 .build();
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -8,11 +8,11 @@ import java.time.Instant;
 import java.util.Map;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.internal.engine.criteria.PassRate;
@@ -38,7 +38,9 @@ class EmpiricalEndToEndIntegrationTest {
     private static final String USE_CASE_ID = "always-passes-use-case";
 
     static class AlwaysPassesServiceContract implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).empirical();
+        }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(true);
         }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -14,6 +14,7 @@ import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.ValueMatcher;
 import org.javai.punit.api.spec.TerminationReason;
 import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -157,7 +158,7 @@ class EngineIntegrationTest {
     void empiricalYieldsInconclusiveUnderStubResolver() {
         Sampling<LlmFactors, Integer, Boolean> sampling = Sampling
                 .<LlmFactors, Integer, Boolean>builder()
-                .serviceContractFactory(f -> new AlwaysPassesServiceContract())
+                .serviceContractFactory(f -> new AlwaysPassesEmpiricalServiceContract())
                 .inputs(1, 2, 3)
                 .samples(20)
                 .build();
@@ -269,7 +270,9 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: custom matcher drives the verdict's pass-rate criterion")
     void testPathInstanceConformanceUsesCustomMatcher() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -305,7 +308,9 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: expectedOutputs without explicit matcher defaults to equality")
     void testPathDefaultsToEqualityMatcher() {
         ServiceContract<LlmFactors, String, String> upperCase = new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.4, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.toUpperCase());
             }
@@ -335,7 +340,9 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: matcher configured on Sampling.Builder.matching(...) drives the verdict")
     void testPathPropagatesMatcherFromSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -399,7 +406,9 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: spec-builder matcher overrides the matcher carried on Sampling")
     void testPathSpecBuilderMatcherOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -469,7 +478,9 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: spec-builder expectedOutputs overrides the expected list carried on Sampling")
     void testPathSpecBuilderExpectedOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
             }
@@ -866,7 +877,19 @@ class EngineIntegrationTest {
     // ── Test doubles ────────────────────────────────────────────────
 
     private static class AlwaysPassesServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+        }
+        @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(Boolean.TRUE);
+        }
+    }
+
+    /** Empirical-posture sibling of {@link AlwaysPassesServiceContract} for the empirical-path test. */
+    private static class AlwaysPassesEmpiricalServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).empirical();
+        }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
         }
@@ -874,7 +897,9 @@ class EngineIntegrationTest {
 
     /** Returns business-level Fail outcomes — the "contract didn't hold" signal. */
     private static class AlwaysReturnsFailServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+        @Override public void criteria(CriteriaBuilder<Boolean> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLO);
+        }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure for input " + input);
         }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Pacing;
 import org.javai.punit.api.Sampling;
@@ -396,7 +397,9 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("mixed criteria: functional PASS + latency FAIL composes to FAIL when both REQUIRED")
     void mixedCriteriaBothRequiredComposesToFail() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
                 return Outcome.ok(Boolean.TRUE);
@@ -425,7 +428,9 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("reportOnly latency: functional PASS + latency FAIL(report-only) composes to PASS")
     void reportOnlyLatencyExcludedFromComposition() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
                 return Outcome.ok(Boolean.TRUE);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
@@ -10,6 +10,7 @@ import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -40,12 +41,14 @@ class PostconditionFailureHistogramTest {
         @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
-        @Override public void postconditions(PostconditionBuilder<Integer> b) {
-            b.ensure("alwaysFails", v ->
-                    Outcome.fail("alwaysFails-mode", "input was " + v));
-            b.ensure("evenFails", v -> v % 2 == 0
-                    ? Outcome.fail("even-mode", "input " + v + " is even")
-                    : Outcome.ok());
+        @Override public void criteria(CriteriaBuilder<Integer> b) {
+            b.addCriterion("contract", pb -> {
+                pb.ensure("alwaysFails", v ->
+                        Outcome.fail("alwaysFails-mode", "input was " + v));
+                pb.ensure("evenFails", v -> v % 2 == 0
+                        ? Outcome.fail("even-mode", "input " + v + " is even")
+                        : Outcome.ok());
+            }).meeting(0.5, org.javai.punit.api.ThresholdOrigin.SLA);
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.Experiment;
@@ -21,7 +21,9 @@ class InlineSamplingFormTest {
     record Factors(String label) {}
 
     private static final ServiceContract<Factors, String, String> ECHO = new ServiceContract<>() {
-        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
+        @Override public void criteria(CriteriaBuilder<String> b) {
+            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+        }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);
         }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -8,7 +8,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -41,7 +41,9 @@ public final class CovariateSubjects {
      */
     private static ServiceContract<NoFactors, Integer, Boolean> covariateServiceContract() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -4,7 +4,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -26,9 +26,11 @@ public final class FeasibilitySubjects {
 
     public static final String USE_CASE_ID = "feasibility-use-case";
 
-    private static ServiceContract<NoFactors, Integer, Boolean> alwaysPasses() {
+    private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesEmpirical() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }
@@ -36,9 +38,29 @@ public final class FeasibilitySubjects {
         };
     }
 
-    private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+    private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesContractual() {
+        return new ServiceContract<>() {
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.9999, ThresholdOrigin.SLA);
+            }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(true);
+            }
+            @Override public String id() { return USE_CASE_ID; }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> empiricalSampling(int samples) {
         return Sampling.<NoFactors, Integer, Boolean>builder()
-                .serviceContractFactory(f -> alwaysPasses())
+                .serviceContractFactory(f -> alwaysPassesEmpirical())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> contractualSampling(int samples) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .serviceContractFactory(f -> alwaysPassesContractual())
                 .inputs(1, 2, 3)
                 .samples(samples)
                 .build();
@@ -53,7 +75,7 @@ public final class FeasibilitySubjects {
         void shouldPass() {
             // Baseline rate 0.50; n=50 against rate 0.50 has min Wilson
             // lower bound at observed=1.0 ≈ 0.949 — well above 0.50 → feasible.
-            PUnit.testing(sampling(50))
+            PUnit.testing(empiricalSampling(50))
                     .criterion(PassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -69,7 +91,7 @@ public final class FeasibilitySubjects {
             // Baseline rate 0.95; n=10 against rate 0.95 has max Wilson
             // lower bound at observed=1.0 ≈ 0.787 — below 0.95 → infeasible.
             // Default intent is VERIFICATION → throw IllegalStateException.
-            PUnit.testing(sampling(10))
+            PUnit.testing(empiricalSampling(10))
                     .criterion(PassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -84,7 +106,7 @@ public final class FeasibilitySubjects {
     public static final class SmokeInfeasible {
         @ProbabilisticTest
         void shouldRunSilently() {
-            PUnit.testing(sampling(10))
+            PUnit.testing(empiricalSampling(10))
                     .criterion(PassRate.<Boolean>empirical())
                     .intent(TestIntent.SMOKE)
                     .assertPasses();
@@ -103,7 +125,7 @@ public final class FeasibilitySubjects {
     public static final class ContractualVerificationInfeasible {
         @ProbabilisticTest
         void shouldFailFast() {
-            PUnit.testing(sampling(50))
+            PUnit.testing(contractualSampling(50))
                     .criterion(PassRate.<Boolean>meeting(0.9999, ThresholdOrigin.SLA))
                     .assertPasses();
         }
@@ -118,7 +140,7 @@ public final class FeasibilitySubjects {
     public static final class ContractualSmokeInfeasible {
         @ProbabilisticTest
         void shouldRunSilently() {
-            PUnit.testing(sampling(50))
+            PUnit.testing(contractualSampling(50))
                     .criterion(PassRate.<Boolean>meeting(0.9999, ThresholdOrigin.SLA))
                     .intent(TestIntent.SMOKE)
                     .assertPasses();

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -4,7 +4,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -34,9 +34,11 @@ public final class PUnitSubjects {
      */
     public record GridPoint(String label) { }
 
-    private static <F> ServiceContract<F, Integer, Boolean> alwaysPasses() {
+    private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesContractual() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.5, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }
@@ -46,9 +48,23 @@ public final class PUnitSubjects {
         };
     }
 
+    private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesEmpirical() {
+        return new ServiceContract<>() {
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(true);
+            }
+            @Override public String id() { return "always-passes-subject"; }
+        };
+    }
+
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFails() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.5, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.fail("nope", "always fails");
             }
@@ -71,7 +87,7 @@ public final class PUnitSubjects {
     public static final class PassingContractualTest {
         @ProbabilisticTest
         void passes() {
-            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20))
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPassesContractual(), 20))
                     .criterion(PassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .assertPasses();
         }
@@ -81,7 +97,7 @@ public final class PUnitSubjects {
     public static final class TransparentStatsTest {
         @ProbabilisticTest
         void passesWithTransparentStats() {
-            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20))
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPassesContractual(), 20))
                     .criterion(PassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .transparentStats()
                     .assertPasses();
@@ -97,7 +113,7 @@ public final class PUnitSubjects {
     public static final class ContractRefPassingTest {
         @ProbabilisticTest
         void passesWithContractRef() {
-            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20))
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPassesContractual(), 20))
                     .criterion(PassRate.<Boolean>meeting(0.5, ThresholdOrigin.SLA))
                     .contractRef("Acme API SLA v3.2 §2.1")
                     .transparentStats()
@@ -139,7 +155,7 @@ public final class PUnitSubjects {
     public static final class InconclusiveEmpiricalTest {
         @ProbabilisticTest
         void inconclusive() {
-            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 20))
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPassesEmpirical(), 20))
                     .criterion(PassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -151,7 +167,7 @@ public final class PUnitSubjects {
     public static final class PassingMeasureExperiment {
         @Experiment
         void measure() {
-            PUnit.measuring(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 100)).run();
+            PUnit.measuring(sampling(PUnitSubjects.<NoFactors>alwaysPassesContractual(), 100)).run();
         }
     }
 
@@ -159,7 +175,7 @@ public final class PUnitSubjects {
     public static final class PassingExploreExperiment {
         @Experiment
         void explore() {
-            PUnit.exploring(sampling(PUnitSubjects.<GridPoint>alwaysPasses(), 5))
+            PUnit.exploring(sampling(PUnitSubjects.<GridPoint>alwaysPassesContractual(), 5))
                     .grid(new GridPoint("alt-1"), new GridPoint("alt-2"))
                     .run();
         }
@@ -176,7 +192,7 @@ public final class PUnitSubjects {
      */
     public static final class EmpiricalSupplierTest {
         private org.javai.punit.api.spec.Experiment baseline() {
-            return PUnit.measuring(sampling(PUnitSubjects.<NoFactors>alwaysPasses(), 100)).build();
+            return PUnit.measuring(sampling(PUnitSubjects.<NoFactors>alwaysPassesEmpirical(), 100)).build();
         }
 
         @ProbabilisticTest
@@ -198,7 +214,7 @@ public final class PUnitSubjects {
      */
     public static final class EmpiricalSupplierBadKindTest {
         private org.javai.punit.api.spec.Experiment exploreBaseline() {
-            return PUnit.exploring(sampling(PUnitSubjects.<GridPoint>alwaysPasses(), 5))
+            return PUnit.exploring(sampling(PUnitSubjects.<GridPoint>alwaysPassesContractual(), 5))
                     .grid(new GridPoint("alt"))
                     .build();
         }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -34,9 +34,11 @@ public final class PreflightInvariantSubjects {
 
     private PreflightInvariantSubjects() { }
 
-    private static ServiceContract<NoFactors, Integer, Boolean> countingAlwaysPasses() {
+    private static ServiceContract<NoFactors, Integer, Boolean> countingEmpirical() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
                 return Outcome.ok(true);
@@ -45,9 +47,30 @@ public final class PreflightInvariantSubjects {
         };
     }
 
-    private static Sampling<NoFactors, Integer, Boolean> sampling(int samples) {
+    private static ServiceContract<NoFactors, Integer, Boolean> countingContractualHighThreshold() {
+        return new ServiceContract<>() {
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.9999, ThresholdOrigin.SLA);
+            }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                INVOKE_COUNT.incrementAndGet();
+                return Outcome.ok(true);
+            }
+            @Override public String id() { return USE_CASE_ID; }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> empiricalSampling(int samples) {
         return Sampling.<NoFactors, Integer, Boolean>builder()
-                .serviceContractFactory(f -> countingAlwaysPasses())
+                .serviceContractFactory(f -> countingEmpirical())
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> contractualHighSampling(int samples) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .serviceContractFactory(f -> countingContractualHighThreshold())
                 .inputs(1, 2, 3)
                 .samples(samples)
                 .build();
@@ -64,7 +87,7 @@ public final class PreflightInvariantSubjects {
         void undersizedAgainstNormativeThreshold() {
             // n=50 against 0.9999 at 95% confidence: Wilson upper-of-perfect
             // ≈ 0.949, well below 0.9999 → infeasible.
-            PUnit.testing(sampling(50))
+            PUnit.testing(contractualHighSampling(50))
                     .criterion(PassRate.<Boolean>meeting(0.9999, ThresholdOrigin.SLA))
                     .assertPasses();
         }
@@ -81,7 +104,7 @@ public final class PreflightInvariantSubjects {
         void undersizedAgainstHighBaselineRate() {
             // n=10 against baseline 0.95 at default 95% confidence:
             // Wilson upper-of-perfect ≈ 0.787 < 0.95 → infeasible.
-            PUnit.testing(sampling(10))
+            PUnit.testing(empiricalSampling(10))
                     .criterion(PassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -99,7 +122,7 @@ public final class PreflightInvariantSubjects {
         public static final String EXPERIMENT_ID = "power-analysis-baseline";
 
         private org.javai.punit.api.spec.Experiment baseline() {
-            return PUnit.measuring(sampling(200))
+            return PUnit.measuring(empiricalSampling(200))
                     .experimentId(EXPERIMENT_ID)
                     .build();
         }
@@ -110,7 +133,7 @@ public final class PreflightInvariantSubjects {
             // the test then runs with that n. By construction the
             // (n, baseline-rate, default-confidence) tuple is feasible.
             int n = PowerAnalysis.sampleSize(this::baseline, 0.05, 0.80);
-            PUnit.testing(sampling(n))
+            PUnit.testing(empiricalSampling(n))
                     .criterion(PassRate.<Boolean>empirical())
                     .assertPasses();
         }
@@ -124,7 +147,7 @@ public final class PreflightInvariantSubjects {
     public static final class PowerAnalysisBaselineMeasure {
         @org.javai.punit.api.Experiment
         void seedBaseline() {
-            PUnit.measuring(sampling(200))
+            PUnit.measuring(empiricalSampling(200))
                     .experimentId(PowerAnalysisDerivedFeasibleTest.EXPERIMENT_ID)
                     .run();
         }
@@ -144,7 +167,7 @@ public final class PreflightInvariantSubjects {
             // PassRate.meeting validates threshold ∈ [0, 1] at
             // construction; -0.1 throws before .assertPasses() is ever
             // called.
-            PUnit.testing(sampling(50))
+            PUnit.testing(contractualHighSampling(50))
                     .criterion(PassRate.<Boolean>meeting(-0.1, ThresholdOrigin.SLA))
                     .assertPasses();
         }
@@ -160,7 +183,7 @@ public final class PreflightInvariantSubjects {
     public static final class ConfigurationCoherenceTest {
         @ProbabilisticTest
         void rejectsEmpiricalOriginOnContractualFactory() {
-            PUnit.testing(sampling(50))
+            PUnit.testing(contractualHighSampling(50))
                     .criterion(PassRate.<Boolean>meeting(0.95, ThresholdOrigin.EMPIRICAL))
                     .assertPasses();
         }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
@@ -6,7 +6,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -32,7 +32,9 @@ public final class PreflightSubjects {
     /** Always-passing service contract that records every invocation. */
     private static ServiceContract<NoFactors, Integer, Boolean> countingServiceContract() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -3,7 +3,7 @@ package org.javai.punit.junit5.testsubjects;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -28,7 +28,9 @@ public final class RoundTripSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> serviceContract() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
             }

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/SoundnessFloorSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/SoundnessFloorSubjects.java
@@ -6,7 +6,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -33,7 +33,9 @@ public final class SoundnessFloorSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> countingAlwaysPasses() {
         return new ServiceContract<>() {
-            @Override public void postconditions(PostconditionBuilder<Boolean> b) { /* none */ }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.50, ThresholdOrigin.SLA);
+            }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -55,9 +56,11 @@ class LatencyEverywhereIntegrationTest {
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
-        @Override public void postconditions(PostconditionBuilder<Integer> b) {
-            b.ensure("length is even", n ->
-                    n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "length=" + n));
+        @Override public void criteria(CriteriaBuilder<Integer> b) {
+            b.addCriterion("contract", pb ->
+                    pb.ensure("length is even", n ->
+                            n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "length=" + n)))
+                    .meeting(0.5, ThresholdOrigin.SLA);
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
@@ -66,8 +66,10 @@ class MultiDimensionVerdictIntegrationTest {
             sleep(SLEEP_MS);
             return Outcome.ok(input.length());
         }
-        @Override public void postconditions(PostconditionBuilder<Integer> b) {
-            b.ensure("non-null length", n -> Outcome.ok());
+        @Override public void criteria(CriteriaBuilder<Integer> b) {
+            b.addCriterion("contract", pb ->
+                    pb.ensure("non-null length", n -> Outcome.ok()))
+                    .meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA);
         }
     }
 
@@ -83,9 +85,11 @@ class MultiDimensionVerdictIntegrationTest {
             sleep(SLEEP_MS);
             return Outcome.ok(input.length());
         }
-        @Override public void postconditions(PostconditionBuilder<Integer> b) {
-            b.ensure("length is even", n ->
-                    n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "n=" + n));
+        @Override public void criteria(CriteriaBuilder<Integer> b) {
+            b.addCriterion("contract", pb ->
+                    pb.ensure("length is even", n ->
+                            n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "n=" + n)))
+                    .meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA);
         }
     }
 


### PR DESCRIPTION
## Summary

Slice 4 of `DIR-CONTRACT-THRESHOLDS-punit`. Each `ServiceContract` whose test paired with `PassRate.meeting(...)` or `PassRate.empirical()` now declares its acceptance posture on the contract side via `criteria(b -> b.addCriterion(id, ...).meeting/empirical(...))`. The test-builder `.criterion(PassRate...)` call stays in place; the eventual retirement of that surface lands in the follow-on PR alongside framework auto-injection.

- 8 test classes migrated + 6 testsubjects updated
- Where a single named contract was reused with incompatible postures (contractual vs empirical, or differing thresholds), it was split into sibling variants so each contract's posture matches its paired test-builder call exactly
- No MDE / power / confidence-floor declarations introduced — `.empirical()` alone is not confidence-first, so no silent uplift triggers

## Test plan

- [x] `./gradlew :punit-core:test` green
- [ ] CI green on push