### PR TITLE
Update docs to modern Criteria authoring surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,12 @@ For sentinel-deployable applications that run probabilistic checks without a tes
 
 ### 2. Write a Probabilistic Test
 
-A service contract wraps the service call and declares its acceptance contract:
+A service contract wraps the service call and declares its acceptance criteria:
 
 ```java
+import static org.javai.punit.api.ThresholdOrigin.SLA;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+
 public class GreetingService implements ServiceContract<NoFactors, String, String> {
     @Override
     public Outcome<String> invoke(String name, TokenTracker tracker) {
@@ -128,9 +131,10 @@ public class GreetingService implements ServiceContract<NoFactors, String, Strin
     }
 
     @Override
-    public void postconditions(ContractBuilder<String> b) {
-        b.ensure("Greeting is non-empty", s ->
-                s == null || s.isBlank()
+    public Criteria<String> criteria() {
+        return meeting().<String>passRate(0.95)
+                .contractRef(SLA, "Service Agreement §4.2")
+                .satisfies("Greeting is non-empty", s -> s == null || s.isBlank()
                         ? Outcome.fail("empty", "no content")
                         : Outcome.ok());
     }
@@ -139,7 +143,7 @@ public class GreetingService implements ServiceContract<NoFactors, String, Strin
 
 `ServiceContract<FT, I, O>` carries three type parameters: `FT` is the factor record (the configuration the service contract is sensitive to — model name, temperature, retry count, …); `I` is the per-sample input; `O` is the output the service returns. When a service contract has no varying factors, declare `FT` as `NoFactors` (an empty record provided by punit) and the framework's no-factor builder overloads do the right thing.
 
-The probabilistic test exercises that service contract with a `Sampling` (factory + inputs + sample count) and asserts a population-level criterion:
+The probabilistic test exercises that service contract with a `Sampling` (factory + inputs + sample count); the contract's criteria are auto-injected:
 
 ```java
 class GreetingServiceTest {
@@ -147,14 +151,12 @@ class GreetingServiceTest {
     void serviceGreetsConsistently() {
         PUnit.testing(Sampling.of(nf -> new GreetingService(), 100,
                         List.of("Alice", "Bob", "Charlie")))
-            .criterion(PassRate.meeting(0.95, ThresholdOrigin.SLA))
-            .contractRef("Service Agreement §4.2")
             .assertPasses();
     }
 }
 ```
 
-This runs 100 samples, requires a 95% success rate at the configured confidence (default 0.95), and records the threshold's provenance as an SLA. The framework terminates early if success is guaranteed or failure becomes inevitable.
+This runs 100 samples against the contract's declared criteria — a 95% pass-rate target with SLA provenance, recorded against "Service Agreement §4.2". The framework terminates early if success is guaranteed or failure becomes inevitable.
 
 ### 3. Run It
 

--- a/docs/DEVELOPER-API.md
+++ b/docs/DEVELOPER-API.md
@@ -32,8 +32,8 @@ the change being a change at all.
 - [The PUnit entry point](#the-punit-entry-point)
 - [The Sampling primitive](#the-sampling-primitive)
 - [Service Contract and Contract](#use-case-and-contract)
-- [Postconditions: the ContractBuilder surface](#postconditions-the-contractbuilder-surface)
-- [Criteria](#criteria)
+- [Declaring acceptance criteria](#declaring-acceptance-criteria)
+- [Criterion types and composition](#criterion-types-and-composition)
 - [The empirical pair pattern](#the-empirical-pair-pattern)
 - [Spec terminals and what each one returns](#spec-terminals-and-what-each-one-returns)
 - [Public package contract](#public-package-contract)
@@ -80,15 +80,29 @@ The author-facing surface is two annotations, both attribute-free.
 void shoppingMeetsBaseline() {
     PUnit.testing(this::shoppingBaseline)
             .samples(100)
-            .criterion(PassRate.empirical())
             .assertPasses();
 }
 
 @Experiment
 void shoppingBaseline() {
-    PUnit.measuring(shoppingSampling(1000), shoppingFactors()).run();
+    PUnit.measuring(shoppingSampling(1000), shoppingFactors())
+            .experimentId("baseline-v1")
+            .run();
 }
 ```
+
+Annotated methods are always `void`. `@Experiment` methods end in
+`.run()` (which writes the baseline / exploration / optimization
+artefact). `@ProbabilisticTest` methods end in `.assertPasses()`
+(which translates the verdict into a JUnit signal). The
+probabilistic test above declares no criterion directly: the
+service contract's `criteria()` method declares the empirical
+posture (`empirical().passRate()`), and the test inherits it.
+
+The `this::shoppingBaseline` reference in the test is a separate,
+non-annotated helper used as a baseline supplier — see
+[The empirical pair pattern](#the-empirical-pair-pattern) for the
+full shape.
 
 Each annotation is a JUnit `@Test` meta-tagged `@Tag("punit")`. Every
 parameter — sample count, intent, criterion, threshold, baseline
@@ -150,7 +164,8 @@ propagate as runtime exceptions.
 
 `build()` is used in the empirical pair pattern (see
 [The empirical pair pattern](#the-empirical-pair-pattern)) to expose
-an `Experiment` value to `PassRate.empiricalFrom(...)`.
+an `Experiment` value that the probabilistic test consumes via
+`PUnit.testing(baselineSupplier)`.
 
 The `@ProbabilisticTest`-annotated method always uses `assertPasses()`
 or `build()`. The `@Experiment`-annotated method always uses `run()`
@@ -210,26 +225,28 @@ public class ShoppingBasketServiceContract
     }
 
     @Override
-    public void postconditions(ContractBuilder<BasketTranslation> b) {
-        b.ensure("Has actions",
-                t -> t.actions().isEmpty()
-                        ? Outcome.fail("empty-actions", "actions list was empty")
-                        : Outcome.ok())
-         .ensure("All actions known", ShoppingBasketServiceContract::allKnown);
+    public Criteria<BasketTranslation> criteria() {
+        return empirical().<BasketTranslation>passRate()
+                .satisfies("Has actions",
+                        t -> t.actions().isEmpty()
+                                ? Outcome.fail("empty-actions", "actions list was empty")
+                                : Outcome.ok())
+                .satisfies("All actions known", ShoppingBasketServiceContract::allKnown);
     }
 }
 ```
 
 `ServiceContract<FT, IT, OT>` extends `Contract<IT, OT>`. The author writes
-one `implements` clause and overrides three methods minimum (`invoke`
-and `postconditions`, plus optional metadata methods).
+one `implements` clause and overrides two methods minimum (`invoke`
+and `criteria`, plus optional metadata methods).
 
 ### What the framework reads from a Service Contract
 
 | Method                                | Purpose                                              | Default                       |
 |---------------------------------------|------------------------------------------------------|-------------------------------|
 | `invoke(IT, TokenTracker)`            | The service call. Returns Outcome.                   | abstract — author overrides   |
-| `postconditions(ContractBuilder<OT>)` | Declares the contract clauses.                       | abstract — author overrides   |
+| `criteria()`                          | Declares the contract's verdict-producing criteria.  | default empty — author overrides |
+| `latency()`                           | Declares latency-percentile commitment, if any.      | default empty                 |
 | `id()`                                | Stable identifier for filenames and logs.            | kebab-cased simple class name |
 | `description()`                       | Human-readable description.                          | empty                         |
 | `warmup()`                            | Discarded warmup invocations before counted samples. | 0                             |
@@ -248,7 +265,7 @@ must not mutate observable behaviour during a configuration's run.
 Pre-existing caches and pools are fine; live reconfiguration in
 response to sample outcomes is not.
 
-### What goes in `invoke` vs `postconditions`
+### What goes in `invoke` vs `criteria`
 
 Keep `invoke` primitive:
 
@@ -260,9 +277,10 @@ Keep `invoke` primitive:
   treatment of a *defect*, not of a sample that didn't meet
   contract.
 - Contract judgement — "the response had this property" or "the
-  response did not have this property" — belongs in
-  `postconditions(ContractBuilder)`. That is where each clause gets
-  a name and surfaces clause-named diagnostics on failure.
+  response did not have this property" — belongs on the criterion
+  declaration's `.satisfies(...)` clauses inside `criteria()`.
+  That is where each clause gets a name and surfaces clause-named
+  diagnostics on failure.
 - Service-level errors (the service returned a structured error
   code) belong in `invoke` returning `Outcome.fail`.
 
@@ -271,90 +289,159 @@ This is a recorded discipline — see
 
 ---
 
-## Postconditions: the ContractBuilder surface
+## Declaring acceptance criteria
 
-`org.javai.punit.api.ContractBuilder<O>` is the authoring surface for
-the contract clauses. Authors never construct one directly — the
-framework supplies a fresh builder to `postconditions(ContractBuilder<O>)`
-and collects the result.
+A service contract declares what counts as a passing sample by
+overriding `Criteria<O> criteria()` and returning a value built up
+from the `Criteria.meeting()` (contractual threshold) and
+`Criteria.empirical()` (baseline-comparison) static factories in
+`org.javai.punit.api.criterion`.
 
-Two methods, both fluent:
+### Declaring a single criterion
 
 ```java
-public final class ContractBuilder<O> {
-    public ContractBuilder<O> ensure(String name, Function<O, Outcome<Void>> predicate);
-    public <D> ContractBuilder<O> deriving(
-            String name,
-            Function<O, D> transform,
-            Consumer<ContractBuilder<D>> sub);
+import static org.javai.punit.api.criterion.Criteria.meeting;
+import static org.javai.punit.api.ThresholdOrigin.SLA;
+
+@Override
+public Criteria<Receipt> criteria() {
+    return meeting().<Receipt>passRate(0.9999)
+            .contractRef(SLA, "Payment Provider SLA v2.3, §4.1")
+            .satisfies("Authorisation returned APPROVED",
+                    r -> r.approved() ? Outcome.ok() : Outcome.fail("declined", r.reason()));
 }
 ```
 
-- **`ensure(name, predicate)`** — leaf clause. Predicate returns
+The criterion declaration's `.name(...)` is optional when the
+contract has only one criterion; missing names default to
+`Criteria.DEFAULT_CRITERION_ID`.
+
+### Declaring multiple criteria
+
+```java
+import static org.javai.punit.api.criterion.Criteria.meeting;
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.criterion.Criteria.of;
+
+@Override
+public Criteria<Receipt> criteria() {
+    return of(
+        meeting().<Receipt>passRate(0.9999)
+            .contractRef(SLA, "Payment Provider SLA v2.3, §4.1")
+            .name("payment-completes")
+            .satisfies("Authorisation returned APPROVED", ...),
+        empirical().<Receipt>passRate()
+            .name("structure-valid")
+            .satisfies("Receipt is parseable", ...));
+}
+```
+
+When more than one criterion is bundled, every declaration must
+supply a `.name(...)` and the names must be unique within the
+bundle. Both rules are enforced by `Criteria.of(...)`.
+
+### Methods on a criterion declaration
+
+- **`.satisfies(name, predicate)`** — leaf clause. Predicate returns
   `Outcome.ok()` on pass or `Outcome.fail(name, message)` on fail.
   The name is the clause's stable identifier in the verdict.
-- **`deriving(name, transform, sub)`** — adds a derivation step that
-  transforms the response mid-chain, then evaluates a sub-builder
-  against the derived value. Used when one clause needs a derived
-  view of the response that several other clauses depend on.
-
-A `Postcondition`, `PostconditionEvaluator`, etc. exist as
-public-but-internal types in `org.javai.punit.api`. Authors compose
-through `ContractBuilder`; do not subclass these types directly.
+- **`.transforming(function)`** — adds a transformation step;
+  subsequent `.satisfies(...)` clauses evaluate against the
+  transformed value. Used when one criterion needs a derived view
+  of the response that several clauses depend on
+  (parse-then-validate).
+- **`.contractRef(origin, ref)`** — stamps the threshold's
+  provenance and a free-text reference (e.g., an SLA document and
+  section number) onto the verdict.
+- **`.name(id)`** — required when the contract bundles more than
+  one criterion; identifies the criterion in the per-criterion
+  verdict rows and in the baseline file.
 
 ---
 
-## Criteria
+## Criterion types and composition
 
 A criterion is a spec-level claim evaluated against the observed
-sample aggregate. Criteria live in
-`org.javai.punit.api.spec.Criterion<OT, S extends BaselineStatistics>`
-as the abstract surface; concrete criteria with statistical
-machinery live in `org.javai.punit.internal.engine.criteria` (so the
-api package stays free of statistical dependencies — see
+sample aggregate. The abstract type lives at
+`org.javai.punit.api.spec.Criterion<OT, S extends BaselineStatistics>`;
+concrete criteria with statistical machinery live under
+`org.javai.punit.internal.engine.criteria` (so the api package
+stays free of statistical dependencies — see
 [Statistics isolation rule](#statistics-isolation-rule)).
 
-### PassRate (Bernoulli pass-rate)
+### Pass-rate criterion factories
 
-Three factory forms:
+Two factory entry points live as static methods on `Criteria`:
 
 ```java
-PassRate.meeting(0.95, ThresholdOrigin.SLA);        // contractual
-PassRate.empirical();                                // closest-match baseline
-PassRate.empiricalFrom(this::shoppingBaseline);     // pinned baseline
+import static org.javai.punit.api.criterion.Criteria.meeting;
+import static org.javai.punit.api.criterion.Criteria.empirical;
+import static org.javai.punit.api.ThresholdOrigin.SLA;
+
+// Contractual — declared threshold, NORMATIVE origin
+meeting().<O>passRate(0.95).contractRef(SLA, "...").satisfies("...", ...);
+
+// Empirical — closest-match baseline lookup
+empirical().<O>passRate().satisfies("...", ...);
 ```
 
-- **`meeting(τ, origin)`** — declared threshold, NORMATIVE origin
-  (SLA / SLO / Policy). With Verification intent the Feasibility
+- **`meeting().passRate(τ)`** — declared threshold, NORMATIVE origin
+  (SLA / SLO / Policy). With VERIFICATION intent the Feasibility
   Gate enforces sample-size adequacy.
-- **`empirical()`** — closest-match baseline lookup; threshold
-  derived at evaluation time from the resolved baseline's pass
-  rate, via the one-sided Wilson lower bound at the test sample
-  size (Statistical Companion §3.4 / §4.3.2).
-- **`empiricalFrom(supplier)`** — pinned baseline; the supplier
-  returns an `Experiment` value built via
-  `Experiment.measuring(...).build()`. See
-  [The empirical pair pattern](#the-empirical-pair-pattern).
+- **`empirical().passRate()`** — closest-match baseline lookup;
+  threshold derived at evaluation time from the resolved baseline's
+  pass rate, via the one-sided Wilson lower bound at the test sample
+  size (Statistical Companion §3.4 / §4.3.2). The baseline is
+  supplied at the test call site via
+  `PUnit.testing(baselineSupplier)` (see
+  [The empirical pair pattern](#the-empirical-pair-pattern)).
 
-### PercentileLatency
+### Latency criterion
 
-Asserts a percentile threshold on the latency-given-success
-distribution. Reads `LatencyStatistics` from the resolved baseline.
+Latency commitments live on the service contract's sibling
+`LatencyCriterion latency()` method, not in the criteria bundle:
 
-### Composing criteria
+```java
+import static java.time.Duration.ofSeconds;
+import static org.javai.punit.api.PercentileKey.P95;
+import static org.javai.punit.api.criterion.Criteria.meeting;
+import static org.javai.punit.api.ThresholdOrigin.SLA;
+
+@Override
+public LatencyCriterion latency() {
+    return meeting().atMost(P95, ofSeconds(1))
+            .contractRef(SLA, "Acme SLA §4.2");
+}
+```
+
+The structural 0..1 cardinality of latency is captured by the
+singular return type rather than by a runtime check inside the
+`criteria()` bundle. A latency criterion auto-injects into every
+probabilistic test against the contract.
+
+### Composing on the test builder (auto-inject + explicit additions)
+
+The modern shape is to declare the contract's posture inside
+`criteria()` and let the test inherit it:
 
 ```java
 PUnit.testing(sampling, factors)
-        .criterion(PassRate.empirical())
-        .criterion(PercentileLatency.atP95(...))
-        .reportOnly(SomeDiagnosticCriterion.of(...))
+        .assertPasses();
+```
+
+For overrides or additional criteria, `.criterion(...)` and
+`.reportOnly(...)` are still available on the test builder:
+
+```java
+PUnit.testing(sampling, factors)
+        .reportOnly(empirical().<O>passRate())   // diagnostic-only
         .assertPasses();
 ```
 
 `.criterion(c)` contributes to the combined verdict; `.reportOnly(c)`
 is evaluated and attached but excluded from composition. The
-combined verdict is the conjunction over `.criterion(...)` calls
-(every contributing criterion must PASS for the verdict to PASS).
+combined verdict is the conjunction over contributing criteria
+(every must PASS for the verdict to PASS).
 
 ---
 
@@ -370,24 +457,44 @@ private Sampling<F, I, O> shoppingSampling(int samples) {
     return Sampling.of(f -> new ShoppingBasketServiceContract(f), samples, ...inputs);
 }
 
+// @Experiment-annotated method actually runs the measure and writes
+// the baseline YAML to disk. Always void; ends in .run().
 @Experiment
-Experiment shoppingBaseline() {
-    return Experiment.measuring(shoppingSampling(1000), shoppingFactors()).build();
+void measureBaseline() {
+    PUnit.measuring(shoppingSampling(1000), shoppingFactors())
+            .experimentId("baseline-v1")
+            .run();
+}
+
+// Plain (non-annotated) helper that builds an Experiment value
+// structurally — used by the test as a baseline supplier to
+// identify which baseline to resolve. Returns Experiment via .build().
+private Experiment baseline() {
+    return PUnit.measuring(shoppingSampling(1000), shoppingFactors())
+            .experimentId("baseline-v1")
+            .build();
 }
 
 @ProbabilisticTest
 void shoppingMeetsBaseline() {
-    PUnit.testing(shoppingSampling(100), shoppingFactors())
-            .criterion(PassRate.empiricalFrom(this::shoppingBaseline))
+    PUnit.testing(this::baseline)
+            .samples(100)
             .assertPasses();
 }
 ```
 
-The shared `Sampling` reference enforces — at compile time — that the
-test and the baseline carry the same use-case factory, same input
-cycle, same loop governors. The shared factors call site enforces
-the same factor record. The framework's empirical-baseline resolver
-matches the test's factors against the measure's stored baseline.
+The two methods carry the same `Sampling`, the same factors, and
+the same `experimentId`. The `@Experiment` method produces the
+baseline file; the `baseline()` helper produces an `Experiment`
+value whose identity (sampling + factors + id) the framework uses
+to look up the matching baseline at test time. Java reference
+semantics enforce that the two stay aligned — share the
+`Sampling` helper and the factors call site, and divergence
+becomes a compile error rather than a silent mismatch.
+
+The service contract's `criteria()` method declares the empirical
+posture (`empirical().passRate()`); no `.criterion(...)` call is
+needed on the test builder.
 
 Why this matters: an empirical probabilistic test asks *"has the
 service's pass rate degraded from the rate the baseline measured?"*
@@ -405,7 +512,7 @@ sameness. The pairing is structural, not a brittle prose convention.
 | `TestBuilder.assertPasses()` | `void`                                          | `AssertionFailedError` on FAIL; `TestAbortedException` on INCONCLUSIVE |
 | `TestBuilder.build()`        | `ProbabilisticTest`                             | engine-level defects propagate                                         |
 | `MeasureBuilder.run()`       | `void` (artefact written to disk)               | engine-level defects propagate                                         |
-| `MeasureBuilder.build()`     | `Experiment` (used by `PassRate.empiricalFrom`) | none                                                                   |
+| `MeasureBuilder.build()`     | `Experiment` (consumed by `PUnit.testing(baselineSupplier)`) | none                                                                   |
 | `ExploreBuilder.run()`       | `void` (artefacts written per configuration)    | engine-level defects propagate                                         |
 | `OptimizeBuilder.run()`      | `void` (history file written)                   | engine-level defects propagate                                         |
 
@@ -431,7 +538,8 @@ prefix and the ArchUnit regression rules.
 
 | Package                                                                               | Contains                                                                                                                                      | Author may import?                                            |
 |---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| `org.javai.punit.api`                                                                 | Annotations, ServiceContract, Contract, ContractBuilder, Sampling, Factor support, ValueMatcher, TestIntent, ThresholdOrigin, Pacing, PacingConfiguration, TokenTracker, … | yes                                                           |
+| `org.javai.punit.api`                                                                 | Annotations, ServiceContract, Contract, Sampling, Factor support, ValueMatcher, TestIntent, ThresholdOrigin, Pacing, PacingConfiguration, TokenTracker, …                              | yes                                                           |
+| `org.javai.punit.api.criterion`                                                       | `Criteria` static factory, criterion declaration types, `LatencyCriterion`, `CriterionPosture`, … — what an author calls from `criteria()` and `latency()`                              | yes                                                           |
 | `org.javai.punit.api.spec`                                                            | Spec types (Spec, Experiment, ProbabilisticTest, Criterion, EvaluationContext, FactorsStepper, NextFactor, BaselineProvider, …)               | yes                                                           |
 | `org.javai.punit.api.covariate`                                                       | Covariate (interface) and built-in covariate categories                                                                                       | yes                                                           |
 | `org.javai.punit.runtime`                                                                      | `PUnit` entry point only — emitters live under `internal.runtime`                                                                             | yes — for `PUnit` only                                        |
@@ -570,10 +678,10 @@ Business-level failures travel as data, not as exceptions. Use
 `org.javai.outcome.Outcome<T>` (from the `org.javai:outcome`
 library): return `Outcome.ok(value)` for success,
 `Outcome.fail(name, message)` for an expected business-level failure.
-In the typed authoring surface this surfaces as `ServiceContractOutcome<OT>`
+In a service contract this is wrapped as `ServiceContractOutcome<OT>`
 whose `value` is an `Outcome<OT>`; authors write
-`ServiceContractOutcome.ok(...)` or `ServiceContractOutcome.fail(...)` indirectly
-through the Contract `apply` dispatch.
+`ServiceContractOutcome.ok(...)` or `ServiceContractOutcome.fail(...)`
+indirectly through the Contract `apply` dispatch.
 
 Reserve `throw` for genuine *defects*: programming mistakes
 (`NullPointerException`, `IllegalStateException`,

--- a/docs/DOMAIN-ONTOLOGY.md
+++ b/docs/DOMAIN-ONTOLOGY.md
@@ -45,10 +45,11 @@ ArchUnit-style architecture test).
   package: org.javai.punit.api
   role_notes: |
     Sealed-by-convention: extends Contract<IT, OT>. An author writes
-    one `class X implements ServiceContract<F, I, O>` and overrides three
-    methods — `invoke`, `postconditions(ContractBuilder)`, plus
-    whichever metadata methods diverge from defaults
-    (`id`, `pacing`, `warmup`, `covariates`, `inputSource`, …).
+    one `class X implements ServiceContract<F, I, O>` and overrides two
+    methods — `invoke` and `criteria()` (returning a `Criteria<O>`
+    value), plus whichever metadata methods diverge from defaults
+    (`id`, `pacing`, `warmup`, `covariates`, `inputSource`,
+    `latency`, …).
     `FT` is the typed factor record; `IT` the per-sample input;
     `OT` the per-sample output value.
   gotchas:
@@ -126,46 +127,47 @@ ArchUnit-style architecture test).
   java_type: Contract<IT, OT>             # interface
   package: org.javai.punit.api
   role_notes: |
-    The operational layer. Carries `invoke` and
-    `postconditions(ContractBuilder<O>)`. ServiceContract extends Contract;
-    the abstract / concrete split is preserved by inheritance.
+    The operational layer. Carries `invoke` and `criteria()`
+    (returning a `Criteria<O>` value). ServiceContract extends
+    Contract; the abstract / concrete split is preserved by
+    inheritance.
   gotchas:
     - **Two "service contract" senses live in the codebase.** The
       *subject* concept is the `ServiceContract<F, I, O>`
       interface — the thing under test. The *judgement* concept
-      lives in `Contract<I, O>` — the postcondition clauses,
-      duration constraint, and instance-conformance matchers.
+      lives in `Contract<I, O>` — the criteria declared via
+      `criteria()`, plus the optional `latency()` commitment.
       `ServiceContract` extends `Contract`. In prose, prefer
-      "Acceptance Contract" or "postconditions" for the judgement
+      "Acceptance Contract" or "criteria" for the judgement
       concept to avoid the overload.
 
-- concept: Postcondition
-  java_type: ContractBuilder<O>::ensure / ::deriving
-  package: org.javai.punit.api
+- concept: Criterion clause (postcondition)
+  java_type: Decl::satisfies / ::transforming (returned by Criteria.meeting() / Criteria.empirical())
+  package: org.javai.punit.api.criterion
   role_notes: |
-    Authors declare clauses by populating the supplied
-    `ContractBuilder<O>` in `postconditions(ContractBuilder)`. Two
-    methods: `ensure(name, predicate)` for leaf clauses;
-    `deriving(name, transform, sub)` for derivations whose nested
-    clauses are populated through a sub-builder lambda. Predicates
-    return `Outcome<Void>`: `Outcome.ok()` on pass,
-    `Outcome.fail(name, message)` on fail.
+    Authors declare clauses by chaining `.satisfies(name, predicate)`
+    on a `Decl` returned from a `Criteria.meeting()` or
+    `Criteria.empirical()` factory inside the service contract's
+    `criteria()` method. Predicates return `Outcome<Void>`:
+    `Outcome.ok()` on pass, `Outcome.fail(name, message)` on fail.
+    `.transforming(function)` adds a derivation step; subsequent
+    `.satisfies(...)` calls evaluate against the transformed value.
   gotchas:
-    - Do not move contract judgement out of `postconditions` into
+    - Do not move contract judgement out of `.satisfies(...)` into
       `invoke`. Failure detail (clause-named diagnostic) only
-      arises when the clause is registered through the builder.
-    - The inline form on `ContractBuilder` is the only canonical
-      surface for postconditions; there is no standalone
-      `Postcondition` / `PostconditionEvaluator` author surface.
+      arises when the clause is registered through a criterion
+      declaration.
+    - Overriding `criteria()` to return a `Criteria<O>` value is
+      the canonical way authors declare acceptance criteria.
 
 - concept: Duration Constraint
   java_type: ServiceContract#maxLatency() returning Optional<Duration>
   package: org.javai.punit.api
   role_notes: |
-    Per-sample wall-clock bound. Independent of postconditions: a
-    duration violation is recorded even if every postcondition
-    passes (cross-framework invariant — "Service Contract aspect
-    independence").
+    Per-sample wall-clock bound. Independent of the criteria
+    clauses: a duration violation is recorded even if every
+    `.satisfies(...)` clause passes (cross-framework invariant —
+    "Service Contract aspect independence").
   gotchas:
     - Do not conflate with PercentileLatency criterion. Duration
       Constraint is per-sample, contractual, fail-fast. Latency
@@ -273,14 +275,16 @@ ArchUnit-style architecture test).
     explicitly).
 
 - concept: Threshold (pass-rate)
-  java_type: PassRate (criterion factory family)
-  package: org.javai.punit.internal.engine.criteria
+  java_type: Criteria.meeting() / Criteria.empirical() static factories returning Decl
+  package: org.javai.punit.api.criterion (author surface) +
+           org.javai.punit.internal.engine.criteria (PassRate impl)
   role_notes: |
-    Three forms: `PassRate.meeting(threshold, ThresholdOrigin)`
-    (NORMATIVE, declared); `PassRate.empirical()` (closest-match
-    baseline lookup); `PassRate.empiricalFrom(supplier)` (pinned
-    baseline). The criterion lives under `engine.criteria` because
-    its evaluate() consumes `BinomialProportionEstimator` —
+    Two author-facing forms:
+    `meeting().passRate(threshold).contractRef(origin, ref)`
+    (NORMATIVE, declared) and `empirical().passRate()` (closest-
+    match baseline lookup at evaluation time). Both lower to the
+    internal `PassRate` criterion under `engine.criteria`, whose
+    `evaluate()` consumes `BinomialProportionEstimator` —
     `Criterion` itself is in `api.spec`, but concrete criteria
     that touch statistics live in `engine.criteria`.
   gotchas:
@@ -292,11 +296,16 @@ ArchUnit-style architecture test).
       belongs in `org.javai.punit.statistics`.
 
 - concept: Threshold (latency)
-  java_type: PercentileLatency (criterion family) + LatencySpec
-  package: org.javai.punit.internal.engine.criteria + org.javai.punit.api
+  java_type: LatencyCriterion returned by ServiceContract#latency()
+  package: org.javai.punit.api.criterion (author surface) +
+           org.javai.punit.internal.engine.criteria (PercentileLatency impl)
   role_notes: |
-    Latency thresholds are declared via `LatencySpec` on the typed
-    authoring surface; evaluation lives in `engine.criteria` via the
+    Latency thresholds are declared by overriding
+    `LatencyCriterion latency()` on the service contract,
+    typically as `meeting().atMost(P95, duration).contractRef(origin, ref)`.
+    The contract has either zero or one latency commitment;
+    that's captured by the singular return type rather than a
+    runtime check. Evaluation lives in `engine.criteria` via the
     `PercentileLatency` criterion.
 
 - concept: Threshold Origin
@@ -450,14 +459,14 @@ ArchUnit-style architecture test).
     Default is VERIFICATION.
 
 - concept: Compliance Testing
