### PR TITLE
Auto-inject spec criteria from contract posture

### DIFF
--- a/punit-core/src/main/java/module-info.java
+++ b/punit-core/src/main/java/module-info.java
@@ -54,4 +54,7 @@ module org.javai.punit.core {
 
     // ── ServiceLoader ─────────────────────────────────────────
     uses org.javai.punit.verdict.VerdictSink;
+    uses org.javai.punit.api.spec.SpecCriterionDeriver;
+    provides org.javai.punit.api.spec.SpecCriterionDeriver
+        with org.javai.punit.internal.engine.criteria.PostureBasedSpecCriterionDeriver;
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -537,11 +537,36 @@ public final class ProbabilisticTest implements Spec {
             if (!expected.isEmpty() && matcher == null) {
                 matcher = ValueMatcher.equality();
             }
+            if (registered.isEmpty()) {
+                autoInjectFromContract(sampling, factors, registered);
+            }
             return new ProbabilisticTest(new Internal<>(this));
         }
     }
 
     private record Registered<OT>(Criterion<OT, ?> criterion, CriterionRole role) {}
+
+    /**
+     * Populate {@code registered} from the contract's criteria postures
+     * when the test builder declared no explicit
+     * {@code .criterion(...)} call. The contract's acceptance posture
+     * is the source of truth; the test builder's call is the
+     * deprecated override that PR #3 retires.
+     *
+     * <p>Derivation is delegated to the {@link SpecCriterionDeriver}
+     * SPI — the implementation in {@code internal.engine.criteria}
+     * maps postures to {@code PassRate} variants. The SPI indirection
+     * is what keeps {@code api.spec} free of {@code internal} imports.
+     */
+    private static <FT, IT, OT> void autoInjectFromContract(
+            Sampling<FT, IT, OT> sampling, FT factors, List<Registered<OT>> registered) {
+        ServiceContract<FT, IT, OT> probe = sampling.serviceContractFactory().apply(factors);
+        SpecCriterionDeriver deriver = SpecCriterionDeriver.lookup();
+        for (org.javai.punit.api.criterion.Criterion<OT> c : probe.criteria()) {
+            deriver.<OT>derive(c.posture()).ifPresent(
+                    sc -> registered.add(new Registered<>(sc, CriterionRole.REQUIRED)));
+        }
+    }
 
     // ── Inline-sampling builder ─────────────────────────────────────
 

