### PR TITLE
Add contract-side latency authoring surface

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -160,6 +160,27 @@ public interface Contract<I, O> {
      * the bundle. Both rules are enforced by
      * {@link Criteria#of(Decl[])}.
      *
+     * <h4>Latency criteria</h4>
+     *
+     * <p>A latency commitment travels through the same authoring
+     * surface as a functional criterion:
+     *
+     * <pre>{@code
+     * @Override public Criteria<Receipt> criteria() {
+     *     return of(
+     *         meeting(0.9999, SLA)
+     *             .name("payment-completes")
+     *             .satisfies("Authorisation returned APPROVED", ...),
+     *         empirical(P95, P99)
+     *             .name("latency-has-not-degraded"));
+     * }
+     * }</pre>
+     *
+     * <p>At most one latency criterion per contract — the engine
+     * captures one duration per sample, so multiple latency
+     * declarations would be redundant or contradictory.
+     * {@link #effectiveCriteria()} enforces the 0..1 cardinality.
+     *
      * <p>The default returns {@link Criteria#empty()}: no explicit
      * declaration. The framework then synthesises a single criterion
      * from the contract's {@link #postconditions()} chain.
@@ -195,7 +216,25 @@ public interface Contract<I, O> {
                                 + " criterion via .where(name, predicate), or"
                                 + " remove the postconditions override.");
             }
-            return declared.asList();
+            List<Criterion<O>> resolved = declared.asList();
+            List<String> latencyIds = new ArrayList<>();
+            for (Criterion<O> c : resolved) {
+                if (c.posture().isLatency()) {
+                    latencyIds.add(c.id());
+                }
+            }
+            if (latencyIds.size() > 1) {
+                throw new IllegalStateException(
+                        "Contract " + getClass().getName()
+                                + " declares " + latencyIds.size() + " latency criteria"
+                                + " (" + String.join(", ", latencyIds) + ");"
+                                + " at most one is permitted because the engine"
+                                + " captures one duration per sample."
+                                + " Combine the percentiles on a single"
+                                + " Acceptance.<O>empirical(...) or"
+                                + " Acceptance.<O>meeting(origin).ceiling(...) decl.");
+            }
+            return resolved;
         }
         return List.of(new DefaultCriterion<>(this));
     }

--- a/punit-core/src/main/java/org/javai/punit/api/PercentileKey.java
+++ b/punit-core/src/main/java/org/javai/punit/api/PercentileKey.java
@@ -1,16 +1,18 @@
-package org.javai.punit.api.spec;
+package org.javai.punit.api;
 
 import java.time.Duration;
 import java.util.OptionalLong;
 
-import org.javai.punit.api.LatencyResult;
-import org.javai.punit.api.LatencySpec;
-
 /**
- * The percentiles the {@link PercentileLatency} criterion can assert
- * against. Each value knows how to project a {@link LatencySpec}'s
- * per-percentile ceiling and a {@link LatencyResult}'s observed
- * percentile.
+ * The percentiles a latency criterion can assert against. Each value
+ * knows how to project a {@link LatencySpec}'s per-percentile ceiling
+ * and a {@link LatencyResult}'s observed percentile.
+ *
+ * <p>Lives at the {@code api} root because both the contract-side
+ * authoring surface ({@code api.criterion.LatencyDecl}) and the
+ * spec-side evaluator ({@code api.spec.PercentileLatency}) reference
+ * it; keeping it here avoids a dependency cycle between the two
+ * packages.
  */
 public enum PercentileKey {
 
@@ -41,6 +43,6 @@ public enum PercentileKey {
     /** The observed duration from a LatencyResult at this percentile. */
     public abstract Duration observed(LatencyResult result);
 
-    /** The stable short-form key used in {@link CriterionResult#detail()} map keys. */
+    /** The stable short-form key used in evaluation-detail map keys. */
     public abstract String detailKey();
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Acceptance.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Acceptance.java
@@ -2,6 +2,7 @@ package org.javai.punit.api.criterion;
 
 import java.util.List;
 
+import org.javai.punit.api.PercentileKey;
 import org.javai.punit.api.ThresholdOrigin;
 
 /**
@@ -27,6 +28,19 @@ import org.javai.punit.api.ThresholdOrigin;
  * <pre>{@code
  * import static org.javai.punit.api.criterion.Acceptance.*;
  * }</pre>
+ *
+ * <p>Functional vs latency factories share two names (
+ * {@code empirical}, {@code meeting}); the compiler picks the right
+ * overload from argument shape:
+ *
+ * <table>
+ *   <caption>Acceptance factory overloads</caption>
+ *   <tr><th>Call</th><th>Returns</th><th>Meaning</th></tr>
+ *   <tr><td>{@code empirical()}</td><td>{@link CriterionDecl}</td><td>functional empirical</td></tr>
+ *   <tr><td>{@code empirical(PercentileKey, PercentileKey...)}</td><td>{@link LatencyDecl}</td><td>empirical latency</td></tr>
+ *   <tr><td>{@code meeting(double, ThresholdOrigin)}</td><td>{@link CriterionDecl}</td><td>contractual pass-rate</td></tr>
+ *   <tr><td>{@code meeting(ThresholdOrigin)}</td><td>{@link LatencyDecl}</td><td>contractual latency (chain {@code .ceiling(...)})</td></tr>
+ * </table>
  */
 public final class Acceptance {
 
@@ -56,5 +70,45 @@ public final class Acceptance {
      */
     public static <O> CriterionDecl<O> zeroTolerance(ThresholdOrigin origin) {
         return new CriterionDecl<>(CriterionPosture.zeroTolerance(origin), List.of());
+    }
+
+    /**
+     * Latency, empirical: per-percentile thresholds are derived from
+     * the resolved baseline at evaluate time. Recommended over the
+     * contractual shape when environments (CI, staging, prod) have
+     * different latency envelopes — per-covariate baselines capture
+     * each envelope without an explicit override.
+     *
+     * <pre>{@code
+     * Acceptance.<Receipt>empirical(P95, P99)
+     *         .name("latency-has-not-degraded");
+     * }</pre>
+     */
+    public static <O> LatencyDecl<O> empirical(PercentileKey first, PercentileKey... rest) {
+        return LatencyDecl.empirical(first, rest);
+    }
+
+    /**
+     * Latency, contractual: per-percentile ceilings are declared on the
+     * decl via {@link LatencyDecl#ceiling}. The threshold is the
+     * supplied duration; the origin is the supplied non-empirical
+     * origin.
+     *
+     * <pre>{@code
+     * Acceptance.<Receipt>meeting(SLA)
+     *         .ceiling(P95, Duration.ofMillis(500))
+     *         .name("latency-p95")
+     *         .contractRef("Payment Provider SLA v2.3 §4.2");
+     * }</pre>
+     *
+     * <p>Best paired with the test-side override mechanism (see
+     * {@code DIR-CRITERIA-OVERRIDE-punit}) so a single fixed-SLA
+     * contract can run across environments with different operating
+     * envelopes. Until override lands, prefer
+     * {@link #empirical(PercentileKey, PercentileKey...) the empirical
+     * shape} for environment-dependent services.
+     */
+    public static <O> LatencyDecl<O> meeting(ThresholdOrigin origin) {
+        return LatencyDecl.contractual(origin);
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
@@ -1,9 +1,12 @@
 package org.javai.punit.api.criterion;
 
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
+import org.javai.punit.api.LatencySpec;
+import org.javai.punit.api.PercentileKey;
 import org.javai.punit.api.ThresholdOrigin;
 
 /**
@@ -45,7 +48,7 @@ import org.javai.punit.api.ThresholdOrigin;
  */
 public final class CriterionPosture {
 
-    /** The four posture kinds. */
+    /** Posture kinds. */
     public enum Kind {
         /** {@code .meeting(rate, origin)} — explicit numeric target. */
         STATISTICAL_CONTRACTUAL,
@@ -54,7 +57,20 @@ public final class CriterionPosture {
         /** {@code .zeroTolerance(origin)} — explicit binary commitment. */
         ZERO_TOLERANCE,
         /** No posture method called — implicit zero-tolerance (step 3 default). */
-        IMPLICIT_ZERO_TOLERANCE
+        IMPLICIT_ZERO_TOLERANCE,
+        /**
+         * Latency, empirical: per-percentile thresholds derived from the
+         * resolved baseline at evaluate time. Authored via
+         * {@code Acceptance.<O>empirical(P95, P99...)}.
+         */
+        LATENCY_EMPIRICAL,
+        /**
+         * Latency, contractual: per-percentile ceilings declared on the
+         * contract via {@code Acceptance.<O>meeting(SLA).ceiling(P95,
+         * ofMillis(500))}. The threshold is the declared duration; the
+         * origin is the supplied non-empirical origin.
+         */
+        LATENCY_CONTRACTUAL
     }
 
     private static final CriterionPosture IMPLICIT =
@@ -64,6 +80,8 @@ public final class CriterionPosture {
                     OptionalDouble.empty(),
                     OptionalDouble.empty(),
                     OptionalDouble.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
                     Optional.empty());
 
     private final Kind kind;
@@ -73,6 +91,8 @@ public final class CriterionPosture {
     private final OptionalDouble mde;
     private final OptionalDouble power;
     private final Optional<String> contractRef;
+    private final Optional<EnumSet<PercentileKey>> assertedPercentiles;
+    private final Optional<LatencySpec> latencySpec;
 
     private CriterionPosture(
             Kind kind,
@@ -81,7 +101,9 @@ public final class CriterionPosture {
             OptionalDouble confidenceFloor,
             OptionalDouble mde,
             OptionalDouble power,
-            Optional<String> contractRef) {
+            Optional<String> contractRef,
+            Optional<EnumSet<PercentileKey>> assertedPercentiles,
+            Optional<LatencySpec> latencySpec) {
         this.kind = kind;
         this.threshold = threshold;
         this.origin = origin;
@@ -89,6 +111,8 @@ public final class CriterionPosture {
         this.mde = mde;
         this.power = power;
         this.contractRef = contractRef;
+        this.assertedPercentiles = assertedPercentiles;
+        this.latencySpec = latencySpec;
     }
 
     /** The implicit-zero-tolerance posture — the default for any criterion that declared no posture method. */
@@ -113,6 +137,8 @@ public final class CriterionPosture {
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -124,6 +150,8 @@ public final class CriterionPosture {
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -140,7 +168,66 @@ public final class CriterionPosture {
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
+    }
+
+    /**
+     * Latency, empirical: {@code Acceptance.<O>empirical(P95, P99...)}.
+     * Per-percentile thresholds are derived from the resolved baseline
+     * at evaluate time.
+     */
+    public static CriterionPosture latencyEmpirical(EnumSet<PercentileKey> asserted) {
+        Objects.requireNonNull(asserted, "asserted");
+        if (asserted.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "latencyEmpirical requires at least one PercentileKey");
+        }
+        return new CriterionPosture(Kind.LATENCY_EMPIRICAL,
+                OptionalDouble.empty(),
+                Optional.of(ThresholdOrigin.EMPIRICAL),
+                OptionalDouble.empty(),
+                OptionalDouble.empty(),
+                OptionalDouble.empty(),
+                Optional.empty(),
+                Optional.of(EnumSet.copyOf(asserted)),
+                Optional.empty());
+    }
+
+    /**
+     * Latency, contractual: {@code Acceptance.<O>meeting(origin).ceiling(...)}.
+     * Per-percentile ceilings are declared on the contract; the origin
+     * is the supplied non-empirical origin.
+     */
+    public static CriterionPosture latencyContractual(LatencySpec spec, ThresholdOrigin origin) {
+        Objects.requireNonNull(spec, "spec");
+        Objects.requireNonNull(origin, "origin");
+        if (!spec.hasAnyThreshold()) {
+            throw new IllegalArgumentException(
+                    "latencyContractual requires at least one ceiling — "
+                            + "chain .ceiling(percentile, duration) on the decl");
+        }
+        if (origin == ThresholdOrigin.EMPIRICAL) {
+            throw new IllegalArgumentException(
+                    "latencyContractual(spec, EMPIRICAL) is contradictory — "
+                            + "call Acceptance.<O>empirical(P95, ...) instead");
+        }
+        EnumSet<PercentileKey> asserted = EnumSet.noneOf(PercentileKey.class);
+        for (PercentileKey k : PercentileKey.values()) {
+            if (k.ceilingMillis(spec).isPresent()) {
+                asserted.add(k);
+            }
+        }
+        return new CriterionPosture(Kind.LATENCY_CONTRACTUAL,
+                OptionalDouble.empty(),
+                Optional.of(origin),
+                OptionalDouble.empty(),
+                OptionalDouble.empty(),
+                OptionalDouble.empty(),
+                Optional.empty(),
+                Optional.of(asserted),
+                Optional.of(spec));
     }
 
     /**
@@ -157,7 +244,8 @@ public final class CriterionPosture {
                     ".atConfidence(c) requires c in (0, 1), got " + confidence);
         }
         return new CriterionPosture(kind, threshold, origin,
-                OptionalDouble.of(confidence), mde, power, contractRef);
+                OptionalDouble.of(confidence), mde, power, contractRef,
+                assertedPercentiles, latencySpec);
     }
 
     /**
@@ -174,7 +262,8 @@ public final class CriterionPosture {
                     ".detectingMde(m) requires m in (0, 1), got " + mdeValue);
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, OptionalDouble.of(mdeValue), power, contractRef);
+                confidenceFloor, OptionalDouble.of(mdeValue), power, contractRef,
+                assertedPercentiles, latencySpec);
     }
 
     /**
@@ -190,7 +279,8 @@ public final class CriterionPosture {
                     ".atPower(p) requires p in (0, 1), got " + powerValue);
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, mde, OptionalDouble.of(powerValue), contractRef);
+                confidenceFloor, mde, OptionalDouble.of(powerValue), contractRef,
+                assertedPercentiles, latencySpec);
     }
 
     /**
@@ -210,7 +300,8 @@ public final class CriterionPosture {
             throw new IllegalArgumentException(".contractRef requires a non-blank string");
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, mde, power, Optional.of(ref));
+                confidenceFloor, mde, power, Optional.of(ref),
+                assertedPercentiles, latencySpec);
     }
 
     private void rejectRigourAdjunct(String methodName) {
@@ -222,6 +313,8 @@ public final class CriterionPosture {
                     "." + methodName + "(...) cannot compose with .meeting(...) — "
                             + "threshold-first is deterministic and accepts no rigour adjuncts; "
                             + "switch to .empirical() if you want a statistical comparison");
+            case LATENCY_EMPIRICAL, LATENCY_CONTRACTUAL -> throw new IllegalStateException(
+                    "." + methodName + "(...) does not apply to latency postures");
             case STATISTICAL_EMPIRICAL -> { /* ok */ }
         }
     }
@@ -285,9 +378,31 @@ public final class CriterionPosture {
         return contractRef;
     }
 
-    /** Whether this posture asks for a statistical evaluation. */
+    /**
+     * Percentiles this latency posture asserts against. Present only
+     * for {@link Kind#LATENCY_EMPIRICAL} / {@link Kind#LATENCY_CONTRACTUAL};
+     * empty otherwise.
+     */
+    public Optional<EnumSet<PercentileKey>> assertedPercentiles() {
+        return assertedPercentiles.map(EnumSet::copyOf);
+    }
+
+    /**
+     * The contractual {@link LatencySpec} with per-percentile ceilings.
+     * Present only for {@link Kind#LATENCY_CONTRACTUAL}; empty otherwise.
+     */
+    public Optional<LatencySpec> latencySpec() {
+        return latencySpec;
+    }
+
+    /** Whether this posture asks for a pass-rate statistical evaluation. */
     public boolean isStatistical() {
         return kind == Kind.STATISTICAL_CONTRACTUAL || kind == Kind.STATISTICAL_EMPIRICAL;
+    }
+
+    /** Whether this posture asks for a latency evaluation. */
+    public boolean isLatency() {
+        return kind == Kind.LATENCY_EMPIRICAL || kind == Kind.LATENCY_CONTRACTUAL;
     }
 
     /** Whether this posture asks for a binary evaluation (zero-tolerance, explicit or implicit). */

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
@@ -7,11 +7,12 @@ import java.util.Optional;
  * be lowered to one runtime {@link Criterion} given an id.
  *
  * <p>The sealed supertype shared by {@link CriterionDecl} (direct,
- * postconditions over the contract's output type {@code O}) and
+ * postconditions over the contract's output type {@code O}),
  * {@link TransformingDecl} (postconditions over a derived type
- * {@code T} after a transform). It is the parameter type accepted by
- * {@link Criteria#of(Decl[]) Criteria.of(...)} so a multi-criterion
- * bundle may mix direct and transforming criteria.
+ * {@code T} after a transform), and {@link LatencyDecl} (per-percentile
+ * latency commitment, empirical or contractual). It is the parameter
+ * type accepted by {@link Criteria#of(Decl[]) Criteria.of(...)} so a
+ * multi-criterion bundle may mix functional and latency criteria.
  *
  * <p>Authors rarely reference this type by name — call-site idiom is
  * {@code Criteria.of(meeting(0.99, SLA).name("a"),
@@ -21,7 +22,7 @@ import java.util.Optional;
  * @param <O> the contract's per-sample output value type
  */
 public sealed interface Decl<O> extends Criteria<O>
-        permits CriterionDecl, TransformingDecl {
+        permits CriterionDecl, TransformingDecl, LatencyDecl {
 
     /**
      * The criterion's name as declared via {@code .name(String)}, or

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/LatencyDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/LatencyDecl.java
@@ -1,0 +1,231 @@
+package org.javai.punit.api.criterion;
+
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.javai.punit.api.LatencySpec;
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.ThresholdOrigin;
+
+/**
+ * A latency-criterion declaration — the value behind one latency row
+ * in a contract's criteria declaration.
+ *
+ * <p>Two shapes:
+ * <ul>
+ *   <li>{@link Mode#EMPIRICAL} — authored via
+ *       {@code Acceptance.<O>empirical(P95, P99)}. Per-percentile
+ *       thresholds are derived from the resolved baseline at evaluate
+ *       time. Recommended when CI / staging / prod have different
+ *       latency envelopes and per-environment baselines (resolved via
+ *       covariates) capture each envelope.</li>
+ *   <li>{@link Mode#CONTRACTUAL} — authored via
+ *       {@code Acceptance.<O>meeting(origin).ceiling(P95, ofMillis(500))}.
+ *       Per-percentile ceilings are declared on the decl; the origin
+ *       is the supplied non-empirical origin. Best paired with the
+ *       test-side override mechanism so a single fixed-SLA contract
+ *       can run across environments with different operating envelopes.</li>
+ * </ul>
+ *
+ * <p>The {@code <O>} type parameter is phantom — latency is captured
+ * by the engine from per-sample timings, not derived from the
+ * contract's output value. The parameter exists so a {@code LatencyDecl}
+ * is uniformly a {@link Decl} that {@link Criteria#of(Decl[])} can
+ * bundle alongside functional declarations.
+ *
+ * <p>Cardinality: at most one latency criterion per contract. The
+ * engine captures one duration per sample; multiple latency
+ * declarations would be redundant or contradictory. Enforced at
+ * runtime in {@link org.javai.punit.api.Contract#effectiveCriteria()}.
+ *
+ * @param <O> the contract's per-sample output value type (phantom)
+ */
+public final class LatencyDecl<O> implements Decl<O> {
+
+    /** Latency authoring shapes. */
+    public enum Mode {
+        /** {@code Acceptance.<O>empirical(P95, P99...)}. */
+        EMPIRICAL,
+        /** {@code Acceptance.<O>meeting(origin).ceiling(...)}. */
+        CONTRACTUAL
+    }
+
+    private final Mode mode;
+    private final EnumSet<PercentileKey> assertedPercentiles;
+    private final LatencySpec spec;
+    private final ThresholdOrigin origin;
+    private final Optional<String> name;
+    private final Optional<String> contractRef;
+
+    LatencyDecl(Mode mode,
+            EnumSet<PercentileKey> assertedPercentiles,
+            LatencySpec spec,
+            ThresholdOrigin origin,
+            Optional<String> name,
+            Optional<String> contractRef) {
+        this.mode = Objects.requireNonNull(mode, "mode");
+        this.assertedPercentiles = EnumSet.copyOf(
+                Objects.requireNonNull(assertedPercentiles, "assertedPercentiles"));
+        this.spec = Objects.requireNonNull(spec, "spec");
+        this.origin = Objects.requireNonNull(origin, "origin");
+        this.name = Objects.requireNonNull(name, "name");
+        this.contractRef = Objects.requireNonNull(contractRef, "contractRef");
+    }
+
+    /**
+     * Empirical-mode factory — {@code Acceptance.<O>empirical(P95, P99...)}.
+     * Framework-internal entry point; authors use the {@link Acceptance}
+     * overloads.
+     */
+    static <O> LatencyDecl<O> empirical(PercentileKey first, PercentileKey... rest) {
+        Objects.requireNonNull(first, "first");
+        Objects.requireNonNull(rest, "rest");
+        EnumSet<PercentileKey> set = EnumSet.of(first);
+        for (PercentileKey k : rest) {
+            if (k == null) {
+                throw new NullPointerException("asserted percentiles must not contain null");
+            }
+            set.add(k);
+        }
+        return new LatencyDecl<>(Mode.EMPIRICAL, set, LatencySpec.disabled(),
+                ThresholdOrigin.EMPIRICAL, Optional.empty(), Optional.empty());
+    }
+
+    /**
+     * Contractual-mode factory — {@code Acceptance.<O>meeting(origin)}.
+     * Returns a decl with no ceilings yet; chain {@link #ceiling} to
+     * declare them.
+     */
+    static <O> LatencyDecl<O> contractual(ThresholdOrigin origin) {
+        Objects.requireNonNull(origin, "origin");
+        if (origin == ThresholdOrigin.EMPIRICAL) {
+            throw new IllegalArgumentException(
+                    "meeting(EMPIRICAL) is contradictory — "
+                            + "call Acceptance.<O>empirical(P95, ...) for empirical latency");
+        }
+        return new LatencyDecl<>(Mode.CONTRACTUAL,
+                EnumSet.noneOf(PercentileKey.class),
+                LatencySpec.disabled(), origin,
+                Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public Optional<String> name() {
+        return name;
+    }
+
+    /**
+     * Set the criterion's name. Required for K&gt;1 contracts; defaults
+     * to {@link Criteria#DEFAULT_CRITERION_ID} for K=1.
+     *
+     * @throws IllegalStateException if {@code .name(...)} has already been called
+     */
+    public LatencyDecl<O> name(String name) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".name(...) requires a non-blank name");
+        }
+        if (this.name.isPresent()) {
+            throw new IllegalStateException(
+                    ".name(...) already supplied as '" + this.name.get()
+                            + "'; cannot reassign to '" + name + "'");
+        }
+        return new LatencyDecl<>(mode, assertedPercentiles, spec, origin,
+                Optional.of(name), contractRef);
+    }
+
+    /**
+     * Declare a per-percentile ceiling. Composes only with the
+     * contractual mode; rejected on empirical decls (their thresholds
+     * come from the baseline, not the contract).
+     */
+    public LatencyDecl<O> ceiling(PercentileKey percentile, Duration duration) {
+        Objects.requireNonNull(percentile, "percentile");
+        Objects.requireNonNull(duration, "duration");
+        if (duration.isNegative() || duration.isZero()) {
+            throw new IllegalArgumentException(
+                    ".ceiling(" + percentile + ", duration) requires duration > 0, got " + duration);
+        }
+        if (mode != Mode.CONTRACTUAL) {
+            throw new IllegalStateException(
+                    ".ceiling(...) composes only with the contractual latency mode "
+                            + "(Acceptance.<O>meeting(origin)); empirical latency thresholds "
+                            + "come from the baseline");
+        }
+        LatencySpec next = withCeiling(spec, percentile, duration.toMillis());
+        EnumSet<PercentileKey> nextAsserted = EnumSet.copyOf(assertedPercentiles);
+        nextAsserted.add(percentile);
+        return new LatencyDecl<>(mode, nextAsserted, next, origin, name, contractRef);
+    }
+
+    /**
+     * Attach an audit pointer — the document and clause that justify
+     * this criterion's commitment.
+     */
+    public LatencyDecl<O> contractRef(String ref) {
+        Objects.requireNonNull(ref, "ref");
+        if (ref.isBlank()) {
+            throw new IllegalArgumentException(".contractRef requires a non-blank string");
+        }
+        return new LatencyDecl<>(mode, assertedPercentiles, spec, origin,
+                name, Optional.of(ref));
+    }
+
+    /** The decl's mode (empirical or contractual). Framework-internal. */
+    public Mode mode() {
+        return mode;
+    }
+
+    /** The decl's asserted percentiles. Framework-internal. */
+    public EnumSet<PercentileKey> assertedPercentiles() {
+        return EnumSet.copyOf(assertedPercentiles);
+    }
+
+    /** The decl's contractual {@link LatencySpec}; disabled for empirical. */
+    public LatencySpec spec() {
+        return spec;
+    }
+
+    /** The decl's origin. {@link ThresholdOrigin#EMPIRICAL} in empirical mode. */
+    public ThresholdOrigin origin() {
+        return origin;
+    }
+
+    @Override
+    public List<Criterion<O>> asList() {
+        return List.of(toRuntime(name.orElse(Criteria.DEFAULT_CRITERION_ID)));
+    }
+
+    @Override
+    public Criterion<O> toRuntime(String id) {
+        CriterionPosture posture = mode == Mode.EMPIRICAL
+                ? CriterionPosture.latencyEmpirical(assertedPercentiles)
+                : CriterionPosture.latencyContractual(spec, origin);
+        if (contractRef.isPresent()) {
+            posture = posture.withContractRef(contractRef.get());
+        }
+        return new DirectCriterion<>(id, List.of(), posture);
+    }
+
+    private static LatencySpec withCeiling(LatencySpec base, PercentileKey p, long millis) {
+        LatencySpec.Builder b = LatencySpec.builder();
+        copyExisting(base, b);
+        switch (p) {
+            case P50 -> b.p50Millis(millis);
+            case P90 -> b.p90Millis(millis);
+            case P95 -> b.p95Millis(millis);
+            case P99 -> b.p99Millis(millis);
+        }
+        return b.build();
+    }
+
+    private static void copyExisting(LatencySpec base, LatencySpec.Builder b) {
+        base.p50Millis().ifPresent(b::p50Millis);
+        base.p90Millis().ifPresent(b::p90Millis);
+        base.p95Millis().ifPresent(b::p95Millis);
+        base.p99Millis().ifPresent(b::p99Millis);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
@@ -109,6 +109,15 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
         return Optional.ofNullable(baselineSupplier);
     }
 
+    /**
+     * The percentiles this criterion asserts against. Read by the
+     * preflight feasibility check to compare against the planned
+     * sample count.
+     */
+    public EnumSet<PercentileKey> assertedPercentiles() {
+        return EnumSet.copyOf(assertedPercentiles);
+    }
+
     @Override
     public String name() {
         return NAME;

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
@@ -13,9 +13,10 @@ import java.util.OptionalLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.LatencySpec;
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.ThresholdOrigin;
 
 /**
  * A percentile-latency criterion. Reads {@link LatencyStatistics} from
@@ -33,6 +34,16 @@ import org.javai.punit.api.LatencySpec;
  *   <li>{@link #empiricalFrom(Supplier, PercentileKey, PercentileKey...)}
  *       — pinned baseline.</li>
  * </ul>
+ *
+ * <p>The conventional authoring path is the contract-side surface:
+ * {@code Acceptance.<O>empirical(P95, P99)} (empirical) or
+ * {@code Acceptance.<O>meeting(SLA).ceiling(P95, ofMillis(500))}
+ * (contractual). The framework's auto-injection then routes the
+ * contract's posture through {@code SpecCriterionDeriver} to a
+ * {@code PercentileLatency} instance — authors do not call these
+ * factories directly. Use them at the test site only when overlaying
+ * (or, post-{@code DIR-CRITERIA-OVERRIDE-punit}, replacing) the
+ * contract-declared latency criterion.
  */
 public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatistics> {
 

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/Feasibility.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/Feasibility.java
@@ -1,14 +1,17 @@
 package org.javai.punit.internal.engine.criteria;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
-import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.Criterion;
 import org.javai.punit.api.spec.PassRateStatistics;
+import org.javai.punit.api.spec.PercentileLatency;
 import org.javai.punit.internal.reporting.InfeasibilityMessageRenderer;
 import org.javai.punit.statistics.StatisticalDefaults;
 import org.javai.punit.statistics.VerificationFeasibilityEvaluator;
@@ -44,8 +47,13 @@ import org.javai.punit.statistics.VerificationFeasibilityEvaluator.FeasibilityRe
  * in need of statistical underwriting than an empirical one: n=50
  * with a 99.99% target at 95% confidence is infeasible regardless of
  * whether the 99.99% came from a measurement or a contract.
- * Non-{@code PassRate} criteria (e.g. {@code PercentileLatency}) are
- * skipped pending their own feasibility model.
+ *
+ * <p>{@link PercentileLatency} criteria get a parallel check that
+ * compares the planned sample count against the order-statistic floor
+ * {@code ⌈1/(1-p)⌉} for each asserted percentile. Below the floor the
+ * empirical percentile collapses toward the max sample and the
+ * assertion stops saying what the author meant. The check emits a
+ * warning (not an abort); SMOKE intent silences it.
  *
  * <p>Empirical criteria require a resolvable baseline at check time.
  * When no baseline file matches, feasibility is silently deferred —
@@ -77,6 +85,9 @@ public final class Feasibility {
             FactorBundle factors,
             TestIntent intent,
             BaselineProvider provider) {
+        if (criterion instanceof PercentileLatency<?> latency) {
+            return checkLatencySampleSize(samples, latency, intent);
+        }
         if (!(criterion instanceof PassRate<?> bernoulli)) {
             return List.of();
         }
@@ -128,5 +139,58 @@ public final class Feasibility {
         // SMOKE intent: the developer has declared "I know this is
         // undersized; treat it as a sentinel." Silent — no warning.
         return List.of();
+    }
+
+    /**
+     * Warn when the planned sample count is below the order-statistic
+     * floor for any asserted percentile. The floor is ⌈1/(1-p)⌉:
+     * P95 needs ≥ 20, P99 needs ≥ 100. Below the floor the empirical
+     * percentile collapses toward the max sample and a population-level
+     * claim about the percentile is unsupported.
+     *
+     * <p>SMOKE intent is silent — symmetric with the pass-rate
+     * feasibility gate; the developer has declared "I know this is
+     * undersized."
+     */
+    private static List<String> checkLatencySampleSize(
+            int samples, PercentileLatency<?> latency, TestIntent intent) {
+        if (intent == TestIntent.SMOKE) {
+            return List.of();
+        }
+        List<String> warnings = new ArrayList<>();
+        for (PercentileKey key : latency.assertedPercentiles()) {
+            int floor = minimumSampleSizeFor(key);
+            if (samples < floor) {
+                warnings.add(String.format(
+                        "Latency criterion '%s' asserts %s but the run is"
+                                + " configured for %d samples; %s needs at"
+                                + " least %d for a meaningful population-level"
+                                + " estimate. The percentile will reflect the"
+                                + " max sample rather than a tail probability.",
+                        latency.name(), key.name(), samples, key.name(), floor));
+            }
+        }
+        return warnings;
+    }
+
+    /**
+     * The minimum sample count for which an order-statistic estimate
+     * of {@code key} has a meaningful population interpretation —
+     * specifically {@code ⌈1 / (1 - p)⌉}.
+     *
+     * <ul>
+     *   <li>P50 → 1 (any non-empty sample)</li>
+     *   <li>P90 → 10</li>
+     *   <li>P95 → 20</li>
+     *   <li>P99 → 100</li>
+     * </ul>
+     */
+    static int minimumSampleSizeFor(PercentileKey key) {
+        return switch (key) {
+            case P50 -> 1;
+            case P90 -> 10;
+            case P95 -> 20;
+            case P99 -> 100;
+        };
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -181,6 +181,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                             "ZERO_TOLERANCE posture without origin"))));
             case IMPLICIT_ZERO_TOLERANCE -> Optional.of(
                     PassRate.<OT>forZeroTolerance(ThresholdOrigin.POLICY));
+            case LATENCY_EMPIRICAL, LATENCY_CONTRACTUAL -> Optional.empty();
         };
     }
 

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PostureBasedSpecCriterionDeriver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PostureBasedSpecCriterionDeriver.java
@@ -2,13 +2,18 @@ package org.javai.punit.internal.engine.criteria;
 
 import java.util.Optional;
 
+import org.javai.punit.api.LatencySpec;
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.CriterionPosture;
 import org.javai.punit.api.spec.Criterion;
+import org.javai.punit.api.spec.PercentileLatency;
 import org.javai.punit.api.spec.SpecCriterionDeriver;
 
 /**
- * The framework's default {@link SpecCriterionDeriver} — maps
- * statistical postures to {@link PassRate} variants.
+ * The framework's default {@link SpecCriterionDeriver}. Maps
+ * statistical-pass-rate postures to {@link PassRate} variants, and
+ * latency postures to {@link PercentileLatency} variants.
  *
  * <p>Registered via {@code META-INF/services} so the api-side builder
  * finds it through {@link java.util.ServiceLoader} without importing
@@ -19,7 +24,28 @@ public final class PostureBasedSpecCriterionDeriver implements SpecCriterionDeri
     @Override
     @SuppressWarnings("unchecked")
     public <O> Optional<Criterion<O, ?>> derive(CriterionPosture posture) {
+        if (posture.isLatency()) {
+            return Optional.of((Criterion<O, ?>) deriveLatency(posture));
+        }
         Optional<PassRate<O>> mapped = PassRate.<O>fromPosture(posture);
         return mapped.map(pr -> (Criterion<O, ?>) pr);
+    }
+
+    private <O> PercentileLatency<O> deriveLatency(CriterionPosture posture) {
+        var asserted = posture.assertedPercentiles().orElseThrow(() -> new IllegalStateException(
+                "latency posture without asserted percentiles"));
+        if (posture.kind() == CriterionPosture.Kind.LATENCY_EMPIRICAL) {
+            PercentileKey[] arr = asserted.toArray(new PercentileKey[0]);
+            PercentileKey first = arr[0];
+            PercentileKey[] rest = new PercentileKey[arr.length - 1];
+            System.arraycopy(arr, 1, rest, 0, rest.length);
+            return PercentileLatency.<O>empirical(first, rest);
+        }
+        // LATENCY_CONTRACTUAL
+        LatencySpec spec = posture.latencySpec().orElseThrow(() -> new IllegalStateException(
+                "LATENCY_CONTRACTUAL posture without LatencySpec"));
+        ThresholdOrigin origin = posture.origin().orElseThrow(() -> new IllegalStateException(
+                "LATENCY_CONTRACTUAL posture without origin"));
+        return PercentileLatency.<O>meeting(spec, origin);
     }
 }

--- a/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
@@ -14,6 +14,7 @@ import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.LatencySpec;
+import org.javai.punit.api.PercentileKey;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContractOutcome;
 import org.junit.jupiter.api.DisplayName;

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/ContractLatencyEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/ContractLatencyEndToEndIntegrationTest.java
@@ -1,0 +1,197 @@
+package org.javai.punit.internal.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.LatencyResult;
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.Sampling;
+import org.javai.punit.api.ServiceContract;
+import org.javai.punit.api.ThresholdOrigin;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.criterion.Acceptance;
+import org.javai.punit.api.criterion.Criteria;
+import org.javai.punit.api.spec.BaselineStatistics;
+import org.javai.punit.api.spec.LatencyStatistics;
+import org.javai.punit.api.spec.ProbabilisticTest;
+import org.javai.punit.api.spec.ProbabilisticTestResult;
+import org.javai.punit.api.spec.Verdict;
+import org.javai.punit.internal.engine.baseline.BaselineRecord;
+import org.javai.punit.internal.engine.baseline.BaselineWriter;
+import org.javai.punit.internal.engine.baseline.FactorsFingerprint;
+import org.javai.punit.internal.engine.baseline.LatencyIndicator;
+import org.javai.punit.internal.engine.baseline.YamlBaselineProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end pin for the contract-side latency authoring surface. The
+ * contract declares its latency commitment via
+ * {@code Acceptance.<O>empirical(P95)} or
+ * {@code Acceptance.<O>meeting(SLA).ceiling(P95, ...)}; the paired
+ * probabilistic test invokes the contract with no explicit
+ * {@code .criterion(...)}, and the framework auto-injects the
+ * latency criterion alongside any functional criteria.
+ *
+ * <p>This pin complements the test-site path covered by
+ * {@code EmpiricalLatencyEndToEndIntegrationTest}: the deriver,
+ * writer, reader, and evaluator chain is the same — only the
+ * authoring surface differs.
+ */
+@DisplayName("Contract-side latency end-to-end — Acceptance.<O>empirical(...) on the contract")
+class ContractLatencyEndToEndIntegrationTest {
+
+    record Factors(String model) { }
+
+    private static final Factors FACTORS = new Factors("model-a");
+    private static final String USE_CASE_ID = "contract-latency-pin";
+
+    /** Contract declares its latency commitment on the criteria value. */
+    static class LatencyOnContract implements ServiceContract<Factors, Integer, Integer> {
+        private final Criteria<Integer> criteria;
+        LatencyOnContract(Criteria<Integer> criteria) { this.criteria = criteria; }
+        @Override public String id() { return USE_CASE_ID; }
+        @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
+            return Outcome.ok(input);
+        }
+        @Override public Criteria<Integer> criteria() { return criteria; }
+    }
+
+    private static Sampling<Factors, Integer, Integer> sampling(Criteria<Integer> criteria, int samples) {
+        return Sampling.<Factors, Integer, Integer>builder()
+                .serviceContractFactory(f -> new LatencyOnContract(criteria))
+                .inputs(1, 2, 3, 4, 5)
+                .samples(samples)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Acceptance.empirical(P95) on contract → auto-injected latency criterion resolves baseline and PASSes")
+    void empiricalLatencyOnContractAutoInjects(@TempDir Path baselineDir) throws IOException {
+        // Baseline asserts p95 = 1 minute — far above any plausible
+        // microbench latency, so observed p95 will be below it.
+        writeLatencyBaseline(baselineDir, Duration.ofMinutes(1), 1000);
+
+        Criteria<Integer> criteria = Acceptance.<Integer>empirical(PercentileKey.P95);
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(criteria, 20), FACTORS)
+                .build();   // no .criterion(...) — auto-injection from contract
+
+        ProbabilisticTestResult result = (ProbabilisticTestResult)
+                new Engine(new YamlBaselineProvider(baselineDir)).run(spec);
+
+        var latencyEntry = result.criterionResults().stream()
+                .filter(ec -> "percentile-latency".equals(ec.result().criterionName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "auto-injection failed: no percentile-latency entry on result"));
+        assertThat(latencyEntry.result().verdict()).isEqualTo(Verdict.PASS);
+        assertThat(latencyEntry.result().detail())
+                .containsEntry("origin", "EMPIRICAL")
+                .containsEntry("baselineSampleCount", 1000)
+                .containsKey("observed.p95")
+                .containsEntry("threshold.p95", 60_000L);
+    }
+
+    @Test
+    @DisplayName("Acceptance.meeting(SLA).ceiling(P95, 500ms) on contract → contractual latency PASSes when observed is below ceiling")
+    void contractualLatencyOnContract(@TempDir Path baselineDir) throws IOException {
+        // Pass-rate baseline is absent; the latency criterion is
+        // contractual so it does not need a baseline.
+        Criteria<Integer> criteria = Acceptance.<Integer>meeting(ThresholdOrigin.SLA)
+                .ceiling(PercentileKey.P95, Duration.ofMillis(500));
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(criteria, 20), FACTORS)
+                .build();
+
+        ProbabilisticTestResult result = (ProbabilisticTestResult)
+                new Engine(new YamlBaselineProvider(baselineDir)).run(spec);
+
+        var latencyEntry = result.criterionResults().stream()
+                .filter(ec -> "percentile-latency".equals(ec.result().criterionName()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(latencyEntry.result().verdict()).isEqualTo(Verdict.PASS);
+        assertThat(latencyEntry.result().detail())
+                .containsEntry("origin", "SLA")
+                .containsEntry("threshold.p95", 500L)
+                .containsKey("observed.p95");
+    }
+
+    @Test
+    @DisplayName("two latency declarations on a contract → effectiveCriteria() throws")
+    void twoLatencyCriteriaRejected() {
+        var contract = new ServiceContract<Factors, Integer, Integer>() {
+            @Override public String id() { return USE_CASE_ID; }
+            @Override public Outcome<Integer> invoke(Integer i, TokenTracker t) { return Outcome.ok(i); }
+            @Override public Criteria<Integer> criteria() {
+                return Criteria.of(
+                        Acceptance.<Integer>empirical(PercentileKey.P95).name("latency-a"),
+                        Acceptance.<Integer>empirical(PercentileKey.P99).name("latency-b"));
+            }
+        };
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(contract::effectiveCriteria)
+                .withMessageContaining("at most one")
+                .withMessageContaining("latency-a")
+                .withMessageContaining("latency-b");
+    }
+
+    @Test
+    @DisplayName("functional + latency on one contract → both criteria resolved, neither shadows the other")
+    void functionalAndLatencyCombine(@TempDir Path baselineDir) throws IOException {
+        writeLatencyBaseline(baselineDir, Duration.ofMinutes(1), 1000);
+
+        Criteria<Integer> criteria = Criteria.of(
+                Acceptance.<Integer>meeting(0.99, ThresholdOrigin.SLA).name("non-negative")
+                        .satisfies("value-not-negative",
+                                v -> v >= 0 ? Outcome.ok() : Outcome.fail("neg", "v=" + v)),
+                Acceptance.<Integer>empirical(PercentileKey.P95).name("latency-stable"));
+
+        ProbabilisticTest spec = ProbabilisticTest
+                .testing(sampling(criteria, 20), FACTORS)
+                .build();
+
+        ProbabilisticTestResult result = (ProbabilisticTestResult)
+                new Engine(new YamlBaselineProvider(baselineDir)).run(spec);
+
+        // Latency criterion auto-injected and resolved.
+        assertThat(result.criterionResults().stream()
+                .anyMatch(ec -> "percentile-latency".equals(ec.result().criterionName())))
+                .as("auto-injection must inject the latency criterion")
+                .isTrue();
+        // Functional pass-rate criterion auto-injected and resolved.
+        assertThat(result.criterionResults().stream()
+                .anyMatch(ec -> "bernoulli-pass-rate".equals(ec.result().criterionName())))
+                .as("auto-injection must inject the pass-rate criterion alongside latency")
+                .isTrue();
+    }
+
+    private static void writeLatencyBaseline(
+            Path baselineDir, Duration pX, int sampleCount) throws IOException {
+        String fingerprint = FactorsFingerprint.of(FactorBundle.of(FACTORS));
+        LatencyResult percentiles = new LatencyResult(pX, pX, pX, pX, sampleCount);
+        LatencyIndicator indicator = new LatencyIndicator(percentiles, sampleCount, sampleCount);
+        Criteria<Integer> dummy = Acceptance.<Integer>empirical(PercentileKey.P95);
+        BaselineRecord record = new BaselineRecord(
+                USE_CASE_ID, "latencyBaseline", fingerprint,
+                sampling(dummy, 1).inputsIdentity(), sampleCount,
+                Instant.parse("2026-05-18T12:00:00Z"),
+                Map.<String, BaselineStatistics>of(
+                        "percentile-latency",
+                        new LatencyStatistics(percentiles, sampleCount)),
+                org.javai.punit.api.covariate.CovariateProfile.empty(),
+                indicator);
+        new BaselineWriter().write(record, baselineDir);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalLatencyEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalLatencyEndToEndIntegrationTest.java
@@ -19,7 +19,7 @@ import org.javai.punit.api.criterion.Criteria;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.LatencyStatistics;
-import org.javai.punit.api.spec.PercentileKey;
+import org.javai.punit.api.PercentileKey;
 import org.javai.punit.api.spec.PercentileLatency;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/CriterionResultDetailTest.java
@@ -21,7 +21,7 @@ import org.javai.punit.api.spec.EvaluationContext;
 import org.javai.punit.api.spec.LatencyStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
 import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
-import org.javai.punit.api.spec.PercentileKey;
+import org.javai.punit.api.PercentileKey;
 import org.javai.punit.api.spec.PercentileLatency;
 import org.javai.punit.api.spec.SampleSummary;
 import org.javai.punit.api.spec.TerminationReason;

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/LatencyFeasibilityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/LatencyFeasibilityTest.java
@@ -1,0 +1,96 @@
+package org.javai.punit.internal.engine.criteria;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.spec.BaselineProvider;
+import org.javai.punit.api.spec.BaselineStatistics;
+import org.javai.punit.api.spec.PercentileLatency;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Latency-criterion preflight feasibility")
+class LatencyFeasibilityTest {
+
+    private static final String CONTRACT_ID = "feasibility-test";
+    private static final FactorBundle EMPTY_FACTORS = FactorBundle.empty();
+    private static final BaselineProvider NULL_PROVIDER = new BaselineProvider() {
+        @Override
+        public <S extends BaselineStatistics> java.util.Optional<S> baselineFor(
+                String id, FactorBundle factors, String name, Class<S> type,
+                org.javai.punit.api.covariate.CovariateProfile profile,
+                java.util.List<org.javai.punit.api.covariate.Covariate> declarations) {
+            return java.util.Optional.empty();
+        }
+        @Override
+        public java.util.Optional<String> baselineInputsIdentityFor(
+                String id, FactorBundle factors,
+                org.javai.punit.api.covariate.CovariateProfile profile,
+                java.util.List<org.javai.punit.api.covariate.Covariate> declarations) {
+            return java.util.Optional.empty();
+        }
+    };
+
+    @Test
+    @DisplayName("samples below floor for P95 produces a warning")
+    void warnsBelowFloorForP95() {
+        List<String> warnings = Feasibility.check(
+                10,
+                PercentileLatency.<Integer>empirical(PercentileKey.P95),
+                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
+
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0))
+                .contains("percentile-latency")
+                .contains("P95")
+                .contains("10 samples")
+                .contains("at least 20");
+    }
+
+    @Test
+    @DisplayName("samples at the floor emits no warning")
+    void silentAtFloorForP95() {
+        List<String> warnings = Feasibility.check(
+                20,
+                PercentileLatency.<Integer>empirical(PercentileKey.P95),
+                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
+        assertThat(warnings).isEmpty();
+    }
+
+    @Test
+    @DisplayName("multiple percentiles produce per-percentile warnings")
+    void warnsForEachAssertedPercentileBelowFloor() {
+        List<String> warnings = Feasibility.check(
+                15,
+                PercentileLatency.<Integer>empirical(PercentileKey.P95, PercentileKey.P99),
+                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
+
+        assertThat(warnings).hasSize(2);
+        assertThat(warnings).anyMatch(w -> w.contains("P95") && w.contains("at least 20"));
+        assertThat(warnings).anyMatch(w -> w.contains("P99") && w.contains("at least 100"));
+    }
+
+    @Test
+    @DisplayName("P50 has floor of 1 — never warns above zero samples")
+    void p50FloorIsOne() {
+        List<String> warnings = Feasibility.check(
+                1,
+                PercentileLatency.<Integer>empirical(PercentileKey.P50),
+                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
+        assertThat(warnings).isEmpty();
+    }
+
+    @Test
+    @DisplayName("SMOKE intent silences the warning")
+    void smokeIntentSilences() {
+        List<String> warnings = Feasibility.check(
+                5,
+                PercentileLatency.<Integer>empirical(PercentileKey.P99),
+                CONTRACT_ID, EMPTY_FACTORS, TestIntent.SMOKE, NULL_PROVIDER);
+        assertThat(warnings).isEmpty();
+    }
+}


### PR DESCRIPTION
Implements [DIR-CONTRACT-LATENCY-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-CONTRACT-LATENCY-punit.md) and [DIR-LATENCY-SAMPLE-SIZE-WARNING-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-LATENCY-SAMPLE-SIZE-WARNING-punit.md).

## Summary

**Contract-side latency authoring (DIR-CONTRACT-LATENCY-punit):**
- `Acceptance.<O>empirical(P95, P99...)` returns a `LatencyDecl` for empirical latency criteria; thresholds derived from the resolved baseline at evaluate time
- `Acceptance.<O>meeting(origin).ceiling(P95, ofMillis(500))` returns a `LatencyDecl` for contractual latency criteria
- Contract-side latency auto-injected through the existing `SpecCriterionDeriver` path — tests collapse to plain `.assertPasses()`
- 0..1 cardinality enforced at `Contract.effectiveCriteria()` time
- `PercentileKey` moves from `api.spec` to `api` (avoids the new `api.criterion → api.spec` cycle)

**Sample-size feasibility warning (DIR-LATENCY-SAMPLE-SIZE-WARNING-punit):**
- Preflight warning when planned `samples < ⌈1/(1-p)⌉` for any asserted percentile (P50 → 1, P90 → 10, P95 → 20, P99 → 100)
- Surfaced on the same stderr channel as baseline-feasibility warnings
- SMOKE intent silences it (symmetric with the pass-rate gate)
- Does not abort the run or alter the verdict

## Test plan

- [x] `./gradlew test` green (punit-core + punit-report + punit-sentinel)
- [x] New `ContractLatencyEndToEndIntegrationTest` pins: empirical auto-injection, contractual auto-injection, two-latency rejection, functional + latency combined
- [x] New `LatencyFeasibilityTest` pins: below-floor warning, at-floor silence, multi-percentile, P50-floor=1, SMOKE silences
- [x] Existing `EmpiricalLatencyEndToEndIntegrationTest` continues to pass (test-site path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)