-  java_type: usage pattern: PassRate.meeting(τ, NORMATIVE) + Verification intent
+  java_type: usage pattern: meeting().passRate(τ).contractRef(NORMATIVE, ref) + Verification intent
   package: pattern, not a type
   role_notes: |
     No dedicated class — emerges from criterion + intent
     composition.
 
 - concept: Conformance Testing
-  java_type: usage pattern: PassRate.empirical() / empiricalFrom(...)
+  java_type: usage pattern: empirical().passRate() on the contract's criteria(); PUnit.testing(baselineSupplier) on the test
   package: pattern, not a type
   role_notes: |
     Same — pattern, not a type.
@@ -546,8 +555,8 @@ differently).
   description: |
     Each PUnit-entry-point builder ends in one of: `.assertPasses()`
     (probabilistic-test side), `.run()` (experiment side), or
-    `.build()` (pair-pattern supplier — an Experiment value handed to
-    PassRate.empiricalFrom).
+    `.build()` (pair-pattern supplier — an Experiment value handed
+    to `PUnit.testing(baselineSupplier)` at the test side).
   rationale: |
     The terminal selects the test-harness translation. Authors
     rarely call `.build()` directly except in the empirical pair
@@ -555,18 +564,21 @@ differently).
     (assertPasses / run) but the supplier-pattern has earned the
     third.
 
