### PR TITLE
Configurable fail-on-expired-baseline policy

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/spec/BaselineLookup.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/BaselineLookup.java
@@ -42,12 +42,20 @@ import org.javai.punit.api.covariate.CovariateProfile;
  *                         candidate matched; surfaces to verdict XML's
  *                         {@code <provenance spec-filename>} for audit
  *                         traceability. Empty otherwise.
+ * @param expired          whether the matched baseline's validity
+ *                         window (if any) has elapsed. {@code false}
+ *                         when no baseline matched, the baseline
+ *                         declared no window, or the window is still
+ *                         open. The fail-on-expired policy reads this
+ *                         structured flag rather than re-parsing the
+ *                         human note appended to {@link #notes()}.
  */
 public record BaselineLookup<S extends BaselineStatistics>(
         Optional<S> selected,
         CovariateProfile baselineProfile,
         List<String> notes,
-        Optional<String> sourceFile) {
+        Optional<String> sourceFile,
+        boolean expired) {
 
     public BaselineLookup {
         Objects.requireNonNull(selected, "selected");
@@ -58,14 +66,28 @@ public record BaselineLookup<S extends BaselineStatistics>(
     }
 
     /**
+     * Convenience constructor defaulting {@link #expired()} to
+     * {@code false} — for callers that don't evaluate expiration
+     * (the resolver sets it explicitly on the selected path).
+     */
+    public BaselineLookup(
+            Optional<S> selected,
+            CovariateProfile baselineProfile,
+            List<String> notes,
+            Optional<String> sourceFile) {
+        this(selected, baselineProfile, notes, sourceFile, false);
+    }
+
+    /**
      * Backward-compatible constructor that omits {@link #sourceFile()}.
-     * Defaults to {@link Optional#empty()}.
+     * Defaults to {@link Optional#empty()} and {@link #expired()} to
+     * {@code false}.
      */
     public BaselineLookup(
             Optional<S> selected,
             CovariateProfile baselineProfile,
             List<String> notes) {
-        this(selected, baselineProfile, notes, Optional.empty());
+        this(selected, baselineProfile, notes, Optional.empty(), false);
     }
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ExpiredBaselinePolicy.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ExpiredBaselinePolicy.java
@@ -1,0 +1,76 @@
+package org.javai.punit.api.spec;
+
+import java.util.Locale;
+
+/**
+ * What an empirical probabilistic test does when the baseline it
+ * resolves has passed its validity window (see baseline expiration).
+ *
+ * <p>An expired baseline always surfaces as a verdict caveat (a
+ * warning on {@link ProbabilisticTestResult#warnings()}). This policy
+ * decides whether expiry <em>also</em> fails the verdict.
+ *
+ * <ul>
+ *   <li>{@link #WARN} (default) — the caveat is informational; the
+ *       verdict reflects the statistics.</li>
+ *   <li>{@link #FAIL} — an expired baseline forces the verdict to
+ *       {@link Verdict#FAIL}, regardless of the observed statistics.
+ *       A stale baseline means the empirical comparison itself is
+ *       untrustworthy, so a statistical PASS against it must not
+ *       stand.</li>
+ * </ul>
+ *
+ * <p>The policy is an operational decision (how strict CI should be),
+ * not a per-contract property — it is resolved from the environment
+ * via {@link #fromEnvironment()} with the framework's standard
+ * precedence (system property, then environment variable, then
+ * default), the same shape as the suite-budget configuration.
+ */
+public enum ExpiredBaselinePolicy {
+
+    /** Expiry is a warning only; the verdict reflects the statistics. */
+    WARN,
+
+    /** Expiry forces the verdict to FAIL. */
+    FAIL;
+
+    /** System property consulted first. */
+    public static final String PROPERTY = "punit.expiration.policy";
+
+    /** Environment variable consulted when the system property is unset. */
+    public static final String ENV_VAR = "PUNIT_EXPIRATION_POLICY";
+
+    /**
+     * Resolve the policy from the environment: system property
+     * {@value #PROPERTY} first, then environment variable
+     * {@value #ENV_VAR}, then the default {@link #WARN}.
+     *
+     * @throws IllegalArgumentException if a value is present but is
+     *         neither {@code WARN} nor {@code FAIL} (case-insensitive)
+     */
+    public static ExpiredBaselinePolicy fromEnvironment() {
+        String raw = System.getProperty(PROPERTY);
+        if (raw == null) {
+            raw = System.getenv(ENV_VAR);
+        }
+        return parse(raw);
+    }
+
+    /**
+     * Parse a configured value; {@code null} / blank yields the
+     * default {@link #WARN}. Unknown values fail fast.
+     */
+    public static ExpiredBaselinePolicy parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return WARN;
+        }
+        String normalised = raw.trim().toUpperCase(Locale.ROOT);
+        return switch (normalised) {
+            case "WARN" -> WARN;
+            case "FAIL" -> FAIL;
+            default -> throw new IllegalArgumentException(
+                    "Unknown expiration policy '" + raw + "' (from " + PROPERTY + " / "
+                            + ENV_VAR + "); accepted values are WARN and FAIL");
+        };
+    }
+}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -207,6 +207,10 @@ public final class ProbabilisticTest implements Spec {
             // that resolves for the same (serviceContractId, factorsFingerprint)
             // tuple sees the same baseline file, so first-non-empty wins.
             Optional<String> baselineFilename = Optional.empty();
+            // True when any resolved baseline has passed its validity
+            // window. Drives the fail-on-expired policy below; the
+            // human caveat is already in `warnings` via lookup notes.
+            boolean anyBaselineExpired = false;
             for (Registered<OT> entry : registered) {
                 BaselineLookupCapture capture = new BaselineLookupCapture();
                 CriterionResult result = evaluate(
@@ -220,6 +224,7 @@ public final class ProbabilisticTest implements Spec {
                 if (baselineFilename.isEmpty() && capture.sourceFile.isPresent()) {
                     baselineFilename = capture.sourceFile;
                 }
+                anyBaselineExpired |= capture.expired;
             }
 
             EngineRunSummary engineSummary = buildEngineSummary(s, evaluated, baselineFilename);
@@ -250,6 +255,20 @@ public final class ProbabilisticTest implements Spec {
                     ? evaluated
                     : substituteFunctionalVerdict(evaluated, perCriterionEvaluation.compositeVerdict());
             Verdict authoritative = Verdict.compose(compositeAdjusted);
+            // Fail-on-expired policy: an expired baseline always carries
+            // a caveat (already in `warnings` via lookup notes); under
+            // the FAIL policy it additionally forces the verdict to FAIL,
+            // dominating the statistical determination — a stale baseline
+            // makes the empirical comparison untrustworthy, so a PASS
+            // against it must not stand. Default (WARN) leaves the
+            // statistical verdict intact.
+            if (anyBaselineExpired
+                    && ExpiredBaselinePolicy.fromEnvironment() == ExpiredBaselinePolicy.FAIL) {
+                warnings.add("expiration policy=FAIL: verdict failed because the resolved "
+                        + "baseline has expired (see the baseline-expiry caveat above) — "
+                        + "re-run the MEASURE experiment to refresh it");
+                authoritative = Verdict.FAIL;
+            }
             // contractRef now lives on the criterion's posture. Surface
             // the first non-empty ref at the result level (the legacy
             // top-level field) — multi-criterion contracts whose
@@ -352,6 +371,7 @@ public final class ProbabilisticTest implements Spec {
             CovariateProfile profile =
                     CovariateProfile.empty();
             Optional<String> sourceFile = Optional.empty();
+            boolean expired = false;
         }
 
         private boolean anyEmpiricalCriterion() {
@@ -385,6 +405,7 @@ public final class ProbabilisticTest implements Spec {
                 warnings.addAll(lookup.notes());
                 capture.profile = lookup.baselineProfile();
                 capture.sourceFile = lookup.sourceFile();
+                capture.expired = lookup.expired();
             } else {
                 resolved = Optional.empty();
             }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineResolver.java
@@ -160,18 +160,24 @@ public final class BaselineResolver {
                     Optional.empty(), CovariateProfile.empty(), report.notes(),
                     Optional.empty());
         }
-        Optional<String> sourceFile = Optional.of(selected.get().filename());
+        BaselineRecord rec = selected.get();
+        Optional<String> sourceFile = Optional.of(rec.filename());
+        // Evaluate the baseline's validity window once: the same status
+        // drives both the human note (warning channel) and the
+        // structured `expired` flag the fail-on-expired policy reads.
+        ExpirationStatus expirationStatus = expirationStatusOf(rec);
+        boolean expired = expirationStatus != null && expirationStatus.isExpired();
         // Surface the integrity warning (if any) for the *selected*
         // candidate only — warnings about candidates that didn't
         // influence the verdict would be noise.
-        List<String> notes = withExpirationWarning(
-                withIntegrityWarning(report.notes(), enumerated, selected.get()),
-                selected.get());
-        CovariateProfile baselineProfile = selected.get().covariateProfile();
-        BaselineStatistics entry = selected.get().statisticsByCriterionName().get(criterionName);
+        List<String> notes = withExpirationNote(
+                withIntegrityWarning(report.notes(), enumerated, rec),
+                rec, expirationStatus);
+        CovariateProfile baselineProfile = rec.covariateProfile();
+        BaselineStatistics entry = rec.statisticsByCriterionName().get(criterionName);
         if (entry == null) {
             return new BaselineLookup<>(
-                    Optional.empty(), baselineProfile, notes, sourceFile);
+                    Optional.empty(), baselineProfile, notes, sourceFile, expired);
         }
         // Backward-compat unwrap: callers that still request
         // PassRateStatistics directly (legacy tests, pinned-baseline
@@ -185,12 +191,13 @@ public final class BaselineResolver {
             Map<String, PassRateStatistics> byCriterion = perCriterion.byCriterion();
             if (byCriterion.isEmpty()) {
                 return new BaselineLookup<>(
-                        Optional.empty(), baselineProfile, notes, sourceFile);
+                        Optional.empty(), baselineProfile, notes, sourceFile, expired);
             }
             if (byCriterion.size() == 1) {
                 PassRateStatistics only = byCriterion.values().iterator().next();
                 return new BaselineLookup<>(
-                        Optional.of(statisticsType.cast(only)), baselineProfile, notes, sourceFile);
+                        Optional.of(statisticsType.cast(only)), baselineProfile, notes,
+                        sourceFile, expired);
             }
             // K>1 + legacy PassRateStatistics request — return empty
             // with a note. Production callers now request
@@ -200,7 +207,7 @@ public final class BaselineResolver {
                     + ") cannot be unwrapped to a single PassRateStatistics — "
                     + "callers should request PerCriterionPassRateStatistics");
             return new BaselineLookup<>(
-                    Optional.empty(), baselineProfile, notesWithNote, sourceFile);
+                    Optional.empty(), baselineProfile, notesWithNote, sourceFile, expired);
         }
         if (!statisticsType.isInstance(entry)) {
             throw new IllegalStateException(
@@ -211,25 +218,32 @@ public final class BaselineResolver {
                             + " — write-side and read-side criterion kinds disagree");
         }
         return new BaselineLookup<>(
-                Optional.of(statisticsType.cast(entry)), baselineProfile, notes, sourceFile);
+                Optional.of(statisticsType.cast(entry)), baselineProfile, notes,
+                sourceFile, expired);
     }
 
     /**
-     * Append a baseline-expiration note when the selected baseline
-     * carries a validity window that is approaching or past its end.
-     * The note rides the lookup's notes channel, which the spec layer
-     * surfaces as a verdict warning. No-op when the baseline declared
-     * no window or is comfortably within it.
+     * Evaluate the selected baseline's validity window, or {@code null}
+     * when it declared none ({@code expiresInDays <= 0}).
      */
