### PR TITLE
Introduce value-form Criteria<O> authoring surface (DIR-CRITERIA-AS-DATA PR #1)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import org.javai.outcome.Outcome;
 import org.javai.outcome.Outcome.Fail;
 import org.javai.outcome.Outcome.Ok;
+import org.javai.punit.api.criterion.Criteria;
 import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.criterion.Criterion;
 import org.javai.punit.api.criterion.CriterionSampleResult;
@@ -148,46 +149,102 @@ public interface Contract<I, O> {
      * @param b the builder to populate
      */
     default void criteria(CriteriaBuilder<O> b) {
-        // Default: no explicit criteria. The default criteria()
-        // accessor synthesises a single criterion from the contract's
-        // existing postconditions.
+        // Default: no explicit criteria. The default
+        // effectiveCriteria() accessor synthesises a single criterion
+        // from the contract's existing postconditions.
     }
 
     /**
-     * Resolves the contract's criteria to an immutable list. The
-     * framework hook; do not override. The default implementation
-     * delegates to {@link #criteria(CriteriaBuilder)}; when the
-     * author has not declared explicit criteria, the result is a
-     * single-criterion list whose postconditions are exactly
-     * {@link #postconditions()}.
+     * Author-facing, value-form criteria declaration — returns a
+     * {@link Criteria} value describing the contract's
+     * verdict-producing strategy. The intended idiom:
+     *
+     * <pre>{@code
+     * import static org.javai.punit.api.criterion.Posture.*;
+     * import static org.javai.punit.api.criterion.Composite.*;
+     *
+     * @Override public Criteria<Receipt> criteria() {
+     *     return meeting(0.9999, SLA)
+     *             .contractRef("Payment Provider SLA v2.3, §4.1");
+     * }
+     * }</pre>
+     *
+     * <p>The default returns {@link Criteria#empty()}: no value-form
+     * declaration. Contracts that declare via the legacy builder
+     * form ({@link #criteria(CriteriaBuilder)}) leave this default in
+     * place. Contracts that declare both forms are rejected at first
+     * {@link #effectiveCriteria()} access.
+     */
+    default Criteria<O> criteria() {
+        return Criteria.empty();
+    }
+
+    /**
+     * Resolves the contract's criteria to an immutable runtime
+     * list. The framework hook; do not override.
+     *
+     * <p>Consults the two authoring surfaces in order:
+     * <ol>
+     *   <li>the value-form {@link #criteria()} — if non-empty, its
+     *       {@link Criteria#asList() asList()} is the result;</li>
+     *   <li>the builder-form {@link #criteria(CriteriaBuilder)} —
+     *       if non-empty, the built list is the result;</li>
+     *   <li>otherwise the K=1 default derived from
+     *       {@link #postconditions()}.</li>
+     * </ol>
      *
      * @throws IllegalStateException if the contract declares both an
-     *         explicit criteria list (non-empty {@code criteria(CriteriaBuilder)}
-     *         override) and a non-empty postcondition chain
-     *         (non-empty {@code postconditions(PostconditionBuilder)}
-     *         override). The two are structurally ambiguous; the
-     *         framework will not pick one for the author.
+     *         explicit criteria list (non-empty
+     *         {@code criteria(CriteriaBuilder)} override) and a
+     *         non-empty postcondition chain (non-empty
+     *         {@code postconditions(PostconditionBuilder)} override),
+     *         or if it declares both the value-form and the
+     *         builder-form simultaneously.
      */
-    default List<Criterion<O>> criteria() {
+    default List<Criterion<O>> effectiveCriteria() {
+        Criteria<O> declared = criteria();
         CriteriaBuilder<O> b = new CriteriaBuilder<>();
         criteria(b);
-        if (b.isEmpty()) {
-            return List.of(new DefaultCriterion<>(this));
-        }
-        if (!postconditions().isEmpty()) {
+        boolean valueFormDeclared = !declared.isEmpty();
+        boolean builderFormDeclared = !b.isEmpty();
+        if (valueFormDeclared && builderFormDeclared) {
             throw new IllegalStateException(
                     "Contract " + getClass().getName()
-                            + " declares both a non-empty postcondition chain"
-                            + " (via postconditions(PostconditionBuilder)) and an"
-                            + " explicit criteria list (via"
-                            + " criteria(CriteriaBuilder)). The two overrides"
-                            + " estimate different quantities; the framework"
-                            + " will not pick one. Move the postconditions"
-                            + " onto a criterion, or remove the explicit"
-                            + " criteria override and rely on the"
-                            + " single-criterion default.");
+                            + " declares criteria via both the value-form"
+                            + " (Criteria<O> criteria() override) and the"
+                            + " builder-form (criteria(CriteriaBuilder<O> b)"
+                            + " override). Pick one.");
         }
-        return b.build();
+        if (valueFormDeclared) {
+            if (!postconditions().isEmpty()) {
+                throw new IllegalStateException(
+                        "Contract " + getClass().getName()
+                                + " declares both a non-empty postcondition chain"
+                                + " (via postconditions(PostconditionBuilder)) and an"
+                                + " explicit criteria value (via Criteria<O>"
+                                + " criteria()). Move the postconditions onto a"
+                                + " criterion via .where(name, predicate), or"
+                                + " remove the postconditions override.");
+            }
+            return declared.asList();
+        }
+        if (builderFormDeclared) {
+            if (!postconditions().isEmpty()) {
+                throw new IllegalStateException(
+                        "Contract " + getClass().getName()
+                                + " declares both a non-empty postcondition chain"
+                                + " (via postconditions(PostconditionBuilder)) and an"
+                                + " explicit criteria list (via"
+                                + " criteria(CriteriaBuilder)). The two overrides"
+                                + " estimate different quantities; the framework"
+                                + " will not pick one. Move the postconditions"
+                                + " onto a criterion, or remove the explicit"
+                                + " criteria override and rely on the"
+                                + " single-criterion default.");
+            }
+            return b.build();
+        }
+        return List.of(new DefaultCriterion<>(this));
     }
 
     /**
@@ -268,7 +325,7 @@ public interface Contract<I, O> {
         // without re-walking the criteria.
         List<PostconditionResult> flat = new ArrayList<>();
         List<CriterionSampleResult> perCriterion = new ArrayList<>();
-        for (Criterion<O> criterion : criteria()) {
+        for (Criterion<O> criterion : effectiveCriteria()) {
             CriterionSampleResult result = criterion.evaluate(value);
             perCriterion.add(result);
             switch (result.outcome()) {

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Composite.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Composite.java
@@ -39,7 +39,7 @@ public final class Composite {
      * One named entry in a {@link CompositeCriteria}: a criterion id
      * and the declaration that produces its verdict.
      */
-    public record Entry<O>(String id, CriterionDecl<O> decl) {
+    public record Entry<O>(String id, Decl<O> decl) {
         public Entry {
             Objects.requireNonNull(id, "id");
             if (id.isBlank()) {
@@ -51,19 +51,19 @@ public final class Composite {
     }
 
     /** Construct an {@link Entry} — the open-ended escape for {@link #composeOf}. */
-    public static <O> Entry<O> entry(String id, CriterionDecl<O> decl) {
+    public static <O> Entry<O> entry(String id, Decl<O> decl) {
         return new Entry<>(id, decl);
     }
 
     /** Compose a single named criterion (K=1 with an explicit id). */
-    public static <O> CompositeCriteria<O> compose(String id1, CriterionDecl<O> d1) {
+    public static <O> CompositeCriteria<O> compose(String id1, Decl<O> d1) {
         return new CompositeCriteria<>(List.of(new Entry<>(id1, d1)));
     }
 
     /** Compose two named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2)));
@@ -71,9 +71,9 @@ public final class Composite {
 
     /** Compose three named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),
@@ -82,10 +82,10 @@ public final class Composite {
 
     /** Compose four named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3,
-            String id4, CriterionDecl<O> d4) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3,
+            String id4, Decl<O> d4) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),
@@ -95,11 +95,11 @@ public final class Composite {
 
     /** Compose five named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3,
-            String id4, CriterionDecl<O> d4,
-            String id5, CriterionDecl<O> d5) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3,
+            String id4, Decl<O> d4,
+            String id5, Decl<O> d5) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),
@@ -110,12 +110,12 @@ public final class Composite {
 
     /** Compose six named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3,
-            String id4, CriterionDecl<O> d4,
-            String id5, CriterionDecl<O> d5,
-            String id6, CriterionDecl<O> d6) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3,
+            String id4, Decl<O> d4,
+            String id5, Decl<O> d5,
+            String id6, Decl<O> d6) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Composite.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Composite.java
@@ -1,0 +1,149 @@
+package org.javai.punit.api.criterion;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Factory for the §1.4.6 composite verdict-producing strategy.
+ * {@link #compose(String, CriterionDecl) compose(...)} names the
+ * methodology procedure: given an ordered list of named criterion
+ * declarations, the contract verdict is the FAIL-dominant
+ * aggregation over their per-criterion verdicts.
+ *
+ * <p>Statically imported, the call site reads {@code compose(...)}:
+ *
+ * <pre>{@code
+ * import static org.javai.punit.api.criterion.Composite.*;
+ *
+ * return compose(
+ *     "sla",              meeting(0.99, SLA).contractRef("Acme SLA v2, §4.1"),
+ *     "valid-structure",  meeting(0.95, SLA).where("parseable", v -> isJson(v)),
+ *     "harmful-content",  zeroTolerance(POLICY));
+ * }</pre>
+ *
+ * <p>K=1 with the default criterion id does <em>not</em> use this
+ * factory — the bare {@link CriterionDecl} is itself a
+ * {@link Criteria} (default id {@value #DEFAULT_CRITERION_ID}).
+ * Use {@link #compose(String, CriterionDecl)} with one entry to give
+ * a K=1 contract a non-default criterion id.
+ */
+public final class Composite {
+
+    /** The default criterion id when a bare {@link CriterionDecl} is returned from {@code Contract.criteria()}. */
+    public static final String DEFAULT_CRITERION_ID = "contract";
+
+    private Composite() { /* utility class */ }
+
+    /**
+     * One named entry in a {@link CompositeCriteria}: a criterion id
+     * and the declaration that produces its verdict.
+     */
+    public record Entry<O>(String id, CriterionDecl<O> decl) {
+        public Entry {
+            Objects.requireNonNull(id, "id");
+            if (id.isBlank()) {
+                throw new IllegalArgumentException(
+                        "entry id must be non-blank");
+            }
+            Objects.requireNonNull(decl, "decl");
+        }
+    }
+
+    /** Construct an {@link Entry} — the open-ended escape for {@link #composeOf}. */
+    public static <O> Entry<O> entry(String id, CriterionDecl<O> decl) {
+        return new Entry<>(id, decl);
+    }
+
+    /** Compose a single named criterion (K=1 with an explicit id). */
+    public static <O> CompositeCriteria<O> compose(String id1, CriterionDecl<O> d1) {
+        return new CompositeCriteria<>(List.of(new Entry<>(id1, d1)));
+    }
+
+    /** Compose two named criteria. */
+    public static <O> CompositeCriteria<O> compose(
+            String id1, CriterionDecl<O> d1,
+            String id2, CriterionDecl<O> d2) {
+        return new CompositeCriteria<>(List.of(
+                new Entry<>(id1, d1),
+                new Entry<>(id2, d2)));
+    }
+
+    /** Compose three named criteria. */
+    public static <O> CompositeCriteria<O> compose(
+            String id1, CriterionDecl<O> d1,
+            String id2, CriterionDecl<O> d2,
+            String id3, CriterionDecl<O> d3) {
+        return new CompositeCriteria<>(List.of(
+                new Entry<>(id1, d1),
+                new Entry<>(id2, d2),
+                new Entry<>(id3, d3)));
+    }
+
+    /** Compose four named criteria. */
+    public static <O> CompositeCriteria<O> compose(
+            String id1, CriterionDecl<O> d1,
+            String id2, CriterionDecl<O> d2,
+            String id3, CriterionDecl<O> d3,
+            String id4, CriterionDecl<O> d4) {
+        return new CompositeCriteria<>(List.of(
+                new Entry<>(id1, d1),
+                new Entry<>(id2, d2),
+                new Entry<>(id3, d3),
+                new Entry<>(id4, d4)));
+    }
+
+    /** Compose five named criteria. */
+    public static <O> CompositeCriteria<O> compose(
+            String id1, CriterionDecl<O> d1,
+            String id2, CriterionDecl<O> d2,
+            String id3, CriterionDecl<O> d3,
+            String id4, CriterionDecl<O> d4,
+            String id5, CriterionDecl<O> d5) {
+        return new CompositeCriteria<>(List.of(
+                new Entry<>(id1, d1),
+                new Entry<>(id2, d2),
+                new Entry<>(id3, d3),
+                new Entry<>(id4, d4),
+                new Entry<>(id5, d5)));
+    }
+
+    /** Compose six named criteria. */
+    public static <O> CompositeCriteria<O> compose(
+            String id1, CriterionDecl<O> d1,
+            String id2, CriterionDecl<O> d2,
+            String id3, CriterionDecl<O> d3,
+            String id4, CriterionDecl<O> d4,
+            String id5, CriterionDecl<O> d5,
+            String id6, CriterionDecl<O> d6) {
+        return new CompositeCriteria<>(List.of(
+                new Entry<>(id1, d1),
+                new Entry<>(id2, d2),
+                new Entry<>(id3, d3),
+                new Entry<>(id4, d4),
+                new Entry<>(id5, d5),
+                new Entry<>(id6, d6)));
+    }
+
+    /**
+     * Compose an arbitrary number of named criteria — the escape
+     * hatch for arities beyond the directly-overloaded {@code compose}
+     * forms. Use {@link #entry(String, CriterionDecl)} to construct
+     * each pair:
+     *
+     * <pre>{@code
+     * return composeOf(
+     *     entry("a", meeting(0.99, SLA)),
+     *     entry("b", meeting(0.95, SLA)),
+     *     entry("c", meeting(0.90, SLA)),
+     *     entry("d", zeroTolerance(POLICY)),
+     *     entry("e", empirical()),
+     *     entry("f", meeting(0.99, SLA)),
+     *     entry("g", meeting(0.99, SLA)));
+     * }</pre>
+     */
+    @SafeVarargs
+    public static <O> CompositeCriteria<O> composeOf(Entry<O>... entries) {
+        return new CompositeCriteria<>(Arrays.asList(entries));
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CompositeCriteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CompositeCriteria.java
@@ -1,0 +1,62 @@
+package org.javai.punit.api.criterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The §1.4.6 composite verdict-producing strategy: a list of named
+ * {@link CriterionDecl}s, evaluated independently and aggregated
+ * FAIL-dominantly to resolve the contract verdict.
+ *
+ * <p>Constructed via {@link Composite#compose(String, CriterionDecl)
+ * Composite.compose(...)} (or {@link Composite#composeOf(Composite.Entry[])
+ * Composite.composeOf(entries...)} for arities beyond the overload
+ * cap). Authors do not construct this type directly.
+ *
+ * <p>Composition order is preserved — the verdict path renders
+ * per-criterion rows in declaration order.
+ *
+ * @param <O> the contract's per-sample output value type
+ */
+public final class CompositeCriteria<O> implements Criteria<O> {
+
+    private final List<Composite.Entry<O>> entries;
+
+    CompositeCriteria(List<Composite.Entry<O>> entries) {
+        Objects.requireNonNull(entries, "entries");
+        if (entries.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "CompositeCriteria requires at least one entry");
+        }
+        for (Composite.Entry<O> e : entries) {
+            Objects.requireNonNull(e, "entry");
+        }
+        rejectDuplicateIds(entries);
+        this.entries = List.copyOf(entries);
+    }
+
+    /** Entries in declaration order. */
+    public List<Composite.Entry<O>> entries() {
+        return entries;
+    }
+
+    @Override
+    public List<Criterion<O>> asList() {
+        List<Criterion<O>> out = new ArrayList<>(entries.size());
+        for (Composite.Entry<O> e : entries) {
+            out.add(e.decl().toRuntime(e.id()));
+        }
+        return List.copyOf(out);
+    }
+
+    private static <O> void rejectDuplicateIds(List<Composite.Entry<O>> entries) {
+        java.util.Set<String> seen = new java.util.HashSet<>(entries.size() * 2);
+        for (Composite.Entry<O> e : entries) {
+            if (!seen.add(e.id())) {
+                throw new IllegalArgumentException(
+                        "duplicate criterion id '" + e.id() + "' in compose(...)");
+            }
+        }
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @param <O> the contract's per-sample output value type
  */
 public sealed interface Criteria<O>
-        permits CriterionDecl, CompositeCriteria, EmptyCriteria {
+        permits Decl, CompositeCriteria, EmptyCriteria {
 
     /**
      * Lower this declaration to the runtime {@link Criterion} list

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
@@ -1,121 +1,72 @@
 package org.javai.punit.api.criterion;
 
-import java.util.Objects;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
-import org.javai.outcome.Outcome;
-import org.javai.punit.api.PostconditionBuilder;
+import java.util.List;
 
 /**
- * Factory entry points for declaring criteria. Two shapes:
+ * The contract's verdict-producing strategy. Given a sample summary,
+ * a {@code Criteria<O>} resolves to a contract verdict via the
+ * §1.4.6 composite-verdict procedure of the Statistical Companion
+ * (FAIL-dominant aggregation over per-criterion verdicts).
+ *
+ * <p>Two concrete shapes:
  *
  * <ul>
- *   <li>{@link #direct(String, Consumer) direct(id, body)} — a
- *       criterion whose postconditions evaluate against the
- *       contract's output. No transform; per-sample outcome is
- *       restricted to {@link CriterionSampleOutcome#PASS PASS} or
- *       {@link CriterionSampleOutcome#FAIL FAIL}.</li>
- *   <li>{@link #transforming(String, Function, Consumer)
- *       transforming(id, transform, body)} — a criterion that first
- *       transforms the contract's output to a derived form, then
- *       evaluates postconditions against the derived value.
- *       Transform failure (the function returns
- *       {@link Outcome.Fail} or throws) classifies the sample
- *       {@link CriterionSampleOutcome#INCONCLUSIVE INCONCLUSIVE};
- *       the postcondition chain is not evaluated.</li>
+ *   <li>{@link CriterionDecl} — a single-criterion strategy. The
+ *       K=1 case: posture, optional postconditions, optional
+ *       refinements (contractRef, confidence floor, MDE/power).
+ *       Returned directly from {@code Posture.meeting(...)} and
+ *       friends; an author with one criterion returns the decl
+ *       directly from {@code Contract.criteria()}.</li>
+ *   <li>{@link CompositeCriteria} — a multi-criterion strategy
+ *       constructed via {@link Composite#compose(String, CriterionDecl)
+ *       compose(...)}. Holds an ordered list of named decls and
+ *       resolves the contract verdict per §1.4.6.</li>
  * </ul>
  *
- * <p>The two factories cover the methodology's two criterion shapes
- * and structurally enforce the one-transform-per-criterion cap: a
- * criterion is produced by exactly one factory call, with either
- * zero or one transform. No API expresses two transforms in one
- * criterion.
+ * <p>A single {@code CriterionDecl} <em>is</em> a {@code Criteria}
+ * directly — the contract's K=1 strategy is the criterion itself.
+ * The framework treats it as a one-entry composite at lowering time,
+ * with the default criterion id {@code "contract"}.
  *
- * <pre>{@code
- * Criterion<ChatResponse> hasContent = Criteria.direct(
- *         "has-content",
- *         b -> b.ensure("non-empty", r -> r.content().isEmpty()
- *                 ? Outcome.fail("empty", "")
- *                 : Outcome.ok()));
+ * <p>{@link #asList()} is the framework's lowering hook: it returns
+ * the runtime {@link Criterion} list the engine, baseline-resolution
+ * path, and verdict path consume. Authors do not call it.
  *
- * Criterion<ChatResponse> validJson = Criteria.transforming(
- *         "valid-json",
- *         ChatResponse::parseJson,
- *         b -> b.ensure("has operations", JsonNode::hasOperations)
- *               .ensure("operations valid", JsonNode::operationsValid));
- * }</pre>
+ * @param <O> the contract's per-sample output value type
  */
-public final class Criteria {
+public sealed interface Criteria<O>
+        permits CriterionDecl, CompositeCriteria, EmptyCriteria {
 
-    private Criteria() {
-        // utility class — no instances
+    /**
+     * Lower this declaration to the runtime {@link Criterion} list
+     * the framework consumes. Framework-internal; authors do not
+     * call this directly.
+     */
+    List<Criterion<O>> asList();
+
+    /**
+     * Whether this is the empty-criteria sentinel — used by the
+     * framework's effective-criteria resolution to distinguish
+     * "author has not declared via the value-form" from "author has
+     * declared an explicit (possibly empty) criteria list."
+     *
+     * <p>Default implementation: never empty. Only
+     * {@link Criteria#empty()} is empty.
+     */
+    default boolean isEmpty() {
+        return false;
     }
 
     /**
-     * Declare a criterion whose postcondition chain evaluates
-     * directly against the contract's output. No transform.
-     *
-     * @param id   the criterion's stable identifier; must be non-null
-     *             and non-blank
-     * @param body a consumer that populates a {@link PostconditionBuilder}
-     *             with the criterion's postcondition chain. The
-     *             builder is fresh; the consumer's calls to
-     *             {@code ensure(...)} populate it.
-     * @param <O>  the contract's per-sample output value type
-     * @return a criterion ready to be added to a {@link CriteriaBuilder}
+     * The empty criteria value — used by the default
+     * {@link org.javai.punit.api.Contract#criteria()} implementation
+     * when no criteria are declared via the value-form. The
+     * framework's lowering treats this as "no explicit criteria;
+     * fall back to the postcondition-derived K=1 default with
+     * implicit zero-tolerance" — same as the empty
+     * {@link CriteriaBuilder} case today.
      */
-    public static <O> Criterion<O> direct(
-            String id, Consumer<PostconditionBuilder<O>> body) {
-        validateId(id);
-        Objects.requireNonNull(body, "body");
-        PostconditionBuilder<O> b = new PostconditionBuilder<>();
-        body.accept(b);
-        return new DirectCriterion<>(id, b.build());
-    }
-
-    /**
-     * Declare a criterion that first transforms the contract's
-     * output {@code O} to a derived form {@code D}, then evaluates
-     * its postcondition chain against the derived value.
-     *
-     * <p>Transform failure (the function returns
-     * {@link Outcome.Fail} or throws a {@link RuntimeException})
-     * classifies the sample INCONCLUSIVE for this criterion; the
-     * postcondition chain is not evaluated. The transform's failure
-     * — name and message — is preserved on the per-sample result for
-     * diagnostics.
-     *
-     * @param id        the criterion's stable identifier; must be
-     *                  non-null and non-blank
-     * @param transform the pre-postcondition transform; receives the
-     *                  contract's produced output and returns an
-     *                  outcome over the derived type
-     * @param body      a consumer that populates a
-     *                  {@link PostconditionBuilder} typed over the derived
-     *                  type. The builder is fresh; the consumer's
-     *                  calls to {@code ensure(...)} populate it.
-     * @param <O>       the contract's per-sample output value type
-     * @param <D>       the derived value type the postcondition chain
-     *                  evaluates against
-     * @return a criterion ready to be added to a {@link CriteriaBuilder}
-     */
-    public static <O, D> Criterion<O> transforming(
-            String id,
-            Function<O, Outcome<D>> transform,
-            Consumer<PostconditionBuilder<D>> body) {
-        validateId(id);
-        Objects.requireNonNull(transform, "transform");
-        Objects.requireNonNull(body, "body");
-        PostconditionBuilder<D> b = new PostconditionBuilder<>();
-        body.accept(b);
-        return new TransformingCriterion<>(id, transform, b.build());
-    }
-
-    private static void validateId(String id) {
-        Objects.requireNonNull(id, "id");
-        if (id.isBlank()) {
-            throw new IllegalArgumentException("id must not be blank");
-        }
+    static <O> Criteria<O> empty() {
+        return EmptyCriteria.instance();
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriteriaBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriteriaBuilder.java
@@ -21,14 +21,14 @@ import org.javai.punit.api.PostconditionBuilder;
  * <ul>
  *   <li>{@link #addCriterion(String, Consumer) addCriterion(id, body)}
  *       — convenience absorbing the
- *       {@link Criteria#direct(String, Consumer) Criteria.direct}
+ *       {@link Criterion#direct(String, Consumer) Criterion.direct}
  *       factory call. Returns a {@link CriterionPostureHandle} on
  *       which {@code .meeting / .empirical / .zeroTolerance /
  *       .atConfidence} declares the criterion's commitment.</li>
  *   <li>{@link #addTransformingCriterion(String, Function, Consumer)
  *       addTransformingCriterion(id, transform, body)} — same shape
  *       for the transform-then-evaluate kind. Absorbs
- *       {@link Criteria#transforming(String, Function, Consumer)}.</li>
+ *       {@link Criterion#transforming(String, Function, Consumer)}.</li>
  *   <li>{@link #add(Criterion) add(criterion)} — primitive entry
  *       point for the rare hand-rolled {@link Criterion}. Returns
  *       the same posture handle, so the posture chain works
@@ -58,7 +58,7 @@ public final class CriteriaBuilder<O> {
      */
     public CriterionPostureHandle<O> addCriterion(
             String id, Consumer<PostconditionBuilder<O>> body) {
-        Criterion<O> criterion = Criteria.direct(id, body);
+        Criterion<O> criterion = Criterion.direct(id, body);
         return commit(criterion);
     }
 
@@ -72,7 +72,7 @@ public final class CriteriaBuilder<O> {
             String id,
             Function<O, Outcome<D>> transform,
             Consumer<PostconditionBuilder<D>> body) {
-        Criterion<O> criterion = Criteria.transforming(id, transform, body);
+        Criterion<O> criterion = Criterion.transforming(id, transform, body);
         return commit(criterion);
     }
 
@@ -80,7 +80,7 @@ public final class CriteriaBuilder<O> {
      * Add a hand-rolled {@link Criterion}. Returns a posture handle
      * for declaring the criterion's commitment.
      *
-     * <p>The {@code Criteria} factory entry points cover the
+     * <p>The {@code Criterion} factory entry points cover the
      * methodology's two shapes (direct, transforming) and structurally
      * enforce the one-transform-per-criterion cap. Prefer them. This
      * primitive is retained for the rare custom case.

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
@@ -1,5 +1,12 @@
 package org.javai.punit.api.criterion;
 
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionBuilder;
+
 /**
  * A named, contract-level partition of the functional dimension. A
  * criterion is a unit that judges a single sample's produced value
@@ -96,5 +103,46 @@ public interface Criterion<O> {
      */
     default CriterionPosture posture() {
         return CriterionPosture.implicit();
+    }
+
+    /**
+     * Construct a criterion whose postcondition chain evaluates
+     * directly against the contract's output. No transform.
+     *
+     * <p>Framework-internal entry point: the value-returning
+     * authoring surface (see {@code Posture.meeting/.empirical/.zeroTolerance}
+     * and {@code Composite.compose}) is the path authors use.
+     */
+    static <O> Criterion<O> direct(
+            String id, Consumer<PostconditionBuilder<O>> body) {
+        validateId(id);
+        Objects.requireNonNull(body, "body");
+        PostconditionBuilder<O> b = new PostconditionBuilder<>();
+        body.accept(b);
+        return new DirectCriterion<>(id, b.build());
+    }
+
+    /**
+     * Construct a criterion that first transforms the contract's
+     * output {@code O} to a derived form {@code D}, then evaluates
+     * its postcondition chain against the derived value.
+     */
+    static <O, D> Criterion<O> transforming(
+            String id,
+            Function<O, Outcome<D>> transform,
+            Consumer<PostconditionBuilder<D>> body) {
+        validateId(id);
+        Objects.requireNonNull(transform, "transform");
+        Objects.requireNonNull(body, "body");
+        PostconditionBuilder<D> b = new PostconditionBuilder<>();
+        body.accept(b);
+        return new TransformingCriterion<>(id, transform, b.build());
+    }
+
+    private static void validateId(String id) {
+        Objects.requireNonNull(id, "id");
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("id must not be blank");
+        }
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
@@ -1,0 +1,192 @@
+package org.javai.punit.api.criterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.PostconditionCheck;
+
+/**
+ * A single-criterion verdict-producing strategy — the value behind
+ * one row in a contract's criteria declaration.
+ *
+ * <p>Carries:
+ * <ul>
+ *   <li>a {@link CriterionPosture} (required) — what counts as
+ *       acceptable: a threshold-first {@code .meeting(...)}, the
+ *       empirical Wilson-vs-baseline procedure, or zero-tolerance;</li>
+ *   <li>an ordered list of named postconditions (optional) — the
+ *       per-sample checks the criterion runs against the contract's
+ *       output. Empty means apply-level {@code Outcome.ok / fail}
+ *       drives the criterion's per-sample outcome.</li>
+ * </ul>
+ *
+ * <p>Authors do not call {@code new CriterionDecl(...)} directly.
+ * The starting point is a posture factory:
+ * <pre>{@code
+ * import static org.javai.punit.api.criterion.Posture.*;
+ *
+ * meeting(0.9999, SLA)
+ *         .contractRef("Payment Provider SLA v2.3, §4.1");
+ *
+ * meeting(0.85, SLA)
+ *         .where("parseable", v -> isJson(v));
+ *
+ * empirical()
+ *         .detectingMde(0.02)
+ *         .atPower(0.95);
+ * }</pre>
+ *
+ * <p>Every chain method returns a new {@code CriterionDecl} —
+ * declarations are values, not builders.
+ *
+ * <p>A bare {@code CriterionDecl<O>} <em>is</em> a {@link Criteria}.
+ * For the K=1 default-id case the author returns the decl directly
+ * from {@code Contract.criteria()}; the framework lowers it to a
+ * one-entry runtime criteria list with the criterion id
+ * {@value Composite#DEFAULT_CRITERION_ID}.
+ *
+ * @param <O> the contract's per-sample output value type
+ */
+public final class CriterionDecl<O> implements Criteria<O> {
+
+    private final CriterionPosture posture;
+    private final List<NamedPostcondition<O>> postconditions;
+
+    CriterionDecl(CriterionPosture posture, List<NamedPostcondition<O>> postconditions) {
+        this.posture = Objects.requireNonNull(posture, "posture");
+        this.postconditions = List.copyOf(postconditions);
+    }
+
+    /** The criterion's posture — the verdict-producing commitment. */
+    public CriterionPosture posture() {
+        return posture;
+    }
+
+    /** Named postconditions in declaration order. May be empty. */
+    public List<NamedPostcondition<O>> postconditions() {
+        return postconditions;
+    }
+
+    /**
+     * Add a named postcondition. The predicate returns {@code true}
+     * for pass; the framework synthesises the failure message when
+     * it returns {@code false}.
+     *
+     * <p>Java's lambda inference picks this overload when the lambda
+     * body is a boolean expression; for richer failure messages use
+     * {@link #where(String, Function)}.
+     */
+    public CriterionDecl<O> where(String name, Predicate<O> predicate) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".where(name, ...) requires a non-blank name");
+        }
+        Objects.requireNonNull(predicate, "predicate");
+        PostconditionCheck<O> wrapped = v -> predicate.test(v)
+                ? Outcome.ok()
+                : Outcome.fail(name,
+                        "postcondition '" + name + "' returned false for value: " + v);
+        return appendPostcondition(name, wrapped);
+    }
+
+    /**
+     * Add a named postcondition that returns its own {@link Outcome}.
+     * Use this overload when the failure message benefits from
+     * diagnostic detail (offending input, parse error, etc.).
+     */
+    public CriterionDecl<O> where(String name, Function<O, Outcome<?>> check) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".where(name, ...) requires a non-blank name");
+        }
+        Objects.requireNonNull(check, "check");
+        PostconditionCheck<O> adapted = v -> {
+            Outcome<?> result = check.apply(v);
+            return switch (result) {
+                case Outcome.Ok<?> ok -> Outcome.ok();
+                case Outcome.Fail<?> fail -> Outcome.fail(fail.failure());
+            };
+        };
+        return appendPostcondition(name, adapted);
+    }
+
+    /**
+     * Attach a human-readable contract reference — the document and
+     * clause that justify this criterion's commitment
+     * (e.g. {@code "Payment Provider SLA v2.3, §4.1"}). Surfaced in
+     * the verdict path so compliance reports cite the authority
+     * alongside the verdict.
+     */
+    public CriterionDecl<O> contractRef(String ref) {
+        return new CriterionDecl<>(posture.withContractRef(ref), postconditions);
+    }
+
+    /**
+     * Set the per-criterion confidence floor — the run cannot
+     * loosen it. Composes only with {@code empirical()}; rejected
+     * by the posture machinery on a {@code .meeting(...)} or
+     * zero-tolerance commitment.
+     */
+    public CriterionDecl<O> atConfidence(double confidence) {
+        return new CriterionDecl<>(posture.withConfidenceFloor(confidence), postconditions);
+    }
+
+    /**
+     * Declare the minimum detectable effect — the smallest regression
+     * (in percentage points off the baseline rate) this criterion
+     * commits to detecting. Composes only with {@code empirical()};
+     * must be paired with {@link #atPower(double)}.
+     */
+    public CriterionDecl<O> detectingMde(double mde) {
+        return new CriterionDecl<>(posture.withMde(mde), postconditions);
+    }
+
+    /**
+     * Declare the statistical power — probability of detecting a true
+     * regression of size MDE. Composes only with {@code empirical()};
+     * must be paired with {@link #detectingMde(double)}.
+     */
+    public CriterionDecl<O> atPower(double power) {
+        return new CriterionDecl<>(posture.withPower(power), postconditions);
+    }
+
+    @Override
+    public List<Criterion<O>> asList() {
+        return List.of(toRuntime(Composite.DEFAULT_CRITERION_ID));
+    }
+
+    /**
+     * Lower this decl to a runtime {@link Criterion} with the given
+     * id. Called by {@link CompositeCriteria} when assembling the
+     * multi-criterion list and by {@link #asList()} for the K=1
+     * default-id case.
+     */
+    Criterion<O> toRuntime(String id) {
+        Criterion<O> base = Criterion.direct(id, this::populatePostconditions);
+        if (base instanceof DirectCriterion<O> direct) {
+            return direct.withPosture(posture);
+        }
+        // Defensive: Criterion.direct always returns DirectCriterion
+        // today, but the wrapper path keeps the framework correct if
+        // that ever changes.
+        return base;
+    }
+
+    private void populatePostconditions(PostconditionBuilder<O> pb) {
+        for (NamedPostcondition<O> p : postconditions) {
+            pb.ensure(p.name(), p.check());
+        }
+    }
+
+    private CriterionDecl<O> appendPostcondition(String name, PostconditionCheck<O> check) {
+        List<NamedPostcondition<O>> next = new ArrayList<>(postconditions.size() + 1);
+        next.addAll(postconditions);
+        next.add(new NamedPostcondition<>(name, check));
+        return new CriterionDecl<>(posture, next);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
@@ -52,7 +52,7 @@ import org.javai.punit.api.PostconditionCheck;
  *
  * @param <O> the contract's per-sample output value type
  */
-public final class CriterionDecl<O> implements Criteria<O> {
+public final class CriterionDecl<O> implements Decl<O> {
 
     private final CriterionPosture posture;
     private final List<NamedPostcondition<O>> postconditions;
@@ -77,9 +77,8 @@ public final class CriterionDecl<O> implements Criteria<O> {
      * for pass; the framework synthesises the failure message when
      * it returns {@code false}.
      *
-     * <p>Java's lambda inference picks this overload when the lambda
-     * body is a boolean expression; for richer failure messages use
-     * {@link #where(String, Function)}.
+     * <p>For richer failure messages — author-supplied symbolic name
+     * and message — use {@link #satisfies(String, Function)}.
      */
     public CriterionDecl<O> where(String name, Predicate<O> predicate) {
         Objects.requireNonNull(name, "name");
@@ -97,12 +96,14 @@ public final class CriterionDecl<O> implements Criteria<O> {
     /**
      * Add a named postcondition that returns its own {@link Outcome}.
      * Use this overload when the failure message benefits from
-     * diagnostic detail (offending input, parse error, etc.).
+     * diagnostic detail (offending input, parse error, etc.) —
+     * {@code Outcome.fail("symbolic-name", "message")} flows through to
+     * the verdict's failure histogram unchanged.
      */
-    public CriterionDecl<O> where(String name, Function<O, Outcome<?>> check) {
+    public CriterionDecl<O> satisfies(String name, Function<O, Outcome<?>> check) {
         Objects.requireNonNull(name, "name");
         if (name.isBlank()) {
-            throw new IllegalArgumentException(".where(name, ...) requires a non-blank name");
+            throw new IllegalArgumentException(".satisfies(name, ...) requires a non-blank name");
         }
         Objects.requireNonNull(check, "check");
         PostconditionCheck<O> adapted = v -> {
@@ -155,18 +156,58 @@ public final class CriterionDecl<O> implements Criteria<O> {
         return new CriterionDecl<>(posture.withPower(power), postconditions);
     }
 
+    /**
+     * Chain a transform — parse, project, derive — that produces a
+     * value of a different type {@code T} the criterion's
+     * postconditions will check. Returns a {@link TransformingDecl}
+     * whose {@code .where(...)} and {@code .satisfies(...)} operate
+     * on {@code T}, not on the contract's output {@code O}.
+     *
+     * <p>Transform semantics:
+     * <ul>
+     *   <li>Transform returns {@link Outcome.Ok Ok(t)} — the
+     *       postcondition chain runs against {@code t}; criterion
+     *       sample is PASS / FAIL based on the chain.</li>
+     *   <li>Transform returns {@link Outcome.Fail Fail(...)} or throws
+     *       — criterion sample is
+     *       {@link CriterionSampleOutcome#INCONCLUSIVE INCONCLUSIVE};
+     *       the postcondition chain is skipped. The failure's
+     *       symbolic name and message flow through to the per-sample
+     *       record for diagnostics.</li>
+     * </ul>
+     *
+     * <p>Posture stays attached to the outer (this) decl; postconditions
+     * already attached here are <em>not</em> carried forward to the
+     * returned {@code TransformingDecl} — postconditions must be
+     * stated either pre-transform (on this decl, via
+     * {@code .where} / {@code .satisfies}) or post-transform
+     * (on the returned decl), not both. Mixing pre- and
+     * post-transform postconditions is a misuse and is rejected.
+     *
+     * @param <T> the derived value type the postcondition chain
+     *            evaluates against on successful transform
+     */
+    public <T> TransformingDecl<O, T> transforming(Function<O, Outcome<T>> transform) {
+        Objects.requireNonNull(transform, "transform");
+        if (!postconditions.isEmpty()) {
+            throw new IllegalStateException(
+                    ".transforming(...) cannot follow .where/.satisfies on the same"
+                            + " criterion decl: postconditions are evaluated either"
+                            + " against the contract's output or against the"
+                            + " transformed value, not both. Either drop the"
+                            + " pre-transform postconditions, or split into two"
+                            + " criteria via Composite.compose(...).");
+        }
+        return new TransformingDecl<>(posture, transform, List.of());
+    }
+
     @Override
     public List<Criterion<O>> asList() {
         return List.of(toRuntime(Composite.DEFAULT_CRITERION_ID));
     }
 
-    /**
-     * Lower this decl to a runtime {@link Criterion} with the given
-     * id. Called by {@link CompositeCriteria} when assembling the
-     * multi-criterion list and by {@link #asList()} for the K=1
-     * default-id case.
-     */
-    Criterion<O> toRuntime(String id) {
+    @Override
+    public Criterion<O> toRuntime(String id) {
         Criterion<O> base = Criterion.direct(id, this::populatePostconditions);
         if (base instanceof DirectCriterion<O> direct) {
             return direct.withPosture(posture);

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
@@ -1,0 +1,29 @@
+package org.javai.punit.api.criterion;
+
+/**
+ * A single-criterion declaration — direct or transforming — that can
+ * be lowered to one runtime {@link Criterion} given an id.
+ *
+ * <p>The sealed supertype shared by {@link CriterionDecl} (direct,
+ * postconditions over the contract's output type {@code O}) and
+ * {@link TransformingDecl} (postconditions over a derived type
+ * {@code T} after a transform). It is the parameter type accepted by
+ * {@link Composite#compose(String, Decl) compose(...)} and
+ * {@link Composite#entry(String, Decl) entry(...)} so a composite may
+ * mix direct and transforming criteria.
+ *
+ * <p>Authors rarely reference this type by name — call-site idiom is
+ * {@code compose("a", meeting(0.99, SLA), "b", empirical().transforming(parse).where(...))}
+ * and inference picks {@code Decl<O>} as the unified type.
+ *
+ * @param <O> the contract's per-sample output value type
+ */
+public sealed interface Decl<O> extends Criteria<O>
+        permits CriterionDecl, TransformingDecl {
+
+    /**
+     * Lower this declaration to a runtime {@link Criterion} with the
+     * given id. Framework-internal; authors do not call this directly.
+     */
+    Criterion<O> toRuntime(String id);
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/EmptyCriteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/EmptyCriteria.java
@@ -1,0 +1,37 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+
+/**
+ * The empty-criteria sentinel value. Returned by
+ * {@link Criteria#empty()} and used as the default for
+ * {@link org.javai.punit.api.Contract#criteria()} when the contract
+ * has not overridden the value-form authoring path. The framework's
+ * lowering treats it as "no explicit criteria; fall back to the
+ * postcondition-derived K=1 default."
+ *
+ * <p>A single instance backs every call to {@link Criteria#empty()};
+ * authors do not see the type.
+ */
+final class EmptyCriteria<O> implements Criteria<O> {
+
+    @SuppressWarnings("rawtypes")
+    private static final EmptyCriteria INSTANCE = new EmptyCriteria<>();
+
+    private EmptyCriteria() { }
+
+    @SuppressWarnings("unchecked")
+    static <O> EmptyCriteria<O> instance() {
+        return (EmptyCriteria<O>) INSTANCE;
+    }
+
+    @Override
+    public List<Criterion<O>> asList() {
+        return List.of();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/NamedPostcondition.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/NamedPostcondition.java
@@ -1,0 +1,22 @@
+package org.javai.punit.api.criterion;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionCheck;
+
+/**
+ * One named postcondition on a {@link CriterionDecl}: a name (used
+ * as the postcondition's identifier in failure exemplars and verdict
+ * detail) and a {@link PostconditionCheck} that maps a sample's
+ * produced value to an {@link Outcome}.
+ *
+ * <p>Built by the {@code .where(...)} overloads on
+ * {@link CriterionDecl}: the predicate form synthesises the check
+ * from a boolean predicate; the rich-message overload accepts the
+ * check directly.
+ *
+ * @param <O> the value type the check evaluates against
+ */
+public record NamedPostcondition<O>(
+        String name,
+        PostconditionCheck<O> check
+) { }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Posture.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Posture.java
@@ -1,0 +1,58 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+
+import org.javai.punit.api.ThresholdOrigin;
+
+/**
+ * Posture factories — the starting point for every
+ * {@link CriterionDecl}.
+ *
+ * <p>Each factory returns a {@code CriterionDecl<O>} whose
+ * {@link CriterionPosture} is the corresponding verdict-producing
+ * strategy. The author then chains
+ * {@link CriterionDecl#where(String, java.util.function.Predicate)
+ * .where(...)},
+ * {@link CriterionDecl#contractRef(String) .contractRef(...)},
+ * {@link CriterionDecl#atConfidence(double) .atConfidence(...)} etc.
+ * to refine the declaration.
+ *
+ * <p>Statically imported, the call site reads {@code meeting(0.85, SLA)}
+ * — not {@code Posture.meeting(...)}. The class is a container for
+ * autocomplete navigation; the static import is the canonical
+ * idiom:
+ *
+ * <pre>{@code
+ * import static org.javai.punit.api.criterion.Posture.*;
+ * }</pre>
+ */
+public final class Posture {
+
+    private Posture() { /* utility class */ }
+
+    /**
+     * Statistical, contractual: PASS iff observed pass-rate ≥
+     * {@code rate}. The threshold is declared explicitly with a
+     * non-empirical origin (SLA / SLO / POLICY).
+     */
+    public static <O> CriterionDecl<O> meeting(double rate, ThresholdOrigin origin) {
+        return new CriterionDecl<>(CriterionPosture.meeting(rate, origin), List.of());
+    }
+
+    /**
+     * Statistical, empirical: threshold derived from the resolved
+     * baseline at evaluate time via the Wilson-lower-bound procedure.
+     */
+    public static <O> CriterionDecl<O> empirical() {
+        return new CriterionDecl<>(CriterionPosture.empirical(), List.of());
+    }
+
+    /**
+     * Explicit zero-tolerance: any failed sample fails the criterion.
+     * The run classifies SMOKE per methodology. Does not compose with
+     * {@code .atConfidence(...)}.
+     */
+    public static <O> CriterionDecl<O> zeroTolerance(ThresholdOrigin origin) {
+        return new CriterionDecl<>(CriterionPosture.zeroTolerance(origin), List.of());
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingDecl.java
@@ -1,0 +1,128 @@
+package org.javai.punit.api.criterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.PostconditionCheck;
+
+/**
+ * A value-form criterion decl whose postcondition chain is evaluated
+ * against a transformed value, not against the contract's raw output.
+ * Returned by {@link CriterionDecl#transforming(Function)}.
+ *
+ * <p>The criterion's posture lives on the parent {@link CriterionDecl}
+ * (the type-witness {@code <O>} is the contract's output type).
+ * The criterion's postconditions live here (the type-witness {@code <T>}
+ * is the transformed value type the postconditions see).
+ *
+ * <p>Transform failure ({@link Outcome.Fail}) or a thrown exception
+ * classifies the criterion's per-sample outcome as
+ * {@link CriterionSampleOutcome#INCONCLUSIVE INCONCLUSIVE} —
+ * <em>distinct</em> from FAIL. The postcondition chain is not
+ * evaluated; the parse / projection failure flows through to the
+ * per-sample record with its symbolic name and message preserved.
+ *
+ * @param <O> the contract's per-sample output value type
+ * @param <T> the transformed value type the postconditions evaluate
+ *            against
+ */
+public final class TransformingDecl<O, T> implements Decl<O> {
+
+    private final CriterionPosture posture;
+    private final Function<O, Outcome<T>> transform;
+    private final List<NamedPostcondition<T>> postconditions;
+
+    TransformingDecl(
+            CriterionPosture posture,
+            Function<O, Outcome<T>> transform,
+            List<NamedPostcondition<T>> postconditions) {
+        this.posture = Objects.requireNonNull(posture, "posture");
+        this.transform = Objects.requireNonNull(transform, "transform");
+        this.postconditions = List.copyOf(postconditions);
+    }
+
+    /** The posture inherited from the parent {@link CriterionDecl}. */
+    public CriterionPosture posture() {
+        return posture;
+    }
+
+    /** Named post-transform postconditions in declaration order. May be empty. */
+    public List<NamedPostcondition<T>> postconditions() {
+        return postconditions;
+    }
+
+    /**
+     * Add a named postcondition over the transformed value. The
+     * predicate returns {@code true} for pass; the framework
+     * synthesises the failure message when it returns {@code false}.
+     *
+     * <p>For richer failure messages use
+     * {@link #satisfies(String, Function)}.
+     */
+    public TransformingDecl<O, T> where(String name, Predicate<T> predicate) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".where(name, ...) requires a non-blank name");
+        }
+        Objects.requireNonNull(predicate, "predicate");
+        PostconditionCheck<T> wrapped = v -> predicate.test(v)
+                ? Outcome.ok()
+                : Outcome.fail(name,
+                        "postcondition '" + name + "' returned false for value: " + v);
+        return appendPostcondition(name, wrapped);
+    }
+
+    /**
+     * Add a named postcondition over the transformed value that
+     * returns its own {@link Outcome}. Use this when the failure
+     * message benefits from diagnostic detail.
+     */
+    public TransformingDecl<O, T> satisfies(String name, Function<T, Outcome<?>> check) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".satisfies(name, ...) requires a non-blank name");
+        }
+        Objects.requireNonNull(check, "check");
+        PostconditionCheck<T> adapted = v -> {
+            Outcome<?> result = check.apply(v);
+            return switch (result) {
+                case Outcome.Ok<?> ok -> Outcome.ok();
+                case Outcome.Fail<?> fail -> Outcome.fail(fail.failure());
+            };
+        };
+        return appendPostcondition(name, adapted);
+    }
+
+    @Override
+    public List<Criterion<O>> asList() {
+        return List.of(toRuntime(Composite.DEFAULT_CRITERION_ID));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Criterion<O> toRuntime(String id) {
+        Criterion<O> base = Criterion.transforming(id, transform, this::populatePostconditions);
+        if (base instanceof TransformingCriterion<?, ?> tc) {
+            return ((TransformingCriterion<O, T>) tc).withPosture(posture);
+        }
+        return base;
+    }
+
+    private void populatePostconditions(PostconditionBuilder<T> pb) {
+        for (NamedPostcondition<T> p : postconditions) {
+            pb.ensure(p.name(), p.check());
+        }
+    }
+
+    private TransformingDecl<O, T> appendPostcondition(String name, PostconditionCheck<T> check) {
+        List<NamedPostcondition<T>> next = new ArrayList<>(postconditions.size() + 1);
+        next.addAll(postconditions);
+        next.add(new NamedPostcondition<>(name, check));
+        return new TransformingDecl<>(posture, transform, next);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -186,7 +186,7 @@ public final class ProbabilisticTest implements Spec {
             // commitment without re-resolving the contract.
             java.util.Map<String, org.javai.punit.api.criterion.CriterionPosture> criterionPostures =
                     new java.util.LinkedHashMap<>();
-            for (org.javai.punit.api.criterion.Criterion<OT> c : contract.criteria()) {
+            for (org.javai.punit.api.criterion.Criterion<OT> c : contract.effectiveCriteria()) {
                 criterionPostures.put(c.id(), c.posture());
             }
             String testInputsIdentity = sampling.inputsIdentity();
@@ -575,7 +575,7 @@ public final class ProbabilisticTest implements Spec {
             Sampling<FT, IT, OT> sampling, FT factors, List<Registered<OT>> registered) {
         ServiceContract<FT, IT, OT> probe = sampling.serviceContractFactory().apply(factors);
         SpecCriterionDeriver deriver = SpecCriterionDeriver.lookup();
-        for (org.javai.punit.api.criterion.Criterion<OT> c : probe.criteria()) {
+        for (org.javai.punit.api.criterion.Criterion<OT> c : probe.effectiveCriteria()) {
             deriver.<OT>derive(c.posture()).ifPresent(sc -> {
                 if (!alreadyRegistered(registered, sc.getClass())) {
                     registered.add(new Registered<>(sc, CriterionRole.REQUIRED));

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/PowerAnalysis.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/PowerAnalysis.java
@@ -312,7 +312,7 @@ public final class PowerAnalysis {
                             : CovariateResolver.defaults().resolve(
                                     declarations, serviceContract.customCovariateResolvers());
                     List<org.javai.punit.api.criterion.Criterion<?>> contractCriteria =
-                            new java.util.ArrayList<>(serviceContract.criteria());
+                            new java.util.ArrayList<>(serviceContract.effectiveCriteria());
                     return new BaselineLookup(serviceContractId, fingerprint, profile, declarations, contractCriteria);
                 }
             };

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/SampleSizeResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/SampleSizeResolver.java
@@ -73,7 +73,7 @@ public final class SampleSizeResolver {
             BaselineProvider baselineProvider,
             int declaredSamples) {
 
-        List<? extends Criterion<OT>> criteria = contract.criteria();
+        List<? extends Criterion<OT>> criteria = contract.effectiveCriteria();
         List<? extends Criterion<OT>> confidenceFirst = criteria.stream()
                 .filter(c -> c.posture().isConfidenceFirst())
                 .toList();

--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -681,7 +681,7 @@ public final class PUnit {
             if (requiredCriteria.isEmpty()) {
                 org.javai.punit.api.spec.SpecCriterionDeriver deriver =
                         org.javai.punit.api.spec.SpecCriterionDeriver.lookup();
-                for (org.javai.punit.api.criterion.Criterion<OT> c : serviceContract.criteria()) {
+                for (org.javai.punit.api.criterion.Criterion<OT> c : serviceContract.effectiveCriteria()) {
                     deriver.<OT>derive(c.posture()).ifPresent(requiredCriteria::add);
                 }
             }
@@ -799,7 +799,7 @@ public final class PUnit {
                 List<String> warnings,
                 CovariateProfile observed,
                 ServiceContract<FT, IT, OT> serviceContract) {
-            Optional<String> contractRefOpt = serviceContract.criteria().stream()
+            Optional<String> contractRefOpt = serviceContract.effectiveCriteria().stream()
                     .map(org.javai.punit.api.criterion.Criterion::posture)
                     .map(org.javai.punit.api.criterion.CriterionPosture::contractRef)
                     .filter(Optional::isPresent)
@@ -977,7 +977,7 @@ public final class PUnit {
                                     .resolve(declarations, serviceContract.customCovariateResolvers());
                     BaselineProvider provider = ProfileBoundBaselineProvider.bind(
                             raw, profile, declarations);
-                    Optional<String> contractRef = serviceContract.criteria().stream()
+                    Optional<String> contractRef = serviceContract.effectiveCriteria().stream()
                             .map(org.javai.punit.api.criterion.Criterion::posture)
                             .map(org.javai.punit.api.criterion.CriterionPosture::contractRef)
                             .filter(Optional::isPresent)

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
@@ -1,0 +1,179 @@
+package org.javai.punit.api.criterion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.javai.punit.api.criterion.Composite.compose;
+import static org.javai.punit.api.criterion.Composite.composeOf;
+import static org.javai.punit.api.criterion.Composite.entry;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Contract;
+import org.javai.punit.api.ThresholdOrigin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Criteria-as-data — value-form authoring surface")
+class CriteriaAsDataTest {
+
+    @Test
+    @DisplayName("K=1 bare decl IS a Criteria, lowers to one-entry list with default id 'contract'")
+    void bareDeclIsCriteria() {
+        Criteria<String> c = Posture.<String>meeting(0.85, ThresholdOrigin.SLA);
+
+        assertThat(c.asList()).hasSize(1);
+        assertThat(c.asList().get(0).id()).isEqualTo("contract");
+        assertThat(c.asList().get(0).posture().kind())
+                .isEqualTo(CriterionPosture.Kind.STATISTICAL_CONTRACTUAL);
+        assertThat(c.asList().get(0).posture().threshold().getAsDouble()).isEqualTo(0.85);
+    }
+
+    @Test
+    @DisplayName("posture chain is value-preserving: .meeting().contractRef().atConfidence() composes via posture")
+    void postureChainPreservesValues() {
+        CriterionDecl<String> decl = Posture.<String>empirical()
+                .atConfidence(0.99)
+                .contractRef("doc-v1");
+
+        CriterionPosture p = decl.posture();
+        assertThat(p.kind()).isEqualTo(CriterionPosture.Kind.STATISTICAL_EMPIRICAL);
+        assertThat(p.confidenceFloor().getAsDouble()).isEqualTo(0.99);
+        assertThat(p.contractRef()).contains("doc-v1");
+    }
+
+    @Test
+    @DisplayName(".where(name, Predicate) — synthesised failure carries the postcondition name")
+    void wherePredicateSynthesisesFailure() {
+        Predicate<String> isEmpty = String::isEmpty;
+        Predicate<String> startsWithA = s -> s.startsWith("a");
+        CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+                .where("non-empty", isEmpty)
+                .where("starts-with-a", startsWithA);
+
+        assertThat(decl.postconditions()).hasSize(2);
+        assertThat(decl.postconditions().get(0).name()).isEqualTo("non-empty");
+
+        Outcome<?> failResult = decl.postconditions().get(0).check().check("x");
+        assertThat(failResult).isInstanceOf(Outcome.Fail.class);
+        Outcome.Fail<?> fail = (Outcome.Fail<?>) failResult;
+        assertThat(fail.failure().id().name()).isEqualTo("non-empty");
+        assertThat(fail.failure().message()).contains("non-empty").contains("returned false").contains("x");
+    }
+
+    @Test
+    @DisplayName(".where(name, Function<O, Outcome<?>>) — author-supplied message preserved verbatim")
+    void whereRichFunctionPreservesMessage() {
+        Function<String, Outcome<?>> parseable = v -> Outcome.fail("notJson", "v=" + v);
+        CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+                .where("parseable", parseable);
+
+        Outcome<?> result = decl.postconditions().get(0).check().check("garbage");
+        assertThat(result).isInstanceOf(Outcome.Fail.class);
+        Outcome.Fail<?> fail = (Outcome.Fail<?>) result;
+        assertThat(fail.failure().id().name()).isEqualTo("notJson");
+        assertThat(fail.failure().message()).isEqualTo("v=garbage");
+    }
+
+    @Test
+    @DisplayName("compose(id, decl) — K=1 with explicit id")
+    void composeOneExplicitId() {
+        Criteria<String> c = compose("payment-success",
+                Posture.<String>meeting(0.9999, ThresholdOrigin.SLA));
+
+        assertThat(c.asList()).hasSize(1);
+        assertThat(c.asList().get(0).id()).isEqualTo("payment-success");
+    }
+
+    @Test
+    @DisplayName("compose(...) — K>1 composite, declaration order preserved")
+    void composeMany() {
+        Criteria<String> c = compose(
+                "a", Posture.<String>meeting(0.99, ThresholdOrigin.SLA),
+                "b", Posture.<String>meeting(0.95, ThresholdOrigin.SLA),
+                "c", Posture.<String>zeroTolerance(ThresholdOrigin.POLICY));
+
+        assertThat(c.asList()).hasSize(3);
+        assertThat(c.asList().get(0).id()).isEqualTo("a");
+        assertThat(c.asList().get(1).id()).isEqualTo("b");
+        assertThat(c.asList().get(2).id()).isEqualTo("c");
+    }
+
+    @Test
+    @DisplayName("composeOf(entry, entry, ...) — escape hatch for arbitrary K")
+    void composeOfEntries() {
+        Criteria<String> c = composeOf(
+                entry("a", Posture.<String>meeting(0.99, ThresholdOrigin.SLA)),
+                entry("b", Posture.<String>meeting(0.95, ThresholdOrigin.SLA)));
+
+        assertThat(c.asList()).hasSize(2);
+        assertThat(c.asList().get(0).id()).isEqualTo("a");
+        assertThat(c.asList().get(1).id()).isEqualTo("b");
+    }
+
+    @Test
+    @DisplayName("duplicate criterion ids in compose(...) rejected at construction")
+    void duplicateIdsRejected() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> compose(
+                        "a", Posture.<String>meeting(0.99, ThresholdOrigin.SLA),
+                        "a", Posture.<String>meeting(0.95, ThresholdOrigin.SLA)))
+                .withMessageContaining("duplicate");
+    }
+
+    @Test
+    @DisplayName("Contract.criteria() default returns empty; effectiveCriteria() falls back to K=1 default")
+    void defaultContractFallsBackToK1Default() {
+        Contract<Object, String> c = new Contract<>() {
+            @Override public Outcome<String> invoke(Object input,
+                    org.javai.punit.api.TokenTracker t) {
+                return Outcome.ok("ok");
+            }
+        };
+
+        assertThat(c.criteria().isEmpty()).isTrue();
+        assertThat(c.effectiveCriteria()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Contract.criteria() value-form: bare decl drives effectiveCriteria")
+    void valueFormDrivesEffectiveCriteria() {
+        Contract<Object, String> c = new Contract<>() {
+            @Override public Outcome<String> invoke(Object input,
+                    org.javai.punit.api.TokenTracker t) {
+                return Outcome.ok("ok");
+            }
+            @Override public Criteria<String> criteria() {
+                return Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+                        .contractRef("doc-v1");
+            }
+        };
+
+        assertThat(c.effectiveCriteria()).hasSize(1);
+        assertThat(c.effectiveCriteria().get(0).id()).isEqualTo("contract");
+        assertThat(c.effectiveCriteria().get(0).posture().contractRef()).contains("doc-v1");
+    }
+
+    @Test
+    @DisplayName("Contract that declares both value-form and builder-form is rejected at effectiveCriteria()")
+    void coexistenceRejected() {
+        Contract<Object, String> c = new Contract<>() {
+            @Override public Outcome<String> invoke(Object input,
+                    org.javai.punit.api.TokenTracker t) {
+                return Outcome.ok("ok");
+            }
+            @Override public Criteria<String> criteria() {
+                return Posture.<String>meeting(0.85, ThresholdOrigin.SLA);
+            }
+            @Override public void criteria(CriteriaBuilder<String> b) {
+                b.addCriterion("other", pb -> { });
+            }
+        };
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(c::effectiveCriteria)
+                .withMessageContaining("value-form")
+                .withMessageContaining("builder-form");
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
@@ -6,7 +6,6 @@ import static org.javai.punit.api.criterion.Composite.compose;
 import static org.javai.punit.api.criterion.Composite.composeOf;
 import static org.javai.punit.api.criterion.Composite.entry;
 
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.javai.outcome.Outcome;
@@ -63,17 +62,99 @@ class CriteriaAsDataTest {
     }
 
     @Test
-    @DisplayName(".where(name, Function<O, Outcome<?>>) — author-supplied message preserved verbatim")
-    void whereRichFunctionPreservesMessage() {
-        Function<String, Outcome<?>> parseable = v -> Outcome.fail("notJson", "v=" + v);
+    @DisplayName(".satisfies(name, Function<O, Outcome<?>>) — author-supplied message preserved verbatim")
+    void satisfiesRichFunctionPreservesMessage() {
         CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
-                .where("parseable", parseable);
+                .satisfies("parseable", v -> Outcome.fail("notJson", "v=" + v));
 
         Outcome<?> result = decl.postconditions().get(0).check().check("garbage");
         assertThat(result).isInstanceOf(Outcome.Fail.class);
         Outcome.Fail<?> fail = (Outcome.Fail<?>) result;
         assertThat(fail.failure().id().name()).isEqualTo("notJson");
         assertThat(fail.failure().message()).isEqualTo("v=garbage");
+    }
+
+    @Test
+    @DisplayName(".satisfies takes a bare lambda — no overload ambiguity, no type-witness needed")
+    void satisfiesDisambiguatedWithoutHelp() {
+        // The key Finding #1 regression-guard: a slide-friendly lambda
+        // with a generic Outcome.fail in its body must compile without
+        // a cast or a typed local.
+        CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+                .satisfies("transaction succeeds", r -> r.startsWith("OK")
+                        ? Outcome.ok()
+                        : Outcome.fail("transaction-failed", "got=" + r));
+
+        Outcome<?> okResult = decl.postconditions().get(0).check().check("OK-123");
+        assertThat(okResult).isInstanceOf(Outcome.Ok.class);
+        Outcome<?> failResult = decl.postconditions().get(0).check().check("ERR-500");
+        assertThat(failResult).isInstanceOf(Outcome.Fail.class);
+    }
+
+    @Test
+    @DisplayName(".transforming(parse).where/.satisfies — postconditions evaluate against derived value")
+    void transformingChainEvaluatesAgainstDerived() {
+        TransformingDecl<String, Integer> decl = Posture.<String>empirical()
+                .transforming(s -> {
+                    try {
+                        return Outcome.ok(Integer.parseInt(s));
+                    } catch (NumberFormatException e) {
+                        return Outcome.fail("not-a-number", "s=" + s);
+                    }
+                })
+                .where("positive", n -> n > 0)
+                .satisfies("even", n -> n % 2 == 0
+                        ? Outcome.ok()
+                        : Outcome.fail("odd", "n=" + n));
+
+        assertThat(decl.postconditions()).hasSize(2);
+
+        Criterion<String> rt = decl.toRuntime("parsed-number");
+        assertThat(rt.id()).isEqualTo("parsed-number");
+        assertThat(rt.posture().kind()).isEqualTo(CriterionPosture.Kind.STATISTICAL_EMPIRICAL);
+
+        // Successful transform → postcondition chain runs
+        assertThat(rt.evaluate("4").outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+        // Transform ok, postcondition fails → FAIL
+        assertThat(rt.evaluate("3").outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
+        // Transform fails → INCONCLUSIVE (chain skipped)
+        CriterionSampleResult parseFail = rt.evaluate("xyz");
+        assertThat(parseFail.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
+        assertThat(parseFail.reason()).isPresent();
+        assertThat(parseFail.reason().get().failure().id().name()).isEqualTo("not-a-number");
+    }
+
+    @Test
+    @DisplayName(".transforming(...) rejects pre-transform postconditions on the same decl")
+    void transformingRejectsPreTransformPostconditions() {
+        org.assertj.core.api.Assertions.assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> Posture.<String>empirical()
+                        .where("non-empty", s -> !s.isEmpty())
+                        .transforming(s -> Outcome.ok(Integer.parseInt(s))))
+                .withMessageContaining(".transforming");
+    }
+
+    @Test
+    @DisplayName("compose mixes direct and transforming criteria under one composite")
+    void composeMixesDirectAndTransforming() {
+        Criteria<String> c = compose(
+                "response-not-empty", Posture.<String>empirical()
+                        .where("non-blank", s -> !s.isBlank()),
+                "parses", Posture.<String>empirical()
+                        .transforming(s -> {
+                            try {
+                                return Outcome.ok(Integer.parseInt(s));
+                            } catch (NumberFormatException e) {
+                                return Outcome.fail("not-a-number", "s=" + s);
+                            }
+                        })
+                        .where("positive", n -> n > 0));
+
+        assertThat(c.asList()).hasSize(2);
+        assertThat(c.asList().get(0).id()).isEqualTo("response-not-empty");
+        assertThat(c.asList().get(1).id()).isEqualTo("parses");
+        assertThat(c.asList().get(1).evaluate("nope").outcome())
+                .isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
     }
 
     @Test

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriterionShimTest.java
@@ -60,7 +60,7 @@ class CriterionShimTest {
 
         @Override
         public void criteria(CriteriaBuilder<String> b) {
-            b.add(Criteria.direct("well-formed",
+            b.add(Criterion.direct("well-formed",
                     cb -> cb.ensure("non-empty", v ->
                             v.isEmpty()
                                     ? Outcome.fail("empty", "")
@@ -84,7 +84,7 @@ class CriterionShimTest {
 
         @Override
         public void criteria(CriteriaBuilder<String> b) {
-            b.add(Criteria.direct("other",
+            b.add(Criterion.direct("other",
                     cb -> cb.ensure("starts-with-h", v ->
                             v.startsWith("h")
                                     ? Outcome.ok()
@@ -106,7 +106,7 @@ class CriterionShimTest {
             legacy.addAll(p.evaluateAll(value));
         }
 
-        Criterion<String> sole = contract.criteria().get(0);
+        Criterion<String> sole = contract.effectiveCriteria().get(0);
         CriterionSampleResult result = sole.evaluate(value);
 
         assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
@@ -124,7 +124,7 @@ class CriterionShimTest {
     void singleCriterionDefaultClassifiesFailWhenAnyPostconditionFails() {
         var contract = new SingleStreamContract();
         // "world" passes "non-empty" but fails "starts with greeting".
-        CriterionSampleResult result = contract.criteria().get(0).evaluate("world");
+        CriterionSampleResult result = contract.effectiveCriteria().get(0).evaluate("world");
 
         assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
         assertThat(result.postconditionResults()).hasSize(2);
@@ -135,8 +135,8 @@ class CriterionShimTest {
     @Test
     void singleCriterionIdIsStableAcrossCalls() {
         var contract = new SingleStreamContract();
-        String first = contract.criteria().get(0).id();
-        String second = contract.criteria().get(0).id();
+        String first = contract.effectiveCriteria().get(0).id();
+        String second = contract.effectiveCriteria().get(0).id();
         assertThat(first).isEqualTo(second);
         assertThat(first).isNotBlank();
         assertThat(first).matches("[a-z0-9-]+");
@@ -145,7 +145,7 @@ class CriterionShimTest {
     @Test
     void defaultCriterionIdDerivedFromContractClass() {
         var contract = new SingleStreamContract();
-        String id = contract.criteria().get(0).id();
+        String id = contract.effectiveCriteria().get(0).id();
         // SingleStreamContract → single-stream-contract.
         assertThat(id).isEqualTo("single-stream-contract");
     }
@@ -153,7 +153,7 @@ class CriterionShimTest {
     @Test
     void explicitCriteriaListIsReturnedAsIs() {
         var contract = new ExplicitCriteriaContract();
-        List<Criterion<String>> criteria = contract.criteria();
+        List<Criterion<String>> criteria = contract.effectiveCriteria();
 
         assertThat(criteria).hasSize(1);
         assertThat(criteria.get(0).id()).isEqualTo("well-formed");
@@ -164,7 +164,7 @@ class CriterionShimTest {
     @Test
     void bothOverriddenThrowsAtCriteriaAccess() {
         var contract = new BothOverriddenContract();
-        assertThatThrownBy(contract::criteria)
+        assertThatThrownBy(contract::effectiveCriteria)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("postconditions(PostconditionBuilder)")
                 .hasMessageContaining("criteria(CriteriaBuilder)")

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
@@ -32,7 +32,7 @@ class InconclusiveFoldsIntoFailTest {
 
         @Override
         public void criteria(CriteriaBuilder<String> b) {
-            b.add(Criteria.transforming(
+            b.add(Criterion.transforming(
                     "parsed-positive",
                     s -> {
                         try {

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/TransformingCriterionTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/TransformingCriterionTest.java
@@ -18,7 +18,7 @@ class TransformingCriterionTest {
 
     @Test
     void transformSucceedsAllPassesYieldsPass() {
-        Criterion<String> c = Criteria.transforming(
+        Criterion<String> c = Criterion.transforming(
                 "parsed-positive",
                 s -> Outcome.ok(Integer.parseInt(s)),
                 b -> b.ensure("positive", (Integer n) -> n > 0
@@ -35,7 +35,7 @@ class TransformingCriterionTest {
 
     @Test
     void transformSucceedsAnyPostconditionFailsYieldsFail() {
-        Criterion<String> c = Criteria.transforming(
+        Criterion<String> c = Criterion.transforming(
                 "parsed-positive",
                 s -> Outcome.ok(Integer.parseInt(s)),
                 b -> b.ensure("positive", (Integer n) -> n > 0
@@ -52,7 +52,7 @@ class TransformingCriterionTest {
 
     @Test
     void transformReturnsFailYieldsInconclusiveCarryingTheFailure() {
-        Criterion<String> c = Criteria.transforming(
+        Criterion<String> c = Criterion.transforming(
                 "parsed-positive",
                 s -> Outcome.<Integer>fail("parse-error", "expected an integer"),
                 b -> b.ensure("positive", (Integer n) -> Outcome.ok()));
@@ -71,7 +71,7 @@ class TransformingCriterionTest {
     void transformThrowsYieldsInconclusiveCarryingTheExceptionMessage() {
         java.util.function.Function<String, Outcome<Integer>> blowUp =
                 s -> { throw new IllegalStateException("kaboom"); };
-        Criterion<String> c = Criteria.transforming(
+        Criterion<String> c = Criterion.transforming(
                 "parsed-positive",
                 blowUp,
                 b -> b.ensure("positive", (Integer n) -> Outcome.ok()));
@@ -87,7 +87,7 @@ class TransformingCriterionTest {
 
     @Test
     void directCriterionWithoutTransformOperatesOverContractOutput() {
-        Criterion<String> c = Criteria.direct(
+        Criterion<String> c = Criterion.direct(
                 "non-empty",
                 b -> b.ensure("non-empty", v -> v.isEmpty()
                         ? Outcome.fail("empty", "")
@@ -102,20 +102,20 @@ class TransformingCriterionTest {
 
     @Test
     void factoryValidatesIdAndArguments() {
-        assertThatThrownBy(() -> Criteria.direct(null, b -> {}))
+        assertThatThrownBy(() -> Criterion.direct(null, b -> {}))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> Criteria.direct("", b -> {}))
+        assertThatThrownBy(() -> Criterion.direct("", b -> {}))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("blank");
-        assertThatThrownBy(() -> Criteria.direct("id", null))
+        assertThatThrownBy(() -> Criterion.direct("id", null))
                 .isInstanceOf(NullPointerException.class);
 
-        assertThatThrownBy(() -> Criteria.transforming(null, s -> Outcome.ok(s), b -> {}))
+        assertThatThrownBy(() -> Criterion.transforming(null, s -> Outcome.ok(s), b -> {}))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> Criteria.transforming("id", null, b -> {}))
+        assertThatThrownBy(() -> Criterion.transforming("id", null, b -> {}))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() ->
-                Criteria.transforming("id", (String s) -> Outcome.ok(s), null))
+                Criterion.transforming("id", (String s) -> Outcome.ok(s), null))
                 .isInstanceOf(NullPointerException.class);
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
@@ -13,7 +13,7 @@ import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
-import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Criterion;
 import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.NextFactor;
@@ -140,9 +140,9 @@ class OptimizeOutputWriterTest {
             @Override public String id() { return "two-criterion-contract"; }
             @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public void criteria(CriteriaBuilder<String> b) {
-                b.add(Criteria.direct("always-passes",
+                b.add(Criterion.direct("always-passes",
                         cb -> cb.ensure("passes", v -> Outcome.ok())));
-                b.add(Criteria.direct("starts-with-a",
+                b.add(Criterion.direct("starts-with-a",
                         cb -> cb.ensure("first-char-a", v ->
                                 v.startsWith("a")
                                         ? Outcome.ok()


### PR DESCRIPTION
## Summary

PR #1 of DIR-CRITERIA-AS-DATA-punit. Introduces the value-form
authoring surface for contract criteria, alongside the existing
\`CriteriaBuilder\` form. Subsequent PRs in the directive migrate
authoring sites and retire the builder form.

A contract's verdict-producing strategy can now be declared as a
returned value:

\`\`\`java
import static org.javai.punit.api.criterion.Posture.*;
import static org.javai.punit.api.criterion.Composite.*;
import static org.javai.punit.api.ThresholdOrigin.*;

@Override public Criteria<Receipt> criteria() {
    return meeting(0.9999, SLA)
            .contractRef(\"Payment Provider SLA v2.3, §4.1\");
}
\`\`\`

For K>1, \`compose(\"id1\", decl1, \"id2\", decl2, ...)\` (Map.of-style
overloads N=1..6) with \`composeOf(entry, ...)\` as the escape hatch.

## What's new

- Sealed \`Criteria<O>\` interface permitting \`CriterionDecl<O>\`,
  \`CompositeCriteria<O>\`, \`EmptyCriteria<O>\`.
- \`Posture\` factories: \`meeting(rate, origin)\`, \`empirical()\`,
  \`zeroTolerance(origin)\`. Designed for static import.
- \`Composite\` factories: \`compose(...)\` overloads, \`composeOf(...)\`,
  \`entry(...)\`. Default criterion id is \`\"contract\"\` for K=1
  bare-decl form.
- \`.where(name, Predicate<O>)\` and \`.where(name, Function<O, Outcome<?>>)\`
  attach postconditions without exposing the \`PostconditionBuilder\`.
- \`Contract.criteria()\` is now the value-form authoring hook
  (defaults to \`Criteria.empty()\`); the existing runtime accessor
  is renamed \`effectiveCriteria()\`.
- Coexistence of value-form and builder-form is rejected at
  \`effectiveCriteria()\` access with a diagnostic message.

## What hasn't changed

- The builder form \`criteria(CriteriaBuilder<O>)\` remains in place
  and produces the same runtime list as before. No authoring sites
  are migrated in this PR.
- \`Criterion.direct\` / \`Criterion.transforming\` are static methods
  on \`Criterion\` (relocated from the old top-level \`Criteria\`
  factory class, which is superseded by the sealed interface).

## Test plan

- [x] \`./gradlew :punit-core:test\` — 1646 tests pass
- [x] \`./gradlew :punit-report:test :punit-sentinel:test\` — green
- [x] New \`CriteriaAsDataTest\` covers: bare-decl-as-Criteria,
      posture chain value-preservation, \`.where\` overloads,
      \`compose\` K=1/K>1, \`composeOf\`, duplicate-id rejection,
      default empty criteria, value-form override, coexistence
      rejection
- [x] ArchUnit + RequirementCodeIsolation rules green

🤖 Generated with [Claude Code](https://claude.com/claude-code)