### PR TITLE
Embed cross-reference anchor on TransparentStatsRenderer

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/reporting/TransparentStatsRenderer.java
@@ -61,6 +61,7 @@ import org.javai.punit.api.spec.Verdict;
  * <p>Output is plain text — readable in IDE test consoles,
  * surefire reports, and CI logs without further processing.
  */
+// javai-ref: JVI-G3NPRSS — do not remove (resolves in javai-orchestrator)
 public final class TransparentStatsRenderer {
 
     private static final String LABEL_INDENT = "      ";


### PR DESCRIPTION
One opaque `// javai-ref:` line at owning-artifact granularity on `TransparentStatsRenderer`, binding the transparent-statistics renderer to its orchestrator cross-reference concept.

No requirement code in source; the anchor is opaque and resolves in javai-orchestrator. Verified by the orchestrator's `anchors.py check` (0 errors, inventory reconciliation clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)