### PR TITLE
Add expected-value matching: Expected, ValueMatcher, .matchedBy / .matchedByEquality

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -3,6 +3,7 @@ package org.javai.punit.api;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.javai.outcome.Outcome;
 import org.javai.outcome.Outcome.Ok;
@@ -227,8 +228,12 @@ public interface Contract<I, O> {
         Duration duration = Duration.ofNanos(System.nanoTime() - start);
         long sampleTokens = Math.max(0L, tracker.totalTokens() - startTokens);
 
+        Optional<O> expected = expectedFrom(input);
+        if (expected.isEmpty()) {
+            requireMatchingCompatible(input);
+        }
         ClauseEvaluation clauseEvaluation = result instanceof Ok<O> ok
-                ? evaluateClauses(ok.value())
+                ? evaluateClauses(ok.value(), expected)
                 : ClauseEvaluation.empty();   // postcondition evaluation skipped on apply-level failure
 
         return new ServiceContractOutcome<>(
@@ -240,7 +245,43 @@ public interface Contract<I, O> {
                 clauseEvaluation.criterionSampleResults());
     }
 
-    private ClauseEvaluation evaluateClauses(O value) {
+    /**
+     * Read the sample's known-expected output if the input declares
+     * one via {@link Expected}. The unchecked cast on the return value
+     * relies on the author having parameterised {@code Expected<OT>}
+     * with the contract's output type {@code O}; a mismatch would
+     * surface as a {@link ClassCastException} at the matcher call site.
+     */
+    @SuppressWarnings("unchecked")
+    private Optional<O> expectedFrom(I input) {
+        if (input instanceof Expected<?> e) {
+            return Optional.ofNullable((O) e.expected());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Fail fast at the first sample when a criterion declares a
+     * matching postcondition (via {@code .matchedBy(...)} or
+     * {@code .matchedByEquality()}) but the sampling's input type
+     * does not implement {@link Expected}.
+     */
+    private void requireMatchingCompatible(I input) {
+        for (Criterion<O> criterion : effectiveCriteria()) {
+            if (criterion.requiresExpected()) {
+                throw new IllegalStateException(
+                        "Criterion '" + criterion.id() + "' declares .matchedBy(...), "
+                                + "which requires the sampling's input type to implement "
+                                + "org.javai.punit.api.Expected. The current input is of "
+                                + "type " + input.getClass().getName() + ", which does "
+                                + "not implement Expected. Either implement Expected<...> "
+                                + "on that input type, or replace .matchedBy(...) with "
+                                + ".satisfies(...) on the criterion.");
+            }
+        }
+    }
+
+    private ClauseEvaluation evaluateClauses(O value, Optional<O> expected) {
         // Walk criteria via per-sample evaluate(value). For each criterion
         // we get a three-valued CriterionSampleResult; the verdict path
         // (which consumes a flat List<PostconditionResult>) is fed the
@@ -257,7 +298,7 @@ public interface Contract<I, O> {
         List<PostconditionResult> flat = new ArrayList<>();
         List<CriterionSampleResult> perCriterion = new ArrayList<>();
         for (Criterion<O> criterion : effectiveCriteria()) {
-            CriterionSampleResult result = criterion.evaluate(value);
+            CriterionSampleResult result = criterion.evaluate(value, expected);
             perCriterion.add(result);
             switch (result.outcome()) {
                 case PASS, FAIL -> flat.addAll(result.postconditionResults());

--- a/punit-core/src/main/java/org/javai/punit/api/Expected.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Expected.java
@@ -1,0 +1,38 @@
+package org.javai.punit.api;
+
+/**
+ * Marks a per-sample input type that carries a known expected output.
+ *
+ * <p>Implementing {@code Expected<OT>} on a sample type unlocks the
+ * reference-matching criterion shape on the contract's criteria:
+ * {@link org.javai.punit.api.criterion.CriterionDecl#matchedBy(
+ * java.util.function.Supplier)} and
+ * {@link org.javai.punit.api.criterion.CriterionDecl#matchedByEquality()}
+ * route the value returned by {@link #expected()} to a
+ * {@link org.javai.punit.api.criterion.ValueMatcher} alongside the
+ * actual value produced by {@link Contract#invoke}.
+ *
+ * <p>The expected value's type is the contract's output type
+ * {@code OT}. A sample whose ground truth has a different shape
+ * should narrow its contract's {@code OT} to match, rather than
+ * smuggling a projection through this interface.
+ *
+ * <p>A sample type either carries ground truth (implements this
+ * interface) or it does not; this interface does not return an
+ * {@link java.util.Optional}. Sampling runs that mix expected-bearing
+ * and expected-less samples should split into two sample types
+ * rather than loosening the contract.
+ *
+ * @param <OT> the expected output value type — must match the
+ *             contract's per-sample output type
+ */
+public interface Expected<OT> {
+
+    /**
+     * The known-correct output for this input. Routed to a
+     * {@link org.javai.punit.api.criterion.ValueMatcher} when the
+     * criterion declares {@code .matchedBy(...)} or
+     * {@code .matchedByEquality()}.
+     */
+    OT expected();
+}

--- a/punit-core/src/main/java/org/javai/punit/api/Postcondition.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Postcondition.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.javai.outcome.Outcome;
+import org.javai.punit.api.criterion.ValueMatcher;
 
 /**
  * A named predicate over a single sample's produced value. A
@@ -60,19 +61,28 @@ import org.javai.outcome.Outcome;
  *
  * @param <T> the type the postcondition evaluates
  */
-public sealed interface Postcondition<T> permits Postcondition.Leaf {
+public sealed interface Postcondition<T> permits Postcondition.Leaf, Postcondition.Matching {
 
     /** Human-readable description; non-blank. */
     String description();
 
     /**
      * Evaluate this postcondition and return one summary result.
+     *
+     * <p>This signature is well-defined for the {@link Leaf} variant,
+     * whose predicate sees the produced value alone. The {@link Matching}
+     * variant requires both an expected and an actual value, and so
+     * throws on this method — callers in the engine pattern-match on
+     * the variant and route to {@link Matching#match(Object, Object)}
+     * directly.
      */
     PostconditionResult evaluate(T value);
 
     /**
      * Evaluate this postcondition and return every contributing
-     * result. For a {@link Leaf} this is a singleton list.
+     * result. For a {@link Leaf} this is a singleton list. For a
+     * {@link Matching} this is undefined without an expected value
+     * — see {@link #evaluate(Object)}.
      */
     List<PostconditionResult> evaluateAll(T value);
 
@@ -119,6 +129,78 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf {
                 case Outcome.Ok<?> ignored -> PostconditionResult.passed(description);
                 case Outcome.Fail<?> f -> PostconditionResult.failed(description, f);
             };
+        }
+
+        @Override
+        public List<PostconditionResult> evaluateAll(T value) {
+            return List.of(evaluate(value));
+        }
+    }
+
+    /**
+     * A reference-matching postcondition: one description and a
+     * {@link ValueMatcher} that judges an actual value against an
+     * expected value of the same type. Produced by
+     * {@link org.javai.punit.api.criterion.CriterionDecl#matchedBy(
+     * java.util.function.Supplier)} and
+     * {@link org.javai.punit.api.criterion.CriterionDecl#matchedByEquality()}
+     * on the criterion builder; the expected value is sourced at
+     * sample time from the input's {@link Expected#expected()}.
+     *
+     * <p>This variant cannot be evaluated through the value-only
+     * {@link #evaluate(Object)} method on the sealed interface — the
+     * engine pattern-matches on the variant and calls
+     * {@link #match(Object, Object)} directly. The interface-method
+     * implementation throws to surface engine-side misuse.
+     */
+    record Matching<T>(String description, ValueMatcher<T> matcher)
+            implements Postcondition<T> {
+
+        public Matching {
+            Objects.requireNonNull(description, "description");
+            Objects.requireNonNull(matcher, "matcher");
+            if (description.isBlank()) {
+                throw new IllegalArgumentException("description must not be blank");
+            }
+        }
+
+        /**
+         * Apply the matcher to the {@code (expected, actual)} pair and
+         * fold the resulting {@link Outcome} into a
+         * {@link PostconditionResult} carrying this postcondition's
+         * description.
+         *
+         * <p>A {@link RuntimeException} thrown from the matcher is a
+         * defect under the framework's {@code Outcome}-vs-exception
+         * convention and is folded into a failed
+         * {@link PostconditionResult} carrying the exception's message
+         * as the reason — same treatment as {@link Leaf}.
+         */
+        public PostconditionResult match(T expected, T actual) {
+            Outcome<Void> result;
+            try {
+                result = matcher.match(expected, actual);
+            } catch (RuntimeException e) {
+                String reason = e.getMessage() != null
+                        ? e.getMessage()
+                        : e.getClass().getSimpleName();
+                return PostconditionResult.failed(description, reason);
+            }
+            return switch (result) {
+                case Outcome.Ok<?> ignored -> PostconditionResult.passed(description);
+                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f);
+            };
+        }
+
+        @Override
+        public PostconditionResult evaluate(T value) {
+            throw new IllegalStateException(
+                    "Matching postcondition '" + description
+                            + "' requires an expected value; the engine must "
+                            + "pattern-match on the Postcondition variant and "
+                            + "route Matching through Matching.match(expected, actual). "
+                            + "Reaching Postcondition.evaluate(value) on a Matching "
+                            + "variant indicates an engine-side defect.");
         }
 
         @Override

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Criterion.java
@@ -1,5 +1,7 @@
 package org.javai.punit.api.criterion;
 
+import java.util.Optional;
+
 /**
  * A named, contract-level partition of the functional dimension. A
  * criterion is a unit that judges a single sample's produced value
@@ -68,6 +70,51 @@ public interface Criterion<O> {
      * @return the criterion's per-sample evaluation record
      */
     CriterionSampleResult evaluate(O value);
+
+    /**
+     * Evaluate this criterion against one sample's produced value
+     * with an optional known-expected value of the same type
+     * supplied alongside.
+     *
+     * <p>The expected value is present when the sampling's input
+     * type implements {@link org.javai.punit.api.Expected} and the
+     * criterion carries at least one reference-matching postcondition
+     * (declared via {@code .matchedBy(...)} or
+     * {@code .matchedByEquality()}). Criteria with no matching
+     * postcondition ignore the expected value.
+     *
+     * <p>The default implementation delegates to {@link #evaluate(Object)}
+     * and ignores the expected value — appropriate for hand-rolled
+     * implementations that do not use the matching postcondition
+     * shape. The factory-produced implementations override to route
+     * the expected value into {@link org.javai.punit.api.Postcondition.Matching}
+     * variants in their chain.
+     *
+     * @param value    the contract's produced output for this sample
+     * @param expected the sample's known-correct output, present iff
+     *                 the input implements {@link org.javai.punit.api.Expected}
+     * @return the criterion's per-sample evaluation record
+     */
+    default CriterionSampleResult evaluate(O value, Optional<O> expected) {
+        return evaluate(value);
+    }
+
+    /**
+     * Whether this criterion needs the sample's known-expected value
+     * to evaluate. Returns {@code true} when the criterion carries at
+     * least one {@link org.javai.punit.api.Postcondition.Matching}
+     * postcondition; {@code false} otherwise.
+     *
+     * <p>The framework's sample-dispatch path uses this to fail fast,
+     * at the first sample, when criteria declare {@code .matchedBy(...)}
+     * but the sampling's input type does not implement
+     * {@link org.javai.punit.api.Expected}. Hand-rolled
+     * {@link Criterion} implementations that do not use the matching
+     * postcondition shape leave this at its default of {@code false}.
+     */
+    default boolean requiresExpected() {
+        return false;
+    }
 
     /**
      * The criterion's run-time commitment — what counts as acceptable,

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.javai.outcome.Outcome;
 import org.javai.punit.api.Postcondition;
@@ -217,6 +218,62 @@ public final class CriterionDecl<O> implements Decl<O> {
      */
     public CriterionDecl<O> atPower(double power) {
         return new CriterionDecl<>(posture.withPower(power), postconditions, name);
+    }
+
+    /**
+     * Judge the contract's output against the sample's known-expected
+     * value via a {@link ValueMatcher}. Returns a terminal
+     * {@link MatchingDecl} that carries the matcher and offers only
+     * {@link MatchingDecl#name(String) .name(...)} for further
+     * configuration.
+     *
+     * <p>The sampling's input type must implement
+     * {@link org.javai.punit.api.Expected Expected&lt;OT&gt;} — the
+     * framework reads {@code input.expected()} once per sample and
+     * routes the result alongside the contract's produced value to
+     * the matcher. The requirement is enforced at sampling-construction
+     * time; a sampling whose input type does not implement
+     * {@code Expected} but is paired with a criteria carrying
+     * {@code .matchedBy(...)} fails fast with a clear message.
+     *
+     * <p>{@code Supplier} rather than a direct {@link ValueMatcher}
+     * lets matchers carry per-sampling state if needed. In the common
+     * stateless case the call is {@code MyMatcher::new}.
+     *
+     * <p>A matching criterion is purposefully equivalence-only:
+     * {@code .matchedBy} may not follow any {@code .where} /
+     * {@code .satisfies} on the same decl, and {@link MatchingDecl}
+     * does not offer further postcondition chaining. To pair an
+     * equivalence check with an intrinsic check (e.g. non-blank
+     * output), declare two criteria via
+     * {@link Criteria#of(Decl[])}.
+     *
+     * @throws IllegalStateException if any {@code .where} /
+     *         {@code .satisfies} postcondition has already been added
+     *         to this decl
+     */
+    public MatchingDecl<O> matchedBy(Supplier<? extends ValueMatcher<O>> matcher) {
+        Objects.requireNonNull(matcher, "matcher");
+        if (!postconditions.isEmpty()) {
+            throw new IllegalStateException(
+                    ".matchedBy(...) cannot follow .where/.satisfies on the same"
+                            + " criterion decl: a matching criterion is purposefully"
+                            + " equivalence-only. Either drop the postconditions, or"
+                            + " split into two criteria via Criteria.of(...).");
+        }
+        return new MatchingDecl<>(posture, matcher, name);
+    }
+
+    /**
+     * Shorthand for {@code .matchedBy(ValueMatcher::equality)} — the
+     * common case where the actual output is expected to be
+     * {@link java.util.Objects#equals(Object, Object) Objects.equals}
+     * to the sample's expected output. See
+     * {@link ValueMatcher#equality()} for the matcher's behaviour and
+     * the failure name / message it emits on mismatch.
+     */
+    public MatchingDecl<O> matchedByEquality() {
+        return matchedBy(ValueMatcher::equality);
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/Decl.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @param <O> the contract's per-sample output value type
  */
 public sealed interface Decl<O> extends Criteria<O>
-        permits CriterionDecl, TransformingDecl {
+        permits CriterionDecl, TransformingDecl, MatchingDecl {
 
     /**
      * The criterion's name as declared via {@code .name(String)}, or

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/DirectCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/DirectCriterion.java
@@ -3,6 +3,7 @@ package org.javai.punit.api.criterion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.javai.punit.api.Postcondition;
 import org.javai.punit.api.PostconditionResult;
@@ -51,7 +52,22 @@ final class DirectCriterion<O> implements Criterion<O> {
 
     @Override
     public CriterionSampleResult evaluate(O value) {
-        return evaluateChain(id, postconditions, value);
+        return evaluateChain(id, postconditions, value, Optional.empty());
+    }
+
+    @Override
+    public CriterionSampleResult evaluate(O value, Optional<O> expected) {
+        return evaluateChain(id, postconditions, value, expected);
+    }
+
+    @Override
+    public boolean requiresExpected() {
+        for (Postcondition<O> p : postconditions) {
+            if (p instanceof Postcondition.Matching<O>) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -63,13 +79,30 @@ final class DirectCriterion<O> implements Criterion<O> {
      * postcondition is evaluated and its result preserved on the
      * record, so a downstream consumer can see the full diagnostic
      * picture for the sample.
+     *
+     * <p>{@link Postcondition.Matching} variants in the chain route
+     * through {@link Postcondition.Matching#match(Object, Object)}
+     * with the supplied expected value. A matching postcondition
+     * without an expected value (caller passed {@link Optional#empty()})
+     * is an engine-side defect and surfaces as an
+     * {@link IllegalStateException}.
      */
     static <T> CriterionSampleResult evaluateChain(
-            String id, List<Postcondition<T>> chain, T value) {
+            String id, List<Postcondition<T>> chain, T value, Optional<T> expected) {
         List<PostconditionResult> results = new ArrayList<>();
         boolean anyFailed = false;
         for (Postcondition<T> p : chain) {
-            List<PostconditionResult> pResults = p.evaluateAll(value);
+            List<PostconditionResult> pResults = switch (p) {
+                case Postcondition.Leaf<T> leaf -> leaf.evaluateAll(value);
+                case Postcondition.Matching<T> m -> List.of(m.match(
+                        expected.orElseThrow(() -> new IllegalStateException(
+                                "criterion '" + id + "' has matching postcondition '"
+                                        + m.description() + "' but no expected value was "
+                                        + "supplied; the sampling-construction guard "
+                                        + "should have caught this — the sampling's input "
+                                        + "type must implement org.javai.punit.api.Expected.")),
+                        value));
+            };
             results.addAll(pResults);
             for (PostconditionResult r : pResults) {
                 if (r.failed()) {

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/MatchingDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/MatchingDecl.java
@@ -1,0 +1,92 @@
+package org.javai.punit.api.criterion;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.javai.punit.api.Postcondition;
+
+/**
+ * A terminal criterion decl whose verdict is determined by a single
+ * {@link ValueMatcher} comparing an expected to an actual value of
+ * the same type.
+ *
+ * <p>Produced by {@link CriterionDecl#matchedBy(Supplier)} and
+ * {@link CriterionDecl#matchedByEquality()}. A {@code MatchingDecl}
+ * carries the criterion's posture, name, and matcher supplier; it
+ * offers only {@link #name(String)} as further configuration (so the
+ * criterion's identifier in the verdict path can be set after the
+ * matcher is supplied). It does <em>not</em> expose further
+ * {@code .satisfies} / {@code .where} / {@code .matchedBy} chaining
+ * — a matching criterion is purposefully <em>just</em> an
+ * equivalence judgement. To pair expected-value matching with an
+ * intrinsic check, declare two criteria via
+ * {@link Criteria#of(Decl[])}.
+ *
+ * <p>The matcher supplier is invoked once per runtime criterion at
+ * {@link #toRuntime(String)} time; matchers that carry per-sampling
+ * state can return a fresh instance each call. Stateless matchers
+ * may share a single instance.
+ *
+ * @param <O> the contract's per-sample output value type
+ */
+public final class MatchingDecl<O> implements Decl<O> {
+
+    private final CriterionPosture posture;
+    private final Supplier<? extends ValueMatcher<O>> matcher;
+    private final Optional<String> name;
+
+    MatchingDecl(CriterionPosture posture,
+            Supplier<? extends ValueMatcher<O>> matcher,
+            Optional<String> name) {
+        this.posture = Objects.requireNonNull(posture, "posture");
+        this.matcher = Objects.requireNonNull(matcher, "matcher");
+        this.name = Objects.requireNonNull(name, "name");
+    }
+
+    @Override
+    public Optional<String> name() {
+        return name;
+    }
+
+    /**
+     * Set the criterion's name — used by baseline storage,
+     * diagnostics, and override targeting. Doubles as the
+     * postcondition description in the verdict's
+     * failures-by-postcondition histogram, since a matching criterion
+     * carries exactly one postcondition.
+     *
+     * @throws IllegalStateException if {@code .name(...)} has already
+     *         been called on this decl
+     * @throws IllegalArgumentException if {@code name} is blank
+     */
+    public MatchingDecl<O> name(String name) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException(".name(...) requires a non-blank name");
+        }
+        if (this.name.isPresent()) {
+            throw new IllegalStateException(
+                    ".name(...) already supplied as '" + this.name.get()
+                            + "'; cannot reassign to '" + name + "'");
+        }
+        return new MatchingDecl<>(posture, matcher, Optional.of(name));
+    }
+
+    @Override
+    public List<Criterion<O>> asList() {
+        return List.of(toRuntime(name.orElse(Criteria.DEFAULT_CRITERION_ID)));
+    }
+
+    @Override
+    public Criterion<O> toRuntime(String id) {
+        Objects.requireNonNull(id, "id");
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("id must not be blank");
+        }
+        String description = name.orElse(id);
+        Postcondition<O> postcondition = new Postcondition.Matching<>(description, matcher.get());
+        return new DirectCriterion<>(id, List.of(postcondition)).withPosture(posture);
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingCriterion.java
@@ -2,6 +2,7 @@ package org.javai.punit.api.criterion;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.javai.outcome.Outcome;
@@ -78,7 +79,7 @@ final class TransformingCriterion<O, D> implements Criterion<O> {
         }
         return switch (derived) {
             case Outcome.Ok<D> ok ->
-                    DirectCriterion.evaluateChain(id, postconditions, ok.value());
+                    DirectCriterion.evaluateChain(id, postconditions, ok.value(), Optional.empty());
             case Outcome.Fail<D> f ->
                     CriterionSampleResult.inconclusive(id, f);
         };

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/ValueMatcher.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/ValueMatcher.java
@@ -1,0 +1,68 @@
+package org.javai.punit.api.criterion;
+
+import java.util.Objects;
+
+import org.javai.outcome.Outcome;
+
+/**
+ * Equivalence between an expected and an actual value of the same
+ * type — the unit of work behind a criterion's
+ * {@link CriterionDecl#matchedBy(java.util.function.Supplier) .matchedBy(...)}
+ * declaration.
+ *
+ * <p>The framework invokes {@link #match(Object, Object)} once per
+ * sample, with the expected value sourced from the sample's
+ * {@link org.javai.punit.api.Expected#expected()} implementation and
+ * the actual value sourced from the contract's
+ * {@link org.javai.punit.api.Contract#invoke}. Return
+ * {@link Outcome#ok()} when the two values are equivalent under this
+ * matcher's notion of equivalence; return
+ * {@link Outcome#fail(String, String)} with a stable failure name and
+ * a human-readable message otherwise. The failure name and message
+ * are surfaced verbatim through the verdict's
+ * {@code failuresByPostcondition} histogram — there is no framework
+ * synthesis.
+ *
+ * <p>The signature is deliberately {@code (expected, actual)} only.
+ * A matcher that needs to read the sample's input or other context
+ * is no longer a value matcher; declare a postcondition via
+ * {@link CriterionDecl#satisfies(String, java.util.function.Function)}
+ * instead.
+ *
+ * <p>Per the framework's {@code Outcome}-vs-exception convention, a
+ * {@code ValueMatcher} that throws is a defect. The framework treats
+ * a thrown exception from {@code match} as an aborting condition,
+ * not a sample failure.
+ *
+ * @param <OT> the value type compared
+ */
+@FunctionalInterface
+public interface ValueMatcher<OT> {
+
+    /**
+     * Decide whether {@code actual} is equivalent to {@code expected}
+     * under this matcher's notion of equivalence.
+     *
+     * @return {@link Outcome#ok()} on equivalence;
+     *         {@link Outcome#fail(String, String)} carrying a stable
+     *         failure name and a human-readable message otherwise
+     */
+    Outcome<Void> match(OT expected, OT actual);
+
+    /**
+     * Default value matcher backed by {@link Objects#equals(Object, Object)}.
+     * Use as {@code .matchedBy(ValueMatcher::equality)} when the
+     * comparison is plain object equality; the criterion-builder
+     * convenience {@link CriterionDecl#matchedByEquality()} is the
+     * shortest path to the same matcher.
+     *
+     * <p>On mismatch, fails as
+     * {@code Outcome.fail("not-equal", "expected " + expected + " but got " + actual)}.
+     */
+    static <OT> ValueMatcher<OT> equality() {
+        return (expected, actual) -> Objects.equals(expected, actual)
+                ? Outcome.ok()
+                : Outcome.fail("not-equal",
+                        "expected " + expected + " but got " + actual);
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/api/criterion/MatchedByTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/criterion/MatchedByTest.java
@@ -1,0 +1,216 @@
+package org.javai.punit.api.criterion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.javai.punit.api.criterion.Criteria.empirical;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.javai.outcome.Outcome;
+import org.javai.punit.api.Expected;
+import org.javai.punit.api.Postcondition;
+import org.javai.punit.api.PostconditionResult;
+import org.javai.punit.api.ServiceContract;
+import org.javai.punit.api.ServiceContractOutcome;
+import org.javai.punit.api.TokenTracker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Reference-matching criterion — .matchedBy / .matchedByEquality")
+class MatchedByTest {
+
+    private record AudioSample(String data, String expected) implements Expected<String> {
+        @Override
+        public String expected() {
+            return expected;
+        }
+    }
+
+    private record PlainSample(String data) {
+    }
+
+    private static class SttContract implements ServiceContract<Object, AudioSample, String> {
+        @Override
+        public Outcome<String> invoke(AudioSample input, TokenTracker tracker) {
+            return Outcome.ok(input.data());
+        }
+
+        @Override
+        public Criteria<String> criteria() {
+            return empirical().<String>passRate()
+                    .name("transcript-matches-expected")
+                    .matchedByEquality();
+        }
+    }
+
+    private static class SttContractPlain implements ServiceContract<Object, PlainSample, String> {
+        @Override
+        public Outcome<String> invoke(PlainSample input, TokenTracker tracker) {
+            return Outcome.ok(input.data());
+        }
+
+        @Override
+        public Criteria<String> criteria() {
+            return empirical().<String>passRate()
+                    .name("transcript-matches-expected")
+                    .matchedByEquality();
+        }
+    }
+
+    @Test
+    @DisplayName("ValueMatcher.equality — equal values produce Outcome.ok")
+    void equalityOnEqualValues() {
+        Outcome<Void> result = ValueMatcher.<String>equality().match("hello", "hello");
+
+        assertThat(result).isInstanceOf(Outcome.Ok.class);
+    }
+
+    @Test
+    @DisplayName("ValueMatcher.equality — unequal values produce Outcome.fail with 'not-equal' name")
+    void equalityOnUnequalValues() {
+        Outcome<Void> result = ValueMatcher.<String>equality().match("hello", "world");
+
+        assertThat(result).isInstanceOf(Outcome.Fail.class);
+        Outcome.Fail<Void> fail = (Outcome.Fail<Void>) result;
+        assertThat(fail.failure().id().name()).isEqualTo("not-equal");
+        assertThat(fail.failure().message()).contains("hello").contains("world");
+    }
+
+    @Test
+    @DisplayName("Postcondition.Matching.match folds matcher success into a passed PostconditionResult")
+    void matchingPostconditionPassedResult() {
+        Postcondition.Matching<String> m = new Postcondition.Matching<>(
+                "label", ValueMatcher.equality());
+
+        PostconditionResult r = m.match("a", "a");
+
+        assertThat(r.failed()).isFalse();
+        assertThat(r.description()).isEqualTo("label");
+    }
+
+    @Test
+    @DisplayName("Postcondition.Matching.match folds matcher failure into a failed PostconditionResult carrying the matcher's failure name")
+    void matchingPostconditionFailedResult() {
+        Postcondition.Matching<String> m = new Postcondition.Matching<>(
+                "label", ValueMatcher.equality());
+
+        PostconditionResult r = m.match("a", "b");
+
+        assertThat(r.failed()).isTrue();
+        assertThat(r.description()).isEqualTo("label");
+    }
+
+    @Test
+    @DisplayName("Postcondition.Matching.evaluate(value) throws — interface method requires expected; engine must pattern-match")
+    void matchingEvaluateByValueAloneThrows() {
+        Postcondition.Matching<String> m = new Postcondition.Matching<>(
+                "label", ValueMatcher.equality());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> m.evaluate("a"))
+                .withMessageContaining("Matching postcondition");
+    }
+
+    @Test
+    @DisplayName(".matchedByEquality returns a MatchingDecl that lowers to a DirectCriterion with one Matching postcondition")
+    void matchedByEqualityProducesMatchingDecl() {
+        MatchingDecl<String> decl = empirical().<String>passRate()
+                .name("equality")
+                .matchedByEquality();
+
+        List<Criterion<String>> runtime = decl.asList();
+        assertThat(runtime).hasSize(1);
+        Criterion<String> c = runtime.get(0);
+        assertThat(c.id()).isEqualTo("equality");
+        assertThat(c.requiresExpected()).isTrue();
+    }
+
+    @Test
+    @DisplayName(".matchedBy(supplier) produces a MatchingDecl using the supplied matcher")
+    void matchedByCustomMatcher() {
+        ValueMatcher<String> caseInsensitive = (expected, actual) ->
+                expected.equalsIgnoreCase(actual)
+                        ? Outcome.ok()
+                        : Outcome.fail("case-mismatch", expected + " vs " + actual);
+
+        Criterion<String> c = empirical().<String>passRate()
+                .name("ci-eq")
+                .matchedBy(() -> caseInsensitive)
+                .asList()
+                .get(0);
+
+        CriterionSampleResult ok = c.evaluate("HELLO", Optional.of("hello"));
+        assertThat(ok.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+
+        CriterionSampleResult bad = c.evaluate("hello", Optional.of("world"));
+        assertThat(bad.outcome()).isEqualTo(CriterionSampleOutcome.FAIL);
+    }
+
+    @Test
+    @DisplayName(".matchedBy after .satisfies is rejected — matching criteria are equivalence-only")
+    void matchedByAfterSatisfiesIsRejected() {
+        CriterionDecl<String> withSatisfies = empirical().<String>passRate()
+                .satisfies("non-empty", v -> v.isEmpty()
+                        ? Outcome.fail("empty", "empty")
+                        : Outcome.ok());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> withSatisfies.matchedByEquality())
+                .withMessageContaining("cannot follow");
+    }
+
+    @Test
+    @DisplayName("DirectCriterion.requiresExpected — false when the chain has no Matching postcondition")
+    void requiresExpectedFalseForPlainSatisfies() {
+        Criterion<String> c = empirical().<String>passRate()
+                .satisfies("ok", v -> Outcome.ok())
+                .asList()
+                .get(0);
+
+        assertThat(c.requiresExpected()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Engine end-to-end — Expected input routes to matcher; matching values produce PASS")
+    void endToEndPass() {
+        SttContract contract = new SttContract();
+        AudioSample sample = new AudioSample("hello", "hello");
+
+        ServiceContractOutcome<AudioSample, String> outcome =
+                contract.apply(sample, TokenTracker.create());
+
+        assertThat(outcome.value()).isInstanceOf(Outcome.Ok.class);
+        assertThat(outcome.criterionSampleResults()).hasSize(1);
+        assertThat(outcome.criterionSampleResults().get(0).outcome())
+                .isEqualTo(CriterionSampleOutcome.PASS);
+    }
+
+    @Test
+    @DisplayName("Engine end-to-end — mismatched values produce FAIL with the matcher's failure name")
+    void endToEndFail() {
+        SttContract contract = new SttContract();
+        AudioSample sample = new AudioSample("hello", "world");
+
+        ServiceContractOutcome<AudioSample, String> outcome =
+                contract.apply(sample, TokenTracker.create());
+
+        assertThat(outcome.criterionSampleResults().get(0).outcome())
+                .isEqualTo(CriterionSampleOutcome.FAIL);
+        assertThat(outcome.postconditionResults())
+                .anySatisfy(r -> assertThat(r.failed()).isTrue());
+    }
+
+    @Test
+    @DisplayName("Sampling-construction guard — input not implementing Expected, paired with .matchedBy, fails fast with input-typed message")
+    void inputNotImplementingExpectedIsRejected() {
+        SttContractPlain contract = new SttContractPlain();
+        PlainSample sample = new PlainSample("hello");
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> contract.apply(sample, TokenTracker.create()))
+                .withMessageContaining(".matchedBy")
+                .withMessageContaining("Expected")
+                .withMessageContaining(PlainSample.class.getName());
+    }
+}


### PR DESCRIPTION
## Summary

Re-introduces expected-value matching as a first-class authoring concept on the criterion API, via:

- `org.javai.punit.api.Expected<OT>` — marker interface on the per-sample input type, declaring the sample knows its expected output
- `org.javai.punit.api.criterion.ValueMatcher<OT>` — SAM with `.match(expected, actual) → Outcome<Void>`, plus a static `equality()` factory backed by `Objects.equals`
- `CriterionDecl.matchedBy(Supplier<? extends ValueMatcher<O>>)` and the `matchedByEquality()` shorthand — both produce a terminal `MatchingDecl<O>`

A matching criterion is purposefully equivalence-only: `.matchedBy` cannot follow `.where` / `.satisfies` on the same decl, and `MatchingDecl` offers no further postcondition chaining. To pair a matcher with an intrinsic check, declare two criteria via `Criteria.of(...)`.

Wiring is purely additive. `Postcondition` gains a `Matching<T>` sibling in its sealed hierarchy. `Contract.apply` extracts `expected` once per sample from `Expected<O>` on the input and threads it into `Criterion.evaluate(value, expected)`. Criteria with no `Matching` postcondition ignore the expected.

A criterion declaring `.matchedBy` paired with an input that does not implement `Expected` fails fast at the first apply with a clear input-typed message. `Criterion.requiresExpected()` exposes the requirement at the criterion level so the guard runs without engine-side pattern matching.

Authoring shape:

```java
empirical().<Transcription>passRate()
    .name(\"transcript-matches-expected\")
    .matchedByEquality();
```

Or with a custom matcher:

```java
empirical().<Transcription>passRate()
    .name(\"transcript-matches-expected\")
    .matchedBy(NormalisedTranscriptMatcher::new);
```

Refs DIR-EXPECTED-VALUE-MATCHING-punit (orchestrator).

## Test plan

- [x] 12 new tests in \`MatchedByTest\` covering ValueMatcher, the Matching postcondition, the criterion-builder surface, the .matchedBy-after-.satisfies rejection, end-to-end pass/fail through Contract.apply, and the missing-Expected guard
- [x] Full \`./gradlew test\` green — no regressions across punit-core, punit-report, punit-sentinel, or the Gradle plugin
- [ ] Migrate the \`stteval\` SpeechToTextServiceContract (separate change) to use \`Expected<Transcription>\` + \`.matchedByEquality()\`, dropping the synthetic \`JudgedTranscription\` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)