### PR TITLE
Production-path conformance for latency-threshold derivation

### DIFF
--- a/punit-core/src/test/java/org/javai/punit/statistics/conformance/LatencyConformanceTest.java
+++ b/punit-core/src/test/java/org/javai/punit/statistics/conformance/LatencyConformanceTest.java
@@ -2,6 +2,21 @@ package org.javai.punit.statistics.conformance;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Contract;
+import org.javai.punit.api.FactorBundle;
+import org.javai.punit.api.LatencyResult;
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.PostconditionBuilder;
+import org.javai.punit.api.ServiceContractOutcome;
+import org.javai.punit.api.TestIntent;
+import org.javai.punit.api.TokenTracker;
+import org.javai.punit.api.spec.CriterionResult;
+import org.javai.punit.api.spec.EvaluationContext;
+import org.javai.punit.api.spec.PercentileLatency;
+import org.javai.punit.api.spec.SampleSummary;
+import org.javai.punit.api.spec.TerminationReason;
+import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.statistics.LatencyStatistics;
 import org.javai.punit.statistics.LatencyThresholdDeriver;
 import org.junit.jupiter.api.DisplayName;
@@ -12,8 +27,12 @@ import org.junit.jupiter.api.TestFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -249,4 +268,196 @@ class LatencyConformanceTest {
             }
         }
     }
