### PR TITLE
Migrate punit-core test sources to value-form factories (DIR-CRITERIA-PROVENANCE-AND-KIND PR #2)

### DIFF
--- a/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/InconclusiveFoldsIntoFailTest.java
@@ -27,7 +27,7 @@ class InconclusiveFoldsIntoFailTest {
 
         @Override
         public Criteria<String> criteria() {
-            return Acceptance.<String>zeroTolerance(ThresholdOrigin.POLICY)
+            return Criteria.meeting().<String>zeroTolerance()
                     .transforming(s -> {
                         try {
                             return Outcome.ok(Integer.parseInt(s));

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/AutoInjectionFromPostureTest.java
@@ -8,7 +8,7 @@ import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.spec.Verdict;
@@ -40,7 +40,7 @@ class AutoInjectionFromPostureTest {
                 return Outcome.ok(true);
             }
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.95);
+                return meeting().passRate(0.95);
             }
         };
 
@@ -64,7 +64,7 @@ class AutoInjectionFromPostureTest {
                 return Outcome.fail("nope", "never passes");
             }
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.95);
+                return meeting().passRate(0.95);
             }
         };
 

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/ContractLatencyEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/ContractLatencyEndToEndIntegrationTest.java
@@ -16,7 +16,6 @@ import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.criterion.Criteria;
 import org.javai.punit.api.criterion.LatencyCriterion;
 import org.javai.punit.api.spec.BaselineStatistics;
@@ -82,7 +81,7 @@ class ContractLatencyEndToEndIntegrationTest {
         writeLatencyBaseline(baselineDir, Duration.ofMinutes(1), 1000);
 
         Criteria<Integer> criteria = Criteria.empty();
-        LatencyCriterion latency = LatencyCriterion.empirical(PercentileKey.P95);
+        LatencyCriterion latency = Criteria.empirical().atMost(PercentileKey.P95);
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling(criteria, latency, 20), FACTORS)
                 .build();   // no .criterion(...) — auto-injection from contract
