### PR TITLE
Introduce value-form criterion factory surface (DIR-CRITERIA-PROVENANCE-AND-KIND PR #1)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/criterion/ContractualDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/ContractualDecl.java
@@ -1,0 +1,71 @@
+package org.javai.punit.api.criterion;
+
+import java.time.Duration;
+
+import org.javai.punit.api.PercentileKey;
+
+/**
+ * The kind selector returned by {@link Criteria#meeting()}.
+ *
+ * <p>Opens a contractual-mode chain — the threshold is supplied by
+ * the author (a rate, a per-percentile duration ceiling), not derived
+ * from a baseline. The origin defaults to
+ * {@link org.javai.punit.api.ThresholdOrigin#UNSPECIFIED} and is
+ * overridden when the author later calls
+ * {@code .contractRef(origin, ref)} on the kind-specific decl.
+ *
+ * <p>Three kind-selector methods, each returning a kind-specific
+ * decl:
+ * <ul>
+ *   <li>{@link #passRate(double)} → {@link CriterionDecl} —
+ *       statistical pass-rate criterion at the supplied rate.</li>
+ *   <li>{@link #zeroTolerance()} → {@link CriterionDecl} — explicit
+ *       any-failure-fails commitment.</li>
+ *   <li>{@link #atMost(PercentileKey, Duration)} →
+ *       {@link LatencyCriterion} — contractual latency criterion
+ *       with the supplied per-percentile ceiling. Chain further
+ *       {@code .atMost(...)} calls on the returned criterion to
+ *       declare additional ceilings.</li>
+ * </ul>
+ *
+ * <p>The interface itself is non-generic; the type parameter
+ * {@code <O>} enters the chain at the kind-selector method that
+ * needs it ({@code passRate}, {@code zeroTolerance}). The latency
+ * kind selector has no type parameter — latency criteria care about
+ * durations, not per-sample outcome values.
+ *
+ * <p>This is the new authoring surface introduced by
+ * {@code DIR-CRITERIA-PROVENANCE-AND-KIND-punit}. The legacy
+ * {@link Acceptance} factory remains in place during the migration
+ * window.
+ */
+public interface ContractualDecl {
+
+    /**
+     * Statistical, contractual pass-rate criterion. PASS iff
+     * observed pass-rate ≥ {@code rate}.
+     *
+     * @param rate the required pass-rate, in {@code [0, 1)}
+     */
+    <O> CriterionDecl<O> passRate(double rate);
+
+    /**
+     * Explicit zero-tolerance criterion. Any failed sample fails
+     * the criterion.
+     */
+    <O> CriterionDecl<O> zeroTolerance();
+
+    /**
+     * Contractual latency ceiling at the asserted percentile.
+     * Returns a {@link LatencyCriterion} suitable for return from
+     * {@link org.javai.punit.api.Contract#latency()}. Chain further
+     * {@code .atMost(...)} calls on the returned criterion to
+     * declare additional ceilings.
+     *
+     * <p>The monotonicity check fires when two or more
+     * {@code .atMost(...)} calls disagree with the order-statistic
+     * ordering (higher percentile assigned a lower duration than a
+     * lower percentile).
+     */
+    LatencyCriterion atMost(PercentileKey key, Duration value);
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/ContractualDeclImpl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/ContractualDeclImpl.java
@@ -1,0 +1,43 @@
+package org.javai.punit.api.criterion;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+import org.javai.punit.api.PercentileKey;
+import org.javai.punit.api.ThresholdOrigin;
+
+/**
+ * Package-private singleton implementation of {@link ContractualDecl}.
+ * Stateless — every method constructs and returns a fresh decl.
+ */
+final class ContractualDeclImpl implements ContractualDecl {
+
+    static final ContractualDeclImpl INSTANCE = new ContractualDeclImpl();
+
+    private ContractualDeclImpl() {
+        /* singleton */
+    }
+
+    @Override
+    public <O> CriterionDecl<O> passRate(double rate) {
+        return new CriterionDecl<>(
+                CriterionPosture.meeting(ThresholdOrigin.UNSPECIFIED, rate),
+                List.of());
+    }
+
+    @Override
+    public <O> CriterionDecl<O> zeroTolerance() {
+        return new CriterionDecl<>(
+                CriterionPosture.zeroTolerance(ThresholdOrigin.UNSPECIFIED),
+                List.of());
+    }
+
+    @Override
+    public LatencyCriterion atMost(PercentileKey key, Duration value) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        return LatencyCriterion.meeting(ThresholdOrigin.UNSPECIFIED,
+                LatencyCriterion.ceiling(key, value));
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criteria.java
@@ -122,6 +122,62 @@ public sealed interface Criteria<O>
      *         any decl in a K>1 bundle is unnamed, or if two decls
      *         share a name
      */
+    /**
+     * Open a contractual-mode kind-selector chain. The author calls
+     * one of the kind-selector methods on the returned
+     * {@link ContractualDecl} to declare a pass-rate, zero-tolerance,
+     * or latency criterion.
+     *
+     * <p>Origin defaults to
+     * {@link org.javai.punit.api.ThresholdOrigin#UNSPECIFIED} and is
+     * overridden when the author later calls
+     * {@code .contractRef(origin, ref)} on the kind-specific decl.
+     *
+     * <p>The factory is non-generic — the type parameter
+     * {@code <O>} enters the chain at the kind-selector step
+     * ({@code .passRate(...)}, {@code .zeroTolerance()}), or not at
+     * all in the latency case. Witness placement at the call site:
+     *
+     * <pre>{@code
+     * // K=1 — target-type inference works through a single chain.
+     * @Override public Criteria<String> criteria() {
+     *     return meeting().passRate(0.85).where("parseable", v -> isJson(v));
+     * }
+     *
+     * // K>1 — explicit witness on the kind-selector method.
+     * @Override public Criteria<Response> criteria() {
+     *     return of(
+     *         meeting().<Response>passRate(0.99).name("body").where(...),
+     *         meeting().<Response>zeroTolerance().name("pii").where(...));
+     * }
+     *
+     * // Latency — no witness anywhere; .atMost(...) returns
+     * // LatencyCriterion which has no type parameter.
+     * @Override public LatencyCriterion latency() {
+     *     return meeting().atMost(P95, ofSeconds(1));
+     * }
+     * }</pre>
+     */
+    static ContractualDecl meeting() {
+        return ContractualDeclImpl.INSTANCE;
+    }
+
+    /**
+     * Open an empirical-mode kind-selector chain. The author calls
+     * one of the kind-selector methods on the returned
+     * {@link EmpiricalDecl} to declare an empirical pass-rate or
+     * empirical latency criterion.
+     *
+     * <p>No origin parameter applies — the baseline IS the source
+     * of the threshold.
+     *
+     * <p>The factory is non-generic for the same reason as
+     * {@link #meeting()}.
+     */
+    static EmpiricalDecl empirical() {
+        return EmpiricalDeclImpl.INSTANCE;
+    }
+
     @SafeVarargs
     static <O> Criteria<O> of(Decl<O>... decls) {
         Objects.requireNonNull(decls, "decls");

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
@@ -166,6 +166,28 @@ public final class CriterionDecl<O> implements Decl<O> {
     }
 
     /**
+     * Attach a contract reference and update the origin in one call.
+     * Designed for the new {@link Criteria#meeting()} authoring shape
+     * where the chain opens with origin
+     * {@link org.javai.punit.api.ThresholdOrigin#UNSPECIFIED} and the
+     * author later names both the source category and the document
+     * reference on the same line:
+     *
+     * <pre>{@code
+     * meeting().passRate(0.9999).contractRef(SLA, "Payment SLA v2.3 §4.1")
+     * }</pre>
+     *
+     * <p>{@code origin} must be a non-empirical origin (SLA / SLO /
+     * POLICY / UNSPECIFIED). Rejected on empirical-mode postures —
+     * the baseline IS the source.
+     */
+    public CriterionDecl<O> contractRef(
+            org.javai.punit.api.ThresholdOrigin origin, String ref) {
+        return new CriterionDecl<>(
+                posture.withContractRef(origin, ref), postconditions, name);
+    }
+
+    /**
      * Set the per-criterion confidence floor — the run cannot
      * loosen it. Composes only with {@code empirical()}; rejected
      * by the posture machinery on a {@code .meeting(...)} or

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
@@ -308,6 +308,43 @@ public final class CriterionPosture {
                 assertedPercentiles, latencySpec);
     }
 
+    /**
+     * Returns a copy of this posture with both the origin and the
+     * contract reference updated in one step. Used by the new
+     * authoring surface where {@code Criteria.meeting()} opens a
+     * chain with origin {@link ThresholdOrigin#UNSPECIFIED} and the
+     * author later names both the source category and the document
+     * reference together via
+     * {@code .contractRef(ThresholdOrigin, String)}.
+     *
+     * <p>{@code newOrigin} must not be {@link ThresholdOrigin#EMPIRICAL}
+     * — empirical-mode criteria reach this posture machinery via
+     * {@code Criteria.empirical()}, not via {@code contractRef}.
+     * Empirical-mode postures reject the call entirely.
+     */
+    public CriterionPosture withContractRef(ThresholdOrigin newOrigin, String ref) {
+        Objects.requireNonNull(newOrigin, "origin");
+        Objects.requireNonNull(ref, "contractRef");
+        if (ref.isBlank()) {
+            throw new IllegalArgumentException(".contractRef requires a non-blank string");
+        }
+        if (newOrigin == ThresholdOrigin.EMPIRICAL) {
+            throw new IllegalArgumentException(
+                    ".contractRef(EMPIRICAL, ...) is contradictory — empirical "
+                            + "criteria are sourced from the baseline, not from a "
+                            + "named document");
+        }
+        if (kind == Kind.STATISTICAL_EMPIRICAL || kind == Kind.LATENCY_EMPIRICAL) {
+            throw new IllegalStateException(
+                    ".contractRef(origin, ref) cannot retag an empirical-mode "
+                            + "criterion with a contractual origin; the baseline "
+                            + "IS the source");
+        }
+        return new CriterionPosture(kind, threshold, Optional.of(newOrigin),
+                confidenceFloor, mde, power, Optional.of(ref),
+                assertedPercentiles, latencySpec);
+    }
+
     private void rejectRigourAdjunct(String methodName) {
         switch (kind) {
             case ZERO_TOLERANCE, IMPLICIT_ZERO_TOLERANCE -> throw new IllegalStateException(

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/EmpiricalDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/EmpiricalDecl.java
@@ -1,0 +1,52 @@
+package org.javai.punit.api.criterion;
+
+import org.javai.punit.api.PercentileKey;
+
+/**
+ * The kind selector returned by {@link Criteria#empirical()}.
+ *
+ * <p>Opens an empirical-mode chain — the threshold is derived from
+ * the resolved baseline at evaluate time, not supplied by the author.
+ *
+ * <p>Two kind-selector methods:
+ * <ul>
+ *   <li>{@link #passRate()} → {@link CriterionDecl} — empirical
+ *       pass-rate criterion (Wilson-vs-baseline procedure). No rate
+ *       argument — the threshold is derived from the baseline.</li>
+ *   <li>{@link #atMost(PercentileKey)} → {@link LatencyCriterion} —
+ *       empirical latency criterion at the asserted percentile. No
+ *       duration argument — the upper bound is derived from the
+ *       baseline at the configured confidence.</li>
+ * </ul>
+ *
+ * <p>No {@code zeroTolerance()} method — zero-tolerance is
+ * intrinsically contractual (the threshold is exactly 1.0, with no
+ * baseline to derive from).
+ *
+ * <p>The interface itself is non-generic; the type parameter
+ * {@code <O>} enters the chain at {@code passRate()}. The latency
+ * kind selector has no type parameter — latency criteria care about
+ * durations, not per-sample outcome values.
+ *
+ * <p>This is the new authoring surface introduced by
+ * {@code DIR-CRITERIA-PROVENANCE-AND-KIND-punit}. The legacy
+ * {@link Acceptance} factory remains in place during the migration
+ * window.
+ */
+public interface EmpiricalDecl {
+
+    /**
+     * Statistical, empirical pass-rate criterion. Threshold derived
+     * from the resolved baseline via the Wilson-lower-bound procedure.
+     */
+    <O> CriterionDecl<O> passRate();
+
+    /**
+     * Empirical latency criterion at the asserted percentile.
+     * Returns a {@link LatencyCriterion} suitable for return from
+     * {@link org.javai.punit.api.Contract#latency()}. Chain further
+     * {@code .atMost(...)} calls on the returned criterion to assert
+     * additional percentiles.
+     */
+    LatencyCriterion atMost(PercentileKey key);
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/EmpiricalDeclImpl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/EmpiricalDeclImpl.java
@@ -1,0 +1,30 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.javai.punit.api.PercentileKey;
+
+/**
+ * Package-private singleton implementation of {@link EmpiricalDecl}.
+ * Stateless — every method constructs and returns a fresh decl.
+ */
+final class EmpiricalDeclImpl implements EmpiricalDecl {
+
+    static final EmpiricalDeclImpl INSTANCE = new EmpiricalDeclImpl();
+
+    private EmpiricalDeclImpl() {
+        /* singleton */
+    }
+
+    @Override
+    public <O> CriterionDecl<O> passRate() {
+        return new CriterionDecl<>(CriterionPosture.empirical(), List.of());
+    }
+
+    @Override
+    public LatencyCriterion atMost(PercentileKey key) {
+        Objects.requireNonNull(key, "key");
+        return LatencyCriterion.empirical(key);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/LatencyCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/LatencyCriterion.java
@@ -163,6 +163,181 @@ public final class LatencyCriterion {
     }
 
     /**
+     * Attach a contract reference and update the origin in one call.
+     * Designed for the new {@link Criteria#meeting()} authoring shape
+     * where {@code meeting()} opens the chain with origin
+     * {@link ThresholdOrigin#UNSPECIFIED} and the author later names
+     * the source on the same line as the reference text.
+     *
+     * <p>{@code origin} must be a non-empirical origin (SLA / SLO /
+     * POLICY / UNSPECIFIED).
+     */
+    public LatencyCriterion contractRef(ThresholdOrigin origin, String ref) {
+        Objects.requireNonNull(origin, "origin");
+        Objects.requireNonNull(ref, "ref");
+        if (ref.isBlank()) {
+            throw new IllegalArgumentException(".contractRef requires a non-blank string");
+        }
+        if (origin == ThresholdOrigin.EMPIRICAL) {
+            throw new IllegalArgumentException(
+                    ".contractRef(EMPIRICAL, ...) is contradictory — "
+                            + "use empirical() for baseline-derived criteria");
+        }
+        if (mode == Mode.NONE) {
+            throw new IllegalStateException(
+                    ".contractRef cannot be set on LatencyCriterion.none()");
+        }
+        if (mode == Mode.EMPIRICAL) {
+            throw new IllegalStateException(
+                    ".contractRef(origin, ref) cannot be set on an empirical "
+                            + "latency criterion — the baseline IS the source");
+        }
+        return new LatencyCriterion(mode, assertedPercentiles, spec, origin,
+                Optional.of(ref), confidenceFloor);
+    }
+
+    /**
+     * Chain an additional contractual ceiling at the given
+     * percentile. Used by the new {@link Criteria#meeting()}
+     * authoring shape:
+     *
+     * <pre>{@code
+     * @Override public LatencyCriterion latency() {
+     *     return meeting()
+     *             .atMost(P95, ofSeconds(1))
+     *             .atMost(P99, ofSeconds(5))
+     *             .contractRef(SLA, "Acme Payment SLA v3.2 §4.2");
+     * }
+     * }</pre>
+     *
+     * <p>Rejected on empirical-mode criteria (use
+     * {@link #atMost(PercentileKey)} with no duration). Rejected on
+     * the {@link #none()} sentinel.
+     *
+     * <p><b>Monotonicity check.</b> Per Statistical Companion §12.4.2
+     * the published per-percentile ceilings must be monotone non-
+     * decreasing in percentile level (observed P50 ≤ P90 ≤ P95 ≤ P99
+     * by definition of order statistics). If this call would assign
+     * a higher percentile a lower duration than a previously-declared
+     * lower percentile (or vice versa), the call is rejected with
+     * {@link IllegalArgumentException} naming both percentiles and
+     * both durations.
+     */
+    public LatencyCriterion atMost(PercentileKey key, Duration value) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(value, "value");
+        if (mode == Mode.EMPIRICAL) {
+            throw new IllegalStateException(
+                    ".atMost(percentile, duration) cannot be chained on an "
+                            + "empirical latency criterion — empirical bounds are "
+                            + "derived from the baseline. Use .atMost(percentile) "
+                            + "without a duration.");
+        }
+        if (mode == Mode.NONE) {
+            throw new IllegalStateException(
+                    ".atMost(...) cannot be chained on LatencyCriterion.none(); "
+                            + "open a chain via Criteria.meeting() instead");
+        }
+        if (assertedPercentiles.contains(key)) {
+            throw new IllegalArgumentException(
+                    "duplicate percentile in ceilings: " + key);
+        }
+        checkMonotonicity(key, value);
+        EnumSet<PercentileKey> nextAsserted = EnumSet.copyOf(assertedPercentiles);
+        nextAsserted.add(key);
+        LatencySpec nextSpec = specWithCeiling(spec, key, value.toMillis());
+        return new LatencyCriterion(Mode.CONTRACTUAL, nextAsserted, nextSpec,
+                origin, contractRef, confidenceFloor);
+    }
+
+    /**
+     * Chain an additional empirical-mode percentile assertion. Used
+     * by the new {@link Criteria#empirical()} authoring shape:
+     *
+     * <pre>{@code
+     * @Override public LatencyCriterion latency() {
+     *     return empirical().atMost(P95).atMost(P99).atConfidence(0.99);
+     * }
+     * }</pre>
+     *
+     * <p>Rejected on contractual-mode criteria (use
+     * {@link #atMost(PercentileKey, Duration)} with an explicit
+     * duration). Rejected on the {@link #none()} sentinel.
+     */
+    public LatencyCriterion atMost(PercentileKey key) {
+        Objects.requireNonNull(key, "key");
+        if (mode == Mode.CONTRACTUAL) {
+            throw new IllegalStateException(
+                    ".atMost(percentile) without a duration cannot be chained on a "
+                            + "contractual latency criterion. Use "
+                            + ".atMost(percentile, duration) for a contractual ceiling.");
+        }
+        if (mode == Mode.NONE) {
+            throw new IllegalStateException(
+                    ".atMost(...) cannot be chained on LatencyCriterion.none(); "
+                            + "open a chain via Criteria.empirical() instead");
+        }
+        if (assertedPercentiles.contains(key)) {
+            throw new IllegalArgumentException(
+                    "duplicate percentile in empirical assertions: " + key);
+        }
+        EnumSet<PercentileKey> nextAsserted = EnumSet.copyOf(assertedPercentiles);
+        nextAsserted.add(key);
+        return new LatencyCriterion(Mode.EMPIRICAL, nextAsserted, spec, origin,
+                contractRef, confidenceFloor);
+    }
+
+    private void checkMonotonicity(PercentileKey newKey, Duration newValue) {
+        long newMs = newValue.toMillis();
+        for (PercentileKey existing : assertedPercentiles) {
+            long existingMs = existingCeilingMillis(existing);
+            if (existing.ordinal() < newKey.ordinal() && existingMs > newMs) {
+                throw monotonicityFailure(existing, existingMs, newKey, newMs);
+            }
+            if (existing.ordinal() > newKey.ordinal() && existingMs < newMs) {
+                throw monotonicityFailure(newKey, newMs, existing, existingMs);
+            }
+        }
+    }
+
+    private IllegalArgumentException monotonicityFailure(
+            PercentileKey lower, long lowerMs,
+            PercentileKey higher, long higherMs) {
+        return new IllegalArgumentException(String.format(
+                "%s atMost (%dms) cannot be lower than %s atMost (%dms) — "
+                        + "observed %s ≥ %s, so the %s constraint dominates and "
+                        + "the %s declaration is unreachable. Either raise %s's "
+                        + "allowance, lower %s's, or remove the redundant declaration.",
+                higher, higherMs, lower, lowerMs,
+                higher, lower, higher, lower, higher, lower));
+    }
+
+    private long existingCeilingMillis(PercentileKey key) {
+        return switch (key) {
+            case P50 -> spec.p50Millis().orElseThrow();
+            case P90 -> spec.p90Millis().orElseThrow();
+            case P95 -> spec.p95Millis().orElseThrow();
+            case P99 -> spec.p99Millis().orElseThrow();
+        };
+    }
+
+    private static LatencySpec specWithCeiling(
+            LatencySpec base, PercentileKey key, long millis) {
+        LatencySpec.Builder b = LatencySpec.builder();
+        base.p50Millis().ifPresent(b::p50Millis);
+        base.p90Millis().ifPresent(b::p90Millis);
+        base.p95Millis().ifPresent(b::p95Millis);
+        base.p99Millis().ifPresent(b::p99Millis);
+        switch (key) {
+            case P50 -> b.p50Millis(millis);
+            case P90 -> b.p90Millis(millis);
+            case P95 -> b.p95Millis(millis);
+            case P99 -> b.p99Millis(millis);
+        }
+        return b.build();
+    }
+
+    /**
      * Set the per-criterion confidence floor for the binomial
      * order-statistic upper bound (Statistical Companion §12.4.2).
      * Composes only with {@link Mode#EMPIRICAL}; rejected on

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaFactoryTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/CriteriaFactoryTest.java
@@ -1,0 +1,271 @@
+package org.javai.punit.api.criterion;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.javai.punit.api.PercentileKey.P50;
+import static org.javai.punit.api.PercentileKey.P95;
+import static org.javai.punit.api.PercentileKey.P99;
+import static org.javai.punit.api.ThresholdOrigin.POLICY;
+import static org.javai.punit.api.ThresholdOrigin.SLA;
+import static org.javai.punit.api.ThresholdOrigin.UNSPECIFIED;
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the new value-form authoring surface introduced by
+ * {@code DIR-CRITERIA-PROVENANCE-AND-KIND-punit} — the no-arg
+ * {@link Criteria#meeting()} / {@link Criteria#empirical()} factories
+ * and the kind-selector first chain methods.
+ *
+ * <p>The legacy {@link Acceptance} factories remain in place during
+ * the migration window; the equivalence checks here pin both
+ * surfaces against each other so a regression on either side
+ * surfaces visibly.
+ */
+@DisplayName("Criteria.meeting() / Criteria.empirical() — value-form factories")
+class CriteriaFactoryTest {
+
+    @Nested
+    @DisplayName("Contractual chain — meeting()")
+    class ContractualChain {
+
+        @Test
+        @DisplayName("meeting().passRate(rate) lowers identically to Acceptance.meeting(UNSPECIFIED, rate)")
+        void passRateEquivalence() {
+            CriterionDecl<String> viaNew = meeting().passRate(0.85);
+            CriterionDecl<String> viaLegacy = Acceptance.meeting(UNSPECIFIED, 0.85);
+
+            assertThat(viaNew.posture().kind()).isEqualTo(viaLegacy.posture().kind());
+            assertThat(viaNew.posture().origin()).isEqualTo(viaLegacy.posture().origin());
+            assertThat(viaNew.posture().threshold()).isEqualTo(viaLegacy.posture().threshold());
+        }
+
+        @Test
+        @DisplayName("meeting().zeroTolerance() lowers identically to Acceptance.zeroTolerance(UNSPECIFIED)")
+        void zeroToleranceEquivalence() {
+            CriterionDecl<String> viaNew = meeting().zeroTolerance();
+            CriterionDecl<String> viaLegacy = Acceptance.zeroTolerance(UNSPECIFIED);
+
+            assertThat(viaNew.posture().kind()).isEqualTo(viaLegacy.posture().kind());
+            assertThat(viaNew.posture().origin()).isEqualTo(viaLegacy.posture().origin());
+        }
+
+        @Test
+        @DisplayName(".contractRef(origin, ref) updates both the origin and the reference")
+        void contractRefUpdatesOriginAndRef() {
+            CriterionDecl<String> decl = meeting().<String>passRate(0.9999)
+                    .contractRef(SLA, "Payment Provider SLA v2.3, §4.1");
+
+            assertThat(decl.posture().origin()).hasValue(SLA);
+            assertThat(decl.posture().contractRef())
+                    .hasValue("Payment Provider SLA v2.3, §4.1");
+        }
+
+        @Test
+        @DisplayName(".contractRef(SLA, ref) on zero-tolerance carries origin + ref through")
+        void zeroToleranceContractRef() {
+            CriterionDecl<String> decl = meeting().<String>zeroTolerance()
+                    .contractRef(POLICY, "Security Policy §1.2")
+                    .where("no-secret-key", v -> !v.contains("AKIA"));
+
+            assertThat(decl.posture().origin()).hasValue(POLICY);
+            assertThat(decl.posture().contractRef()).hasValue("Security Policy §1.2");
+            assertThat(decl.postconditions()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("postconditions and refinements chain through after the kind selector")
+        void postconditionsAndRefinementsChain() {
+            CriterionDecl<String> decl = meeting().<String>passRate(0.85)
+                    .name("parseable-json")
+                    .where("parseable", v -> v.startsWith("{"));
+
+            assertThat(decl.name()).hasValue("parseable-json");
+            assertThat(decl.postconditions()).hasSize(1);
+            assertThat(decl.postconditions().get(0).name()).isEqualTo("parseable");
+        }
+    }
+
+    @Nested
+    @DisplayName("Empirical chain — empirical()")
+    class EmpiricalChain {
+
+        @Test
+        @DisplayName("empirical().passRate() lowers identically to Acceptance.empirical()")
+        void passRateEquivalence() {
+            CriterionDecl<String> viaNew = empirical().passRate();
+            CriterionDecl<String> viaLegacy = Acceptance.empirical();
+
+            assertThat(viaNew.posture().kind()).isEqualTo(viaLegacy.posture().kind());
+        }
+
+        @Test
+        @DisplayName("empirical refinements chain through")
+        void empiricalRefinementsChain() {
+            CriterionDecl<String> decl = empirical().<String>passRate()
+                    .atConfidence(0.99)
+                    .detectingMde(0.02)
+                    .atPower(0.95);
+
+            assertThat(decl.posture().confidenceFloor()).isPresent();
+            assertThat(decl.posture().mde()).isPresent();
+            assertThat(decl.posture().power()).isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("Contractual latency — meeting().atMost(...)")
+    class ContractualLatency {
+
+        @Test
+        @DisplayName("meeting().atMost(P95, ofSeconds(1)) is equivalent to LatencyCriterion.meeting(UNSPECIFIED, ceiling(P95, ofSeconds(1)))")
+        void singlePercentileEquivalence() {
+            LatencyCriterion viaNew = meeting().atMost(P95, ofSeconds(1));
+            LatencyCriterion viaLegacy = LatencyCriterion.meeting(UNSPECIFIED,
+                    LatencyCriterion.ceiling(P95, ofSeconds(1)));
+
+            // Both lower to runtime DirectCriterion with the same posture shape.
+            assertThat(viaNew.toRuntime().id()).isEqualTo(viaLegacy.toRuntime().id());
+            assertThat(viaNew.isPresent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("chained .atMost(...) accepts strictly increasing durations across rising percentiles")
+        void chainedAtMostStrictlyIncreasing() {
+            LatencyCriterion decl = meeting()
+                    .atMost(P95, ofSeconds(1))
+                    .atMost(P99, ofSeconds(5))
+                    .contractRef(SLA, "Acme Payment SLA v3.2 §4.2");
+
+            assertThat(decl.isPresent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("chained .atMost(...) accepts equal durations (uniform cap)")
+        void chainedAtMostEqualDurations() {
+            LatencyCriterion decl = meeting()
+                    .atMost(P95, ofMillis(500))
+                    .atMost(P99, ofMillis(500));
+
+            assertThat(decl.isPresent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("chained .atMost(...) accepts out-of-order declaration with monotone values")
+        void chainedAtMostOutOfDeclarationOrder() {
+            LatencyCriterion decl = meeting()
+                    .atMost(P99, ofSeconds(5))
+                    .atMost(P95, ofSeconds(1));
+
+            assertThat(decl.isPresent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("monotonicity violation: higher percentile assigned a lower duration is rejected")
+        void monotonicityViolationHigherPercentileLowerDuration() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> meeting()
+                            .atMost(P95, ofMillis(1000))
+                            .atMost(P99, ofMillis(800)))
+                    .withMessageContaining("P99")
+                    .withMessageContaining("P95")
+                    .withMessageContaining("800ms")
+                    .withMessageContaining("1000ms")
+                    .withMessageContaining("unreachable");
+        }
+
+        @Test
+        @DisplayName("monotonicity violation: out-of-order declaration is still rejected")
+        void monotonicityViolationOutOfOrder() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> meeting()
+                            .atMost(P99, ofMillis(800))
+                            .atMost(P95, ofMillis(1000)))
+                    .withMessageContaining("P99")
+                    .withMessageContaining("P95");
+        }
+
+        @Test
+        @DisplayName("monotonicity violation across three percentiles is rejected")
+        void monotonicityViolationThreePercentiles() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> meeting()
+                            .atMost(P50, ofMillis(100))
+                            .atMost(P95, ofMillis(500))
+                            .atMost(P99, ofMillis(300)));
+        }
+
+        @Test
+        @DisplayName("duplicate percentile is rejected")
+        void duplicatePercentileRejected() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> meeting()
+                            .atMost(P95, ofSeconds(1))
+                            .atMost(P95, ofSeconds(2)))
+                    .withMessageContaining("duplicate");
+        }
+
+        @Test
+        @DisplayName(".atMost(P95) with no duration is rejected on a contractual chain")
+        void atMostWithoutDurationRejectedOnContractual() {
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(() -> meeting()
+                            .atMost(P95, ofSeconds(1))
+                            .atMost(P99))
+                    .withMessageContaining("contractual");
+        }
+    }
+
+    @Nested
+    @DisplayName("Empirical latency — empirical().atMost(...)")
+    class EmpiricalLatency {
+
+        @Test
+        @DisplayName("empirical().atMost(P95) is equivalent to LatencyCriterion.empirical(P95)")
+        void singlePercentileEquivalence() {
+            LatencyCriterion viaNew = empirical().atMost(P95);
+            LatencyCriterion viaLegacy = LatencyCriterion.empirical(P95);
+
+            assertThat(viaNew.toRuntime().id()).isEqualTo(viaLegacy.toRuntime().id());
+            assertThat(viaNew.isPresent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("chained .atMost(...) accumulates asserted percentiles")
+        void chainedAtMostAccumulates() {
+            LatencyCriterion decl = empirical().atMost(P95).atMost(P99).atConfidence(0.99);
+            assertThat(decl.isPresent()).isTrue();
+        }
+
+        @Test
+        @DisplayName(".atMost(P95, duration) is rejected on an empirical chain")
+        void atMostWithDurationRejectedOnEmpirical() {
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(() -> empirical()
+                            .atMost(P95)
+                            .atMost(P99, ofSeconds(5)))
+                    .withMessageContaining("empirical");
+        }
+
+        @Test
+        @DisplayName("duplicate percentile is rejected")
+        void duplicatePercentileRejected() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> empirical().atMost(P95).atMost(P95));
+        }
+
+        @Test
+        @DisplayName(".contractRef(SLA, ref) is rejected on an empirical latency criterion")
+        void contractRefRejectedOnEmpirical() {
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(() -> empirical().atMost(P95).contractRef(SLA, "doc"))
+                    .withMessageContaining("empirical");
+        }
+    }
+}


### PR DESCRIPTION
Implements PR #1 of [DIR-CRITERIA-PROVENANCE-AND-KIND-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-CRITERIA-PROVENANCE-AND-KIND-punit.md).

## Summary

Adds a parallel value-form authoring surface alongside the existing \`Acceptance\` / \`LatencyCriterion.meeting/.empirical\` factories. Purely additive — no existing surface changes; both old and new shapes coexist during the migration window.

### Factories on \`Criteria\` (no-arg)

- \`Criteria.meeting()\` → \`ContractualDecl\` — opens a contractual chain with origin defaulting to \`UNSPECIFIED\`. The origin is later overridden by \`.contractRef(origin, ref)\` on the kind-specific decl.
- \`Criteria.empirical()\` → \`EmpiricalDecl\` — opens an empirical chain. Baseline IS the source; no origin parameter applies.

Both factories are non-generic. The type parameter \`<O>\` enters the chain at the kind-selector method that needs it (\`.passRate(...)\`, \`.zeroTolerance()\`), not on the factory. The latency kind selector \`.atMost(...)\` has no type parameter — latency is outcome-independent.

### Kind selectors

\`ContractualDecl\`:
- \`<O> CriterionDecl<O> passRate(double rate)\` — pass-rate criterion at supplied rate.
- \`<O> CriterionDecl<O> zeroTolerance()\` — explicit any-failure-fails.
- \`LatencyCriterion atMost(PercentileKey, Duration)\` — contractual latency ceiling.

\`EmpiricalDecl\`:
- \`<O> CriterionDecl<O> passRate()\` — empirical pass-rate (no rate; derived from baseline).
- \`LatencyCriterion atMost(PercentileKey)\` — empirical latency assertion (no duration; derived from baseline).

No \`zeroTolerance()\` on \`EmpiricalDecl\` — zero-tolerance is intrinsically contractual.

### \`LatencyCriterion\` chain additions

- \`.atMost(PercentileKey, Duration)\` — chain an additional ceiling on a contractual-mode criterion.
- \`.atMost(PercentileKey)\` — chain an additional asserted percentile on an empirical-mode criterion.
- \`.contractRef(ThresholdOrigin, String)\` — overload binding origin + reference text in one call.

The contractual \`.atMost(...)\` enforces monotonicity at the chain method itself: a declaration that assigns a higher percentile a lower duration than a lower percentile is rejected with \`IllegalArgumentException\` naming both percentiles, both durations, and the methodology reason. Out-of-order declarations whose values are monotone by percentile level are accepted. Equal durations are accepted.

### \`CriterionDecl\` / \`CriterionPosture\` additions

- \`CriterionDecl.contractRef(ThresholdOrigin, String)\` overload.
- \`CriterionPosture.withContractRef(ThresholdOrigin, String)\` overload backing it. Rejects \`EMPIRICAL\` origin and rejects retagging an empirical-mode posture as contractual.

## Test plan

- [x] \`./gradlew :punit-core:test --tests \"*CriteriaFactoryTest*\"\` — 19 new tests green.
- [x] \`./gradlew test\` — full suite green; no regressions on existing surface.

New test cases cover:

- Equivalence of new-form and legacy-form factories (pass-rate, zero-tolerance, empirical, latency, both single- and multi-percentile).
- \`.contractRef(origin, ref)\` updating both fields.
- Chained \`.atMost(...)\` accepting strictly increasing, equal, and out-of-declaration-order monotone values.
- Monotonicity violations rejected with the prescribed diagnostic.
- Mode-mismatch rejection: \`.atMost(P95)\` (no value) on contractual chain; \`.atMost(P95, 1s)\` on empirical chain; \`.contractRef(origin, ref)\` on empirical latency criterion.

## Follow-on PRs

Per the directive's migration plan: PR #2 migrates \`punit-core\` test sources to the new factories; PR #3 migrates \`punitexamples\` + refreshes \`docs/USER-GUIDE.md\`; PR #4 retires the legacy \`Acceptance\` / \`LatencyCriterion.meeting/.empirical\` factories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)