### PR TITLE
Persist baseline expiration window into punit-baseline-3

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.function.Function;
 
@@ -144,6 +145,20 @@ public final class Experiment implements Spec {
     public Kind kind() { return kind; }
     public String experimentId() { return internal.experimentId(); }
     public int samples() { return internal.samples(); }
+
+    /**
+     * The baseline validity window in days, when the measure declared
+     * one via {@code .expiresInDays(n)}. Empty for explore and
+     * optimize, and for measures that declared no expiration (or
+     * declared {@code 0}). Consumed by the baseline emitter so the
+     * window is persisted into the baseline spec.
+     */
+    public OptionalInt expiresInDays() {
+        if (internal instanceof MeasureInternal<?, ?, ?> m) {
+            return m.expiresInDays.map(OptionalInt::of).orElseGet(OptionalInt::empty);
+        }
+        return OptionalInt.empty();
+    }
 
     /**
      * Diagnostic accessor populated only after a measure experiment

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineReader.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineReader.java
@@ -2,6 +2,7 @@ package org.javai.punit.internal.engine.baseline;
 
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_COVARIATES;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_CRITERIA;
+import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_EXPIRES_IN_DAYS;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_FACTORS_FINGERPRINT;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_GENERATED_AT;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_INPUTS_IDENTITY;
@@ -122,6 +123,12 @@ public final class BaselineReader {
         String inputsIdentity = requireString(root, FIELD_INPUTS_IDENTITY);
         int sampleCount = requireInt(root, FIELD_SAMPLE_COUNT);
         Instant generatedAt = requireInstant(root, FIELD_GENERATED_AT);
+        // Expiration: optional. Absent → 0 (no expiration).
+        // expiresInDays is authoritative; the emitted expiresAt is a
+        // derived convenience and is not read back here.
+        int expiresInDays = root.containsKey(FIELD_EXPIRES_IN_DAYS)
+                ? requireInt(root, FIELD_EXPIRES_IN_DAYS)
+                : 0;
 
         Map<String, Object> statsMap = requireMap(root, FIELD_STATISTICS);
         Map<String, BaselineStatistics> entries = new LinkedHashMap<>();
@@ -148,7 +155,7 @@ public final class BaselineReader {
         return new BaselineRecord(
                 serviceContractId, methodName, factorsFingerprint,
                 inputsIdentity, sampleCount, generatedAt, entries, profile,
-                latencyIndicator);
+                latencyIndicator, expiresInDays);
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineRecord.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineRecord.java
@@ -38,6 +38,11 @@ import org.javai.punit.api.spec.BaselineStatistics;
  *        Part of the baseline's identity — a baseline measured under
  *        one profile must not silently match a test running under a
  *        different profile.
+ * @param expiresInDays       the baseline validity window in days, or
+ *        {@code 0} for no expiration. When positive, the measure
+ *        declared {@code .expiresInDays(n)}; the writer emits it and the
+ *        derived {@code expiresAt} into the baseline so a paired test can
+ *        evaluate staleness.
  */
 public record BaselineRecord(
         String serviceContractId,
@@ -48,7 +53,8 @@ public record BaselineRecord(
         Instant generatedAt,
         Map<String, BaselineStatistics> statisticsByCriterionName,
         CovariateProfile covariateProfile,
-        LatencyIndicator latencyIndicator) {
+        LatencyIndicator latencyIndicator,
+        int expiresInDays) {
 
     public BaselineRecord {
         Objects.requireNonNull(serviceContractId, "serviceContractId");
@@ -72,6 +78,10 @@ public record BaselineRecord(
             throw new IllegalArgumentException(
                     "sampleCount must be non-negative, got " + sampleCount);
         }
+        if (expiresInDays < 0) {
+            throw new IllegalArgumentException(
+                    "expiresInDays must be non-negative (0 = no expiration), got " + expiresInDays);
+        }
         if (statisticsByCriterionName.isEmpty()) {
             throw new IllegalArgumentException(
                     "statisticsByCriterionName must not be empty — a baseline with no "
@@ -81,8 +91,29 @@ public record BaselineRecord(
     }
 
     /**
+     * Convenience constructor matching the pre-expiration canonical
+     * signature; defaults {@link #expiresInDays()} to {@code 0}
+     * (no expiration).
+     */
+    public BaselineRecord(
+            String serviceContractId,
+            String methodName,
+            String factorsFingerprint,
+            String inputsIdentity,
+            int sampleCount,
+            Instant generatedAt,
+            Map<String, BaselineStatistics> statisticsByCriterionName,
+            CovariateProfile covariateProfile,
+            LatencyIndicator latencyIndicator) {
+        this(serviceContractId, methodName, factorsFingerprint, inputsIdentity,
+                sampleCount, generatedAt, statisticsByCriterionName,
+                covariateProfile, latencyIndicator, 0);
+    }
+
+    /**
      * Backward-compatible 8-arg constructor that defaults
-     * {@link #latencyIndicator()} to {@link LatencyIndicator#empty()}.
+     * {@link #latencyIndicator()} to {@link LatencyIndicator#empty()}
+     * and {@link #expiresInDays()} to {@code 0}.
      */
     public BaselineRecord(
             String serviceContractId,
@@ -95,15 +126,15 @@ public record BaselineRecord(
             CovariateProfile covariateProfile) {
         this(serviceContractId, methodName, factorsFingerprint, inputsIdentity,
                 sampleCount, generatedAt, statisticsByCriterionName,
-                covariateProfile, LatencyIndicator.empty());
+                covariateProfile, LatencyIndicator.empty(), 0);
     }
 
     /**
      * Convenience constructor for callers that don't carry a covariate
      * profile (covariate-insensitive baselines, tests that don't
      * exercise covariate resolution). Equivalent to the canonical
-     * constructor with {@link CovariateProfile#empty()} and
-     * {@link LatencyIndicator#empty()}.
+     * constructor with {@link CovariateProfile#empty()},
+     * {@link LatencyIndicator#empty()}, and no expiration.
      */
     public BaselineRecord(
             String serviceContractId,
@@ -115,7 +146,7 @@ public record BaselineRecord(
             Map<String, BaselineStatistics> statisticsByCriterionName) {
         this(serviceContractId, methodName, factorsFingerprint, inputsIdentity,
                 sampleCount, generatedAt, statisticsByCriterionName,
-                CovariateProfile.empty(), LatencyIndicator.empty());
+                CovariateProfile.empty(), LatencyIndicator.empty(), 0);
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSchema.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSchema.java
@@ -40,6 +40,13 @@ final class BaselineSchema {
     static final String FIELD_STATISTICS = "statistics";
     static final String FIELD_COVARIATES = "covariates";
 
+    // Baseline expiration. Both omitted entirely when there is
+    // no expiration window (expiresInDays == 0). expiresInDays is the
+    // authoritative input; expiresAt is the derived (generatedAt +
+    // expiresInDays) convenience the reader recomputes rather than trusts.
+    static final String FIELD_EXPIRES_IN_DAYS = "expiresInDays";
+    static final String FIELD_EXPIRES_AT = "expiresAt";
+
     // PassRate / PassRateStatistics
     static final String FIELD_OBSERVED_PASS_RATE = "observedPassRate";
 

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineWriter.java
@@ -3,6 +3,8 @@ package org.javai.punit.internal.engine.baseline;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.CRITERION_BERNOULLI_PASS_RATE;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.CRITERION_PERCENTILE_LATENCY;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_COVARIATES;
+import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_EXPIRES_AT;
+import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_EXPIRES_IN_DAYS;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_FACTORS_FINGERPRINT;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_GENERATED_AT;
 import static org.javai.punit.internal.engine.baseline.BaselineSchema.FIELD_INPUTS_IDENTITY;
@@ -99,6 +101,18 @@ public final class BaselineWriter {
         root.put(FIELD_INPUTS_IDENTITY, record.inputsIdentity());
         root.put(FIELD_SAMPLE_COUNT, record.sampleCount());
         root.put(FIELD_GENERATED_AT, DateTimeFormatter.ISO_INSTANT.format(record.generatedAt()));
+
+        // Baseline expiration baseline expiration: emit only when a window was
+        // declared. expiresInDays is authoritative; expiresAt is the
+        // derived generatedAt + window, written for human readers and
+        // recomputed (not trusted) on load. Positioned before the
+        // appended contentFingerprint so both fall under the integrity
+        // hash.
+        if (record.expiresInDays() > 0) {
+            root.put(FIELD_EXPIRES_IN_DAYS, record.expiresInDays());
+            root.put(FIELD_EXPIRES_AT, DateTimeFormatter.ISO_INSTANT.format(
+                    record.generatedAt().plus(Duration.ofDays(record.expiresInDays()))));
+        }
 
         // The legacy criterion-named "percentile-latency" entry is
         // no longer emitted to YAML — the canonical location for

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
@@ -112,10 +112,11 @@ public final class BaselineEmitter {
                     "MEASURE experiment recorded zero samples — nothing to baseline. "
                             + "Check the spec's sample count and budget configuration.");
         }
+        int expiresInDays = experiment.expiresInDays().orElse(0);
         BaselineRecord record = experiment.dispatch(new Spec.Dispatcher<>() {
             @Override
             public <FT, IT, OT> BaselineRecord apply(TypedSpec<FT, IT, OT> typed) {
-                return composeRecord(typed, summary, experiment.experimentId());
+                return composeRecord(typed, summary, experiment.experimentId(), expiresInDays);
             }
         });
         sink.accept(record.filename(), new BaselineWriter().toYaml(record));
@@ -125,7 +126,8 @@ public final class BaselineEmitter {
     private static <FT, IT, OT> BaselineRecord composeRecord(
             TypedSpec<FT, IT, OT> typed,
             SampleSummary<?> rawSummary,
-            String experimentId) {
+            String experimentId,
+            int expiresInDays) {
         Iterator<Configuration<FT, IT, OT>> configs = typed.configurations();
         if (!configs.hasNext()) {
             throw new IllegalStateException(
@@ -187,7 +189,8 @@ public final class BaselineEmitter {
                 Instant.now(),
                 stats,
                 profile,
-                latencyIndicator);
+                latencyIndicator,
+                expiresInDays);
     }
 
     /**

--- a/punit-core/src/test/java/org/javai/punit/internal/runtime/BaselineEmitterTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/runtime/BaselineEmitterTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -18,6 +20,8 @@ import org.javai.punit.api.ServiceContract;
 import org.javai.punit.api.spec.Experiment;
 import org.javai.punit.api.spec.NextFactor;
 import org.javai.punit.internal.engine.Engine;
+import org.javai.punit.internal.engine.baseline.BaselineReader;
+import org.javai.punit.internal.engine.baseline.BaselineRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -123,5 +127,73 @@ class BaselineEmitterTest {
 
         // No sample[N] keys, no anchor comments anywhere in the body.
         assertThat(yaml).doesNotContain("sample[0]", "sample[1]", "anchor:");
+    }
+
+    private static Sampling<NoFactors, Integer, String> samplingWithCriteria() {
+        return Sampling.<NoFactors, Integer, String>builder()
+                .serviceContractFactory(f -> EVENS_PASS)
+                .inputs(2, 4)   // both even → all pass
+                .samples(4)
+                .build();
+    }
+
+    @Test
+    @DisplayName("emits expiresInDays + derived expiresAt when the measure declared a "
+            + "validity window, and round-trips through BaselineReader")
+    void emitsExpirationMetadataWhenDeclared() {
+        Experiment measure = Experiment.measuring(samplingWithCriteria(), new NoFactors())
+                .experimentId("baseline-v1")
+                .expiresInDays(30)
+                .build();
+        new Engine().run(measure);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        BaselineEmitter.emit(measure, sink::put);
+        String yaml = sink.values().iterator().next();
+        Map<String, Object> root = new Yaml().load(yaml);
+
+        assertThat(root)
+                .as("a measure declaring .expiresInDays(30) must persist the validity "
+                        + "window — dropping it silently disables baseline expiration")
+                .containsEntry("expiresInDays", 30)
+                .containsKey("expiresAt");
+
+        // expiresAt is generatedAt + 30 days.
+        Instant generatedAt = Instant.parse(root.get("generatedAt").toString());
+        Instant expiresAt = Instant.parse(root.get("expiresAt").toString());
+        assertThat(expiresAt).isEqualTo(generatedAt.plus(Duration.ofDays(30)));
+
+        // Both expiration fields precede contentFingerprint, so they fall
+        // under the integrity hash — a hand-edit would be detected.
+        assertThat(yaml.indexOf("expiresInDays"))
+                .isLessThan(yaml.indexOf("contentFingerprint"));
+        assertThat(yaml.indexOf("expiresAt"))
+                .isLessThan(yaml.indexOf("contentFingerprint"));
+
+        // Round-trips back to the same window.
+        BaselineRecord parsed = new BaselineReader().parse(yaml);
+        assertThat(parsed.expiresInDays()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("omits expiresInDays / expiresAt when no validity window was declared — "
+            + "absent means no expiration, not 0")
+    void omitsExpirationMetadataWhenNotDeclared() {
+        Experiment measure = Experiment.measuring(samplingWithCriteria(), new NoFactors())
+                .experimentId("baseline-v1")
+                .build();
+        new Engine().run(measure);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        BaselineEmitter.emit(measure, sink::put);
+        String yaml = sink.values().iterator().next();
+        Map<String, Object> root = new Yaml().load(yaml);
+
+        assertThat(root)
+                .doesNotContainKey("expiresInDays")
+                .doesNotContainKey("expiresAt");
+
+        // A baseline with no window reads back as 0 (no expiration).
+        assertThat(new BaselineReader().parse(yaml).expiresInDays()).isZero();
     }
 }


### PR DESCRIPTION
## Summary

A measure that declared `.expiresInDays(n)` produced a baseline with **no expiration metadata** — silently disabling baseline expiration. The value was captured on the spec but dropped at the `BaselineRecord` boundary; `BaselineWriter` never emitted it, so an empirical test resolving the baseline skips the staleness check (absent `expiresInDays` ⇒ "no expiration").

Surfaced against the committed example baseline `shopping-basket.baseline-v1-b60d8a8b-5bad-a769.yaml`, produced by `ShoppingBasketMeasure.measureBaseline()` which sets `.expiresInDays(30)` — yet the file carries no window.

## Fix (serialization, end-to-end)

- `Experiment.expiresInDays()` exposes the value the MEASURE internal already stored (empty for explore/optimize).
- `BaselineRecord` gains an `expiresInDays` field (`0` = no expiration); convenience constructors default it so existing call sites compile unchanged.
- `BaselineEmitter.composeRecord` reads it from the experiment.
- `BaselineWriter` emits `expiresInDays` + derived `expiresAt` (`generatedAt + window`) **only when > 0**, before `contentFingerprint` so both fall under the integrity hash. Absent ⇒ no expiration; never emitted as `0`.
- `BaselineReader` parses it back (absent ⇒ `0`); `expiresAt` is derived, not trusted on read.

### Before / after (top-level fields)

```
before: schemaVersion useCaseId methodName factorsFingerprint inputsIdentity sampleCount generatedAt statistics covariates latency contentFingerprint
after:  … generatedAt  expiresInDays  expiresAt  statistics …   (expiresInDays/expiresAt present only when a window was declared)
```

## Regression test

`BaselineEmitterTest` — the integration seam that should have caught the original drop:
- declaring `.expiresInDays(30)` emits both fields, they precede `contentFingerprint`, `expiresAt == generatedAt + 30d`, and the record round-trips through `BaselineReader`;
- no window ⇒ neither field emitted, reads back as `0`.

## Scope

Serialization only. Evaluating the window **at test time** on the typed `ProbabilisticTest` path is a separate change — `BaselineLookup` carries no temporal fields today, so surfacing the warning requires threading `(generatedAt, expiresInDays)` through the lookup into the verdict. Tracked as a follow-up. This PR is the prerequisite (without persistence there is nothing to evaluate).

Refs `DIR-BUG-BASELINE-EXPIRATION-NOT-EMITTED-punit`.

## Test plan

- [x] `./gradlew :punit-core:test` green (incl. ArchUnit + `RequirementCodeIsolationTest`)
- [ ] Regenerate the committed `punitexamples` baseline so it carries `expiresInDays: 30` + `expiresAt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)