@@ -107,9 +106,9 @@ class ContractLatencyEndToEndIntegrationTest {
     @DisplayName("Contract.latency() contractual ceiling → contractual latency PASSes when observed below ceiling")
     void contractualLatencyOnContract(@TempDir Path baselineDir) throws IOException {
         Criteria<Integer> criteria = Criteria.empty();
-        LatencyCriterion latency = LatencyCriterion.meeting(
-                ThresholdOrigin.SLA,
-                LatencyCriterion.ceiling(PercentileKey.P95, Duration.ofMillis(500)));
+        LatencyCriterion latency = Criteria.meeting()
+                .atMost(PercentileKey.P95, Duration.ofMillis(500))
+                .contractRef(ThresholdOrigin.SLA, "test-contract-ref");
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling(criteria, latency, 20), FACTORS)
                 .build();
@@ -133,10 +132,10 @@ class ContractLatencyEndToEndIntegrationTest {
     void functionalAndLatencyCombine(@TempDir Path baselineDir) throws IOException {
         writeLatencyBaseline(baselineDir, Duration.ofMinutes(1), 1000);
 
-        Criteria<Integer> criteria = Acceptance.<Integer>meeting(ThresholdOrigin.SLA, 0.99)
+        Criteria<Integer> criteria = Criteria.meeting().<Integer>passRate(0.99)
                 .satisfies("value-not-negative",
                         v -> v >= 0 ? Outcome.ok() : Outcome.fail("neg", "v=" + v));
-        LatencyCriterion latency = LatencyCriterion.empirical(PercentileKey.P95);
+        LatencyCriterion latency = Criteria.empirical().atMost(PercentileKey.P95);
 
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling(criteria, latency, 20), FACTORS)
@@ -162,7 +161,7 @@ class ContractLatencyEndToEndIntegrationTest {
             @Override public String id() { return USE_CASE_ID; }
             @Override public Outcome<Integer> invoke(Integer i, TokenTracker t) { return Outcome.ok(i); }
             @Override public Criteria<Integer> criteria() {
-                return Acceptance.<Integer>empirical()
+                return Criteria.empirical().<Integer>passRate()
                         .satisfies("v >= 0", v -> v >= 0 ? Outcome.ok() : Outcome.fail("neg", "v=" + v));
             }
         };
@@ -179,7 +178,7 @@ class ContractLatencyEndToEndIntegrationTest {
             @Override public String id() { return USE_CASE_ID; }
             @Override public Outcome<Integer> invoke(Integer i, TokenTracker t) { return Outcome.ok(i); }
             @Override public LatencyCriterion latency() {
-                return LatencyCriterion.empirical(PercentileKey.P95);
+                return Criteria.empirical().atMost(PercentileKey.P95);
             }
         };
 
@@ -198,7 +197,7 @@ class ContractLatencyEndToEndIntegrationTest {
         LatencyIndicator indicator = new LatencyIndicator(percentiles, sorted, sampleCount, sampleCount);
         BaselineRecord record = new BaselineRecord(
                 USE_CASE_ID, "latencyBaseline", fingerprint,
-                sampling(Criteria.empty(), LatencyCriterion.empirical(PercentileKey.P95), 1)
+                sampling(Criteria.empty(), Criteria.empirical().atMost(PercentileKey.P95), 1)
                         .inputsIdentity(),
                 sampleCount,
                 Instant.parse("2026-05-18T12:00:00Z"),

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EarlyTerminationIntegrationTest.java
@@ -2,11 +2,12 @@ package org.javai.punit.internal.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.Sampling;
-import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.EngineResult;
@@ -39,7 +40,7 @@ class EarlyTerminationIntegrationTest {
     /** Returns Outcome.ok every sample. Contract posture: meeting(0.5, SLA). */
     private static class AlwaysPass implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.meeting(ThresholdOrigin.SLA, 0.5);
+            return meeting().passRate(0.5);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -49,7 +50,7 @@ class EarlyTerminationIntegrationTest {
     /** Always-pass variant whose contract posture is meeting(0.20, SLA). */
     private static class AlwaysPassLowThreshold implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.meeting(ThresholdOrigin.SLA, 0.20);
+            return meeting().passRate(0.20);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -59,7 +60,7 @@ class EarlyTerminationIntegrationTest {
     /** Always-pass variant whose contract posture is empirical. */
     private static class AlwaysPassEmpirical implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.empirical();
+            return empirical().passRate();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -69,7 +70,7 @@ class EarlyTerminationIntegrationTest {
     /** Returns Outcome.fail every sample — a clean failure-inevitable shape. */
     private static class AlwaysFail implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.meeting(ThresholdOrigin.SLA, 0.95);
+            return meeting().passRate(0.95);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure");
@@ -86,7 +87,7 @@ class EarlyTerminationIntegrationTest {
         private int seen = 0;
         FailsThenPasses(int failsFirst) { this.failsFirst = failsFirst; }
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.meeting(ThresholdOrigin.SLA, 0.80);
+            return meeting().passRate(0.80);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return ++seen <= failsFirst

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -12,8 +12,9 @@ import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
+import static org.javai.punit.api.criterion.Criteria.empirical;
+
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.spec.BaselineProvider;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
@@ -39,7 +40,7 @@ class EmpiricalEndToEndIntegrationTest {
 
     static class AlwaysPassesServiceContract implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.empirical();
+            return empirical().passRate();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalLatencyEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalLatencyEndToEndIntegrationTest.java
@@ -14,7 +14,7 @@ import org.javai.punit.api.LatencyResult;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.TokenTracker;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.empirical;
 import org.javai.punit.api.criterion.Criteria;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.Experiment;
@@ -70,7 +70,7 @@ class EmpiricalLatencyEndToEndIntegrationTest {
         @Override public Outcome<Integer> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(input);
         }
-        @Override public Criteria<Integer> criteria() { return Acceptance.empirical(); }
+        @Override public Criteria<Integer> criteria() { return empirical().passRate(); }
     }
 
     private static Sampling<Factors, Integer, Integer> sampling(int samples) {

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineIntegrationTest.java
@@ -13,7 +13,8 @@ import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.spec.TerminationReason;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -437,7 +438,8 @@ class EngineIntegrationTest {
 
     private static class AlwaysPassesServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.meeting(ThresholdOrigin.SLA, 0.95);
+            return meeting().<Boolean>passRate(0.95)
+                    .contractRef(ThresholdOrigin.SLA, "test-contract-ref");
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -447,7 +449,7 @@ class EngineIntegrationTest {
     /** Empirical-posture sibling of {@link AlwaysPassesServiceContract} for the empirical-path test. */
     private static class AlwaysPassesEmpiricalServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.empirical();
+            return empirical().passRate();
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -457,7 +459,7 @@ class EngineIntegrationTest {
     /** Returns business-level Fail outcomes — the "contract didn't hold" signal. */
     private static class AlwaysReturnsFailServiceContract implements ServiceContract<LlmFactors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return Acceptance.meeting(ThresholdOrigin.SLO, 0.95);
+            return meeting().passRate(0.95);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.fail("contract_violation", "scripted failure for input " + input);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -10,7 +10,7 @@ import org.javai.outcome.Outcome;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Pacing;
 import org.javai.punit.api.Sampling;
@@ -398,7 +398,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void mixedCriteriaBothRequiredComposesToFail() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.95);
+                return meeting().passRate(0.95);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);
@@ -428,7 +428,7 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void reportOnlyLatencyExcludedFromComposition() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.95);
+                return meeting().passRate(0.95);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/PostconditionFailureHistogramTest.java
@@ -11,7 +11,7 @@ import org.javai.punit.api.spec.ProbabilisticTest;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
@@ -42,7 +42,7 @@ class PostconditionFailureHistogramTest {
             return Outcome.ok(input);
         }
         @Override public Criteria<Integer> criteria() {
-            return Acceptance.<Integer>meeting(org.javai.punit.api.ThresholdOrigin.SLA, 0.5)
+            return meeting().<Integer>passRate(0.5)
                     .satisfies("alwaysFails", v ->
                             Outcome.fail("alwaysFails-mode", "input was " + v))
                     .satisfies("evenFails", v -> v % 2 == 0

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/PowerAnalysisTest.java
@@ -367,7 +367,7 @@ class PowerAnalysisTest {
                     return Outcome.ok(input);
                 }
                 @Override public org.javai.punit.api.criterion.Criteria<String> criteria() {
-                    return org.javai.punit.api.criterion.Acceptance.<String>empirical()
+                    return org.javai.punit.api.criterion.Criteria.empirical().<String>passRate()
                             .name("the-criterion")
                             .detectingMde(mde).atPower(power)
                             .satisfies("always", v -> Outcome.ok());
@@ -407,12 +407,12 @@ class PowerAnalysisTest {
                 @Override public org.javai.punit.api.criterion.Criteria<String> criteria() {
                     return org.javai.punit.api.criterion.Criteria.of(
                             // Looser: MDE 0.10 / power 0.50  → smaller N
-                            org.javai.punit.api.criterion.Acceptance.<String>empirical()
+                            org.javai.punit.api.criterion.Criteria.empirical().<String>passRate()
                                     .name("loose")
                                     .detectingMde(0.10).atPower(0.50)
                                     .satisfies("always", v -> Outcome.ok()),
                             // Tighter: MDE 0.02 / power 0.95 → larger N
-                            org.javai.punit.api.criterion.Acceptance.<String>empirical()
+                            org.javai.punit.api.criterion.Criteria.empirical().<String>passRate()
                                     .name("tight")
                                     .detectingMde(0.02).atPower(0.95)
                                     .satisfies("always", v -> Outcome.ok()));

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/baseline/SampleSizeResolverTest.java
@@ -14,7 +14,8 @@ import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.junit.jupiter.api.DisplayName;
@@ -48,7 +49,7 @@ class SampleSizeResolverTest {
                 return Outcome.ok(input);
             }
             @Override public Criteria<String> criteria() {
-                return Acceptance.<String>empirical()
+                return empirical().<String>passRate()
                         .name("the-criterion")
                         .detectingMde(mde)
                         .atPower(power)
@@ -64,7 +65,7 @@ class SampleSizeResolverTest {
                 return Outcome.ok(input);
             }
             @Override public Criteria<String> criteria() {
-                return Acceptance.<String>meeting(ThresholdOrigin.SLA, 0.90)
+                return meeting().<String>passRate(0.90)
                         .name("threshold-criterion")
                         .satisfies("always", v -> Outcome.ok());
             }
@@ -164,11 +165,11 @@ class SampleSizeResolverTest {
             }
             @Override public Criteria<String> criteria() {
                 return Criteria.of(
-                        Acceptance.<String>empirical()
+                        empirical().<String>passRate()
                                 .name("loose")
                                 .detectingMde(0.10).atPower(0.50)
                                 .satisfies("always", v -> Outcome.ok()),
-                        Acceptance.<String>empirical()
+                        empirical().<String>passRate()
                                 .name("tight")
                                 .detectingMde(0.02).atPower(0.95)
                                 .satisfies("always", v -> Outcome.ok()));

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/criteria/InlineSamplingFormTest.java
@@ -6,8 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.Experiment;
@@ -23,7 +24,7 @@ class InlineSamplingFormTest {
 
     private static final ServiceContract<Factors, String, String> ECHO = new ServiceContract<>() {
         @Override public Criteria<String> criteria() {
-            return Acceptance.meeting(ThresholdOrigin.SLA, 0.95);
+            return meeting().passRate(0.95);
         }
         @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
             return Outcome.ok(input);

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
@@ -15,7 +15,7 @@ import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.internal.engine.Engine;
@@ -142,10 +142,10 @@ class OptimizeOutputWriterTest {
             @Override public void postconditions(PostconditionBuilder<String> b) { /* none */ }
             @Override public Criteria<String> criteria() {
                 return Criteria.of(
-                        Acceptance.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                        meeting().<String>zeroTolerance()
                                 .name("always-passes")
                                 .satisfies("passes", v -> Outcome.ok()),
-                        Acceptance.<String>zeroTolerance(ThresholdOrigin.POLICY)
+                        meeting().<String>zeroTolerance()
                                 .name("starts-with-a")
                                 .satisfies("first-char-a", v ->
                                         v.startsWith("a")

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/CovariateSubjects.java
@@ -4,9 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.javai.punit.api.criterion.Criteria.empirical;
+
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.covariate.CovariateCategory;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
@@ -42,7 +43,7 @@ public final class CovariateSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> covariateServiceContract() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.empirical();
+                return empirical().passRate();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/FeasibilitySubjects.java
@@ -1,11 +1,12 @@
 package org.javai.punit.junit5.testsubjects;
 
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.TestIntent;
-import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -29,7 +30,7 @@ public final class FeasibilitySubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesEmpirical() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.empirical();
+                return empirical().passRate();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -41,7 +42,7 @@ public final class FeasibilitySubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> alwaysPassesContractual() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.9999);
+                return meeting().passRate(0.9999);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PUnitSubjects.java
@@ -1,11 +1,13 @@
 package org.javai.punit.junit5.testsubjects;
 
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -37,7 +39,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesContractual() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.5);
+                return meeting().passRate(0.5);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -51,7 +53,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesEmpirical() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.empirical();
+                return empirical().passRate();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -63,7 +65,7 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFails() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.5);
+                return meeting().passRate(0.5);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.fail("nope", "always fails");
@@ -77,8 +79,8 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysPassesWithContractRef() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.<Boolean>meeting(ThresholdOrigin.SLA, 0.5)
-                        .contractRef(CONTRACT_REF_FIXTURE);
+                return meeting().<Boolean>passRate(0.5)
+                        .contractRef(ThresholdOrigin.SLA, CONTRACT_REF_FIXTURE);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);
@@ -90,8 +92,8 @@ public final class PUnitSubjects {
     private static <F> ServiceContract<F, Integer, Boolean> alwaysFailsWithContractRef() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.<Boolean>meeting(ThresholdOrigin.SLA, 0.5)
-                        .contractRef(CONTRACT_REF_FIXTURE);
+                return meeting().<Boolean>passRate(0.5)
+                        .contractRef(ThresholdOrigin.SLA, CONTRACT_REF_FIXTURE);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.fail("nope", "always fails");

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightInvariantSubjects.java
@@ -2,11 +2,12 @@ package org.javai.punit.junit5.testsubjects;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.ProbabilisticTest;
-import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -37,7 +38,7 @@ public final class PreflightInvariantSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> countingEmpirical() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.empirical();
+                return empirical().passRate();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();
@@ -50,7 +51,7 @@ public final class PreflightInvariantSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> countingContractualHighThreshold() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.meeting(ThresholdOrigin.SLA, 0.9999);
+                return meeting().passRate(0.9999);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/PreflightSubjects.java
@@ -2,11 +2,12 @@ package org.javai.punit.junit5.testsubjects;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.javai.punit.api.criterion.Criteria.empirical;
+
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.NoFactors;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
@@ -32,7 +33,7 @@ public final class PreflightSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> countingServiceContract() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.empirical();
+                return empirical().passRate();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 INVOKE_COUNT.incrementAndGet();

--- a/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
+++ b/punit-core/src/test/java/org/javai/punit/junit5/testsubjects/RoundTripSubjects.java
@@ -1,8 +1,9 @@
 package org.javai.punit.junit5.testsubjects;
 
+import static org.javai.punit.api.criterion.Criteria.empirical;
+
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
 import org.javai.punit.api.Experiment;
 import org.javai.punit.api.ProbabilisticTest;
 import org.javai.punit.api.NoFactors;
@@ -29,7 +30,7 @@ public final class RoundTripSubjects {
     private static ServiceContract<NoFactors, Integer, Boolean> serviceContract() {
         return new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return Acceptance.empirical();
+                return empirical().passRate();
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 return Outcome.ok(true);

--- a/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -9,9 +9,8 @@ import java.util.Map;
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.PostconditionBuilder;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.Sampling;
-import org.javai.punit.api.ThresholdOrigin;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.Experiment;
@@ -57,7 +56,7 @@ class LatencyEverywhereIntegrationTest {
             return Outcome.ok(input.length());
         }
         @Override public Criteria<Integer> criteria() {
-            return Acceptance.<Integer>meeting(ThresholdOrigin.SLA, 0.5)
+            return meeting().<Integer>passRate(0.5)
                     .satisfies("length is even", n ->
                             n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "length=" + n));
         }

--- a/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/runtime/MultiDimensionVerdictIntegrationTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.criterion.Criteria;
-import org.javai.punit.api.criterion.Acceptance;
+import static org.javai.punit.api.criterion.Criteria.meeting;
 import org.javai.punit.api.LatencySpec;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.ThresholdOrigin;
@@ -67,7 +67,7 @@ class MultiDimensionVerdictIntegrationTest {
             return Outcome.ok(input.length());
         }
         @Override public Criteria<Integer> criteria() {
-            return Acceptance.<Integer>meeting(ThresholdOrigin.SLA, FUNCTIONAL_THRESHOLD)
+            return meeting().<Integer>passRate(FUNCTIONAL_THRESHOLD)
                     .satisfies("non-null length", n -> Outcome.ok());
         }
     }
@@ -85,7 +85,7 @@ class MultiDimensionVerdictIntegrationTest {
             return Outcome.ok(input.length());
         }
         @Override public Criteria<Integer> criteria() {
-            return Acceptance.<Integer>meeting(ThresholdOrigin.SLA, FUNCTIONAL_THRESHOLD)
+            return meeting().<Integer>passRate(FUNCTIONAL_THRESHOLD)
                     .satisfies("length is even", n ->
                             n % 2 == 0 ? Outcome.ok() : Outcome.fail("odd-length", "n=" + n));
         }


### PR DESCRIPTION
Implements PR #2 of [DIR-CRITERIA-PROVENANCE-AND-KIND-punit](https://github.com/javai-org/javai-orchestrator/blob/main/plan/directives/DIR-CRITERIA-PROVENANCE-AND-KIND-punit.md).

## Summary

Migrates 21 test files in \`punit-core/src/test/java\` from the legacy \`Acceptance.meeting\` / \`Acceptance.empirical\` / \`Acceptance.zeroTolerance\` / \`LatencyCriterion.meeting\` / \`LatencyCriterion.empirical\` factories to the new \`Criteria.meeting()\` / \`Criteria.empirical()\` factories introduced in punit#194.

\`CriteriaAsDataTest\` is left on the legacy \`Acceptance\` surface deliberately — it exists to exercise that factory specifically and will be retired alongside \`Acceptance\` in PR #4.

## Migration shape

For most calls, origin tagging is dropped (becomes \`UNSPECIFIED\`):

- \`Acceptance.meeting(SLA, rate)\` → \`meeting().passRate(rate)\`
- \`Acceptance.empirical()\` → \`empirical().passRate()\`
- \`Acceptance.<O>zeroTolerance(POLICY)\` → \`meeting().<O>zeroTolerance()\`
- \`LatencyCriterion.empirical(P95)\` → \`Criteria.empirical().atMost(P95)\`
- \`LatencyCriterion.meeting(SLA, ceiling(P95, d))\` → \`Criteria.meeting().atMost(P95, d).contractRef(SLA, ref)\`

Where a downstream assertion depended on the SLA tag specifically, origin is preserved via the new two-arg \`.contractRef(ThresholdOrigin, String)\` form. Identified during the test run:

- \`AlwaysPassesServiceContract\` in \`EngineIntegrationTest\` — asserts \`detail.containsEntry(\"origin\", \"SLA\")\`.
- \`contractualLatencyOnContract\` in \`ContractLatencyEndToEndIntegrationTest\` — asserts \`detail.containsEntry(\"origin\", \"SLA\")\`.
- \`alwaysPassesWithContractRef\` / \`alwaysFailsWithContractRef\` in \`PUnitSubjects\` — already had a \`.contractRef(...)\` call; migrated to the two-arg form preserving SLA.

## Test plan

- [x] \`./gradlew test\` — full suite 1621/1621 green.
- [x] No regression on \`CriteriaFactoryTest\` from PR #1.

## Follow-on

PR #3 migrates \`punitexamples\` + refreshes \`docs/USER-GUIDE.md\`. PR #4 retires the legacy \`Acceptance\` factory and \`LatencyCriterion.meeting\` / \`.empirical\` factories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)