-- name: api / api.spec / engine boundary
+- name: api / api.criterion / api.spec / engine boundary
   description: |
     `org.javai.punit.api` carries types an author touches when
-    *authoring* (ServiceContract, Contract, ContractBuilder, Sampling,
-    Factor support, annotations, intent, origin, value matchers,
-    pacing, postcondition primitives that survive). `api.spec`
+    *authoring* (ServiceContract, Contract, Sampling, Factor
+    support, annotations, intent, origin, value matchers,
+    pacing). `org.javai.punit.api.criterion`
+    carries the types an author calls from `criteria()` and
+    `latency()`: the `Criteria` static factory, criterion
+    declaration types, `LatencyCriterion`, `CriterionPosture`. `api.spec`
     carries the typed spec surface (Experiment, ProbabilisticTest,
     Criterion, EvaluationContext, FactorsStepper, …). `engine.*`
-    is internal — engine.criteria, engine.baseline,
-    engine.explore, engine.optimize, engine.covariate,
-    engine.emit, engine.budget, engine.pacing, engine.spec.
-    Authors should never import from `engine.*`.
+    is internal — engine.criteria (PassRate, PercentileLatency
+    impls), engine.baseline, engine.explore, engine.optimize,
+    engine.covariate, engine.emit, engine.budget, engine.pacing,
+    engine.spec. Authors should never import from `engine.*`.
   enforcement: |
     `CoreArchitectureTest` (package-level rules in punit-core) +
     `AbstractionLevelArchitectureTest` (cross-cutting abstraction
@@ -576,11 +588,14 @@ differently).
   description: |
     Author publishes a `Sampling<F, I, O>` helper used by both a
     measure baseline (`@Experiment` returning `Experiment` via
-    `Experiment.measuring(...).build()`) and a probabilistic test
-    (`@ProbabilisticTest` with `PassRate.empiricalFrom(::baseline)`).
-    Java reference semantics enforce that the test and the
-    baseline draw from the same sampling population — same use
-    case, same inputs, same factors, same governors.
+    `PUnit.measuring(...).build()`) and a probabilistic test
+    (`@ProbabilisticTest` calling `PUnit.testing(this::baseline)`).
+    The service contract declares the empirical posture
+    (`empirical().passRate()`) in `criteria()`; the test passes
+    the baseline supplier directly to `PUnit.testing(...)`. Java
+    reference semantics enforce that the test and the baseline
+    draw from the same sampling population — same service
+    contract, same inputs, same factors, same governors.
   rationale: |
     Statistical coherence of "has the service degraded since the
     baseline?" requires the test and baseline to be drawn from

