### PR TITLE
Relicense from ARL-1.0 to Apache 2.0; adopt DCO

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,18 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dco-check:
+    name: Signed-off-by check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commits for DCO sign-off
+        uses: tisonkun/actions-dco@v1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (license)
+
+- **Relicensed from Attribution Required License (ARL-1.0) to
+  Apache License, Version 2.0.** All source, build metadata
+  (`punit-core`, `punit-sentinel`, `punit-report`, umbrella POM),
+  and documentation now reference Apache 2.0. The `LICENSE` and
+  `NOTICE` files at the repository root carry the canonical text.
+  Versions of PUnit published prior to this change remain
+  available under their original ARL-1.0 terms; the relicense
+  applies from this release forward.
+- **Contributions now governed by the Developer Certificate of
+  Origin (DCO).** The DCO 1.1 text is committed verbatim as
+  `dco.txt`; `CONTRIBUTING.md` documents the `git commit -s`
+  sign-off requirement. A GitHub Actions workflow
+  (`.github/workflows/dco.yml`) blocks unsigned commits on pull
+  requests. No separate contributor agreement is required —
+  Apache 2.0 §5 (inbound = outbound) combined with the per-commit
+  DCO sign-off carries the legal weight.
+
 ### Changed (MEASURE baseline schema — per-methodology-criterion shape)
 
 - **Baseline YAML schema bumps from `punit-baseline-2` to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to PUnit
+
+Thank you for your interest in contributing to PUnit. This document
+describes how to submit contributions and the legal terms that apply.
+
+## License
+
+PUnit is licensed under the [Apache License, Version 2.0](LICENSE).
+All contributions are accepted under the same license.
+
+## Developer Certificate of Origin
+
+All contributions are subject to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+The DCO text is available verbatim in the [dco.txt](dco.txt) file in the
+root of this repository.
+
+By signing off your commits, you certify that you wrote the contribution
+or otherwise have the right to submit it under the project's license. No
+separate contributor agreement is required.
+
+### Signing your commits
+
+Add a `Signed-off-by` line to every commit message:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The easiest way is to use the `-s` (or `--signoff`) flag with `git commit`:
+
+```
+git commit -s -m "Your commit message"
+```
+
+The name and email must match the values configured in your git
+identity (`git config user.name` and `git config user.email`).
+
+To sign off a series of existing commits before pushing, use:
+
+```
+git rebase --signoff <base-branch>
+```
+
+Unsigned commits will be blocked by automated checks on pull requests.
+
+## Reporting issues
+
+Please use [GitHub Issues](https://github.com/javai-org/punit/issues) for
+bug reports and feature requests. Include a minimal reproducer where
+possible.
+
+## Pull requests
+
+- Fork the repository and create a topic branch from `main`.
+- Keep changes focused; one logical change per pull request.
+- Ensure all commits are signed off (see above).
+- Run the test suite locally before opening the pull request.
+- Reference any related issue in the pull request description.

--- a/LICENSE
+++ b/LICENSE
@@ -1,39 +1,202 @@
-Attribution Required License (ARL-1.0)
 
-Copyright (c) 2026 Mike Mannion
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1) Attribution Requirement.
-Any application, service, work product, or deliverable that uses the Software
-(or a substantial portion of it), whether distributed to third parties or used
-internally, must include the following attribution in a credits, acknowledgements,
-or "About" section that is reasonably visible to recipients/users:
+   1. Definitions.
 
-  "Built with PUnit by Mike Mannion."
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-This attribution may be satisfied in end-user documentation for products that
-do not reasonably have a user-visible credits/About screen (e.g., libraries,
-batch jobs, backend services), provided it is included in the primary documentation
-or repository README of the deliverable.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-2) Preservation of Notice.
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-3) No Endorsement.
-Use of Mike Mannion’s name for endorsement or promotion of derived products is
-prohibited without prior written permission, except for the attribution required
-by Section 1.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,11 @@
 PUnit
-Copyright (c) 2026 Mike Mannion
+Copyright 2026 Mike Mannion
 
