### PR TITLE
Move contractRef from test builder to the criterion posture

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
@@ -62,7 +62,8 @@ public final class CriterionPosture {
                     Optional.empty(),
                     OptionalDouble.empty(),
                     OptionalDouble.empty(),
-                    OptionalDouble.empty());
+                    OptionalDouble.empty(),
+                    Optional.empty());
 
     private final Kind kind;
     private final OptionalDouble threshold;
@@ -70,6 +71,7 @@ public final class CriterionPosture {
     private final OptionalDouble confidenceFloor;
     private final OptionalDouble mde;
     private final OptionalDouble power;
+    private final Optional<String> contractRef;
 
     private CriterionPosture(
             Kind kind,
@@ -77,13 +79,15 @@ public final class CriterionPosture {
             Optional<ThresholdOrigin> origin,
             OptionalDouble confidenceFloor,
             OptionalDouble mde,
-            OptionalDouble power) {
+            OptionalDouble power,
+            Optional<String> contractRef) {
         this.kind = kind;
         this.threshold = threshold;
         this.origin = origin;
         this.confidenceFloor = confidenceFloor;
         this.mde = mde;
         this.power = power;
+        this.contractRef = contractRef;
     }
 
     /** The implicit-zero-tolerance posture — the default for any criterion that declared no posture method. */
@@ -107,7 +111,8 @@ public final class CriterionPosture {
                 Optional.of(origin),
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
-                OptionalDouble.empty());
+                OptionalDouble.empty(),
+                Optional.empty());
     }
 
     /** Statistical, empirical: {@code .empirical()}. */
@@ -117,7 +122,8 @@ public final class CriterionPosture {
                 Optional.of(ThresholdOrigin.EMPIRICAL),
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
-                OptionalDouble.empty());
+                OptionalDouble.empty(),
+                Optional.empty());
     }
 
     /** Explicit zero-tolerance: {@code .zeroTolerance(origin)}. */
