### PR TITLE
Honour §12.4.2 saturation + §12.5.2.1 existence gate

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/EvaluationContext.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/EvaluationContext.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.criterion.CriterionPosture;
 
 /**
@@ -66,5 +67,15 @@ public interface EvaluationContext<OT, S extends BaselineStatistics> {
      */
     default Map<String, CriterionPosture> criterionPostures() {
         return Map.of();
+    }
+
+    /**
+     * The test's declared {@link TestIntent}. Defaults to
+     * {@link TestIntent#VERIFICATION} for back-compat with hand-built
+     * test fixtures; production code paths propagate the spec's
+     * configured intent.
+     */
+    default TestIntent intent() {
+        return TestIntent.VERIFICATION;
     }
 }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PercentileLatency.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
 
 /**
@@ -176,6 +177,7 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
         Map<PercentileKey, Duration> thresholds;
         Map<PercentileKey, Integer> thresholdRanks = new EnumMap<>(PercentileKey.class);
         Map<PercentileKey, Long> baselinePercentileMs = new EnumMap<>(PercentileKey.class);
+        EnumSet<PercentileKey> saturated = EnumSet.noneOf(PercentileKey.class);
         ThresholdOrigin resolvedOrigin;
         Integer baselineSampleCount = null;
 
@@ -206,7 +208,7 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
                 return sizeViolation.get();
             }
             thresholds = thresholdsFromBaseline(
-                    stats, thresholdRanks, baselinePercentileMs);
+                    stats, thresholdRanks, baselinePercentileMs, saturated);
             resolvedOrigin = ThresholdOrigin.EMPIRICAL;
             baselineSampleCount = stats.sampleCount();
         }
@@ -221,6 +223,30 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
             if (threshold != null && obs.compareTo(threshold) > 0) {
                 breachedKeys.add(key);
             }
+        }
+
+        // Saturation routing (companion §12.4.2 / §12.5.2.1): under
+        // VERIFICATION the methodology requires INCONCLUSIVE — no
+        // finite-sample distribution-free upper bound is available at
+        // the configured confidence. Under SMOKE, the advisory
+        // t_{(n)} is reported and PASS/FAIL proceeds on it.
+        boolean anySaturated = !saturated.isEmpty();
+        if (anySaturated && ctx.intent() == TestIntent.VERIFICATION) {
+            Map<String, Object> satDetail = new LinkedHashMap<>();
+            satDetail.put("assertedPercentiles", assertedCsv());
+            satDetail.put("origin", resolvedOrigin.name());
+            satDetail.put("confidence", confidence);
+            satDetail.put("baselineSampleCount", baselineSampleCount);
+            for (PercentileKey key : saturated) {
+                satDetail.put("saturated." + key.detailKey(), true);
+            }
+            String reason = String.format(
+                    "no finite-sample upper bound available at confidence=%s for percentile(s) %s "
+                            + "with baseline n=%d; verdict INCONCLUSIVE per Statistical Companion §12.5.2.1",
+                    confidence, saturated.stream().map(PercentileKey::detailKey)
+                            .collect(Collectors.joining(",")),
+                    baselineSampleCount == null ? 0 : baselineSampleCount);
+            return new CriterionResult(NAME, Verdict.INCONCLUSIVE, reason, satDetail);
         }
 
         Verdict verdict = breachedKeys.isEmpty() ? Verdict.PASS : Verdict.FAIL;
@@ -249,6 +275,9 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
         if (mode != Mode.CONTRACTUAL) {
             detail.put("baselineSampleCount", baselineSampleCount);
             detail.put("confidence", confidence);
+            for (PercentileKey key : saturated) {
+                detail.put("saturated." + key.detailKey(), true);
+            }
         }
 
         String explanation = breachedKeys.isEmpty()
@@ -317,7 +346,8 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
     private Map<PercentileKey, Duration> thresholdsFromBaseline(
             LatencyStatistics stats,
             Map<PercentileKey, Integer> thresholdRanks,
-            Map<PercentileKey, Long> baselinePercentileMs) {
+            Map<PercentileKey, Long> baselinePercentileMs,
+            EnumSet<PercentileKey> saturatedPercentiles) {
         long[] sortedMs = stats.sortedLatenciesMs();
         double[] sortedDouble = new double[sortedMs.length];
         for (int i = 0; i < sortedMs.length; i++) {
@@ -331,6 +361,9 @@ public final class PercentileLatency<OT> implements Criterion<OT, LatencyStatist
             map.put(key, Duration.ofMillis((long) derived.threshold()));
             thresholdRanks.put(key, derived.rank());
             baselinePercentileMs.put(key, (long) derived.baselinePercentile());
+            if (derived.saturated()) {
+                saturatedPercentiles.add(key);
+            }
         }
         return map;
     }

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -375,6 +375,7 @@ public final class ProbabilisticTest implements Spec {
                 BaselineProvider provider,
                 java.util.Set<String> warnings,
                 BaselineLookupCapture capture) {
+            TestIntent testIntent = this.intent;
             Criterion raw = criterion;
             Optional<? extends BaselineStatistics> resolved;
             if (criterion.isEmpirical()) {
@@ -401,6 +402,7 @@ public final class ProbabilisticTest implements Spec {
                 public java.util.Map<String, org.javai.punit.api.criterion.CriterionPosture> criterionPostures() {
                     return criterionPostures;
                 }
+                @Override public TestIntent intent() { return testIntent; }
             };
             return (CriterionResult) raw.evaluate(ctx);
         }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/Feasibility.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/Feasibility.java
@@ -157,6 +157,33 @@ public final class Feasibility {
         if (intent == TestIntent.SMOKE) {
             return List.of();
         }
+        // Confidence-bound existence gate (companion §12.5.2.1): for a
+        // distribution-free upper bound to exist within the sample, we
+        // need n_s >= ⌈log(α) / log(p)⌉ where α = 1 - confidence.
+        // VERIFICATION aborts when this fails; the run cannot
+        // underwrite a verdict at the configured confidence. SMOKE is
+        // silenced above.
+        double alpha = 1.0 - latency.confidence();
+        for (PercentileKey key : latency.assertedPercentiles()) {
+            int existenceFloor = (int) Math.ceil(Math.log(alpha) / Math.log(key.value()));
+            if (samples < existenceFloor) {
+                throw new IllegalStateException(String.format(
+                        "Latency criterion '%s' asserts %s at confidence %s, but the run is"
+                                + " configured for %d samples; the confidence-bound existence"
+                                + " gate (Statistical Companion §12.5.2.1) requires at least"
+                                + " %d samples for an upper bound to exist within the sample"
+                                + " at this confidence. Either raise the sample count, lower"
+                                + " the confidence, drop the asserted percentile, or run under"
+                                + " SMOKE intent to silence the gate.",
+                        latency.name(), key.name(), latency.confidence(),
+                        samples, existenceFloor));
+            }
+        }
+        // Non-degeneracy floor (companion §12.5.2): warning only.
+        // Surfaces a less-strict floor (P95 → 20, P99 → 100) that the
+        // existence gate above generally subsumes at α=0.05; kept as a
+        // diagnostic for runs where the existence gate did not fire
+        // (e.g. relaxed confidence).
         List<String> warnings = new ArrayList<>();
         for (PercentileKey key : latency.assertedPercentiles()) {
             int floor = minimumSampleSizeFor(key);

--- a/punit-core/src/main/java/org/javai/punit/statistics/LatencyThresholdDeriver.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/LatencyThresholdDeriver.java
@@ -8,19 +8,29 @@ import org.apache.commons.statistics.distribution.BinomialDistribution;
 /**
  * Derives latency thresholds from baseline data.
  *
- * <p>The canonical derivation (javai-R v1.1, &sect;12.4) is the
+ * <p>The canonical derivation (Statistical Companion &sect;12.4.2) is the
  * <b>exact binomial order-statistic upper confidence bound</b> on the baseline
  * percentile {@code Q(p)}:
  *
  * <pre>
  * tau = t_{(k)}
- * where k = qbinom(1 - alpha, n_s, p) + 1,
- *       clamped to [ceil(p * n_s), n_s]
+ * where k_raw = qbinom(1 - alpha, n_s, p) + 1,
+ *       k     = max(ceil(p * n_s), k_raw)   when k_raw &lt;= n_s
  * </pre>
  *
  * <p>{@code t_{(k)}} is the {@code k}-th order statistic (1-indexed) of the sorted
  * baseline successful-response latencies. The threshold is therefore an
  * observed baseline latency value &mdash; integer-ms by construction.
+ *
+ * <p><b>Saturation.</b> When {@code k_raw > n_s} the construction's existence
+ * condition (companion &sect;12.5.2.1) is not met — no finite-sample
+ * distribution-free upper confidence bound on {@code Q(p)} is available at
+ * the configured confidence. The deriver does <b>not</b> silently clamp
+ * {@code k_raw} to {@code n_s}; instead it returns
+ * {@link Threshold#saturated()} {@code true} carrying the advisory
+ * value {@code t_{(n_s)}} (which is <b>not</b> an exact bound). Callers
+ * decide what to do — under {@code VERIFICATION} the methodology requires
+ * INCONCLUSIVE; under {@code SMOKE} the advisory may be reported.
  *
  * <p>This construction is non-parametric, distribution-free, and exact for any
  * continuous underlying latency distribution.
@@ -63,16 +73,32 @@ public final class LatencyThresholdDeriver {
         // returns the smallest x such that P(X <= x) >= q, matching R's qbinom(q, n, p).
         BinomialDistribution binomial = BinomialDistribution.of(n, p);
         int qb = binomial.inverseCumulativeProbability(1.0 - alpha);
-        int k = qb + 1;
+        int kRaw = qb + 1;
 
         int pointRank = (int) Math.ceil(p * n);
         if (pointRank < 1) pointRank = 1;
-        k = Math.max(pointRank, Math.min(k, n));
 
-        double threshold = sorted[k - 1];
+        boolean saturated = kRaw > n;
+        int k;
+        double threshold;
+        if (saturated) {
+            // No finite-sample bound exists at this confidence
+            // (companion §12.4.2 / §12.5.2.1). The advisory value
+            // t_{(n)} is reported with saturated=true so the caller
+            // (PercentileLatency.evaluate) can route VERIFICATION to
+            // INCONCLUSIVE and SMOKE to an advisory PASS/FAIL. The
+            // deriver MUST NOT silently clamp k_raw to n and present
+            // t_{(n)} as an exact bound.
+            k = n;
+            threshold = sorted[n - 1];
+        } else {
+            k = Math.max(pointRank, kRaw);
+            threshold = sorted[k - 1];
+        }
+
         double baselinePercentile = LatencyStatistics.nearestRankPercentile(sorted, p);
 
-        return new Threshold(k, threshold, baselinePercentile, n);
+        return new Threshold(k, threshold, baselinePercentile, n, saturated);
     }
 
     /**
@@ -82,8 +108,18 @@ public final class LatencyThresholdDeriver {
      * @param threshold          the {@code k}-th order statistic value
      * @param baselinePercentile the nearest-rank point estimate {@code Q(p)}
      * @param n                  the baseline sample count
+     * @param saturated          {@code true} when {@code k_raw > n} — the
+     *                           {@code threshold} is the advisory {@code t_{(n)}},
+     *                           not an exact bound at the configured confidence
      */
