### PR TITLE
Tighten PassRate.meeting threshold range to [0, 1)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -92,9 +92,9 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
 
     static <OT> PassRate<OT> meeting(double threshold, ThresholdOrigin origin) {
         Objects.requireNonNull(origin, "origin");
-        if (threshold < 0.0 || threshold > 1.0 || Double.isNaN(threshold)) {
+        if (threshold < 0.0 || threshold >= 1.0 || Double.isNaN(threshold)) {
             throw new IllegalArgumentException(
-                    "threshold must be in [0, 1], got " + threshold);
+                    "threshold must be in [0, 1), got " + threshold);
         }
         if (origin == ThresholdOrigin.EMPIRICAL) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
## Summary

Align the internal \`PassRate.meeting(threshold, origin)\` validation
with the user-facing \`Acceptance.meeting(rate, origin)\` validation
and with §1.4.5 of the Statistical Companion: \`rate == 1.0\` is
rejected because the Wilson lower bound at p̂ = 1 is strictly less
than 1 for every finite n and α < 1; an inferential test against
p* = 1 cannot pass at any finite sample size.

## Background

Surfaced as a sanity check during the
\`DIR-CRITERIA-AS-DATA-punit\` migration: \`Acceptance.meeting(1.0, SLA)\`
correctly throws (range \`[0, 1)\`), but the package-private
\`PassRate.meeting\` accepted \`1.0\` (range \`[0, 1]\`). Unreachable
from user code today, but a defense-in-depth gap.

## Test plan

- [x] \`./gradlew :punit-core:test\` — green (no existing tests
      asserted on the previous error message text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)