--- a/punit-core/src/main/java/org/javai/punit/api/spec/SpecCriterionDeriver.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/SpecCriterionDeriver.java
@@ -1,0 +1,58 @@
+package org.javai.punit.api.spec;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import org.javai.punit.api.criterion.CriterionPosture;
+
+/**
+ * Derives a spec-level {@link Criterion} from a contract criterion's
+ * posture — the bridge between the contract's acceptance commitment
+ * (e.g. {@code .meeting(0.95, SLA)}) and the spec-side evaluator that
+ * computes the per-criterion verdict at run conclude time.
+ *
+ * <p>The interface lives in {@code api.spec} so the test-spec builder
+ * can consult it without importing internals; the implementation
+ * lives alongside the spec-criterion classes in the engine's criteria
+ * package and is wired in via {@link ServiceLoader}. This SPI
+ * indirection is what keeps the public {@code api.spec} package
+ * boundary clean.
+ *
+ * <p>Two outcomes:
+ * <ul>
+ *   <li>A {@link CriterionPosture} that expresses a statistical
+ *       commitment (e.g. {@code STATISTICAL_CONTRACTUAL} or
+ *       {@code STATISTICAL_EMPIRICAL}) produces a non-empty
+ *       result.</li>
+ *   <li>A non-statistical posture (zero-tolerance, explicit or
+ *       implicit) returns {@link Optional#empty()} — those criteria
+ *       are evaluated by a different path (the SMOKE classifier wired
+ *       in step 2 of the contract-thresholds directive).</li>
+ * </ul>
+ */
+public interface SpecCriterionDeriver {
+
+    /**
+     * Map a contract criterion's posture to its spec-level evaluator.
+     *
+     * @param posture the contract criterion's acceptance commitment
+     * @param <O> the contract's output value type
+     * @return the spec-side criterion when one applies to this
+     *         posture; empty otherwise
+     */
+    <O> Optional<Criterion<O, ?>> derive(CriterionPosture posture);
+
+    /**
+     * Locate the registered {@link SpecCriterionDeriver}
+     * implementation via {@link ServiceLoader}. Throws if none is on
+     * the classpath — that is a packaging bug (the implementation in
+     * {@code internal.engine.criteria} ships with the framework).
+     */
+    static SpecCriterionDeriver lookup() {
+        return ServiceLoader.load(SpecCriterionDeriver.class)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "no SpecCriterionDeriver implementation on the classpath — "
+                                + "this is a punit packaging defect"));
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -117,6 +117,47 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
     }
 
     /**
+     * Derive a pass-rate spec-criterion from a contract criterion's
+     * posture. Used by the test-spec builder when no
+     * {@code .criterion(...)} was registered: the contract's
+     * acceptance posture drives the spec's evaluator.
+     *
+     * <p>Maps:
+     * <ul>
+     *   <li>{@code STATISTICAL_CONTRACTUAL} → {@link #meeting(double, ThresholdOrigin)}</li>
+     *   <li>{@code STATISTICAL_EMPIRICAL} → {@link #empirical()}</li>
+     * </ul>
+     *
+     * <p>{@code ZERO_TOLERANCE} and {@code IMPLICIT_ZERO_TOLERANCE}
+     * postures are not pass-rate criteria and return {@code empty()} —
+     * the caller is responsible for wiring the SMOKE-classifying
+     * evaluator for those.
+     */
+    public static <OT> Optional<PassRate<OT>> fromPosture(
+            org.javai.punit.api.criterion.CriterionPosture posture) {
+        Objects.requireNonNull(posture, "posture");
+        return switch (posture.kind()) {
+            case STATISTICAL_CONTRACTUAL -> {
+                double threshold = posture.threshold().orElseThrow(() -> new IllegalStateException(
+                        "STATISTICAL_CONTRACTUAL posture without threshold"));
+                ThresholdOrigin origin = posture.origin().orElseThrow(() -> new IllegalStateException(
+                        "STATISTICAL_CONTRACTUAL posture without origin"));
+                PassRate<OT> base = PassRate.meeting(threshold, origin);
+                yield Optional.of(posture.confidenceFloor().isPresent()
+                        ? base.atConfidence(posture.confidenceFloor().getAsDouble())
+                        : base);
+            }
+            case STATISTICAL_EMPIRICAL -> {
+                PassRate<OT> base = PassRate.empirical();
+                yield Optional.of(posture.confidenceFloor().isPresent()
+                        ? base.atConfidence(posture.confidenceFloor().getAsDouble())
+                        : base);
+            }
+            case ZERO_TOLERANCE, IMPLICIT_ZERO_TOLERANCE -> Optional.empty();
+        };
+    }
+
+    /**
      * Returns a new criterion with the declared confidence — used for
      * the empirical path's Wilson-score lower-bound comparison.
      */

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PostureBasedSpecCriterionDeriver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PostureBasedSpecCriterionDeriver.java
@@ -1,0 +1,25 @@
+package org.javai.punit.internal.engine.criteria;
+
+import java.util.Optional;
+
+import org.javai.punit.api.criterion.CriterionPosture;
+import org.javai.punit.api.spec.Criterion;
+import org.javai.punit.api.spec.SpecCriterionDeriver;
+
+/**
+ * The framework's default {@link SpecCriterionDeriver} — maps
+ * statistical postures to {@link PassRate} variants.
+ *
+ * <p>Registered via {@code META-INF/services} so the api-side builder
+ * finds it through {@link java.util.ServiceLoader} without importing
+ * the {@code internal} namespace.
+ */
+public final class PostureBasedSpecCriterionDeriver implements SpecCriterionDeriver {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <O> Optional<Criterion<O, ?>> derive(CriterionPosture posture) {
+        Optional<PassRate<O>> mapped = PassRate.<O>fromPosture(posture);
+        return mapped.map(pr -> (Criterion<O, ?>) pr);
+    }
+}

