### PR TITLE
Surface baseline expiration as a verdict caveat (typed path)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
@@ -5,6 +5,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -19,6 +20,8 @@ import org.javai.punit.api.spec.BaselineStatistics;
 import org.javai.punit.api.spec.PassRateStatistics;
 import org.javai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.javai.punit.api.spec.ProbabilisticTestResult;
+import org.javai.punit.verdict.ExpirationPolicy;
+import org.javai.punit.verdict.ExpirationStatus;
 
 /**
  * Exact-match baseline resolver. Looks up a baseline by
@@ -161,8 +164,9 @@ public final class BaselineResolver {
         // Surface the integrity warning (if any) for the *selected*
         // candidate only — warnings about candidates that didn't
         // influence the verdict would be noise.
-        List<String> notes = withIntegrityWarning(
-                report.notes(), enumerated, selected.get());
+        List<String> notes = withExpirationWarning(
+                withIntegrityWarning(report.notes(), enumerated, selected.get()),
+                selected.get());
         CovariateProfile baselineProfile = selected.get().covariateProfile();
         BaselineStatistics entry = selected.get().statisticsByCriterionName().get(criterionName);
         if (entry == null) {
@@ -208,6 +212,50 @@ public final class BaselineResolver {
         }
         return new BaselineLookup<>(
                 Optional.of(statisticsType.cast(entry)), baselineProfile, notes, sourceFile);
+    }
+
+    /**
+     * Append a baseline-expiration note when the selected baseline
+     * carries a validity window that is approaching or past its end.
+     * The note rides the lookup's notes channel, which the spec layer
+     * surfaces as a verdict warning. No-op when the baseline declared
+     * no window or is comfortably within it.
+     */
+    private static List<String> withExpirationWarning(
+            List<String> notes, BaselineRecord selected) {
+        if (selected.expiresInDays() <= 0) {
+            return notes;
+        }
+        ExpirationStatus status = new ExpirationPolicy(
+                selected.expiresInDays(), selected.generatedAt())
+                .evaluateAt(Instant.now());
+        if (!status.requiresWarning()) {
+            return notes;
+        }
+        List<String> combined = new ArrayList<>(notes.size() + 1);
+        combined.addAll(notes);
+        combined.add(expirationNote(selected, status));
+        return combined;
+    }
+
+    private static String expirationNote(BaselineRecord selected, ExpirationStatus status) {
+        String base = "baseline '" + selected.filename() + "' (measured "
+                + selected.generatedAt() + ", validity " + selected.expiresInDays()
+                + " days)";
+        return switch (status) {
+            case ExpirationStatus.Expired e -> base + " has expired "
+                    + e.expiredAgo().toDays() + " day(s) ago — re-run the MEASURE "
+                    + "experiment to refresh it";
+            case ExpirationStatus.ExpiringImminently s -> base + " expires imminently ("
+                    + s.remaining().toDays() + " day(s) remaining) — plan to re-run the "
+                    + "MEASURE experiment";
+            case ExpirationStatus.ExpiringSoon s -> base + " expires soon ("
+                    + s.remaining().toDays() + " day(s) remaining) — consider re-running "
+                    + "the MEASURE experiment";
+            // requiresWarning() gates the call, so Valid / NoExpiration are unreachable;
+            // fall back to the base description rather than throwing.
+            default -> base;
+        };
     }
 
     private static List<String> withIntegrityWarning(

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 
@@ -12,6 +13,7 @@ import org.javai.punit.api.FactorBundle;
 import org.javai.punit.api.Sampling;
 import org.javai.punit.api.TokenTracker;
 import org.javai.punit.api.ServiceContract;
+import org.javai.punit.api.covariate.CovariateProfile;
 import static org.javai.punit.api.criterion.Criteria.empirical;
 
 import org.javai.punit.api.criterion.Criteria;
@@ -25,6 +27,7 @@ import org.javai.punit.api.spec.Verdict;
 import org.javai.punit.internal.engine.baseline.BaselineRecord;
 import org.javai.punit.internal.engine.baseline.BaselineWriter;
 import org.javai.punit.internal.engine.baseline.FactorsFingerprint;
+import org.javai.punit.internal.engine.baseline.LatencyIndicator;
 import org.javai.punit.internal.engine.baseline.YamlBaselineProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -160,6 +163,64 @@ class EmpiricalEndToEndIntegrationTest {
         assertThat(result.criterionResults().get(0).result().explanation())
                 .contains("inputs identity")
                 .contains("re-run the baseline measure");
+    }
+
+    /**
+     * Writes a baseline with a validity window, measured at
+     * {@code generatedAt}. Recorded inputs identity matches
+     * {@link #sampling(int)} so the empirical comparison proceeds.
+     */
+    private static void writeBaselineWithWindow(
+            Path baselineDir, double passRate, int sampleCount,
+            int expiresInDays, Instant generatedAt) throws IOException {
+        String fingerprint = FactorsFingerprint.of(FactorBundle.of(FACTORS));
+        BaselineRecord record = new BaselineRecord(
+                USE_CASE_ID, "measureBaseline", fingerprint,
+                sampling(1).inputsIdentity(), sampleCount, generatedAt,
+                Map.<String, BaselineStatistics>of(
+                        "bernoulli-pass-rate",
+                        PerCriterionPassRateStatistics.of("contract", passRate, sampleCount)),
+                CovariateProfile.empty(), LatencyIndicator.empty(), expiresInDays);
+        new BaselineWriter().write(record, baselineDir);
+    }
+
+    @Test
+    @DisplayName("an expired baseline surfaces an expiration caveat on the verdict's warnings "
+            + "without dismissing the PASS — the reader is told to pay attention, not to "
+            + "discard the result")
+    void expiredBaselineSurfacesCaveatButKeepsVerdict(@TempDir Path baselineDir)
+            throws IOException {
+        // Measured 400 days ago with a 30-day validity window → long expired.
+        writeBaselineWithWindow(baselineDir, 0.80, 1000, 30,
+                Instant.now().minus(Duration.ofDays(400)));
+
+        var engine = new Engine(new YamlBaselineProvider(baselineDir));
+        var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(20)));
+
+        // The expiration is a CAVEAT, not a dismissal: an always-passing test
+        // against a baseline at p = 0.80 still PASSES.
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+
+        // …and the verdict carries the expiration as a warning the reader must heed,
+        // naming the baseline and that it has expired.
+        assertThat(result.warnings())
+                .as("an expired baseline must surface as a verdict caveat the reader can act on")
+                .anyMatch(w -> w.contains("expired") && w.contains(USE_CASE_ID));
+    }
+
+    @Test
+    @DisplayName("a baseline comfortably within its validity window surfaces no expiration caveat")
+    void freshBaselineSurfacesNoCaveat(@TempDir Path baselineDir) throws IOException {
+        // Measured just now with a 30-day window → far from expiry.
+        writeBaselineWithWindow(baselineDir, 0.80, 1000, 30, Instant.now());
+
+        var engine = new Engine(new YamlBaselineProvider(baselineDir));
+        var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(20)));
+
+        assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+        assertThat(result.warnings())
+                .as("a baseline well within its window must not raise an expiration caveat")
+                .noneMatch(w -> w.contains("expired") || w.contains("expires"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #204. That PR restored *persistence* of the baseline expiration window (`expiresInDays` / `expiresAt`). This PR restores *evaluation* of it on the live empirical-resolution path, which never read it: `BaselineLookup` carries no temporal fields, and expiration was only ever evaluated by the legacy `ExecutionSpecification` path — so an expired baseline produced no warning.

## Fix

`BaselineResolver.lookup(...)` now evaluates expiration where the selected `BaselineRecord` (carrying `generatedAt` + `expiresInDays`) is in hand, mirroring the existing `withIntegrityWarning(...)`:

- When `selected.expiresInDays() > 0`, build `verdict.ExpirationPolicy(expiresInDays, generatedAt)`, `.evaluateAt(now)`, and — when `ExpirationStatus.requiresWarning()` — append a human-readable note (distinct for expired / expiring-imminently / expiring-soon, naming the baseline file, its measurement time, and its window).
- The note rides the existing `BaselineLookup.notes()` → `ProbabilisticTestResult.warnings()` channel, so it surfaces as a verdict **caveat**.

The verdict's PASS / FAIL determination is unchanged — expiration is a caveat the reader must heed, not a dismissal (EX08 default = *warn, not fail*).

## Test (verdict-level)

`EmpiricalEndToEndIntegrationTest`:
- a baseline measured 400 days ago with a 30-day window → verdict stays **PASS** and `result.warnings()` carries an `expired` caveat naming the baseline;
- a fresh baseline (window not approaching) → no expiration caveat.

## Scope

Warning only. Configurable **fail-on-expired** (`punit.expiration.policy=FAIL`) is deliberately out of scope (it's a verdict-path policy decision, tracked separately). Threshold-band wording (EX08 prose 20% vs. shipped `ExpirationPolicy` 25%/10%) is a doc reconciliation, also separate.

Refs `DIR-BASELINE-EXPIRATION-TYPED-PATH-EVAL-punit`.

## Test plan

- [x] `./gradlew :punit-core:test` green (incl. ArchUnit — `baseline → verdict` dependency permitted — and `RequirementCodeIsolationTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)