### PR TITLE
Value-form polish: .satisfies + .transforming (DIR-CRITERIA-AS-DATA PR #2)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Composite.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Composite.java
@@ -39,7 +39,7 @@ public final class Composite {
      * One named entry in a {@link CompositeCriteria}: a criterion id
      * and the declaration that produces its verdict.
      */
-    public record Entry<O>(String id, CriterionDecl<O> decl) {
+    public record Entry<O>(String id, Decl<O> decl) {
         public Entry {
             Objects.requireNonNull(id, "id");
             if (id.isBlank()) {
@@ -51,19 +51,19 @@ public final class Composite {
     }
 
     /** Construct an {@link Entry} — the open-ended escape for {@link #composeOf}. */
-    public static <O> Entry<O> entry(String id, CriterionDecl<O> decl) {
+    public static <O> Entry<O> entry(String id, Decl<O> decl) {
         return new Entry<>(id, decl);
     }
 
     /** Compose a single named criterion (K=1 with an explicit id). */
-    public static <O> CompositeCriteria<O> compose(String id1, CriterionDecl<O> d1) {
+    public static <O> CompositeCriteria<O> compose(String id1, Decl<O> d1) {
         return new CompositeCriteria<>(List.of(new Entry<>(id1, d1)));
     }
 
     /** Compose two named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2)));
@@ -71,9 +71,9 @@ public final class Composite {
 
     /** Compose three named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),
@@ -82,10 +82,10 @@ public final class Composite {
 
     /** Compose four named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3,
-            String id4, CriterionDecl<O> d4) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3,
+            String id4, Decl<O> d4) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),
@@ -95,11 +95,11 @@ public final class Composite {
 
     /** Compose five named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3,
-            String id4, CriterionDecl<O> d4,
-            String id5, CriterionDecl<O> d5) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3,
+            String id4, Decl<O> d4,
+            String id5, Decl<O> d5) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),
@@ -110,12 +110,12 @@ public final class Composite {
 
     /** Compose six named criteria. */
     public static <O> CompositeCriteria<O> compose(
-            String id1, CriterionDecl<O> d1,
-            String id2, CriterionDecl<O> d2,
-            String id3, CriterionDecl<O> d3,
-            String id4, CriterionDecl<O> d4,
-            String id5, CriterionDecl<O> d5,
-            String id6, CriterionDecl<O> d6) {
+            String id1, Decl<O> d1,
+            String id2, Decl<O> d2,
+            String id3, Decl<O> d3,
+            String id4, Decl<O> d4,
+            String id5, Decl<O> d5,
+            String id6, Decl<O> d6) {
         return new CompositeCriteria<>(List.of(
                 new Entry<>(id1, d1),
                 new Entry<>(id2, d2),

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @param <O> the contract's per-sample output value type
  */
 public sealed interface Criteria<O>
-        permits CriterionDecl, CompositeCriteria, EmptyCriteria {
+        permits Decl, CompositeCriteria, EmptyCriteria {
 
     /**
      * Lower this declaration to the runtime {@link Criterion} list

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
@@ -52,7 +52,7 @@ import org.javai.punit.api.PostconditionCheck;
  *
  * @param <O> the contract's per-sample output value type
  */
-public final class CriterionDecl<O> implements Criteria<O> {
+public final class CriterionDecl<O> implements Decl<O> {
 
     private final CriterionPosture posture;
     private final List<NamedPostcondition<O>> postconditions;
@@ -77,9 +77,8 @@ public final class CriterionDecl<O> implements Criteria<O> {
      * for pass; the framework synthesises the failure message when
      * it returns {@code false}.
      *
-     * <p>Java's lambda inference picks this overload when the lambda
-     * body is a boolean expression; for richer failure messages use
-     * {@link #where(String, Function)}.
+     * <p>For richer failure messages — author-supplied symbolic name
+     * and message — use {@link #satisfies(String, Function)}.
      */
     public CriterionDecl<O> where(String name, Predicate<O> predicate) {
         Objects.requireNonNull(name, "name");
@@ -97,12 +96,14 @@ public final class CriterionDecl<O> implements Criteria<O> {
     /**
      * Add a named postcondition that returns its own {@link Outcome}.
      * Use this overload when the failure message benefits from
-     * diagnostic detail (offending input, parse error, etc.).
+     * diagnostic detail (offending input, parse error, etc.) —
+     * {@code Outcome.fail("symbolic-name", "message")} flows through to
+     * the verdict's failure histogram unchanged.
      */
-    public CriterionDecl<O> where(String name, Function<O, Outcome<?>> check) {
+    public CriterionDecl<O> satisfies(String name, Function<O, Outcome<?>> check) {
         Objects.requireNonNull(name, "name");
         if (name.isBlank()) {
-            throw new IllegalArgumentException(".where(name, ...) requires a non-blank name");
+            throw new IllegalArgumentException(".satisfies(name, ...) requires a non-blank name");
         }
         Objects.requireNonNull(check, "check");
         PostconditionCheck<O> adapted = v -> {
@@ -155,18 +156,58 @@ public final class CriterionDecl<O> implements Criteria<O> {
         return new CriterionDecl<>(posture.withPower(power), postconditions);
     }
 
+    /**
+     * Chain a transform — parse, project, derive — that produces a
+     * value of a different type {@code T} the criterion's
+     * postconditions will check. Returns a {@link TransformingDecl}
+     * whose {@code .where(...)} and {@code .satisfies(...)} operate
+     * on {@code T}, not on the contract's output {@code O}.
+     *
+     * <p>Transform semantics:
+     * <ul>
+     *   <li>Transform returns {@link Outcome.Ok Ok(t)} — the
+     *       postcondition chain runs against {@code t}; criterion
+     *       sample is PASS / FAIL based on the chain.</li>
+     *   <li>Transform returns {@link Outcome.Fail Fail(...)} or throws
+     *       — criterion sample is
+     *       {@link CriterionSampleOutcome#INCONCLUSIVE INCONCLUSIVE};
+     *       the postcondition chain is skipped. The failure's
+     *       symbolic name and message flow through to the per-sample
+     *       record for diagnostics.</li>
+     * </ul>
+     *
+     * <p>Posture stays attached to the outer (this) decl; postconditions
+     * already attached here are <em>not</em> carried forward to the
+     * returned {@code TransformingDecl} — postconditions must be
+     * stated either pre-transform (on this decl, via
+     * {@code .where} / {@code .satisfies}) or post-transform
+     * (on the returned decl), not both. Mixing pre- and
+     * post-transform postconditions is a misuse and is rejected.
+     *
+     * @param <T> the derived value type the postcondition chain
+     *            evaluates against on successful transform
+     */
+    public <T> TransformingDecl<O, T> transforming(Function<O, Outcome<T>> transform) {
+        Objects.requireNonNull(transform, "transform");
+        if (!postconditions.isEmpty()) {
+            throw new IllegalStateException(
+                    ".transforming(...) cannot follow .where/.satisfies on the same"
+                            + " criterion decl: postconditions are evaluated either"
+                            + " against the contract's output or against the"
+                            + " transformed value, not both. Either drop the"
+                            + " pre-transform postconditions, or split into two"
+                            + " criteria via Composite.compose(...).");
+        }
+        return new TransformingDecl<>(posture, transform, List.of());
+    }
+
     @Override
     public List<Criterion<O>> asList() {
         return List.of(toRuntime(Composite.DEFAULT_CRITERION_ID));
     }
 
-    /**
-     * Lower this decl to a runtime {@link Criterion} with the given
-     * id. Called by {@link CompositeCriteria} when assembling the
-     * multi-criterion list and by {@link #asList()} for the K=1
-     * default-id case.
-     */
-    Criterion<O> toRuntime(String id) {
+    @Override
+    public Criterion<O> toRuntime(String id) {
         Criterion<O> base = Criterion.direct(id, this::populatePostconditions);
         if (base instanceof DirectCriterion<O> direct) {
             return direct.withPosture(posture);

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
@@ -1,0 +1,29 @@
+package org.javai.punit.api.criterion;
+
+/**
+ * A single-criterion declaration — direct or transforming — that can
+ * be lowered to one runtime {@link Criterion} given an id.
+ *
+ * <p>The sealed supertype shared by {@link CriterionDecl} (direct,
+ * postconditions over the contract's output type {@code O}) and
+ * {@link TransformingDecl} (postconditions over a derived type
+ * {@code T} after a transform). It is the parameter type accepted by
+ * {@link Composite#compose(String, Decl) compose(...)} and
+ * {@link Composite#entry(String, Decl) entry(...)} so a composite may
+ * mix direct and transforming criteria.
+ *
+ * <p>Authors rarely reference this type by name — call-site idiom is
+ * {@code compose("a", meeting(0.99, SLA), "b", empirical().transforming(parse).where(...))}
+ * and inference picks {@code Decl<O>} as the unified type.
+ *
+ * @param <O> the contract's per-sample output value type
+ */
+public sealed interface Decl<O> extends Criteria<O>
+        permits CriterionDecl, TransformingDecl {
+
+    /**
+     * Lower this declaration to a runtime {@link Criterion} with the
+     * given id. Framework-internal; authors do not call this directly.
+     */
+    Criterion<O> toRuntime(String id);
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingDecl.java
@@ -1,0 +1,128 @@
+package org.javai.punit.api.criterion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.PostconditionCheck;
+
+/**
+ * A value-form criterion decl whose postcondition chain is evaluated
+ * against a transformed value, not against the contract's raw output.
+ * Returned by {@link CriterionDecl#transforming(Function)}.
+ *
+ * <p>The criterion's posture lives on the parent {@link CriterionDecl}
+ * (the type-witness {@code <O>} is the contract's output type).
+ * The criterion's postconditions live here (the type-witness {@code <T>}
+ * is the transformed value type the postconditions see).
+ *
+ * <p>Transform failure ({@link Outcome.Fail}) or a thrown exception
+ * classifies the criterion's per-sample outcome as
+ * {@link CriterionSampleOutcome#INCONCLUSIVE INCONCLUSIVE} —
+ * <em>distinct</em> from FAIL. The postcondition chain is not
+ * evaluated; the parse / projection failure flows through to the
+ * per-sample record with its symbolic name and message preserved.
+ *
+ * @param <O> the contract's per-sample output value type
+ * @param <T> the transformed value type the postconditions evaluate
+ *            against
+ */
+public final class TransformingDecl<O, T> implements Decl<O> {
+
+    private final CriterionPosture posture;
+    private final Function<O, Outcome<T>> transform;
+    private final List<NamedPostcondition<T>> postconditions;
+
+    TransformingDecl(
+            CriterionPosture posture,
+            Function<O, Outcome<T>> transform,
+            List<NamedPostcondition<T>> postconditions) {
+        this.posture = Objects.requireNonNull(posture, "posture");
+        this.transform = Objects.requireNonNull(transform, "transform");
+        this.postconditions = List.copyOf(postconditions);
+    }
+
+    /** The posture inherited from the parent {@link CriterionDecl}. */
+    public CriterionPosture posture() {
+        return posture;
+    }
+
+    /** Named post-transform postconditions in declaration order. May be empty. */
+    public List<NamedPostcondition<T>> postconditions() {
+        return postconditions;
+    }
+
+    /**
+     * Add a named postcondition over the transformed value. The
+     * predicate returns {@code true} for pass; the framework
+     * synthesises the failure message when it returns {@code false}.
+     *
+     * <p>For richer failure messages use
+     * {@link #satisfies(String, Function)}.
+     */
+    public TransformingDecl<O, T> where(String name, Predicate<T> predicate) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".where(name, ...) requires a non-blank name");
+        }
+        Objects.requireNonNull(predicate, "predicate");
+        PostconditionCheck<T> wrapped = v -> predicate.test(v)
+                ? Outcome.ok()
+                : Outcome.fail(name,
+                        "postcondition '" + name + "' returned false for value: " + v);
+        return appendPostcondition(name, wrapped);
+    }
+
+    /**
+     * Add a named postcondition over the transformed value that
+     * returns its own {@link Outcome}. Use this when the failure
+     * message benefits from diagnostic detail.
+     */
+    public TransformingDecl<O, T> satisfies(String name, Function<T, Outcome<?>> check) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".satisfies(name, ...) requires a non-blank name");
+        }
+        Objects.requireNonNull(check, "check");
+        PostconditionCheck<T> adapted = v -> {
+            Outcome<?> result = check.apply(v);
+            return switch (result) {
+                case Outcome.Ok<?> ok -> Outcome.ok();
+                case Outcome.Fail<?> fail -> Outcome.fail(fail.failure());
+            };
+        };
+        return appendPostcondition(name, adapted);
+    }
+
+    @Override
+    public List<Criterion<O>> asList() {
+        return List.of(toRuntime(Composite.DEFAULT_CRITERION_ID));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Criterion<O> toRuntime(String id) {
+        Criterion<O> base = Criterion.transforming(id, transform, this::populatePostconditions);
+        if (base instanceof TransformingCriterion<?, ?> tc) {
+            return ((TransformingCriterion<O, T>) tc).withPosture(posture);
+        }
+        return base;
+    }
+
+    private void populatePostconditions(PostconditionBuilder<T> pb) {
+        for (NamedPostcondition<T> p : postconditions) {
+            pb.ensure(p.name(), p.check());
+        }
+    }
+
+    private TransformingDecl<O, T> appendPostcondition(String name, PostconditionCheck<T> check) {
+        List<NamedPostcondition<T>> next = new ArrayList<>(postconditions.size() + 1);
+        next.addAll(postconditions);
+        next.add(new NamedPostcondition<>(name, check));
+        return new TransformingDecl<>(posture, transform, next);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
@@ -6,7 +6,6 @@ import static org.javai.punit.api.criterion.Composite.compose;
 import static org.javai.punit.api.criterion.Composite.composeOf;
 import static org.javai.punit.api.criterion.Composite.entry;
 
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.javai.outcome.Outcome;
@@ -63,17 +62,99 @@ class CriteriaAsDataTest {
     }
 
     @Test
-    @DisplayName(".where(name, Function<O, Outcome<?>>) — author-supplied message preserved verbatim")
-    void whereRichFunctionPreservesMessage() {
-        Function<String, Outcome<?>> parseable = v -> Outcome.fail("notJson", "v=" + v);
+    @DisplayName(".satisfies(name, Function<O, Outcome<?>>) — author-supplied message preserved verbatim")
+    void satisfiesRichFunctionPreservesMessage() {
         CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
-                .where("parseable", parseable);
+                .satisfies("parseable", v -> Outcome.fail("notJson", "v=" + v));
 
         Outcome<?> result = decl.postconditions().get(0).check().check("garbage");
         assertThat(result).isInstanceOf(Outcome.Fail.class);
         Outcome.Fail<?> fail = (Outcome.Fail<?>) result;
         assertThat(fail.failure().id().name()).isEqualTo("notJson");
         assertThat(fail.failure().message()).isEqualTo("v=garbage");
+    }
+
+    @Test
+    @DisplayName(".satisfies takes a bare lambda — no overload ambiguity, no type-witness needed")
+    void satisfiesDisambiguatedWithoutHelp() {
+        // The key Finding #1 regression-guard: a slide-friendly lambda
+        // with a generic Outcome.fail in its body must compile without
+        // a cast or a typed local.
+        CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+                .satisfies("transaction succeeds", r -> r.startsWith("OK")
+                        ? Outcome.ok()
+                        : Outcome.fail("transaction-failed", "got=" + r));
+
+        Outcome<?> okResult = decl.postconditions().get(0).check().check("OK-123");
+        assertThat(okResult).isInstanceOf(Outcome.Ok.class);
+        Outcome<?> failResult = decl.postconditions().get(0).check().check("ERR-500");
+        assertThat(failResult).isInstanceOf(Outcome.Fail.class);
+    }
+
+    @Test
+    @DisplayName(".transforming(parse).where/.satisfies — postconditions evaluate against derived value")
+    void transformingChainEvaluatesAgainstDerived() {
+        TransformingDecl<String, Integer> decl = Posture.<String>empirical()
+                .transforming(s -> {
+                    try {
+                        return Outcome.ok(Integer.parseInt(s));
+                    } catch (NumberFormatException e) {
+                        return Outcome.fail("not-a-number", "s=" + s);
+                    }
+                })
+                .where("positive", n -> n > 0)
+                .satisfies("even", n -> n % 2 == 0
+                        ? Outcome.ok()
+                        : Outcome.fail("odd", "n=" + n));
+
+        assertThat(decl.postconditions()).hasSize(2);
+
+        Criterion<String> rt = decl.toRuntime("parsed-number");
+        assertThat(rt.id()).isEqualTo("parsed-number");
+        assertThat(rt.posture().kind()).isEqualTo(CriterionPosture.Kind.STATISTICAL_EMPIRICAL);
+
+        // Successful transform → postcondition chain runs
+        assertThat(rt.evaluate("4").outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+        // Transform ok, postcondition fails → FAIL
+        assertThat(rt.evaluate("3").outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
+        // Transform fails → INCONCLUSIVE (chain skipped)
+        CriterionSampleResult parseFail = rt.evaluate("xyz");
+        assertThat(parseFail.outcome()).isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
+        assertThat(parseFail.reason()).isPresent();
+        assertThat(parseFail.reason().get().failure().id().name()).isEqualTo("not-a-number");
+    }
+
+    @Test
+    @DisplayName(".transforming(...) rejects pre-transform postconditions on the same decl")
+    void transformingRejectsPreTransformPostconditions() {
+        org.assertj.core.api.Assertions.assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> Posture.<String>empirical()
+                        .where("non-empty", s -> !s.isEmpty())
+                        .transforming(s -> Outcome.ok(Integer.parseInt(s))))
+                .withMessageContaining(".transforming");
+    }
+
+    @Test
+    @DisplayName("compose mixes direct and transforming criteria under one composite")
+    void composeMixesDirectAndTransforming() {
+        Criteria<String> c = compose(
+                "response-not-empty", Posture.<String>empirical()
+                        .where("non-blank", s -> !s.isBlank()),
+                "parses", Posture.<String>empirical()
+                        .transforming(s -> {
+                            try {
+                                return Outcome.ok(Integer.parseInt(s));
+                            } catch (NumberFormatException e) {
+                                return Outcome.fail("not-a-number", "s=" + s);
+                            }
+                        })
+                        .where("positive", n -> n > 0));
+
+        assertThat(c.asList()).hasSize(2);
+        assertThat(c.asList().get(0).id()).isEqualTo("response-not-empty");
+        assertThat(c.asList().get(1).id()).isEqualTo("parses");
+        assertThat(c.asList().get(1).evaluate("nope").outcome())
+                .isEqualTo(CriterionSampleOutcome.INCONCLUSIVE);
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #2 of DIR-CRITERIA-AS-DATA-punit. Two value-form fixes surfaced
by a migration spike against \`punitexamples\`:

- Finding #1 — \`.where\` overload ambiguity was a slide-killer.
- Finding #3 — transforming-criterion gap blocks shopping-basket
  migration.

Stacked on PR #181 (\`feature/criteria-as-data-pr1\`).

## What's new

- \`.satisfies(name, Function<O, Outcome<?>>)\` replaces the rich-form
  \`.where(name, Function<O, Outcome<?>>)\`. \`.where(name, Predicate<O>)\`
  is unchanged. The two names disambiguate without any cast or typed
  local — slide-clean.
- \`CriterionDecl<O>.transforming(Function<O, Outcome<T>>)\` returns a
  new \`TransformingDecl<O, T>\` whose \`.where(Predicate<T>)\` and
  \`.satisfies(Function<T, Outcome<?>>)\` operate on the transformed
  value. Posture stays on the parent. INCONCLUSIVE-on-failed-transform
  semantics preserved end-to-end via the existing
  \`TransformingCriterion\` runtime.
- New sealed interface \`Decl<O> extends Criteria<O>\` shared by
  \`CriterionDecl\` and \`TransformingDecl\`. \`Composite.compose(...)\`
  and \`Composite.Entry\` take \`Decl<O>\` so a composite may mix direct
  and transforming criteria — required by the shopping-basket
  pedagogy.
- Mixing pre-transform postconditions with \`.transforming(...)\` on
  the same decl is rejected at construction with a diagnostic message
  pointing to \`Composite.compose(...)\` as the split.

## Slide / pedagogy preview

K=1 (payment):

\`\`\`java
@Override public Criteria<PaymentResult> criteria() {
    return meeting(0.99, SLA)
            .contractRef(\"Acme Payment SLA v3.2 §4.1\")
            .satisfies(\"transaction succeeds\", r -> r.success()
                    ? Outcome.ok()
                    : Outcome.fail(\"transaction-failed\", \"errorCode=\" + r.errorCode()));
}
\`\`\`

K=2 (shopping basket, transforming):

\`\`\`java
@Override public Criteria<String> criteria() {
    return compose(
        \"response-not-empty\", empirical()
                .satisfies(\"non-empty\", checkResponseNotEmpty),
        \"valid-json\", empirical()
                .transforming(ShoppingActionValidator::parse)
                .satisfies(\"actions valid\", checkActionsValidForContext)
                .satisfies(\"quantities positive\", checkQuantitiesArePositiveIntegers));
}
\`\`\`

## What's out of scope

- Finding #2 (type-inference through \`compose(...)\`) — bites K>1
  only; the slide is K=1. Tracked as a follow-on.
- Migration of \`punit-core\` authoring sites or \`punitexamples\`.
  Those happen in PR #3 (formerly #2 in the directive's numbering).
- Retirement of the builder form. That happens in PR #4 (formerly #3).

## Test plan

- [x] \`./gradlew :punit-core:test :punit-report:test :punit-sentinel:test\` — green
- [x] New tests in \`CriteriaAsDataTest\`:
      - \`satisfiesRichFunctionPreservesMessage\`
      - \`satisfiesDisambiguatedWithoutHelp\` (Finding #1 regression-guard)
      - \`transformingChainEvaluatesAgainstDerived\` (covers PASS / FAIL / INCONCLUSIVE)
      - \`transformingRejectsPreTransformPostconditions\`
      - \`composeMixesDirectAndTransforming\` (mixed-shape composite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)