-    private static List<String> withExpirationWarning(
-            List<String> notes, BaselineRecord selected) {
+    private static ExpirationStatus expirationStatusOf(BaselineRecord selected) {
         if (selected.expiresInDays() <= 0) {
-            return notes;
+            return null;
         }
-        ExpirationStatus status = new ExpirationPolicy(
-                selected.expiresInDays(), selected.generatedAt())
+        return new ExpirationPolicy(selected.expiresInDays(), selected.generatedAt())
                 .evaluateAt(Instant.now());
-        if (!status.requiresWarning()) {
+    }
+
+    /**
+     * Append a baseline-expiration note when the evaluated status calls
+     * for a warning (approaching or expired). The note rides the
+     * lookup's notes channel, which the spec layer surfaces as a
+     * verdict caveat. No-op when there is no window or the window is
+     * comfortably open.
+     */
+    private static List<String> withExpirationNote(
+            List<String> notes, BaselineRecord selected, ExpirationStatus status) {
+        if (status == null || !status.requiresWarning()) {
             return notes;
         }
         List<String> combined = new ArrayList<>(notes.size() + 1);

--- a/punit-core/src/test/java/org/javai/punit/api/spec/ExpiredBaselinePolicyTest.java
+++ b/punit-core/src/test/java/org/javai/punit/api/spec/ExpiredBaselinePolicyTest.java
@@ -1,0 +1,37 @@
+package org.javai.punit.api.spec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ExpiredBaselinePolicy — config parsing")
+class ExpiredBaselinePolicyTest {
+
+    @Test
+    @DisplayName("null or blank defaults to WARN")
+    void defaultsToWarn() {
+        assertThat(ExpiredBaselinePolicy.parse(null)).isEqualTo(ExpiredBaselinePolicy.WARN);
+        assertThat(ExpiredBaselinePolicy.parse("")).isEqualTo(ExpiredBaselinePolicy.WARN);
+        assertThat(ExpiredBaselinePolicy.parse("   ")).isEqualTo(ExpiredBaselinePolicy.WARN);
+    }
+
+    @Test
+    @DisplayName("WARN / FAIL parse case- and whitespace-insensitively")
+    void parsesKnownValues() {
+        assertThat(ExpiredBaselinePolicy.parse("WARN")).isEqualTo(ExpiredBaselinePolicy.WARN);
+        assertThat(ExpiredBaselinePolicy.parse("fail")).isEqualTo(ExpiredBaselinePolicy.FAIL);
+        assertThat(ExpiredBaselinePolicy.parse("  Fail  ")).isEqualTo(ExpiredBaselinePolicy.FAIL);
+    }
+
+    @Test
+    @DisplayName("an unknown value fails fast, naming the bad value and the accepted set")
+    void rejectsUnknownValue() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ExpiredBaselinePolicy.parse("STRICT"))
+                .withMessageContaining("STRICT")
+                .withMessageContaining("WARN")
+                .withMessageContaining("FAIL");
+    }
+}

--- a/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/internal/engine/EmpiricalEndToEndIntegrationTest.java
@@ -224,6 +224,60 @@ class EmpiricalEndToEndIntegrationTest {
     }
 
     @Test
+    @DisplayName("under the fail-on-expired policy, an expired baseline fails the verdict "
+            + "even when the statistics would pass — a stale baseline can't underwrite a PASS")
+    void expiredBaselineFailsVerdictUnderFailPolicy(@TempDir Path baselineDir)
+            throws IOException {
+        writeBaselineWithWindow(baselineDir, 0.80, 1000, 30,
+                Instant.now().minus(Duration.ofDays(400)));
+
+        String previous = System.getProperty("punit.expiration.policy");
+        System.setProperty("punit.expiration.policy", "FAIL");
+        try {
+            var engine = new Engine(new YamlBaselineProvider(baselineDir));
+            var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(20)));
+
+            assertThat(result.verdict())
+                    .as("FAIL policy must force an expired baseline's verdict to FAIL")
+                    .isEqualTo(Verdict.FAIL);
+            assertThat(result.warnings())
+                    .anyMatch(w -> w.contains("expired") && w.contains(USE_CASE_ID));
+            assertThat(result.warnings())
+                    .anyMatch(w -> w.contains("policy=FAIL"));
+        } finally {
+            restoreProperty("punit.expiration.policy", previous);
+        }
+    }
+
+    @Test
+    @DisplayName("under the fail-on-expired policy, a baseline within its window is unaffected — "
+            + "still PASS, no expiration caveat")
+    void freshBaselineUnaffectedUnderFailPolicy(@TempDir Path baselineDir) throws IOException {
+        writeBaselineWithWindow(baselineDir, 0.80, 1000, 30, Instant.now());
+
+        String previous = System.getProperty("punit.expiration.policy");
+        System.setProperty("punit.expiration.policy", "FAIL");
+        try {
+            var engine = new Engine(new YamlBaselineProvider(baselineDir));
+            var result = (ProbabilisticTestResult) engine.run(empiricalTest(sampling(20)));
+
+            assertThat(result.verdict()).isEqualTo(Verdict.PASS);
+            assertThat(result.warnings())
+                    .noneMatch(w -> w.contains("expired") || w.contains("policy=FAIL"));
+        } finally {
+            restoreProperty("punit.expiration.policy", previous);
+        }
+    }
+
+    private static void restoreProperty(String key, String previous) {
+        if (previous == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, previous);
+        }
+    }
+
+    @Test
     @DisplayName("the empty provider returns Optional.empty for any query")
     void baselineProviderEmptyContract() {
         var resolved = BaselineProvider.EMPTY.baselineFor(


### PR DESCRIPTION
## Summary

Adds the opt-in strict mode for baseline expiration. After #205 an expired baseline surfaces as a verdict **caveat** (warning); this PR lets an operator additionally make expiry **fail** the verdict.

- **Default unchanged** (`WARN`): expiry is a caveat; the verdict reflects the statistics.
- **`punit.expiration.policy=FAIL`** (env `PUNIT_EXPIRATION_POLICY`): an expired baseline forces the verdict to `FAIL` regardless of the observed statistics — a stale baseline makes the empirical comparison untrustworthy, so a PASS against it must not stand.

## Design

- **`ExpiredBaselinePolicy`** (`api.spec`) — `WARN` / `FAIL` enum, resolved system-property → env-var → default (`WARN`), unknown values fail fast (`{WARN, FAIL}`).
- **Structured signal, not string-sniffing** — `BaselineLookup` gains a `boolean expired`. Deliberately a boolean, **not** the `verdict.ExpirationStatus` type, to avoid an `api.spec → verdict` dependency (ArchUnit-clean). The policy reads the flag; the human caveat still rides the existing notes → warnings channel.
- **Single evaluation** — `BaselineResolver.lookup(...)` evaluates the window once (`verdict.ExpirationPolicy`) and surfaces both the caveat note and the `expired` flag.
- **Applied at verdict composition** — `ProbabilisticTest.Internal.conclude` flips the composed verdict to `FAIL` (with an explanatory warning) when any resolved baseline is expired and policy = `FAIL`. Only fully `Expired` baselines fail; approaching bands stay warn-only.

## Tests (verdict-level)

`EmpiricalEndToEndIntegrationTest`:
- `FAIL` policy + expired baseline → verdict **FAIL** even though the always-passing test would PASS; warnings carry the expiry caveat and the `policy=FAIL` reason.
- `FAIL` policy + fresh baseline → unaffected (PASS, no caveat).
- Default (`WARN`) behaviour retained from #205.

`ExpiredBaselinePolicyTest` — config parsing (default WARN, case/whitespace-insensitive WARN/FAIL, unknown → fail fast).

## Scope

Strict mode is opt-in; existing runs do not start failing on expiry without the operator electing it. Only `Expired` fails — never the approaching bands.

Refs `DIR-EXPIRATION-FAIL-POLICY-punit`.

## Test plan

- [x] `./gradlew :punit-core:test` green (incl. ArchUnit — no `api.spec → verdict` dependency introduced — and `RequirementCodeIsolationTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)