+
+    /**
+     * End-to-end conformance against the bootstrap fixture, driven
+     * through the production evaluation path
+     * ({@code PercentileLatency.evaluate} reading a baseline
+     * {@code LatencyStatistics}) rather than calling
+     * {@code LatencyThresholdDeriver} in isolation. Guards against
+     * a class of regression where the deriver remains correct on its
+     * own but a refactor detaches it from the hot path or rewires the
+     * detail-map value.
+     *
+     * <p>For non-saturated cases the test asserts exact equality of
+     * the {@code threshold.<p>} detail-map entry against the fixture's
+     * {@code expected.threshold}, and verdict PASS (the synthetic
+     * observed latencies are well below threshold).
+     *
+     * <p>For saturated cases (companion §12.4.2) the test exercises
+     * both intents: under VERIFICATION → INCONCLUSIVE with
+     * {@code saturated.<p>=true}; under SMOKE → advisory PASS with
+     * the same flag set and the threshold equal to the fixture's
+     * advisory value at the saturation ceiling.
+     */
+    @Nested
+    @DisplayName("latency_threshold_bootstrap (production path: PercentileLatency.evaluate)")
+    class ProductionPath {
+
+        @TestFactory
+        @DisplayName("Threshold derived on the production path matches the fixture, per intent")
+        Collection<DynamicTest> cases() {
+            JsonNode suite = loadSuite("latency_threshold_bootstrap.json");
+
+            var tests = new ArrayList<DynamicTest>();
+            for (JsonNode c : suite.get("cases")) {
+                String name = c.get("name").asText();
+                var inputs = c.get("inputs");
+                var expected = c.get("expected");
+
+                tests.add(DynamicTest.dynamicTest(name, () -> {
+                    long[] baselineLatenciesMs = toLongArray(inputs.get("baseline_latencies"));
+                    double p = inputs.get("p").asDouble();
+                    double confidence = inputs.get("confidence").asDouble();
+                    long expectedThreshold = expected.get("threshold").asLong();
+                    boolean saturated = expected.get("saturated").asBoolean();
+                    PercentileKey key = percentileKeyFor(p);
+
+                    org.javai.punit.api.spec.LatencyStatistics baseline =
+                            buildBaseline(baselineLatenciesMs);
+                    PercentileLatency<String> criterion =
+                            PercentileLatency.empirical(confidence, key);
+
+                    // VERIFICATION: saturated → INCONCLUSIVE with the
+                    // saturation flag; non-saturated → PASS with
+                    // threshold.<p> equal to fixture's expected.threshold.
+                    CriterionResult verification = criterion.evaluate(
+                            evaluationContext(baseline, TestIntent.VERIFICATION));
+                    if (saturated) {
+                        assertThat(verification.verdict())
+                                .as("case=%s VERIFICATION verdict (saturated)", name)
+                                .isEqualTo(Verdict.INCONCLUSIVE);
+                        assertThat(verification.detail())
+                                .as("case=%s saturated.%s flag", name, key.detailKey())
+                                .containsEntry("saturated." + key.detailKey(), true);
+                    } else {
+                        assertThat(verification.verdict())
+                                .as("case=%s VERIFICATION verdict (non-saturated)", name)
+                                .isEqualTo(Verdict.PASS);
+                        assertThat(verification.detail())
+                                .as("case=%s threshold.%s on production path", name, key.detailKey())
+                                .containsEntry("threshold." + key.detailKey(), expectedThreshold);
+                    }
+
+                    // SMOKE on the saturated case: advisory PASS on
+                    // t_{(n)}, threshold.<p> present and equal to the
+                    // fixture's published threshold, saturated flag
+                    // still surfaced.
+                    if (saturated) {
+                        CriterionResult smoke = criterion.evaluate(
+                                evaluationContext(baseline, TestIntent.SMOKE));
+                        assertThat(smoke.verdict())
+                                .as("case=%s SMOKE verdict (saturated, advisory)", name)
+                                .isEqualTo(Verdict.PASS);
+                        assertThat(smoke.detail())
+                                .as("case=%s SMOKE threshold.%s (advisory)", name, key.detailKey())
+                                .containsEntry("threshold." + key.detailKey(), expectedThreshold);
+                        assertThat(smoke.detail())
+                                .as("case=%s SMOKE saturated.%s flag", name, key.detailKey())
+                                .containsEntry("saturated." + key.detailKey(), true);
+                    }
+                }));
+            }
+            return tests;
+        }
+
+        private PercentileKey percentileKeyFor(double p) {
+            if (p == 0.95) return PercentileKey.P95;
+            if (p == 0.99) return PercentileKey.P99;
+            throw new IllegalArgumentException(
+                    "fixture case asserts percentile " + p
+                            + ", which has no PercentileKey on the production surface");
+        }
+
+        private org.javai.punit.api.spec.LatencyStatistics buildBaseline(long[] sortedAscMs) {
+            // sortedLatenciesMs is the only field the deriver reads;
+            // percentile point estimates are reporting metadata. Fill
+            // them honestly from the sorted vector so the baseline
+            // object is internally consistent.
+            LatencyResult percentiles = new LatencyResult(
+                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.50)),
+                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.90)),
+                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.95)),
+                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.99)),
+                    sortedAscMs.length);
+            return new org.javai.punit.api.spec.LatencyStatistics(
+                    percentiles, sortedAscMs, sortedAscMs.length);
+        }
+
+        private long nearestRankMs(long[] sortedAsc, double p) {
+            int index = (int) Math.ceil(p * sortedAsc.length) - 1;
+            index = Math.max(0, Math.min(index, sortedAsc.length - 1));
+            return sortedAsc[index];
+        }
+
+        private EvaluationContext<String, org.javai.punit.api.spec.LatencyStatistics>
+                evaluationContext(
+                        org.javai.punit.api.spec.LatencyStatistics baseline,
+                        TestIntent intent) {
+            int testSampleCount = Math.max(1, baseline.sampleCount() / 2);
+            SampleSummary<String> summary = buildSummary(testSampleCount);
+            String identity = "sha256:test-fixed-identity";
+            return new EvaluationContext<>() {
+                @Override public SampleSummary<String> summary() { return summary; }
+                @Override public Optional<org.javai.punit.api.spec.LatencyStatistics> baseline() {
+                    return Optional.of(baseline);
+                }
+                @Override public FactorBundle factors() {
+                    return FactorBundle.of(new Object());
+                }
+                @Override public String testInputsIdentity() { return identity; }
+                @Override public Optional<String> baselineInputsIdentity() {
+                    return Optional.of(identity);
+                }
+                @Override public TestIntent intent() { return intent; }
+            };
+        }
+
+        private SampleSummary<String> buildSummary(int sampleCount) {
+            // Synthetic observed latencies safely below every published
+            // bootstrap-case threshold (smallest threshold across the
+            // four cases is 419 ms); the test asserts on the deriver's
+            // threshold value flowing through evaluate, not on the
+            // observation-vs-threshold comparison.
+            LatencyResult observed = new LatencyResult(
+                    Duration.ofMillis(1),
+                    Duration.ofMillis(1),
+                    Duration.ofMillis(1),
+                    Duration.ofMillis(1),
+                    sampleCount);
+            var outcomes = new ArrayList<ServiceContractOutcome<?, String>>(sampleCount);
+            for (int i = 0; i < sampleCount; i++) {
+                outcomes.add(new ServiceContractOutcome<>(
+                        Outcome.ok("ok"), STUB_CONTRACT, List.of(),
+                        0L, Duration.ofMillis(1)));
+            }
+            return new SampleSummary<>(
+                    outcomes,
+                    Duration.ofMillis(1),
+                    sampleCount, 0, 0L, 0,
+                    observed,
+                    TerminationReason.COMPLETED,
+                    List.of(),
+                    Map.of(), LatencyResult.empty(), List.of());
+        }
+
+        private long[] toLongArray(JsonNode node) {
+            if (!node.isArray()) {
+                throw new IllegalArgumentException(
+                        "baseline_latencies must be a JSON array");
+            }
+            long[] out = new long[node.size()];
+            for (int i = 0; i < node.size(); i++) {
+                out[i] = node.get(i).asLong();
+            }
+            return out;
+        }
+    }
+
+    private static final Contract<Object, String> STUB_CONTRACT = new Contract<>() {
+        @Override public Outcome<String> invoke(Object input, TokenTracker tracker) {
+            return Outcome.ok("ok");
+        }
+        @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
+    };
 }