-This product includes software developed by Mike Mannion.
+This product includes software developed by Mike Mannion and the
+javai project contributors (https://javai.org).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -183,8 +183,11 @@ The **[Statistical Companion](docs/STATISTICAL-COMPANION.md)** covers the mathem
 
 ## License
 
-Attribution Required License (ARL-1.0) — see [LICENSE](LICENSE) for details.
+Apache License, Version 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
 ## Contributing
 
-Contributions are welcome. Please open an issue or pull request on [GitHub](https://github.com/javai-org/punit).
+Contributions are welcome. All contributions are accepted under Apache 2.0 and
+require a [Developer Certificate of Origin](dco.txt) sign-off (`git commit -s`).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details. Please open an issue or pull
+request on [GitHub](https://github.com/javai-org/punit).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,8 +174,8 @@ mavenPublishing {
 
         licenses {
             license {
-                name.set("Attribution Required License (ARL-1.0)")
-                url.set("https://github.com/javai-org/punit/blob/main/LICENSE")
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
             }
         }
 

--- a/dco.txt
+++ b/dco.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/docs/OPERATIONAL-FLOW.md
+++ b/docs/OPERATIONAL-FLOW.md
@@ -2,7 +2,7 @@
 
 This document describes the end-to-end workflow for using **PUnit** to test systems characterized by uncertainty—systems that don't always produce the same output for the same input.
 
-All attribution licensing is ARL.
+Licensed under the Apache License, Version 2.0.
 
 ---
 

--- a/punit-core/build.gradle.kts
+++ b/punit-core/build.gradle.kts
@@ -173,8 +173,8 @@ mavenPublishing {
 
         licenses {
             license {
-                name.set("Attribution Required License (ARL-1.0)")
-                url.set("https://github.com/javai-org/punit/blob/main/LICENSE")
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
             }
         }
 

--- a/punit-report/build.gradle.kts
+++ b/punit-report/build.gradle.kts
@@ -38,8 +38,8 @@ mavenPublishing {
 
         licenses {
             license {
-                name.set("Attribution Required License (ARL-1.0)")
-                url.set("https://github.com/javai-org/punit/blob/main/LICENSE")
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
             }
         }
 

--- a/punit-sentinel/build.gradle.kts
+++ b/punit-sentinel/build.gradle.kts
@@ -40,8 +40,8 @@ mavenPublishing {
 
         licenses {
             license {
-                name.set("Attribution Required License (ARL-1.0)")
-                url.set("https://github.com/javai-org/punit/blob/main/LICENSE")
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
             }
         }
 


### PR DESCRIPTION
## Summary

- Relicenses PUnit from the prior Attribution Required License (ARL-1.0) to the **Apache License, Version 2.0**. `LICENSE` now carries the canonical Apache 2.0 text; `NOTICE` follows the Apache convention. Maven POM license blocks updated in the umbrella build script and the three publishable modules (`punit-core`, `punit-sentinel`, `punit-report`).
- Adopts the **Developer Certificate of Origin** as the contributor model — no separate CLA. `dco.txt` carries the verbatim DCO 1.1 text; `CONTRIBUTING.md` documents `git commit -s`; `.github/workflows/dco.yml` blocks unsigned commits on pull requests.
- README License and Contributing sections rewritten to point at the new files. The lone `docs/OPERATIONAL-FLOW.md` ARL reference is corrected. CHANGELOG entry added under `[Unreleased]`.

Versions of PUnit published prior to this PR remain available under their original ARL-1.0 terms; the relicense applies forward.

## Test plan

- [ ] Review `LICENSE` and `NOTICE` content matches the Apache canonical text.
- [ ] `./gradlew publishToMavenLocal` succeeds and the emitted POMs list "The Apache License, Version 2.0".
- [ ] DCO workflow runs against this PR (the commit on this branch was made without `-s` by design — a follow-up signed commit, or a force-push of a signed-off version, is needed before merge).
- [ ] Confirm no prior contributors other than the project owner exist via `git shortlog -sne main..HEAD` for any historic concerns about relicense consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)