--- a/docs/OPERATIONAL-FLOW.md
+++ b/docs/OPERATIONAL-FLOW.md
@@ -31,13 +31,26 @@ However, we must distinguish between **compliance** and a **smoke test**. A true
 
 If you want an early-warning check without the cost of a full compliance audit, declare your intent as `SMOKE`.
 
+The service contract declares the contractual posture in its
+`criteria()` method; the test sets the intent:
+
 ```java
+// On the service contract
+@Override
+public Criteria<String> criteria() {
+    return meeting().<String>passRate(0.999)
+            .contractRef(SLA, "Customer API SLA §3.1")
+            .satisfies("Output is valid JSON",
+                    output -> JsonValidator.isValid(output)
+                            ? Outcome.ok()
+                            : Outcome.fail("invalid-json", "validator rejected output"));
+}
+
+// On the test
 @ProbabilisticTest
 void apiMeetsSla() {
     PUnit.testing(JsonGenerationServiceContract.sampling(PROMPTS, 100), Tuning.DEFAULT)
-            .criterion(PassRate.meeting(0.999, ThresholdOrigin.SLA))
             .intent(TestIntent.SMOKE)               // smoke, not full compliance audit
-            .contractRef("Customer API SLA §3.1")
             .assertPasses();
 }
 ```
