### PR TITLE
Migrate punit-core authoring sites to value-form (DIR-CRITERIA-AS-DATA PR #3)

### DIFF
--- a/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
@@ -4,9 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Contract;
-import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.PostconditionResult;
 import org.javai.punit.api.ServiceContractOutcome;
+import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
 import org.junit.jupiter.api.Test;
 
@@ -26,24 +26,19 @@ class InconclusiveFoldsIntoFailTest {
         }
 
         @Override
-        public void postconditions(PostconditionBuilder<String> b) {
-            // Empty — the explicit criteria carry the postconditions.
-        }
-
-        @Override
-        public void criteria(CriteriaBuilder<String> b) {
-            b.add(Criterion.transforming(
-                    "parsed-positive",
-                    s -> {
-                        try {
-                            return Outcome.ok(Integer.parseInt(s));
-                        } catch (NumberFormatException e) {
-                            return Outcome.fail("parse-error", "not a number: " + s);
-                        }
-                    },
-                    cb -> cb.ensure("positive", (Integer n) -> n > 0
-                            ? Outcome.ok()
-                            : Outcome.fail("non-positive", "n=" + n))));
+        public Criteria<String> criteria() {
+            return Composite.compose("parsed-positive",
+                    Posture.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                            .transforming(s -> {
+                                try {
+                                    return Outcome.ok(Integer.parseInt(s));
+                                } catch (NumberFormatException e) {
+                                    return Outcome.fail("parse-error", "not a number: " + s);
+                                }
+                            })
+                            .satisfies("positive", (Integer n) -> n > 0
+                                    ? Outcome.ok()
+                                    : Outcome.fail("non-positive", "n=" + n)));
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
@@ -7,7 +7,8 @@ import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
@@ -38,9 +39,8 @@ class AutoInjectionFromPostureTest {
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker t) {
                 return Outcome.ok(true);
             }
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { })
-                        .meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
         };
 
@@ -63,9 +63,8 @@ class AutoInjectionFromPostureTest {
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker t) {
                 return Outcome.fail("nope", "never passes");
             }
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { })
-                        .meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
         };
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
@@ -3,7 +3,8 @@ package org.javai.punit.internal.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -37,8 +38,8 @@ class EarlyTerminationIntegrationTest {
 
     /** Returns Outcome.ok every sample. Contract posture: meeting(0.5, SLA). */
     private static class AlwaysPass implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.5, ThresholdOrigin.SLA);
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.meeting(0.5, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -47,8 +48,8 @@ class EarlyTerminationIntegrationTest {
 
     /** Always-pass variant whose contract posture is meeting(0.20, SLA). */
     private static class AlwaysPassLowThreshold implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.20, ThresholdOrigin.SLA);
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.meeting(0.20, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -57,8 +58,8 @@ class EarlyTerminationIntegrationTest {
 
     /** Always-pass variant whose contract posture is empirical. */
     private static class AlwaysPassEmpirical implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).empirical();
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.empirical();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -67,8 +68,8 @@ class EarlyTerminationIntegrationTest {
 
     /** Returns Outcome.fail every sample — a clean failure-inevitable shape. */
     private static class AlwaysFail implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.meeting(0.95, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure");
@@ -84,8 +85,8 @@ class EarlyTerminationIntegrationTest {
         private final int failsFirst;
         private int seen = 0;
         FailsThenPasses(int failsFirst) { this.failsFirst = failsFirst; }
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.80, ThresholdOrigin.SLA);
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.meeting(0.80, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return ++seen <= failsFirst

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -12,7 +12,8 @@ import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
@@ -37,8 +38,8 @@ class EmpiricalEndToEndIntegrationTest {
     private static final String USE_CASE_ID = "always-passes-use-case";
 
     static class AlwaysPassesServiceContract implements ServiceContract<Factors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).empirical();
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.empirical();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -14,7 +14,8 @@ import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.ValueMatcher;
 import org.javai.punit.api.spec.TerminationReason;
 import org.javai.punit.api.PostconditionBuilder;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -265,8 +266,8 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: custom matcher drives the verdict's pass-rate criterion")
     void testPathInstanceConformanceUsesCustomMatcher() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<String> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -302,8 +303,8 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: expectedOutputs without explicit matcher defaults to equality")
     void testPathDefaultsToEqualityMatcher() {
         ServiceContract<LlmFactors, String, String> upperCase = new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.4, ThresholdOrigin.SLA);
+            @Override public Criteria<String> criteria() {
+                return Posture.meeting(0.4, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.toUpperCase());
@@ -333,8 +334,8 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: matcher configured on Sampling.Builder.matching(...) drives the verdict")
     void testPathPropagatesMatcherFromSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<String> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -398,8 +399,8 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: spec-builder matcher overrides the matcher carried on Sampling")
     void testPathSpecBuilderMatcherOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<String> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -469,8 +470,8 @@ class EngineIntegrationTest {
     @DisplayName("ProbabilisticTest: spec-builder expectedOutputs overrides the expected list carried on Sampling")
     void testPathSpecBuilderExpectedOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<String> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -865,8 +866,8 @@ class EngineIntegrationTest {
     // ── Test doubles ────────────────────────────────────────────────
 
     private static class AlwaysPassesServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.meeting(0.95, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -875,8 +876,8 @@ class EngineIntegrationTest {
 
     /** Empirical-posture sibling of {@link AlwaysPassesServiceContract} for the empirical-path test. */
     private static class AlwaysPassesEmpiricalServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).empirical();
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.empirical();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -885,8 +886,8 @@ class EngineIntegrationTest {
 
     /** Returns business-level Fail outcomes — the "contract didn't hold" signal. */
     private static class AlwaysReturnsFailServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
-        @Override public void criteria(CriteriaBuilder<Boolean> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLO);
+        @Override public Criteria<Boolean> criteria() {
+            return Posture.meeting(0.95, ThresholdOrigin.SLO);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure for input " + input);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -9,7 +9,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.PostconditionBuilder;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Pacing;
 import org.javai.punit.api.Sampling;
@@ -396,8 +397,8 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("mixed criteria: functional PASS + latency FAIL composes to FAIL when both REQUIRED")
     void mixedCriteriaBothRequiredComposesToFail() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
@@ -426,8 +427,8 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     @DisplayName("reportOnly latency: functional PASS + latency FAIL(report-only) composes to PASS")
     void reportOnlyLatencyExcludedFromComposition() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
@@ -10,7 +10,8 @@ import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.PostconditionBuilder;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -40,14 +41,13 @@ class PostconditionFailureHistogramTest {
         @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
-        @Override public void criteria(CriteriaBuilder<Integer> b) {
-            b.addCriterion("contract", pb -> {
-                pb.ensure("alwaysFails", v ->
-                        Outcome.fail("alwaysFails-mode", "input was " + v));
-                pb.ensure("evenFails", v -> v % 2 == 0
-                        ? Outcome.fail("even-mode", "input " + v + " is even")
-                        : Outcome.ok());
-            }).meeting(0.5, org.javai.punit.api.ThresholdOrigin.SLA);
+        @Override public Criteria<Integer> criteria() {
+            return Posture.<Integer>meeting(0.5, org.javai.punit.api.ThresholdOrigin.SLA)
+                    .satisfies("alwaysFails", v ->
+                            Outcome.fail("alwaysFails-mode", "input was " + v))
+                    .satisfies("evenFails", v -> v % 2 == 0
+                            ? Outcome.fail("even-mode", "input " + v + " is even")
+                            : Outcome.ok());
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
@@ -13,7 +13,9 @@ import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Composite;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
@@ -46,11 +48,12 @@ class SampleSizeResolverTest {
             @Override public Outcome<String> invoke(String input, TokenTracker t) {
                 return Outcome.ok(input);
             }
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("the-criterion", pb -> pb.ensure("always", v -> Outcome.ok()))
-                        .empirical()
-                        .detectingMde(mde)
-                        .atPower(power);
+            @Override public Criteria<String> criteria() {
+                return Composite.compose("the-criterion",
+                        Posture.<String>empirical()
+                                .detectingMde(mde)
+                                .atPower(power)
+                                .satisfies("always", v -> Outcome.ok()));
             }
         };
     }
@@ -61,9 +64,10 @@ class SampleSizeResolverTest {
             @Override public Outcome<String> invoke(String input, TokenTracker t) {
                 return Outcome.ok(input);
             }
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("threshold-criterion", pb -> pb.ensure("always", v -> Outcome.ok()))
-                        .meeting(0.90, ThresholdOrigin.SLA);
+            @Override public Criteria<String> criteria() {
+                return Composite.compose("threshold-criterion",
+                        Posture.<String>meeting(0.90, ThresholdOrigin.SLA)
+                                .satisfies("always", v -> Outcome.ok()));
             }
         };
     }
@@ -159,11 +163,14 @@ class SampleSizeResolverTest {
             @Override public Outcome<String> invoke(String input, TokenTracker t) {
                 return Outcome.ok(input);
             }
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.addCriterion("loose", pb -> pb.ensure("always", v -> Outcome.ok()))
-                        .empirical().detectingMde(0.10).atPower(0.50);
-                b.addCriterion("tight", pb -> pb.ensure("always", v -> Outcome.ok()))
-                        .empirical().detectingMde(0.02).atPower(0.95);
+            @Override public Criteria<String> criteria() {
+                return Composite.compose(
+                        "loose", Posture.<String>empirical()
+                                .detectingMde(0.10).atPower(0.50)
+                                .satisfies("always", v -> Outcome.ok()),
+                        "tight", Posture.<String>empirical()
+                                .detectingMde(0.02).atPower(0.95)
+                                .satisfies("always", v -> Outcome.ok()));
             }
         };
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
@@ -6,7 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.Experiment;
@@ -21,8 +22,8 @@ class InlineSamplingFormTest {
     record Factors(String label) {}
 
     private static final ServiceContract<Factors, String, String> ECHO = new ServiceContract<>() {
-        @Override public void criteria(CriteriaBuilder<String> b) {
-            b.addCriterion("contract", pb -> { /* none */ }).meeting(0.95, ThresholdOrigin.SLA);
+        @Override public Criteria<String> criteria() {
+            return Posture.meeting(0.95, ThresholdOrigin.SLA);
         }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
@@ -13,8 +13,10 @@ import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
-import org.javai.punit.api.criterion.Criterion;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.criterion.Composite;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.internal.engine.Engine;
@@ -139,14 +141,15 @@ class OptimizeOutputWriterTest {
         ServiceContract<LlmFactors, String, String> contract = new ServiceContract<>() {
             @Override public String id() { return "two-criterion-contract"; }
             @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
-            @Override public void criteria(CriteriaBuilder<String> b) {
-                b.add(Criterion.direct("always-passes",
-                        cb -> cb.ensure("passes", v -> Outcome.ok())));
-                b.add(Criterion.direct("starts-with-a",
-                        cb -> cb.ensure("first-char-a", v ->
-                                v.startsWith("a")
-                                        ? Outcome.ok()
-                                        : Outcome.fail("no-a", "input " + v))));
+            @Override public Criteria<String> criteria() {
+                return Composite.compose(
+                        "always-passes", Posture.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                                .satisfies("passes", v -> Outcome.ok()),
+                        "starts-with-a", Posture.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                                .satisfies("first-char-a", v ->
+                                        v.startsWith("a")
+                                                ? Outcome.ok()
+                                                : Outcome.fail("no-a", "input " + v)));
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -5,10 +5,11 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -40,8 +41,8 @@ public final class CovariateSubjects {
      */
     private static ServiceContract<NoFactors, Integer, Boolean> covariateServiceContract() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -1,10 +1,11 @@
 package org.javai.punit.junit5.testsubjects;
 
 import org.javai.outcome.Outcome;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -27,8 +28,8 @@ public final class FeasibilitySubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesEmpirical() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -39,8 +40,8 @@ public final class FeasibilitySubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesContractual() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.9999, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.9999, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -4,7 +4,8 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -35,8 +36,8 @@ public final class PUnitSubjects {
 
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesContractual() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.5, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.5, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -49,8 +50,8 @@ public final class PUnitSubjects {
 
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesEmpirical() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -61,8 +62,8 @@ public final class PUnitSubjects {
 
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFails() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.5, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.5, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.fail("nope", "always fails");
@@ -75,9 +76,8 @@ public final class PUnitSubjects {
 
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesWithContractRef() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ })
-                        .meeting(0.5, ThresholdOrigin.SLA)
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.<Boolean>meeting(0.5, ThresholdOrigin.SLA)
                         .contractRef(CONTRACT_REF_FIXTURE);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
@@ -89,9 +89,8 @@ public final class PUnitSubjects {
 
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFailsWithContractRef() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ })
-                        .meeting(0.5, ThresholdOrigin.SLA)
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.<Boolean>meeting(0.5, ThresholdOrigin.SLA)
                         .contractRef(CONTRACT_REF_FIXTURE);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
@@ -3,9 +3,10 @@ package org.javai.punit.junit5.testsubjects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.javai.outcome.Outcome;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
-import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -35,8 +36,8 @@ public final class PreflightInvariantSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> countingEmpirical() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
@@ -48,8 +49,8 @@ public final class PreflightInvariantSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> countingContractualHighThreshold() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).meeting(0.9999, ThresholdOrigin.SLA);
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.meeting(0.9999, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
@@ -5,7 +5,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -30,8 +31,8 @@ public final class PreflightSubjects {
     /** Always-passing service contract that records every invocation. */
     private static ServiceContract<NoFactors, Integer, Boolean> countingServiceContract() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -1,9 +1,10 @@
 package org.javai.punit.junit5.testsubjects;
 
 import org.javai.outcome.Outcome;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.criterion.CriteriaBuilder;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -27,8 +28,8 @@ public final class RoundTripSubjects {
 
     private static ServiceContract<NoFactors, Integer, Boolean> serviceContract() {
         return new ServiceContract<>() {
-            @Override public void criteria(CriteriaBuilder<Boolean> b) {
-                b.addCriterion("contract", pb -> { /* none */ }).empirical();
+            @Override public Criteria<Boolean> criteria() {
+                return Posture.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -8,7 +8,8 @@ import java.util.Map;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.PostconditionBuilder;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -55,11 +56,10 @@ class LatencyEverywhereIntegrationTest {
         @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input.length());
         }
-        @Override public void criteria(CriteriaBuilder<Integer> b) {
-            b.addCriterion("contract", pb ->
-                    pb.ensure("length is even", n ->
-                            n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "length=" + n)))
-                    .meeting(0.5, ThresholdOrigin.SLA);
+        @Override public Criteria<Integer> criteria() {
+            return Posture.<Integer>meeting(0.5, ThresholdOrigin.SLA)
+                    .satisfies("length is even", n ->
+                            n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "length=" + n));
         }
     }
 

--- a/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
@@ -5,7 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.javai.outcome.Outcome;
-import org.javai.punit.api.criterion.CriteriaBuilder;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.criterion.Posture;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
@@ -65,10 +66,9 @@ class MultiDimensionVerdictIntegrationTest {
             sleep(SLEEP_MS);
             return Outcome.ok(input.length());
         }
-        @Override public void criteria(CriteriaBuilder<Integer> b) {
-            b.addCriterion("contract", pb ->
-                    pb.ensure("non-null length", n -> Outcome.ok()))
-                    .meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA);
+        @Override public Criteria<Integer> criteria() {
+            return Posture.<Integer>meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA)
+                    .satisfies("non-null length", n -> Outcome.ok());
         }
     }
 
@@ -84,11 +84,10 @@ class MultiDimensionVerdictIntegrationTest {
             sleep(SLEEP_MS);
             return Outcome.ok(input.length());
         }
-        @Override public void criteria(CriteriaBuilder<Integer> b) {
-            b.addCriterion("contract", pb ->
-                    pb.ensure("length is even", n ->
-                            n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "n=" + n)))
-                    .meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA);
+        @Override public Criteria<Integer> criteria() {
+            return Posture.<Integer>meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA)
+                    .satisfies("length is even", n ->
+                            n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "n=" + n));
         }
     }
 


### PR DESCRIPTION
## Summary

PR #3 of DIR-CRITERIA-AS-DATA-punit. 18 punit-core test files
migrated off \`criteria(CriteriaBuilder<O>)\` onto the value-form
\`Criteria<O> criteria()\` introduced by PR #181 (and polished by
PR #182's \`.satisfies\` / \`.transforming\`).

This PR is the boring application of the value-form patterns to
punit-core's own test sites. The builder-form remains in place — it
is retired in PR #4.

## Migration patterns applied

K=1 bare-decl with a posture:
\`\`\`java
@Override public Criteria<Integer> criteria() {
    return Posture.<Integer>meeting(0.5, ThresholdOrigin.SLA)
            .satisfies(\"length is even\", n ->
                    n % 2 == 0 ? Outcome.ok() : Outcome.fail(\"odd-length\", \"length=\" + n));
}
\`\`\`

K>1 composite (SampleSizeResolverTest, OptimizeOutputWriterTest):
\`\`\`java
@Override public Criteria<String> criteria() {
    return Composite.compose(
            \"loose\", Posture.<String>empirical().detectingMde(0.10).atPower(0.50)
                    .satisfies(\"always\", v -> Outcome.ok()),
            \"tight\", Posture.<String>empirical().detectingMde(0.02).atPower(0.95)
                    .satisfies(\"always\", v -> Outcome.ok()));
}
\`\`\`

K=1 transforming (InconclusiveFoldsIntoFailTest):
\`\`\`java
@Override public Criteria<String> criteria() {
    return Composite.compose(\"parsed-positive\",
            Posture.<String>zeroTolerance(ThresholdOrigin.POLICY)
                    .transforming(s -> ...)
                    .satisfies(\"positive\", n -> ...));
}
\`\`\`

## Builder-form sites retained for PR #4

Four sites still use \`criteria(CriteriaBuilder<O>)\`, each by design
— they test the legacy authoring path itself, not the contracts that
use it:

- \`ImplicitZeroToleranceTest\` — covers the no-posture-method
  shortcut on the builder. Value-form has no equivalent (postures
  are explicit). Deleted in PR #4 along with the builder.
- \`CriterionShimTest\` — tests the shim and coexistence-rejection
  of the two authoring forms. Deleted in PR #4.
- \`CriteriaAsDataTest.coexistenceRejected\` — verifies the
  value-form correctly rejects builder + value-form on the same
  contract. That subset is deleted in PR #4; the rest stays.

## Test plan

- [x] \`./gradlew :punit-core:test :punit-report:test :punit-sentinel:test\` — green
- [x] No semantic changes; only authoring-surface migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)