@@ -132,7 +138,8 @@ public final class CriterionPosture {
                 Optional.of(origin),
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
-                OptionalDouble.empty());
+                OptionalDouble.empty(),
+                Optional.empty());
     }
 
     /**
@@ -149,7 +156,7 @@ public final class CriterionPosture {
                     ".atConfidence(c) requires c in (0, 1), got " + confidence);
         }
         return new CriterionPosture(kind, threshold, origin,
-                OptionalDouble.of(confidence), mde, power);
+                OptionalDouble.of(confidence), mde, power, contractRef);
     }
 
     /**
@@ -166,7 +173,7 @@ public final class CriterionPosture {
                     ".detectingMde(m) requires m in (0, 1), got " + mdeValue);
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, OptionalDouble.of(mdeValue), power);
+                confidenceFloor, OptionalDouble.of(mdeValue), power, contractRef);
     }
 
     /**
@@ -182,7 +189,27 @@ public final class CriterionPosture {
                     ".atPower(p) requires p in (0, 1), got " + powerValue);
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, mde, OptionalDouble.of(powerValue));
+                confidenceFloor, mde, OptionalDouble.of(powerValue), contractRef);
+    }
+
+    /**
+     * Returns a copy of this posture with the given contract reference —
+     * a human-readable pointer to the document and clause that justify
+     * the commitment (e.g. {@code "Payment Provider SLA v2.3, §4.1"}).
+     * Surfaced in the verdict path so compliance reports cite the
+     * authority alongside the verdict.
+     *
+     * <p>Composes with every posture kind, including implicit
+     * zero-tolerance; the ref is informational, not part of the
+     * commitment's math.
+     */
+    public CriterionPosture withContractRef(String ref) {
+        Objects.requireNonNull(ref, "contractRef");
+        if (ref.isBlank()) {
+            throw new IllegalArgumentException(".contractRef requires a non-blank string");
+        }
+        return new CriterionPosture(kind, threshold, origin,
+                confidenceFloor, mde, power, Optional.of(ref));
     }
 
     private void rejectRigourAdjunct(String methodName) {
@@ -245,6 +272,16 @@ public final class CriterionPosture {
     /** Statistical power when declared via {@code .atPower(...)}, empty otherwise. */
     public OptionalDouble power() {
         return power;
+    }
+
+    /**
+     * Author-supplied audit pointer to the contract clause that
+     * justifies this criterion's commitment — for example
+     * {@code "Payment Provider SLA v2.3, §4.1"}. Empty when not
+     * declared.
+     */
+    public Optional<String> contractRef() {
+        return contractRef;
     }
 
     /** Whether this posture asks for a statistical evaluation. */

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPostureHandle.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPostureHandle.java
@@ -111,4 +111,17 @@ public final class CriterionPostureHandle<O> {
         builder.setPostureAt(criterionIndex, current.withPower(power));
         return this;
     }
+
+    /**
+     * Attach a human-readable contract reference to this criterion —
+     * the document and clause that justify the commitment
+     * (e.g. {@code "Payment Provider SLA v2.3, §4.1"}). Surfaced in the
+     * verdict path so compliance reports cite the authority alongside
+     * the verdict. Composes with every posture kind.
+     */
+    public CriterionPostureHandle<O> contractRef(String ref) {
+        CriterionPosture current = builder.postureAt(criterionIndex);
+        builder.setPostureAt(criterionIndex, current.withContractRef(ref));
+        return this;
+    }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -259,13 +259,25 @@ public final class ProbabilisticTest implements Spec {
                     ? evaluated
                     : substituteFunctionalVerdict(evaluated, perCriterionEvaluation.compositeVerdict());
             Verdict authoritative = Verdict.compose(compositeAdjusted);
+            // contractRef now lives on the criterion's posture. Surface
+            // the first non-empty ref at the result level (the legacy
+            // top-level field) — multi-criterion contracts whose
+            // criteria cite different clauses are still uncommon enough
+            // that "first wins" is a safe default. The per-criterion
+            // refs travel alongside on each EvaluatedCriterion's result
+            // detail map.
+            Optional<String> contractRefFromContract = criterionPostures.values().stream()
+                    .map(org.javai.punit.api.criterion.CriterionPosture::contractRef)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .findFirst();
             return new ProbabilisticTestResult(
                     authoritative, factorBundle, evaluated, intent,
                     List.copyOf(warnings),
                     CovariateAlignment.compute(
                             CovariateProfile.empty(),
                             baselineProfile),
-                    Optional.empty(),
+                    contractRefFromContract,
                     s.failuresByPostcondition(),
                     engineSummary,
                     perCriterionEvaluation);

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -535,6 +535,9 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                 detail.put("baselineSampleCount", b == null ? null : b.sampleCount());
                 detail.put("baselineRate", b == null ? null : b.observedPassRate());
             }
+            CriterionPosture onlyPosture = ctx.criterionPostures().getOrDefault(
+                    only.criterionId(), CriterionPosture.implicit());
+            onlyPosture.contractRef().ifPresent(ref -> detail.put("contractRef", ref));
         } else {
             detail.put("origin", resolvedOrigin.name());
             detail.put("total", total);

--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -588,7 +588,6 @@ public final class PUnit {
         private final List<Criterion<OT, ?>> requiredCriteria = new ArrayList<>();
         private TestIntent intent = TestIntent.VERIFICATION;
         private Boolean transparentStatsOverride;
-        private String contractRef;
 
         TestBuilder(ProbabilisticTest.Builder<FT, IT, OT> delegate,
                     Sampling<FT, IT, OT> sampling, FT factors) {
@@ -666,20 +665,6 @@ public final class PUnit {
             return this;
         }
 
-        /**
-         * Records a human-readable pointer to the external document
-         * the test's threshold derives from — an SLA paragraph, an
-         * SLO contract, an internal policy reference. The value is
-         * opaque to the framework; it surfaces in the verdict text
-         * and the verdict XML as audit-grade traceability.
-         *
-         * <p>Example: {@code .contractRef("Acme API SLA v3.2 §2.1")}.
-         */
-        public TestBuilder<FT, IT, OT> contractRef(String contractRef) {
-            this.contractRef = contractRef;
-            return this;
-        }
-
         public ProbabilisticTest build() {
             return delegate.build();
         }
@@ -735,9 +720,8 @@ public final class PUnit {
             // structured CovariateAlignment flows downstream — to the
             // verbose renderer here, and to HTML / XML / JSON sinks.
             ProbabilisticTestResult stamped = typed.withCovariates(
-                            CovariateAlignment.compute(
-                                    observed, typed.covariates().baseline()))
-                    .withContractRef(contractRef);
+                    CovariateAlignment.compute(
+                            observed, typed.covariates().baseline()));
             maybeRenderTransparentStats(stamped);
             emitVerdict(stamped, serviceContractId);
             translate(stamped, serviceContractId);
@@ -806,16 +790,21 @@ public final class PUnit {
             if (noBaselineResults.isEmpty()) {
                 return Optional.empty();
             }
-            return Optional.of(synthesiseNoBaselineResult(noBaselineResults, notes, observed));
+            return Optional.of(synthesiseNoBaselineResult(
+                    noBaselineResults, notes, observed, serviceContract));
         }
 
         private ProbabilisticTestResult synthesiseNoBaselineResult(
                 List<EvaluatedCriterion> noBaselineResults,
                 List<String> warnings,
-                CovariateProfile observed) {
-            Optional<String> contractRefOpt = (contractRef == null || contractRef.isBlank())
-                    ? Optional.empty()
-                    : Optional.of(contractRef);
+                CovariateProfile observed,
+                ServiceContract<FT, IT, OT> serviceContract) {
+            Optional<String> contractRefOpt = serviceContract.criteria().stream()
+                    .map(org.javai.punit.api.criterion.Criterion::posture)
+                    .map(org.javai.punit.api.criterion.CriterionPosture::contractRef)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .findFirst();
             return new ProbabilisticTestResult(
                     Verdict.compose(noBaselineResults),
                     FactorBundle.of(factors),
@@ -854,7 +843,6 @@ public final class PUnit {
         private Criterion<?, ?> criterion;
         private TestIntent intent = TestIntent.VERIFICATION;
         private Boolean transparentStatsOverride;
-        private String contractRef;
 
         EmpiricalTestBuilder(Supplier<Experiment> baselineSupplier) {
             this.baselineSupplier = baselineSupplier;
@@ -897,12 +885,6 @@ public final class PUnit {
             return this;
         }
 
-        /** See {@link TestBuilder#contractRef(String)}. */
-        public EmpiricalTestBuilder contractRef(String contractRef) {
-            this.contractRef = contractRef;
-            return this;
-        }
-
         public ProbabilisticTest build() {
             if (samples == null) {
                 throw new IllegalStateException(
@@ -941,9 +923,8 @@ public final class PUnit {
             }
             warnings.forEach(System.err::println);
             ProbabilisticTestResult stamped = typed.withCovariates(
-                            CovariateAlignment.compute(
-                                    ctx.profile, typed.covariates().baseline()))
-                    .withContractRef(contractRef);
+                    CovariateAlignment.compute(
+                            ctx.profile, typed.covariates().baseline()));
             maybeRenderTransparentStats(ctx, stamped);
             emitVerdict(stamped, ctx.serviceContractId);
             translate(stamped, ctx.serviceContractId);
@@ -963,10 +944,12 @@ public final class PUnit {
             final List<Covariate> declarations;
             final BaselineProvider provider;
             final FactorBundle resultFactors;
+            final Optional<String> contractRef;
 
             SpecContext(String serviceContractId, FactorBundle bundle, int samples,
                     CovariateProfile profile, List<Covariate> declarations,
-                    BaselineProvider provider, FactorBundle resultFactors) {
+                    BaselineProvider provider, FactorBundle resultFactors,
+                    Optional<String> contractRef) {
                 this.serviceContractId = serviceContractId;
                 this.bundle = bundle;
                 this.samples = samples;
@@ -974,6 +957,7 @@ public final class PUnit {
                 this.declarations = declarations;
                 this.provider = provider;
                 this.resultFactors = resultFactors;
+                this.contractRef = contractRef;
             }
         }
 
@@ -993,9 +977,15 @@ public final class PUnit {
                                     .resolve(declarations, serviceContract.customCovariateResolvers());
                     BaselineProvider provider = ProfileBoundBaselineProvider.bind(
                             raw, profile, declarations);
+                    Optional<String> contractRef = serviceContract.criteria().stream()
+                            .map(org.javai.punit.api.criterion.Criterion::posture)
+                            .map(org.javai.punit.api.criterion.CriterionPosture::contractRef)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .findFirst();
                     return new SpecContext(
                             serviceContract.id(), bundle, cfg.samples(),
-                            profile, declarations, provider, bundle);
+                            profile, declarations, provider, bundle, contractRef);
                 }
             });
         }
@@ -1029,9 +1019,7 @@ public final class PUnit {
                 SpecContext ctx,
                 List<EvaluatedCriterion> noBaselineResults,
                 List<String> warnings) {
-            Optional<String> contractRefOpt = (contractRef == null || contractRef.isBlank())
-                    ? Optional.empty()
-                    : Optional.of(contractRef);
+            Optional<String> contractRefOpt = ctx.contractRef;
             return new ProbabilisticTestResult(
                     Verdict.compose(noBaselineResults),
                     ctx.resultFactors,

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -71,6 +71,36 @@ public final class PUnitSubjects {
         };
     }
 
+    private static final String CONTRACT_REF_FIXTURE = "Acme API SLA v3.2 §2.1";
+
+    private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesWithContractRef() {
+        return new ServiceContract<>() {
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ })
+                        .meeting(0.5, ThresholdOrigin.SLA)
+                        .contractRef(CONTRACT_REF_FIXTURE);
+            }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok(true);
+            }
+            @Override public String id() { return "always-passes-subject"; }
+        };
+    }
+
+    private static <F> ServiceContract<F, Integer, Boolean> alwaysFailsWithContractRef() {
+        return new ServiceContract<>() {
+            @Override public void criteria(CriteriaBuilder<Boolean> b) {
+                b.addCriterion("contract", pb -> { /* none */ })
+                        .meeting(0.5, ThresholdOrigin.SLA)
+                        .contractRef(CONTRACT_REF_FIXTURE);
+            }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.fail("nope", "always fails");
+            }
+            @Override public String id() { return "always-fails-subject"; }
+        };
+    }
+
     private static <F> Sampling<F, Integer, Boolean> sampling(
             ServiceContract<F, Integer, Boolean> serviceContract, int samples) {
         return Sampling.<F, Integer, Boolean>builder()
@@ -110,8 +140,7 @@ public final class PUnitSubjects {
     public static final class ContractRefPassingTest {
         @ProbabilisticTest
         void passesWithContractRef() {
-            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPassesContractual(), 20))
-                    .contractRef("Acme API SLA v3.2 §2.1")
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysPassesWithContractRef(), 20))
                     .transparentStats()
                     .assertPasses();
         }
@@ -126,8 +155,7 @@ public final class PUnitSubjects {
     public static final class ContractRefFailingTest {
         @ProbabilisticTest
         void failsWithContractRef() {
-            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysFails(), 20))
-                    .contractRef("Acme API SLA v3.2 §2.1")
+            PUnit.testing(sampling(PUnitSubjects.<NoFactors>alwaysFailsWithContractRef(), 20))
                     .assertPasses();
         }
     }


### PR DESCRIPTION
## Summary

A contract reference (e.g. `"Payment Provider SLA v2.3, §4.1"`) is a property of a contract's commitment, not of how the test happens to exercise it. This PR moves the surface from the test builder to the criterion posture.

### API
- `CriterionPosture.withContractRef(String)` and `CriterionPostureHandle.contractRef(String)`. Composes with every posture kind — the ref is informational, not part of the commitment's math.

### Plumbing
- `ProbabilisticTest.Internal.evaluate` derives the result-level `contractRef` from the first contract criterion that declared one. The legacy top-level field still feeds `VerdictTextRenderer`, `TransparentStatsRenderer`, and `ComplianceEvidenceEvaluator` unchanged.
- `PassRate` stamps the per-criterion ref into `CriterionResult.detail()` under the `contractRef` key for K=1 result detail maps.

### Surface retirement
- `PUnit.TestBuilder.contractRef(String)` and `EmpiricalTestBuilder.contractRef(String)` removed.
- `PUnit.TestBuilder` / `EmpiricalTestBuilder`'s no-baseline synthesis paths derive the ref from the contract's criteria.
- `ProbabilisticTestResult.withContractRef(...)` is kept on the public API for now (external callers may use it).

### Tests
- `ContractRefPassingTest` / `ContractRefFailingTest` in `PUnitSubjects` migrated to new dedicated contract factories that carry the ref on the criterion.

## Authoring example

Before — both the threshold and the ref sat on the test:
\`\`\`java
PUnit.testing(paymentGatewaySampling(50))
    .criterion(PassRate.meeting(0.9999, ThresholdOrigin.SLA))
    .contractRef(\"Payment Provider SLA v2.3, §4.1\")
    .assertPasses();
\`\`\`

After — both move to the contract; the test is the elegant assertion:
\`\`\`java
class PaymentGateway implements ServiceContract<...> {
    @Override public void criteria(CriteriaBuilder<...> b) {
        b.addCriterion(\"contract\", pb -> ...)
                .meeting(0.9999, ThresholdOrigin.SLA)
                .contractRef(\"Payment Provider SLA v2.3, §4.1\");
    }
    // ...
}

PUnit.testing(paymentGatewaySampling(50)).assertPasses();
\`\`\`

## Test plan

- [x] \`./gradlew :punit-core:test\` green (full suite)