--- a/punit-core/src/main/resources/META-INF/services/org.javai.punit.api.spec.SpecCriterionDeriver
+++ b/punit-core/src/main/resources/META-INF/services/org.javai.punit.api.spec.SpecCriterionDeriver
@@ -1,0 +1,1 @@
+org.javai.punit.internal.engine.criteria.PostureBasedSpecCriterionDeriver

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
@@ -1,0 +1,104 @@
+package org.javai.punit.internal.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.ServiceContract;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.spec.ProbabilisticTest;
+import org.javai.punit.api.spec.ProbabilisticTestResult;
+import org.javai.punit.api.spec.Verdict;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Auto-injection of spec-criteria from contract posture")
+class AutoInjectionFromPostureTest {
+
+    record Factors(String label) { }
+
+    private static final Factors FACTORS = new Factors("auto-inject");
+
+    private static <O> Sampling<Factors, Integer, O> sampling(
+            ServiceContract<Factors, Integer, O> contract) {
+        return Sampling.<Factors, Integer, O>builder()
+                .serviceContractFactory(f -> contract)
+                .inputs(1, 2, 3)
+                .samples(20)
+                .build();
+    }
+
+    @Test
+    @DisplayName("contract with .meeting() posture and no test-builder criterion yields a PASS via auto-injected PassRate.meeting")
+    void contractualPostureAutoInjects() {
+        ServiceContract<Factors, Integer, Boolean> alwaysPasses = new ServiceContract<>() {
+            @Override public String id() { return "always-passes"; }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker t) {
+                return Outcome.ok(true);
+            }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { })
+                        .meeting(0.95, ThresholdOrigin.SLA);
+            }
+        };
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(alwaysPasses), FACTORS)
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+        assertThat(result.criterionResults()).hasSize(1);
+        assertThat(result.criterionResults().get(0).result().criterionName())
+                .isEqualTo("bernoulli-pass-rate");
+    }
+
+    @Test
+    @DisplayName("contract with .meeting() at high threshold and a failing service yields FAIL via auto-injected criterion")
+    void contractualPostureAutoInjectsAndCanFail() {
+        ServiceContract<Factors, Integer, Boolean> alwaysFails = new ServiceContract<>() {
+            @Override public String id() { return "always-fails"; }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker t) {
+                return Outcome.fail("nope", "never passes");
+            }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { })
+                        .meeting(0.95, ThresholdOrigin.SLA);
+            }
+        };
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(alwaysFails), FACTORS)
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        assertThat(result.verdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("explicit test-builder .criterion(...) suppresses auto-injection — no doubled criterion")
+    void explicitCriterionSuppressesAutoInjection() {
+        ServiceContract<Factors, Integer, Boolean> alwaysPasses = new ServiceContract<>() {
+            @Override public String id() { return "always-passes"; }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker t) {
+                return Outcome.ok(true);
+            }
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { })
+                        .meeting(0.95, ThresholdOrigin.SLA);
+            }
+        };
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(alwaysPasses), FACTORS)
+                .criterion(org.javai.punit.internal.engine.criteria.PassRate.<Boolean>meeting(
+                        0.95, ThresholdOrigin.SLA))
+                .build();
+
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+        assertThat(result.criterionResults()).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1 of PR #3 (`DIR-CONTRACT-THRESHOLDS-punit`). When the test builder has no `.criterion(...)` registered, derive the spec-level evaluator from the contract's criterion postures.

- `STATISTICAL_CONTRACTUAL` → `PassRate.meeting(threshold, origin)` (carries `.atConfidence(...)` if declared)
- `STATISTICAL_EMPIRICAL` → `PassRate.empirical()` (carries `.atConfidence(...)` if declared)
- `ZERO_TOLERANCE` / `IMPLICIT_ZERO_TOLERANCE` → empty (SMOKE classifier lands in the next slice)

Bridge: a `SpecCriterionDeriver` SPI in `api.spec`, implementation in `internal.engine.criteria`, registered via `META-INF/services` + JPMS `provides/uses`. Keeps the api package free of internal imports (per the package-structure ArchUnit rule).

Existing tests are untouched — they all still call `.criterion(PassRate...)` on the test builder, which suppresses auto-injection. A new `AutoInjectionFromPostureTest` exercises the auto-injection path with PASS, FAIL, and explicit-override-suppresses-auto cases.

## Test plan

- [x] `./gradlew :punit-core:test` green (full suite)