@@ -68,10 +81,10 @@ Both paradigms use the same `@ProbabilisticTest` annotation. The difference is w
 
 Regardless of which paradigm you use, you must decide **how to parameterize** your test.
 
-> **Where the threshold comes from, and how the comparison is decided.** PUnit's `PassRate` criterion has two modes:
+> **Where the threshold comes from, and how the comparison is decided.** The pass-rate criterion has two modes, declared via `Criteria.meeting()` or `Criteria.empirical()` on the service contract's `criteria()`:
 >
-> - **Empirical** (`PassRate.empirical()`) — the threshold is the observed pass rate read at runtime from the matched baseline spec (produced by a prior MEASURE experiment). The verdict applies a one-sided **Wilson score lower bound** to the run's observed rate at the configured confidence (default 0.95) and passes iff that lower bound clears the baseline rate. Approaches 1 and 2 below use this mode.
-> - **Contractual** (`PassRate.meeting(threshold, origin)`) — the threshold is an externally-fixed number declared in code (an SLA, SLO, or policy figure). The verdict is a **deterministic** `observed >= threshold` comparison. No Wilson margin: an SLA is an external commitment to a specific number, not a statistical claim against a baseline. Approach 3 uses this mode.
+> - **Empirical** (`empirical().passRate()`) — the threshold is the observed pass rate read at runtime from the matched baseline spec (produced by a prior MEASURE experiment). The verdict applies a one-sided **Wilson score lower bound** to the run's observed rate at the configured confidence (default 0.95) and passes iff that lower bound clears the baseline rate. Approaches 1 and 2 below use this mode.
+> - **Contractual** (`meeting().passRate(threshold).contractRef(origin, ref)`) — the threshold is an externally-fixed number declared in code (an SLA, SLO, or policy figure). The verdict is a **deterministic** `observed >= threshold` comparison. No Wilson margin: an SLA is an external commitment to a specific number, not a statistical claim against a baseline. Approach 3 uses this mode.
 >
 > What the three approaches differ in is which knob the author fixes first.
 