### PR DESCRIPTION
Implements [DIR-LATENCY-PRODUCTION-PATH-CONFORMANCE-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-LATENCY-PRODUCTION-PATH-CONFORMANCE-punit.md).

## Summary

Adds a \`ProductionPath\` nested suite to \`LatencyConformanceTest\` that drives the full \`PercentileLatency.evaluate\` pipeline against \`latency_threshold_bootstrap.json\`, asserting on the \`threshold.<p>\` detail-map value rather than calling \`LatencyThresholdDeriver\` in isolation. Closes the gap noted on punit#191 and punit#192: nothing previously exercised the production wiring against the oracle's published values, so a refactor that detached the deriver from the hot path (or subtly rewired the detail-map value) would pass \`BootstrapComparison\` and still ship a framework that drifted from the oracle.

## Coverage

For each of the four published cases:

- **Non-saturated** (\`lognormal_n200_p95\`, \`lognormal_n935_p95\`, \`lognormal_n935_p99\`): under VERIFICATION, verdict PASS (synthetic observed latencies are well below threshold) and \`threshold.<p>\` exactly equal to the fixture's \`expected.threshold\`.
- **Saturated** (\`lognormal_n200_p99\`, \`k_raw = 201\`, \`n = 200\`): under VERIFICATION → INCONCLUSIVE with \`saturated.p99 = true\` per Statistical Companion §12.4.2 / §12.5.2.1. Under SMOKE → advisory PASS with \`threshold.p99\` equal to the fixture's advisory \`t_{(n)}\` and the saturation flag still surfaced.

The pre-existing \`BootstrapComparison\` suite stays as-is — it remains valuable as the direct-derivation conformance check, independent of wiring.

## Sequencing

The directive flagged that the saturation-aware assertions wait on a javai-R release carrying the \`saturated\` field. Today \`fetchConformanceData\` resolves \`latest\` → \`v0.8.1\`, which ships the field (released today, ahead of writing this test).

## Test plan

- [x] \`./gradlew :punit-core:test --tests \"*ProductionPath*\"\` — 4/4 green
- [x] \`./gradlew test\` — full suite green, including \`RequirementCodeIsolationTest\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)