### PR TITLE
Rename author-facing Posture factory class to Acceptance

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -128,7 +128,7 @@ public interface Contract<I, O> {
      * verdict-producing strategy. The intended idiom:
      *
      * <pre>{@code
-     * import static org.javai.punit.api.criterion.Posture.*;
+     * import static org.javai.punit.api.criterion.Acceptance.*;
      * import static org.javai.punit.api.criterion.Composite.*;
      *
      * @Override public Criteria<Receipt> criteria() {

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Acceptance.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Acceptance.java
@@ -5,12 +5,14 @@ import java.util.List;
 import org.javai.punit.api.ThresholdOrigin;
 
 /**
- * Posture factories — the starting point for every
- * {@link CriterionDecl}.
+ * Acceptance-mode factories — the starting point for every
+ * {@link CriterionDecl}. Each factory expresses how a criterion
+ * resolves to a verdict: a contractual threshold to be met
+ * ({@code meeting}), a baseline-derived threshold to be matched
+ * ({@code empirical}), or zero tolerance for failed samples
+ * ({@code zeroTolerance}).
  *
- * <p>Each factory returns a {@code CriterionDecl<O>} whose
- * {@link CriterionPosture} is the corresponding verdict-producing
- * strategy. The author then chains
+ * <p>The author then chains
  * {@link CriterionDecl#where(String, java.util.function.Predicate)
  * .where(...)},
  * {@link CriterionDecl#contractRef(String) .contractRef(...)},
@@ -18,17 +20,17 @@ import org.javai.punit.api.ThresholdOrigin;
  * to refine the declaration.
  *
  * <p>Statically imported, the call site reads {@code meeting(0.85, SLA)}
- * — not {@code Posture.meeting(...)}. The class is a container for
+ * — not {@code Acceptance.meeting(...)}. The class is a container for
  * autocomplete navigation; the static import is the canonical
  * idiom:
  *
  * <pre>{@code
- * import static org.javai.punit.api.criterion.Posture.*;
+ * import static org.javai.punit.api.criterion.Acceptance.*;
  * }</pre>
  */
-public final class Posture {
+public final class Acceptance {
 
-    private Posture() { /* utility class */ }
+    private Acceptance() { /* utility class */ }
 
     /**
      * Statistical, contractual: PASS iff observed pass-rate ≥

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
@@ -14,7 +14,7 @@ import java.util.List;
  *   <li>{@link CriterionDecl} — a single-criterion strategy. The
  *       K=1 case: posture, optional postconditions, optional
  *       refinements (contractRef, confidence floor, MDE/power).
- *       Returned directly from {@code Posture.meeting(...)} and
+ *       Returned directly from {@code Acceptance.meeting(...)} and
  *       friends; an author with one criterion returns the decl
  *       directly from {@code Contract.criteria()}.</li>
  *   <li>{@link CompositeCriteria} — a multi-criterion strategy

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
@@ -91,7 +91,7 @@ public interface Criterion<O> {
     /**
      * The criterion's run-time commitment — what counts as acceptable,
      * and optionally how confidently to evaluate it. Authored via the
-     * {@link Posture} factories ({@code meeting(...)}, {@code empirical()},
+     * {@link Acceptance} factories ({@code meeting(...)}, {@code empirical()},
      * {@code zeroTolerance(...)}); read by the framework's evaluation
      * path when it computes the per-criterion verdict from the run's
      * sample counts.
@@ -110,7 +110,7 @@ public interface Criterion<O> {
      * directly against the contract's output. No transform.
      *
      * <p>Framework-internal entry point: the value-returning
-     * authoring surface (see {@code Posture.meeting/.empirical/.zeroTolerance}
+     * authoring surface (see {@code Acceptance.meeting/.empirical/.zeroTolerance}
      * and {@code Composite.compose}) is the path authors use.
      */
     static <O> Criterion<O> direct(

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
@@ -28,7 +28,7 @@ import org.javai.punit.api.PostconditionCheck;
  * <p>Authors do not call {@code new CriterionDecl(...)} directly.
  * The starting point is a posture factory:
  * <pre>{@code
- * import static org.javai.punit.api.criterion.Posture.*;
+ * import static org.javai.punit.api.criterion.Acceptance.*;
  *
  * meeting(0.9999, SLA)
  *         .contractRef("Payment Provider SLA v2.3, §4.1");
@@ -176,7 +176,7 @@ public final class CriterionDecl<O> implements Decl<O> {
      *       record for diagnostics.</li>
      * </ul>
      *
-     * <p>Posture stays attached to the outer (this) decl; postconditions
+     * <p>Acceptance stays attached to the outer (this) decl; postconditions
      * already attached here are <em>not</em> carried forward to the
      * returned {@code TransformingDecl} — postconditions must be
      * stated either pre-transform (on this decl, via

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
@@ -9,7 +9,7 @@ import org.javai.punit.api.ThresholdOrigin;
 /**
  * The methodology criterion's run-time *commitment*: what counts as
  * acceptable, optionally how confidently to evaluate it. Authored on
- * the criterion via the {@link Posture} factories
+ * the criterion via the {@link Acceptance} factories
  * ({@code meeting(rate, origin)}, {@code empirical()},
  * {@code zeroTolerance(origin)}); consumed by the framework's
  * evaluation path when it computes a per-criterion verdict from the

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -387,7 +387,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                         posture.confidenceFloor().getAsDouble()));
             }
 
-            // Posture-driven shortcut: STATISTICAL_CONTRACTUAL and
+            // Acceptance-driven shortcut: STATISTICAL_CONTRACTUAL and
             // ZERO_TOLERANCE skip the legacy mode handling and use the
             // criterion's own commitment directly.
             if (posture.kind() == CriterionPosture.Kind.STATISTICAL_CONTRACTUAL) {

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaAsDataTest.java
@@ -20,7 +20,7 @@ class CriteriaAsDataTest {
     @Test
     @DisplayName("K=1 bare decl IS a Criteria, lowers to one-entry list with default id 'contract'")
     void bareDeclIsCriteria() {
-        Criteria<String> c = Posture.<String>meeting(0.85, ThresholdOrigin.SLA);
+        Criteria<String> c = Acceptance.<String>meeting(0.85, ThresholdOrigin.SLA);
 
         assertThat(c.asList()).hasSize(1);
         assertThat(c.asList().get(0).id()).isEqualTo("contract");
@@ -32,7 +32,7 @@ class CriteriaAsDataTest {
     @Test
     @DisplayName("posture chain is value-preserving: .meeting().contractRef().atConfidence() composes via posture")
     void postureChainPreservesValues() {
-        CriterionDecl<String> decl = Posture.<String>empirical()
+        CriterionDecl<String> decl = Acceptance.<String>empirical()
                 .atConfidence(0.99)
                 .contractRef("doc-v1");
 
@@ -47,7 +47,7 @@ class CriteriaAsDataTest {
     void wherePredicateSynthesisesFailure() {
         Predicate<String> isEmpty = String::isEmpty;
         Predicate<String> startsWithA = s -> s.startsWith("a");
-        CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+        CriterionDecl<String> decl = Acceptance.<String>meeting(0.85, ThresholdOrigin.SLA)
                 .where("non-empty", isEmpty)
                 .where("starts-with-a", startsWithA);
 
@@ -64,7 +64,7 @@ class CriteriaAsDataTest {
     @Test
     @DisplayName(".satisfies(name, Function<O, Outcome<?>>) — author-supplied message preserved verbatim")
     void satisfiesRichFunctionPreservesMessage() {
-        CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+        CriterionDecl<String> decl = Acceptance.<String>meeting(0.85, ThresholdOrigin.SLA)
                 .satisfies("parseable", v -> Outcome.fail("notJson", "v=" + v));
 
         Outcome<?> result = decl.postconditions().get(0).check().check("garbage");
@@ -80,7 +80,7 @@ class CriteriaAsDataTest {
         // The key Finding #1 regression-guard: a slide-friendly lambda
         // with a generic Outcome.fail in its body must compile without
         // a cast or a typed local.
-        CriterionDecl<String> decl = Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+        CriterionDecl<String> decl = Acceptance.<String>meeting(0.85, ThresholdOrigin.SLA)
                 .satisfies("transaction succeeds", r -> r.startsWith("OK")
                         ? Outcome.ok()
                         : Outcome.fail("transaction-failed", "got=" + r));
@@ -94,7 +94,7 @@ class CriteriaAsDataTest {
     @Test
     @DisplayName(".transforming(parse).where/.satisfies — postconditions evaluate against derived value")
     void transformingChainEvaluatesAgainstDerived() {
-        TransformingDecl<String, Integer> decl = Posture.<String>empirical()
+        TransformingDecl<String, Integer> decl = Acceptance.<String>empirical()
                 .transforming(s -> {
                     try {
                         return Outcome.ok(Integer.parseInt(s));
@@ -128,7 +128,7 @@ class CriteriaAsDataTest {
     @DisplayName(".transforming(...) rejects pre-transform postconditions on the same decl")
     void transformingRejectsPreTransformPostconditions() {
         org.assertj.core.api.Assertions.assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> Posture.<String>empirical()
+                .isThrownBy(() -> Acceptance.<String>empirical()
                         .where("non-empty", s -> !s.isEmpty())
                         .transforming(s -> Outcome.ok(Integer.parseInt(s))))
                 .withMessageContaining(".transforming");
@@ -138,9 +138,9 @@ class CriteriaAsDataTest {
     @DisplayName("compose mixes direct and transforming criteria under one composite")
     void composeMixesDirectAndTransforming() {
         Criteria<String> c = compose(
-                "response-not-empty", Posture.<String>empirical()
+                "response-not-empty", Acceptance.<String>empirical()
                         .where("non-blank", s -> !s.isBlank()),
-                "parses", Posture.<String>empirical()
+                "parses", Acceptance.<String>empirical()
                         .transforming(s -> {
                             try {
                                 return Outcome.ok(Integer.parseInt(s));
@@ -161,7 +161,7 @@ class CriteriaAsDataTest {
     @DisplayName("compose(id, decl) — K=1 with explicit id")
     void composeOneExplicitId() {
         Criteria<String> c = compose("payment-success",
-                Posture.<String>meeting(0.9999, ThresholdOrigin.SLA));
+                Acceptance.<String>meeting(0.9999, ThresholdOrigin.SLA));
 
         assertThat(c.asList()).hasSize(1);
         assertThat(c.asList().get(0).id()).isEqualTo("payment-success");
@@ -171,9 +171,9 @@ class CriteriaAsDataTest {
     @DisplayName("compose(...) — K>1 composite, declaration order preserved")
     void composeMany() {
         Criteria<String> c = compose(
-                "a", Posture.<String>meeting(0.99, ThresholdOrigin.SLA),
-                "b", Posture.<String>meeting(0.95, ThresholdOrigin.SLA),
-                "c", Posture.<String>zeroTolerance(ThresholdOrigin.POLICY));
+                "a", Acceptance.<String>meeting(0.99, ThresholdOrigin.SLA),
+                "b", Acceptance.<String>meeting(0.95, ThresholdOrigin.SLA),
+                "c", Acceptance.<String>zeroTolerance(ThresholdOrigin.POLICY));
 
         assertThat(c.asList()).hasSize(3);
         assertThat(c.asList().get(0).id()).isEqualTo("a");
@@ -185,8 +185,8 @@ class CriteriaAsDataTest {
     @DisplayName("composeOf(entry, entry, ...) — escape hatch for arbitrary K")
     void composeOfEntries() {
         Criteria<String> c = composeOf(
-                entry("a", Posture.<String>meeting(0.99, ThresholdOrigin.SLA)),
-                entry("b", Posture.<String>meeting(0.95, ThresholdOrigin.SLA)));
+                entry("a", Acceptance.<String>meeting(0.99, ThresholdOrigin.SLA)),
+                entry("b", Acceptance.<String>meeting(0.95, ThresholdOrigin.SLA)));
 
         assertThat(c.asList()).hasSize(2);
         assertThat(c.asList().get(0).id()).isEqualTo("a");
@@ -198,8 +198,8 @@ class CriteriaAsDataTest {
     void duplicateIdsRejected() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> compose(
-                        "a", Posture.<String>meeting(0.99, ThresholdOrigin.SLA),
-                        "a", Posture.<String>meeting(0.95, ThresholdOrigin.SLA)))
+                        "a", Acceptance.<String>meeting(0.99, ThresholdOrigin.SLA),
+                        "a", Acceptance.<String>meeting(0.95, ThresholdOrigin.SLA)))
                 .withMessageContaining("duplicate");
     }
 
@@ -226,7 +226,7 @@ class CriteriaAsDataTest {
                 return Outcome.ok("ok");
             }
             @Override public Criteria<String> criteria() {
-                return Posture.<String>meeting(0.85, ThresholdOrigin.SLA)
+                return Acceptance.<String>meeting(0.85, ThresholdOrigin.SLA)
                         .contractRef("doc-v1");
             }
         };

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
@@ -28,7 +28,7 @@ class InconclusiveFoldsIntoFailTest {
         @Override
         public Criteria<String> criteria() {
             return Composite.compose("parsed-positive",
-                    Posture.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                    Acceptance.<String>zeroTolerance(ThresholdOrigin.POLICY)
                             .transforming(s -> {
                                 try {
                                     return Outcome.ok(Integer.parseInt(s));

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
@@ -8,7 +8,7 @@ import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
@@ -40,7 +40,7 @@ class AutoInjectionFromPostureTest {
                 return Outcome.ok(true);
             }
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
         };
 
@@ -64,7 +64,7 @@ class AutoInjectionFromPostureTest {
                 return Outcome.fail("nope", "never passes");
             }
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
         };
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -39,7 +39,7 @@ class EarlyTerminationIntegrationTest {
     /** Returns Outcome.ok every sample. Contract posture: meeting(0.5, SLA). */
     private static class AlwaysPass implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.meeting(0.5, ThresholdOrigin.SLA);
+            return Acceptance.meeting(0.5, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -49,7 +49,7 @@ class EarlyTerminationIntegrationTest {
     /** Always-pass variant whose contract posture is meeting(0.20, SLA). */
     private static class AlwaysPassLowThreshold implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.meeting(0.20, ThresholdOrigin.SLA);
+            return Acceptance.meeting(0.20, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -59,7 +59,7 @@ class EarlyTerminationIntegrationTest {
     /** Always-pass variant whose contract posture is empirical. */
     private static class AlwaysPassEmpirical implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.empirical();
+            return Acceptance.empirical();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -69,7 +69,7 @@ class EarlyTerminationIntegrationTest {
     /** Returns Outcome.fail every sample — a clean failure-inevitable shape. */
     private static class AlwaysFail implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.meeting(0.95, ThresholdOrigin.SLA);
+            return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure");
@@ -86,7 +86,7 @@ class EarlyTerminationIntegrationTest {
         private int seen = 0;
         FailsThenPasses(int failsFirst) { this.failsFirst = failsFirst; }
         @Override public Criteria<Boolean> criteria() {
-            return Posture.meeting(0.80, ThresholdOrigin.SLA);
+            return Acceptance.meeting(0.80, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return ++seen <= failsFirst

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -13,7 +13,7 @@ import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
@@ -39,7 +39,7 @@ class EmpiricalEndToEndIntegrationTest {
 
     static class AlwaysPassesServiceContract implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.empirical();
+            return Acceptance.empirical();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -15,7 +15,7 @@ import org.javai.punit.api.ValueMatcher;
 import org.javai.punit.api.spec.TerminationReason;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -267,7 +267,7 @@ class EngineIntegrationTest {
     void testPathInstanceConformanceUsesCustomMatcher() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
             @Override public Criteria<String> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -304,7 +304,7 @@ class EngineIntegrationTest {
     void testPathDefaultsToEqualityMatcher() {
         ServiceContract<LlmFactors, String, String> upperCase = new ServiceContract<>() {
             @Override public Criteria<String> criteria() {
-                return Posture.meeting(0.4, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.4, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input.toUpperCase());
@@ -335,7 +335,7 @@ class EngineIntegrationTest {
     void testPathPropagatesMatcherFromSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
             @Override public Criteria<String> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -400,7 +400,7 @@ class EngineIntegrationTest {
     void testPathSpecBuilderMatcherOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
             @Override public Criteria<String> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -471,7 +471,7 @@ class EngineIntegrationTest {
     void testPathSpecBuilderExpectedOverridesSampling() {
         ServiceContract<LlmFactors, String, String> returnSameCase = new ServiceContract<>() {
             @Override public Criteria<String> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
                 return Outcome.ok(input);
@@ -867,7 +867,7 @@ class EngineIntegrationTest {
 
     private static class AlwaysPassesServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.meeting(0.95, ThresholdOrigin.SLA);
+            return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -877,7 +877,7 @@ class EngineIntegrationTest {
     /** Empirical-posture sibling of {@link AlwaysPassesServiceContract} for the empirical-path test. */
     private static class AlwaysPassesEmpiricalServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.empirical();
+            return Acceptance.empirical();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -887,7 +887,7 @@ class EngineIntegrationTest {
     /** Returns business-level Fail outcomes — the "contract didn't hold" signal. */
     private static class AlwaysReturnsFailServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Posture.meeting(0.95, ThresholdOrigin.SLO);
+            return Acceptance.meeting(0.95, ThresholdOrigin.SLO);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure for input " + input);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -10,7 +10,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Pacing;
 import org.javai.punit.api.Sampling;
@@ -398,7 +398,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void mixedCriteriaBothRequiredComposesToFail() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
@@ -428,7 +428,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void reportOnlyLatencyExcludedFromComposition() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.95, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
@@ -11,7 +11,7 @@ import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -42,7 +42,7 @@ class PostconditionFailureHistogramTest {
             return Outcome.ok(input);
         }
         @Override public Criteria<Integer> criteria() {
-            return Posture.<Integer>meeting(0.5, org.javai.punit.api.ThresholdOrigin.SLA)
+            return Acceptance.<Integer>meeting(0.5, org.javai.punit.api.ThresholdOrigin.SLA)
                     .satisfies("alwaysFails", v ->
                             Outcome.fail("alwaysFails-mode", "input was " + v))
                     .satisfies("evenFails", v -> v % 2 == 0

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
@@ -368,7 +368,7 @@ class PowerAnalysisTest {
                 }
                 @Override public org.javai.punit.api.criterion.Criteria<String> criteria() {
                     return org.javai.punit.api.criterion.Composite.compose("the-criterion",
-                            org.javai.punit.api.criterion.Posture.<String>empirical()
+                            org.javai.punit.api.criterion.Acceptance.<String>empirical()
                                     .detectingMde(mde).atPower(power)
                                     .satisfies("always", v -> Outcome.ok()));
                 }
@@ -407,11 +407,11 @@ class PowerAnalysisTest {
                 @Override public org.javai.punit.api.criterion.Criteria<String> criteria() {
                     return org.javai.punit.api.criterion.Composite.compose(
                             // Looser: MDE 0.10 / power 0.50  → smaller N
-                            "loose", org.javai.punit.api.criterion.Posture.<String>empirical()
+                            "loose", org.javai.punit.api.criterion.Acceptance.<String>empirical()
                                     .detectingMde(0.10).atPower(0.50)
                                     .satisfies("always", v -> Outcome.ok()),
                             // Tighter: MDE 0.02 / power 0.95 → larger N
-                            "tight", org.javai.punit.api.criterion.Posture.<String>empirical()
+                            "tight", org.javai.punit.api.criterion.Acceptance.<String>empirical()
                                     .detectingMde(0.02).atPower(0.95)
                                     .satisfies("always", v -> Outcome.ok()));
                 }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
@@ -15,7 +15,7 @@ import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.Composite;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
@@ -50,7 +50,7 @@ class SampleSizeResolverTest {
             }
             @Override public Criteria<String> criteria() {
                 return Composite.compose("the-criterion",
-                        Posture.<String>empirical()
+                        Acceptance.<String>empirical()
                                 .detectingMde(mde)
                                 .atPower(power)
                                 .satisfies("always", v -> Outcome.ok()));
@@ -66,7 +66,7 @@ class SampleSizeResolverTest {
             }
             @Override public Criteria<String> criteria() {
                 return Composite.compose("threshold-criterion",
-                        Posture.<String>meeting(0.90, ThresholdOrigin.SLA)
+                        Acceptance.<String>meeting(0.90, ThresholdOrigin.SLA)
                                 .satisfies("always", v -> Outcome.ok()));
             }
         };
@@ -165,10 +165,10 @@ class SampleSizeResolverTest {
             }
             @Override public Criteria<String> criteria() {
                 return Composite.compose(
-                        "loose", Posture.<String>empirical()
+                        "loose", Acceptance.<String>empirical()
                                 .detectingMde(0.10).atPower(0.50)
                                 .satisfies("always", v -> Outcome.ok()),
-                        "tight", Posture.<String>empirical()
+                        "tight", Acceptance.<String>empirical()
                                 .detectingMde(0.02).atPower(0.95)
                                 .satisfies("always", v -> Outcome.ok()));
             }

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
@@ -7,7 +7,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.Experiment;
@@ -23,7 +23,7 @@ class InlineSamplingFormTest {
 
     private static final ServiceContract<Factors, String, String> ECHO = new ServiceContract<>() {
         @Override public Criteria<String> criteria() {
-            return Posture.meeting(0.95, ThresholdOrigin.SLA);
+            return Acceptance.meeting(0.95, ThresholdOrigin.SLA);
         }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
@@ -16,7 +16,7 @@ import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.Composite;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.internal.engine.Engine;
@@ -143,9 +143,9 @@ class OptimizeOutputWriterTest {
             @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Criteria<String> criteria() {
                 return Composite.compose(
-                        "always-passes", Posture.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                        "always-passes", Acceptance.<String>zeroTolerance(ThresholdOrigin.POLICY)
                                 .satisfies("passes", v -> Outcome.ok()),
-                        "starts-with-a", Posture.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                        "starts-with-a", Acceptance.<String>zeroTolerance(ThresholdOrigin.POLICY)
                                 .satisfies("first-char-a", v ->
                                         v.startsWith("a")
                                                 ? Outcome.ok()

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -6,7 +6,7 @@ import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
@@ -42,7 +42,7 @@ public final class CovariateSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> covariateServiceContract() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.empirical();
+                return Acceptance.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -2,7 +2,7 @@ package org.javai.punit.junit5.testsubjects;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
@@ -29,7 +29,7 @@ public final class FeasibilitySubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesEmpirical() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.empirical();
+                return Acceptance.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -41,7 +41,7 @@ public final class FeasibilitySubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesContractual() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.9999, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.9999, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -5,7 +5,7 @@ import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -37,7 +37,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesContractual() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.5, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.5, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -51,7 +51,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesEmpirical() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.empirical();
+                return Acceptance.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -63,7 +63,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFails() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.5, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.5, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.fail("nope", "always fails");
@@ -77,7 +77,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesWithContractRef() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.<Boolean>meeting(0.5, ThresholdOrigin.SLA)
+                return Acceptance.<Boolean>meeting(0.5, ThresholdOrigin.SLA)
                         .contractRef(CONTRACT_REF_FIXTURE);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
@@ -90,7 +90,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFailsWithContractRef() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.<Boolean>meeting(0.5, ThresholdOrigin.SLA)
+                return Acceptance.<Boolean>meeting(0.5, ThresholdOrigin.SLA)
                         .contractRef(CONTRACT_REF_FIXTURE);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.NoFactors;
@@ -37,7 +37,7 @@ public final class PreflightInvariantSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> countingEmpirical() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.empirical();
+                return Acceptance.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
@@ -50,7 +50,7 @@ public final class PreflightInvariantSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> countingContractualHighThreshold() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.meeting(0.9999, ThresholdOrigin.SLA);
+                return Acceptance.meeting(0.9999, ThresholdOrigin.SLA);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
@@ -6,7 +6,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -32,7 +32,7 @@ public final class PreflightSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> countingServiceContract() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.empirical();
+                return Acceptance.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -2,7 +2,7 @@ package org.javai.punit.junit5.testsubjects;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.NoFactors;
@@ -29,7 +29,7 @@ public final class RoundTripSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> serviceContract() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Posture.empirical();
+                return Acceptance.empirical();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
@@ -57,7 +57,7 @@ class LatencyEverywhereIntegrationTest {
             return Outcome.ok(input.length());
         }
         @Override public Criteria<Integer> criteria() {
-            return Posture.<Integer>meeting(0.5, ThresholdOrigin.SLA)
+            return Acceptance.<Integer>meeting(0.5, ThresholdOrigin.SLA)
                     .satisfies("length is even", n ->
                             n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "length=" + n));
         }

--- a/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Posture;
+import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
@@ -67,7 +67,7 @@ class MultiDimensionVerdictIntegrationTest {
             return Outcome.ok(input.length());
         }
         @Override public Criteria<Integer> criteria() {
-            return Posture.<Integer>meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA)
+            return Acceptance.<Integer>meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA)
                     .satisfies("non-null length", n -> Outcome.ok());
         }
     }
@@ -85,7 +85,7 @@ class MultiDimensionVerdictIntegrationTest {
             return Outcome.ok(input.length());
         }
         @Override public Criteria<Integer> criteria() {
-            return Posture.<Integer>meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA)
+            return Acceptance.<Integer>meeting(FUNCTIONAL_THRESHOLD, ThresholdOrigin.SLA)
                     .satisfies("length is even", n ->
                             n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "n=" + n));
         }


### PR DESCRIPTION
## Summary

The static utility class authors call (statically imported) to start a
\`CriterionDecl\` was named \`Posture\` — a methodology term lifted
from the Statistical Companion. To Java testers reading the slide
cold, it does not carry the meaning the methodology gives it.

Renamed to \`Acceptance\`. Testers know "acceptance criteria" as the
umbrella concept; the factories on this class — \`meeting(...)\`,
\`empirical()\`, \`zeroTolerance(...)\` — express *how* each criterion's
acceptance is determined.

## Slide preview

\`\`\`java
import static org.javai.punit.api.criterion.Acceptance.*;
import static org.javai.punit.api.ThresholdOrigin.SLA;

@Override public Criteria<PaymentResult> criteria() {
    return Acceptance.<PaymentResult>meeting(0.99, SLA)
            .contractRef("Acme Payment SLA v3.2 §4.1")
            .satisfies("transaction succeeds", r -> r.success()
                    ? Outcome.ok()
                    : Outcome.fail("transaction-failed", "errorCode=" + r.errorCode()));
}
\`\`\`

## Not in scope

The runtime type \`CriterionPosture\` (the value held by a
\`CriterionDecl\`, accessed via \`.posture()\`) stays. Renaming it is a
larger sweep that also affects \`.posture()\` accessor names,
\`withPosture(...)\` hooks, and \`fromPosture(...)\` internal bridges.
Testers rarely touch \`CriterionPosture\` directly; open a follow-up
if the user-visible surface still feels off.

## Test plan

- [x] \`./gradlew :punit-core:test :punit-report:test :punit-sentinel:test\` — green
- [x] 27 files updated; only bare \`Posture\` identifiers renamed
      (\`CriterionPosture\` and \`withPosture\`/\`fromPosture\` left
      intact).

## Downstream

\`punitexamples\` PR #56 (the value-form migration) will need a rebase
to pick up \`Acceptance\` in place of \`Posture\` — straightforward
once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)