@@ -79,19 +92,20 @@ Regardless of which paradigm you use, you must decide **how to parameterize** yo
 
 *"My budget allows 100 samples per run. Run them against the recorded baseline and let the framework decide."*
 
+The contract declares `empirical().passRate()` in `criteria()`; the test passes the baseline supplier:
+
 ```java
 @ProbabilisticTest
 void sampleSizeFirst() {
     PUnit.testing(this::baseline)
             .samples(100)
-            .criterion(PassRate.empirical())
             .assertPasses();
 }
 ```
 
 **What happens:**
 - PUnit runs the chosen samples.
-- `empirical()` resolves the matched baseline spec at runtime; its observed rate becomes the threshold for this run.
+- The contract's `empirical().passRate()` criterion resolves the matched baseline spec at runtime; its observed rate becomes the threshold for this run.
 - The verdict applies the Wilson lower bound at the default confidence (0.95) to *this* run's observed rate, and passes iff that lower bound clears the baseline.
 - With small N the Wilson margin is wide, so passing requires the observed rate to be clearly above the baseline.
 
@@ -103,6 +117,8 @@ void sampleSizeFirst() {
 
 *"I need to be able to detect a 5-percentage-point regression with 80% probability at 95% confidence. How many samples?"*
 
+The contract again declares the empirical posture in `criteria()`; the test computes the required sample size via `PowerAnalysis`:
+
 ```java
 @ProbabilisticTest
 void confidenceFirst() {
@@ -110,10 +126,13 @@ void confidenceFirst() {
 
     PUnit.testing(this::baseline)
             .samples(n)
-            .criterion(PassRate.empirical().atConfidence(0.95))
             .assertPasses();
 }
 ```
+
+The confidence target (default 0.95) is set on the contract's
+`empirical().passRate().atConfidence(...)` posture if the default
+needs overriding.
 
 **What happens:**
 - `PowerAnalysis.sampleSize(baseline, mde, power)` derives the required N from the baseline rate, the minimum detectable effect (MDE), and the target power.
@@ -128,12 +147,12 @@ void confidenceFirst() {
 
 *"The threshold is fixed by an SLA, SLO, or policy. Verify against it."*
 
+The contract declares `meeting().passRate(0.90).contractRef(SLA, "...")` in `criteria()`; the test is bare:
+
 ```java
 @ProbabilisticTest
 void thresholdFirst() {
     PUnit.testing(MyServiceContract.sampling(INPUTS, 100), MyFactors.DEFAULT)
-            .criterion(PassRate.meeting(0.90, ThresholdOrigin.SLA))
-            .contractRef("Customer API SLA §3.1")
             .assertPasses();
 }
 ```
@@ -147,7 +166,7 @@ void thresholdFirst() {
 
 **Best for:** SLA-style verification of services with externally-committed reliability targets.
 
-> **Antipattern: pinning a contractual threshold to a baseline's observed rate.** Reading a baseline file by eye and pasting its observed rate into `PassRate.meeting(0.935, ThresholdOrigin.EMPIRICAL)` looks like the empirical-pair pattern but isn't. The contractual path is deterministic — `observed >= 0.935` — and natural sampling variance puts the next run's observed rate below 0.935 roughly half the time even when the SUT is performing exactly at baseline. Result: ~50% false-fail rate. The proper baseline-comparison path is `PassRate.empirical()`, which resolves the baseline at runtime, applies the Wilson lower bound at the configured confidence, and gives the test the statistical buffer that the hardcoded contractual approach is missing.
+> **Antipattern: pinning a contractual threshold to a baseline's observed rate.** Reading a baseline file by eye and pasting its observed rate into `meeting().passRate(0.935).contractRef(EMPIRICAL, ...)` looks like the empirical-pair pattern but isn't. The contractual path is deterministic — `observed >= 0.935` — and natural sampling variance puts the next run's observed rate below 0.935 roughly half the time even when the SUT is performing exactly at baseline. Result: ~50% false-fail rate. The proper baseline-comparison path is `empirical().passRate()`, which resolves the baseline at runtime, applies the Wilson lower bound at the configured confidence, and gives the test the statistical buffer that the hardcoded contractual approach is missing.
 
 ### Choosing Your Approach
 
@@ -206,11 +225,12 @@ public final class JsonGenerationServiceContract
     }
 
     @Override
-    public void postconditions(ContractBuilder<String> b) {
-        b.ensure("Output is valid JSON",
-                output -> JsonValidator.isValid(output)
-                        ? Outcome.ok()
-                        : Outcome.fail("invalid-json", "validator rejected output"));
+    public Criteria<String> criteria() {
+        return empirical().<String>passRate()
+                .satisfies("Output is valid JSON",
+                        output -> JsonValidator.isValid(output)
+                                ? Outcome.ok()
+                                : Outcome.fail("invalid-json", "validator rejected output"));
     }
 
     @Override
@@ -272,11 +292,12 @@ contentFingerprint: 7d3a8c1e9b2f4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b
 A few things to notice:
 
 - **`statistics.bernoulli-pass-rate.criteria.<id>`** — pass-rate is
-  always recorded per methodology criterion, one entry per postcondition
-  clause the service contract declared (here, the single clause from
-  Stage 1 surfaces as `output-valid-json`). With multiple postconditions
-  every clause gets its own row; a probabilistic test that picks a
-  per-criterion threshold sees them via the same structure.
+  always recorded per methodology criterion, one entry per criterion
+  the service contract declared (here, the single criterion from
+  Stage 1 surfaces as `output-valid-json`). When the contract
+  bundles multiple criteria every one gets its own row; a
+  probabilistic test that picks a per-criterion threshold sees them
+  via the same structure.
 - **`latency:` is a top-level block, not a criterion.** Percentiles are
   emitted from passing samples only (`basis: passing-samples`); each
   percentile is omitted if too few samples back it (the per-percentile
@@ -307,10 +328,13 @@ The test references the baseline. The threshold is derived at runtime:
 @ProbabilisticTest
 void jsonGenerationMeetsBaseline() {
     PUnit.testing(JsonGenerationServiceContract.sampling(PROMPTS, 100), Tuning.DEFAULT)
-            .criterion(PassRate.empirical())
             .assertPasses();
 }
 ```
+
+The service contract declared `empirical().passRate()` in
+`criteria()` at Stage 1; the test simply runs against the contract
+and the criterion auto-injects.
 
 **What happens at runtime:**
 1. Resolve the baseline by `useCaseId`, `factorsFingerprint`, and

--- a/docs/SENTINEL-DEPLOYMENT-GUIDE.md
+++ b/docs/SENTINEL-DEPLOYMENT-GUIDE.md
@@ -73,7 +73,7 @@ dependencies {
 }
 ```
 
-This module depends on `punit-core` via `api()` — not `testImplementation`. This is the defining characteristic of the Sentinel authoring model: PUnit types (`ServiceContract`, `Contract`, `ContractBuilder`, `Sampling`, `PUnit`, etc.) are production dependencies in this module because the sentinel-deployable classes are production artefacts.
+This module depends on `punit-core` via `api()` — not `testImplementation`. This is the defining characteristic of the Sentinel authoring model: PUnit types (`ServiceContract`, `Contract`, `Criteria`, `Sampling`, `PUnit`, etc.) are production dependencies in this module because the sentinel-deployable classes are production artefacts.
 
 The module must **not** depend on `junit-jupiter-api`. Sentinel-deployable code is JUnit-free. For the contract-first authoring model, see [Part 3 of the User Guide](USER-GUIDE.md#part-3-the-use-case).
 
@@ -129,7 +129,7 @@ The task requires at least one class declaring `@ProbabilisticTest` or `@Experim
 
 Sentinel-deployable classes define **what to measure** and **what to verify** about stochastic behaviour. They are consumed by both the JUnit test suite (because their `@ProbabilisticTest` / `@Experiment` methods are meta-annotated `@Test`) and the Sentinel runner (which discovers them via the build-time manifest).
 
-Placing them in a test source set makes them unavailable to the Sentinel — code in `src/test/java` is never packaged into a deployable JAR. The `app-usecases` module is the bridge: it depends on `app-stochastic` (to invoke stochastic services) and `punit-core` (for `ServiceContract`, `Contract`, `ContractBuilder`, `PUnit`, etc.), and produces a production artefact consumable by both engines.
+Placing them in a test source set makes them unavailable to the Sentinel — code in `src/test/java` is never packaged into a deployable JAR. The `app-usecases` module is the bridge: it depends on `app-stochastic` (to invoke stochastic services) and `punit-core` (for `ServiceContract`, `Contract`, `Criteria`, `PUnit`, etc.), and produces a production artefact consumable by both engines.
 
 This also applies to input data — anything passed to `Sampling.Builder.inputs(...)`. The Sentinel engine needs the same inputs as the JUnit engine. If input data lives in the test source set or a test resource folder, the Sentinel cannot reach it.
 


### PR DESCRIPTION
## Summary

- Rewrites the project README and four `docs/` files (`DEVELOPER-API.md`, `OPERATIONAL-FLOW.md`, `DOMAIN-ONTOLOGY.md`, `SENTINEL-DEPLOYMENT-GUIDE.md`) to describe the current punit API only. The legacy `Contract.postconditions(PostconditionBuilder)` path, the never-existed-under-that-name `ContractBuilder` type, the internal-package `PassRate.meeting/empirical/empiricalFrom` direct factory calls, and the `.criterion(...)` + `.contractRef(...)` calls on the test builder are all gone from user-facing docs.
- Code examples now follow the canonical shape from `punitexamples/PaymentGatewayServiceContract.java`: service contract declares `Criteria<O> criteria()` with `meeting().passRate(...).contractRef(SLA, ...).satisfies(...)` (or `empirical().passRate().satisfies(...)`); latency commitments declared on the sibling `LatencyCriterion latency()` method; the probabilistic test is bare and auto-inherits the contract's criteria.
- `@Experiment` annotated methods are `void` and end in `.run()`. The `Experiment`-returning helper used by `PUnit.testing(baselineSupplier)` is a separate non-annotated `private Experiment baseline()` helper. The empirical pair pattern documentation now shows both pieces.
- Cryptic / API-designer-jargon headings replaced with developer-user language. `Criteria: the value-form authoring surface` → `Declaring acceptance criteria`; `K=1: a bare decl` → `Declaring a single criterion`; `K>1: a bundle via Criteria.of(...)` → `Declaring multiple criteria`; `Decl methods` → `Methods on a criterion declaration`. The duplicate `## Criteria` heading is disambiguated to `## Criterion types and composition`.

This is **documentation only** — no source or test changes. Code-side removal of the legacy `PostconditionBuilder` path is in a separate forthcoming PR.

## Test plan

- [ ] Visually scan README and each updated doc; confirm code snippets compile against the current API surface (cross-reference `punitexamples` if in doubt).
- [ ] Confirm no remaining references to `PassRate.meeting/empirical/empiricalFrom`, `ContractBuilder`, `.contractRef(...)` on test builder, `value-form`, `K=1`, `K>1`, `decl`, `lowering`, or the legacy `postconditions(PostconditionBuilder)` method. The CHANGELOG retains its historical entries; those are intentionally frozen.
- [ ] DCO check passes (commit is signed off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)