-    public record Threshold(int rank, double threshold, double baselinePercentile, int n) {}
+    public record Threshold(
+            int rank, double threshold, double baselinePercentile, int n, boolean saturated) {
+
+        /** Back-compat constructor: non-saturated form. */
+        public Threshold(int rank, double threshold, double baselinePercentile, int n) {
+            this(rank, threshold, baselinePercentile, n, false);
+        }
+    }
 
     /**
      * Result of deriving a latency threshold for a percentile.

--- a/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/PercentileLatencyTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.javai.outcome.Outcome;
+import org.javai.punit.api.TestIntent;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.Contract;
 import org.javai.punit.api.PostconditionBuilder;
@@ -76,12 +77,22 @@ class PercentileLatencyTest {
             Optional<LatencyStatistics> baseline,
             String testIdentity,
             Optional<String> baselineIdentity) {
+        return ctx(summary, baseline, testIdentity, baselineIdentity, TestIntent.VERIFICATION);
+    }
+
+    private static <OT> EvaluationContext<OT, LatencyStatistics> ctx(
+            SampleSummary<OT> summary,
+            Optional<LatencyStatistics> baseline,
+            String testIdentity,
+            Optional<String> baselineIdentity,
+            TestIntent intent) {
         return new EvaluationContext<OT, LatencyStatistics>() {
             @Override public SampleSummary<OT> summary() { return summary; }
             @Override public Optional<LatencyStatistics> baseline() { return baseline; }
             @Override public FactorBundle factors() { return FactorBundle.of(new Factors("x")); }
             @Override public String testInputsIdentity() { return testIdentity; }
             @Override public Optional<String> baselineInputsIdentity() { return baselineIdentity; }
+            @Override public TestIntent intent() { return intent; }
         };
     }
 
@@ -180,6 +191,42 @@ class PercentileLatencyTest {
         // merely above the baseline percentile.
         assertThat(fail.detail()).containsEntry("breach.p95", 1500L);
         assertThat(fail.detail()).containsEntry("breach.p99", 3000L);
+    }
+
+    // ── saturation (companion §12.4.2 / §12.5.2.1) ─────────────────
+
+    @Test
+    @DisplayName("VERIFICATION + saturated baseline → INCONCLUSIVE with saturated.<p>=true detail")
+    void verificationOnSaturationIsInconclusive() {
+        // P99 with baseline n=100 at α=0.05 saturates: qbinom(0.95, 100, 0.99) = 100, k_raw = 101 > 100.
+        PercentileLatency<String> criterion = PercentileLatency.empirical(PercentileKey.P99);
+        LatencyStatistics baseline = LatencyStatistics.fromPercentiles(
+                observed(100, 200, 500, 1000, 100), 100);
+
+        CriterionResult result = criterion.evaluate(
+                ctx(summary(observed(80, 180, 480, 900, 50), 50, 0), Optional.of(baseline),
+                        DEFAULT_IDENTITY, Optional.of(DEFAULT_IDENTITY), TestIntent.VERIFICATION));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.INCONCLUSIVE);
+        assertThat(result.detail()).containsEntry("saturated.p99", true);
+        assertThat(result.explanation()).contains("no finite-sample upper bound")
+                .contains("§12.5.2.1");
+    }
+
+    @Test
+    @DisplayName("SMOKE + saturated baseline → advisory PASS/FAIL with saturated.<p>=true detail")
+    void smokeOnSaturationIsAdvisory() {
+        PercentileLatency<String> criterion = PercentileLatency.empirical(PercentileKey.P99);
+        LatencyStatistics baseline = LatencyStatistics.fromPercentiles(
+                observed(100, 200, 500, 1000, 100), 100);
+
+        // Under SMOKE, the advisory threshold t_{(n)} is used; observed under it -> PASS.
+        CriterionResult result = criterion.evaluate(
+                ctx(summary(observed(80, 180, 480, 900, 50), 50, 0), Optional.of(baseline),
+                        DEFAULT_IDENTITY, Optional.of(DEFAULT_IDENTITY), TestIntent.SMOKE));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+        assertThat(result.detail()).containsEntry("saturated.p99", true);
     }
 
     // ── sample-size constraint (test_N ≤ baseline_N) ───────────────

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/LatencyFeasibilityTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/LatencyFeasibilityTest.java
@@ -1,6 +1,7 @@
 package org.javai.punit.internal.engine.criteria;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 
@@ -35,62 +36,90 @@ class LatencyFeasibilityTest {
         }
     };
 
-    @Test
-    @DisplayName("samples below floor for P95 produces a warning")
-    void warnsBelowFloorForP95() {
-        List<String> warnings = Feasibility.check(
-                10,
-                PercentileLatency.<Integer>empirical(PercentileKey.P95),
-                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
+    // ── Existence gate (companion §12.5.2.1): ⌈log(α) / log(p)⌉ ──
+    //
+    // At α = 0.05 (the default 0.95 confidence):
+    //   P50 → 5
+    //   P90 → 29
+    //   P95 → 59
+    //   P99 → 299
 
-        assertThat(warnings).hasSize(1);
-        assertThat(warnings.get(0))
-                .contains("percentile-latency")
-                .contains("P95")
-                .contains("10 samples")
-                .contains("at least 20");
+    @Test
+    @DisplayName("VERIFICATION: samples below P95 existence floor (59 at α=0.05) → IllegalStateException")
+    void verificationP95Below59Aborts() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> Feasibility.check(
+                        50,
+                        PercentileLatency.<Integer>empirical(PercentileKey.P95),
+                        CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER))
+                .withMessageContaining("P95")
+                .withMessageContaining("50 samples")
+                .withMessageContaining("at least 59")
+                .withMessageContaining("§12.5.2.1");
     }
 
     @Test
-    @DisplayName("samples at the floor emits no warning")
-    void silentAtFloorForP95() {
+    @DisplayName("VERIFICATION: samples at P95 existence floor → no abort, no warning")
+    void verificationP95AtFloorSilent() {
         List<String> warnings = Feasibility.check(
-                20,
+                59,
                 PercentileLatency.<Integer>empirical(PercentileKey.P95),
                 CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
         assertThat(warnings).isEmpty();
     }
 
     @Test
-    @DisplayName("multiple percentiles produce per-percentile warnings")
-    void warnsForEachAssertedPercentileBelowFloor() {
-        List<String> warnings = Feasibility.check(
-                15,
-                PercentileLatency.<Integer>empirical(PercentileKey.P95, PercentileKey.P99),
-                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
-
-        assertThat(warnings).hasSize(2);
-        assertThat(warnings).anyMatch(w -> w.contains("P95") && w.contains("at least 20"));
-        assertThat(warnings).anyMatch(w -> w.contains("P99") && w.contains("at least 100"));
+    @DisplayName("VERIFICATION: samples below P99 existence floor (299) → IllegalStateException")
+    void verificationP99Below299Aborts() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> Feasibility.check(
+                        100,
+                        PercentileLatency.<Integer>empirical(PercentileKey.P99),
+                        CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER))
+                .withMessageContaining("P99")
+                .withMessageContaining("at least 299");
     }
 
     @Test
-    @DisplayName("P50 has floor of 1 — never warns above zero samples")
-    void p50FloorIsOne() {
-        List<String> warnings = Feasibility.check(
-                1,
-                PercentileLatency.<Integer>empirical(PercentileKey.P50),
-                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
-        assertThat(warnings).isEmpty();
+    @DisplayName("VERIFICATION: gate fires on the strictest failing percentile when multiple are asserted")
+    void verificationMultiPercentileFiresOnStrictest() {
+        // 100 samples: passes P95's floor of 59, fails P99's floor of 299.
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> Feasibility.check(
+                        100,
+                        PercentileLatency.<Integer>empirical(PercentileKey.P95, PercentileKey.P99),
+                        CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER))
+                .withMessageContaining("P99");
     }
 
     @Test
-    @DisplayName("SMOKE intent silences the warning")
-    void smokeIntentSilences() {
+    @DisplayName("SMOKE: silences both gates, no abort, no warnings")
+    void smokeSilencesAllGates() {
         List<String> warnings = Feasibility.check(
                 5,
                 PercentileLatency.<Integer>empirical(PercentileKey.P99),
                 CONTRACT_ID, EMPTY_FACTORS, TestIntent.SMOKE, NULL_PROVIDER);
         assertThat(warnings).isEmpty();
+    }
+
+    // ── Non-degeneracy floor (§12.5.2) — only surfaces when the
+    // existence gate is relaxed by lowering confidence enough that
+    // ⌈log(α) / log(p)⌉ falls below the non-degeneracy floor.
+
+    @Test
+    @DisplayName("VERIFICATION + relaxed confidence: non-degeneracy floor warns when existence gate doesn't fire")
+    void nonDegeneracyWarningWhenExistenceGatePasses() {
+        // At confidence 0.50, α=0.50, existence floor for P95 is
+        // ⌈log(0.50)/log(0.95)⌉ = 14. Non-degeneracy floor is 20.
+        // A 15-sample run clears the existence gate but trips the
+        // non-degeneracy warning.
+        List<String> warnings = Feasibility.check(
+                15,
+                PercentileLatency.<Integer>empirical(0.50, PercentileKey.P95),
+                CONTRACT_ID, EMPTY_FACTORS, TestIntent.VERIFICATION, NULL_PROVIDER);
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0))
+                .contains("P95")
+                .contains("at least 20");
     }
 }


### PR DESCRIPTION
Implements [DIR-LATENCY-SATURATION-AND-EXISTENCE-GATE-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-LATENCY-SATURATION-AND-EXISTENCE-GATE-punit.md).

## Summary

Two defects fixed:

1. **\`LatencyThresholdDeriver\` silently clamped \`k = min(k, n)\`** when the binomial-derived rank exceeded the baseline sample size — the exact pattern Statistical Companion §12.4.2 forbids ("does not clamp \`k_raw\` to \`n_s\` and present \`t_{(n_s)}\` as an exact bound"). The deriver now leaves \`k_raw\` alone and returns \`Threshold.saturated()\` = true carrying the advisory \`t_{(n)}\` value.
2. **No §12.5.2.1 confidence-bound existence gate** existed. \`Feasibility\` now computes ⌈log(α)/log(p)⌉ per asserted percentile and aborts the VERIFICATION run when the test's sample count is below the floor. SMOKE silences both gates. The existing §12.5.2 non-degeneracy floor stays as a diagnostic warning for relaxed-confidence configurations.

\`PercentileLatency.evaluate\` routes saturation per intent:
- VERIFICATION → INCONCLUSIVE with \`saturated.<p>=true\` and a reason referencing §12.5.2.1.
- SMOKE → advisory PASS/FAIL on \`t_{(n)}\`, with \`saturated.<p>=true\` in the detail map.

\`EvaluationContext\` grows an \`intent()\` accessor (default VERIFICATION for back-compat). \`ProbabilisticTest\` wires the spec's configured intent through.

## Test plan

- [x] \`./gradlew test\` green
- [x] \`PercentileLatencyTest\` saturation cases: VERIFICATION → INCONCLUSIVE, SMOKE → advisory PASS, both surface \`saturated.p99=true\`
- [x] \`LatencyFeasibilityTest\` rewritten: existence-gate \`IllegalStateException\` at default α=0.05; non-degeneracy warning surfaces at relaxed confidence

## Follow-on

- javai-R fixture extension covering the saturated rank cases (companion §12.4.4's \`n_s=200, p=0.99\` "graceful saturation" demonstration) — the existing \`latency_threshold_bootstrap.json\` already has this case structurally but doesn't pin a \`saturated\` flag. A small javai-R bump can carry it.
- Production-path conformance test (the gap noted on punit#191): a \`LatencyConformanceTest.ProductionPath\` constructing a \`LatencyStatistics\` and running it through \`PercentileLatency.evaluate\`, asserting on the \`threshold.<p>\` detail-map value rather than calling the deriver in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)