### PR TITLE
Embed cross-reference anchors (anchor pilot)

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionDecl.java
@@ -58,6 +58,7 @@ import org.javai.punit.api.PostconditionCheck;
  *
  * @param <O> the contract's per-sample output value type
  */
+// javai-ref: JVI-JGG2K8= — do not remove (resolves in javai-orchestrator)
 public final class CriterionDecl<O> implements Decl<O> {
 
     private final CriterionPosture posture;

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/NamedPostcondition.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/NamedPostcondition.java
@@ -16,6 +16,7 @@ import org.javai.punit.api.PostconditionCheck;
  *
  * @param <O> the value type the check evaluates against
  */
+// javai-ref: JVI-BD4F1AB — do not remove (resolves in javai-orchestrator)
 public record NamedPostcondition<O>(
         String name,
         PostconditionCheck<O> check

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -63,6 +63,7 @@ import org.javai.punit.statistics.ThresholdDeriver;
  * dependencies. The {@link Criterion} interface itself stays in
  * {@code api package}; only this implementation moved.
  */
+// javai-ref: JVI-C5P3EQE — do not remove (resolves in javai-orchestrator)
 public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateStatistics> {
 
     private static final String NAME = "bernoulli-pass-rate";

--- a/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
@@ -115,6 +115,7 @@ public class BinomialProportionEstimator {
      * @param confidenceLevel Confidence level (1-α), e.g., 0.95 for 95% lower bound
      * @return One-sided lower confidence bound for p
      */
+    // javai-ref: JVI-MNVWS4U — do not remove (resolves in javai-orchestrator)
     public double lowerBound(int successes, int trials, double confidenceLevel) {
         validateInputs(successes, trials);
         double pHat = (double) successes / trials;

--- a/punit-core/src/main/java/org/javai/punit/verdict/CriterionRow.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/CriterionRow.java
@@ -31,6 +31,7 @@ import java.util.Objects;
  *                      no threshold was resolved (e.g. the run gated
  *                      INCONCLUSIVE before threshold derivation)
  */
+// javai-ref: JVI-8E4WNW5 — do not remove (resolves in javai-orchestrator)
 public record CriterionRow(
         String criterionId,
         org.javai.punit.api.spec.Verdict verdict,

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
@@ -24,6 +24,7 @@ import org.javai.punit.api.ServiceContractAttributes;
  * <p>All rendering paths (text logs, XML report, HTML report) consume this model.
  * No rendering target has access to information that another lacks.
  */
+// javai-ref: JVI-60WEAWK — do not remove (resolves in javai-orchestrator)
 public record ProbabilisticTestVerdict(
         String correlationId,
         Instant timestamp,


### PR DESCRIPTION
The Java half of the cross-ref anchor pilot (`DIR-CROSS-REF-ANCHORS-orchestrator`),
counterpart to feotest#23. One opaque `javai-ref` anchor (comment-only, **no
logic change**) per owning artifact — each sharing the **same anchor id** as its
Rust counterpart, so the orchestrator derives the cross-language link with no
separately-maintained edge:

| anchor concept | punit artifact | shares id with feotest |
|---|---|---|
| criterion-as-partition-unit | `CriterionDecl` | `criteria::Criterion` |
| named postcondition | `NamedPostcondition` | `criteria::CriterionBuild` |
| three-valued per-criterion verdict | `CriterionRow` | `verdict::CriterionRow` |
| composite verdict | `ProbabilisticTestVerdict` | `verdict::FunctionalAssessment` |
| criterion-denominator (oracle) | `PassRate` | `criteria::CriterionCounts` |
| Wilson lower bound (oracle) | `BinomialProportionEstimator.lowerBound` | `statistics::proportion::lower_bound` |

Anchors are opaque (`JVI-…`), carry no internal taxonomy, and resolve only in
javai-orchestrator's registry — so they survive taxonomy/companion churn and
leak nothing.

**Guard-safe:** `RequirementCodeIsolationTest` passes — the `JVI-` format cannot
match the `\b(CT|EX|…)\d{2}\b` requirement-code regex (no internal word
boundaries in the base32 body).

With this merged, the orchestrator resolver shows the cross-language join:
`anchors.py report CR07` → both `CriterionRow.java` and `assessment.rs`;
`report proportion-wilson-lower-bound` → both `BinomialProportionEstimator.java`
and `proportion.rs`.

Comment-only; placed as plain `//` lines above each declaration (kept out of
javadoc).