### PR TITLE
Fix SentinelConfiguration javadoc: WebhookVerdictSink builder

### DIFF
--- a/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelConfiguration.java
+++ b/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelConfiguration.java
@@ -17,7 +17,7 @@ import org.javai.punit.verdict.VerdictSink;
  * <pre>{@code
  * SentinelConfiguration config = SentinelConfiguration.builder()
  *     .sentinelClass(ShoppingBasketReliability.class)
- *     .verdictSink(new WebhookVerdictSink("https://alerts.example.com/punit"))
+ *     .verdictSink(WebhookVerdictSink.builder("https://alerts.example.com/punit").build())
  *     .environmentMetadata(EnvironmentMetadata.fromEnvironment())
  *     .build();
  * }</pre>


### PR DESCRIPTION
The `SentinelConfiguration` class-javadoc usage example used `new WebhookVerdictSink("...")`, but `WebhookVerdictSink` has no public string constructor — the only public entry point is `WebhookVerdictSink.builder(url).build()`. Corrected the example so it compiles.

Javadoc only — no behavioural change. Found while aligning the orchestrator's requirement-doc catalog with the shipped punit API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)