### PR TITLE
Embed cross-reference anchors: initial multi-owner sweep

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/BudgetExhaustedBehavior.java
+++ b/punit-core/src/main/java/org/javai/punit/api/BudgetExhaustedBehavior.java
@@ -4,6 +4,7 @@ package org.javai.punit.api;
  * Defines the behavior when a budget (time or token) is exhausted
  * before all samples have been executed.
  */
+// javai-ref: JVI-KJS8SB7 — do not remove (resolves in javai-orchestrator)
 public enum BudgetExhaustedBehavior {
     
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Contract.java
@@ -45,6 +45,7 @@ import org.javai.punit.api.criterion.LatencyCriterion;
  * @param <I> the per-sample input type
  * @param <O> the per-sample output value type
  */
+// javai-ref: JVI-GQXC6W9 — do not remove (resolves in javai-orchestrator)
 public interface Contract<I, O> {
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/ControlFactor.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ControlFactor.java
@@ -45,6 +45,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+// javai-ref: JVI-0CRN8G6 — do not remove (resolves in javai-orchestrator)
 public @interface ControlFactor {
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/ExceptionHandling.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ExceptionHandling.java
@@ -4,6 +4,8 @@ package org.javai.punit.api;
  * Defines how non-{@link AssertionError} exceptions thrown by the test method
  * should be handled.
  */
+// javai-ref: JVI-A076E41 — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-EGG7M2* — do not remove (resolves in javai-orchestrator)
 public enum ExceptionHandling {
     
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/InputSource.java
+++ b/punit-core/src/main/java/org/javai/punit/api/InputSource.java
@@ -69,6 +69,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+// javai-ref: JVI-QBEZ3W9 — do not remove (resolves in javai-orchestrator)
 public @interface InputSource {
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/InputSupplier.java
+++ b/punit-core/src/main/java/org/javai/punit/api/InputSupplier.java
@@ -73,6 +73,7 @@ import java.util.function.Supplier;
  *
  * @param <IT> the per-sample input type
  */
+// javai-ref: JVI-WXK2ZQP — do not remove (resolves in javai-orchestrator)
 public interface InputSupplier<IT> {
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/LatencySpec.java
+++ b/punit-core/src/main/java/org/javai/punit/api/LatencySpec.java
@@ -22,6 +22,7 @@ import java.util.OptionalLong;
  * @param p95Millis optional 95th-percentile ceiling, in millis
  * @param p99Millis optional 99th-percentile ceiling, in millis
  */
+// javai-ref: JVI-NBPN769 — do not remove (resolves in javai-orchestrator)
 public record LatencySpec(
         OptionalLong p50Millis,
         OptionalLong p90Millis,

--- a/punit-core/src/main/java/org/javai/punit/api/Pacing.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Pacing.java
@@ -41,6 +41,10 @@ import java.util.OptionalLong;
  *                           in milliseconds
  * @param maxConcurrent optional cap on the number of in-flight samples
  */
+// javai-ref: JVI-PC8GT83 — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-P1GG550 — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-M1TXHHQ — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-FNJKJT5 — do not remove (resolves in javai-orchestrator)
 public record Pacing(
         OptionalDouble maxRequestsPerSecond,
         OptionalDouble maxRequestsPerMinute,

--- a/punit-core/src/main/java/org/javai/punit/api/Postcondition.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Postcondition.java
@@ -61,6 +61,7 @@ import org.javai.punit.api.criterion.ValueMatcher;
  *
  * @param <T> the type the postcondition evaluates
  */
+// javai-ref: JVI-K90P6S1 — do not remove (resolves in javai-orchestrator)
 public sealed interface Postcondition<T> permits Postcondition.Leaf, Postcondition.Matching {
 
     /** Human-readable description; non-blank. */

--- a/punit-core/src/main/java/org/javai/punit/api/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ProbabilisticTest.java
@@ -49,5 +49,6 @@ import org.junit.jupiter.api.Test;
 @Tag("punit")
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+// javai-ref: JVI-DKY6R8R — do not remove (resolves in javai-orchestrator)
 public @interface ProbabilisticTest {
 }

--- a/punit-core/src/main/java/org/javai/punit/api/Sampling.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Sampling.java
@@ -94,6 +94,8 @@ import org.javai.punit.api.spec.ExceptionPolicy;
  *       failure-retention. The 20% case.</li>
  * </ul>
  */
+// javai-ref: JVI-QRV7SYX — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-WXK2ZQP — do not remove (resolves in javai-orchestrator)
 public final class Sampling<FT, IT, OT> {
 
     private final Function<FT, ServiceContract<FT, IT, OT>> serviceContractFactory;

--- a/punit-core/src/main/java/org/javai/punit/api/ServiceContract.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ServiceContract.java
@@ -43,6 +43,7 @@ import org.javai.punit.api.covariate.Covariate;
  * @param <IT> the per-sample input type
  * @param <OT> the per-sample output value type
  */
+// javai-ref: JVI-SMQ2S1R — do not remove (resolves in javai-orchestrator)
 public interface ServiceContract<FT, IT, OT> extends Contract<IT, OT> {
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/ServiceContractAttributes.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ServiceContractAttributes.java
@@ -11,6 +11,7 @@ package org.javai.punit.api;
  * @param warmup number of warmup invocations to discard before counting (0 = no warmup)
  * @param maxConcurrent maximum concurrent sample executions (0 = framework default)
  */
+// javai-ref: JVI-FX47WDW — do not remove (resolves in javai-orchestrator)
 public record ServiceContractAttributes(int warmup, int maxConcurrent) {
 
     /** Default attributes (no warmup, no concurrency override). */

--- a/punit-core/src/main/java/org/javai/punit/api/TestIntent.java
+++ b/punit-core/src/main/java/org/javai/punit/api/TestIntent.java
@@ -36,6 +36,8 @@ package org.javai.punit.api;
  *
  * @see ProbabilisticTest#intent()
  */
+// javai-ref: JVI-Q3H5YYY — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-WKHRGXJ — do not remove (resolves in javai-orchestrator)
 public enum TestIntent {
     /**
      * Evidential intent. Use this when the test is expected to support a confidence-backed

--- a/punit-core/src/main/java/org/javai/punit/api/ThresholdOrigin.java
+++ b/punit-core/src/main/java/org/javai/punit/api/ThresholdOrigin.java
@@ -40,6 +40,7 @@ package org.javai.punit.api;
  * @see ProbabilisticTest#thresholdOrigin()
  * @see ProbabilisticTest#contractRef()
  */
+// javai-ref: JVI-J8G7TKM — do not remove (resolves in javai-orchestrator)
 public enum ThresholdOrigin {
 
 	SLA(true, "Externally agreed normative target (contract/SLA)."),

--- a/punit-core/src/main/java/org/javai/punit/api/TokenChargeRecorder.java
+++ b/punit-core/src/main/java/org/javai/punit/api/TokenChargeRecorder.java
@@ -34,6 +34,7 @@ package org.javai.punit.api;
  * @see ProbabilisticTest#tokenBudget()
  * @see ProbabilisticTest#tokenCharge()
  */
+// javai-ref: JVI-76VA511 — do not remove (resolves in javai-orchestrator)
 public interface TokenChargeRecorder {
     
     /**

--- a/punit-core/src/main/java/org/javai/punit/api/covariate/Covariate.java
+++ b/punit-core/src/main/java/org/javai/punit/api/covariate/Covariate.java
@@ -50,6 +50,7 @@ import java.util.Set;
  * exhaustiveness at compile time. Adding a sixth variant requires
  * extending the framework — user code cannot.
  */
+// javai-ref: JVI-44AD1Q8 — do not remove (resolves in javai-orchestrator)
 public sealed interface Covariate
         permits DayOfWeekCovariate,
                 TimeOfDayCovariate,

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/CriterionPosture.java
@@ -46,6 +46,11 @@ import org.javai.punit.api.ThresholdOrigin;
  * <p>An instance is immutable; the static factory methods produce
  * the four kinds.
  */
+// javai-ref: JVI-0NGDRGR — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-0FVFYBM — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-5YJVXGF — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-6789AKT — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-THPVKXD — do not remove (resolves in javai-orchestrator)
 public final class CriterionPosture {
 
     /** Posture kinds. */

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/LatencyCriterion.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/LatencyCriterion.java
@@ -43,6 +43,8 @@ import org.javai.punit.api.ThresholdOrigin;
  * authored at the call site. Authors who want a project-specific
  * label put it in {@link #contractRef(ThresholdOrigin, String)}.
  */
+// javai-ref: JVI-MPAYH0Q — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-QVNG2SX — do not remove (resolves in javai-orchestrator)
 public final class LatencyCriterion {
 
     /** The fixed id under which a present latency criterion appears in {@code effectiveCriteria()}. */

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/MatchingDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/MatchingDecl.java
@@ -31,6 +31,7 @@ import org.javai.punit.api.Postcondition;
  *
  * @param <O> the contract's per-sample output value type
  */
+// javai-ref: JVI-3P2SEQ4 — do not remove (resolves in javai-orchestrator)
 public final class MatchingDecl<O> implements Decl<O> {
 
     private final CriterionPosture posture;

--- a/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingDecl.java
+++ b/punit-core/src/main/java/org/javai/punit/api/criterion/TransformingDecl.java
@@ -33,6 +33,7 @@ import org.javai.punit.api.PostconditionCheck;
  * @param <T> the transformed value type the postconditions evaluate
  *            against
  */
+// javai-ref: JVI-Q8BDYMS — do not remove (resolves in javai-orchestrator)
 public final class TransformingDecl<O, T> implements Decl<O> {
 
     private final CriterionPosture posture;

--- a/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/Experiment.java
@@ -326,6 +326,7 @@ public final class Experiment implements Spec {
         }
     }
 
+    // javai-ref: JVI-315MNJX — do not remove (resolves in javai-orchestrator)
     public static final class MeasureBuilder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -444,6 +445,7 @@ public final class Experiment implements Spec {
         }
     }
 
+    // javai-ref: JVI-HGF78G* — do not remove (resolves in javai-orchestrator)
     public static final class ExploreBuilder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -625,6 +627,7 @@ public final class Experiment implements Spec {
         }
     }
 
+    // javai-ref: JVI-PS5XC2C — do not remove (resolves in javai-orchestrator)
     public static final class OptimizeBuilder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -779,6 +782,7 @@ public final class Experiment implements Spec {
         }
     }
 
+    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
     public static final class InlineMeasureBuilder<FT, IT, OT> {
 
         private final InlineSamplingState<FT, IT, OT> sampling;
@@ -872,6 +876,7 @@ public final class Experiment implements Spec {
         }
     }
 
+    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
     public static final class InlineExploreBuilder<FT, IT, OT> {
 
         private final InlineSamplingState<FT, IT, OT> sampling;
@@ -966,6 +971,7 @@ public final class Experiment implements Spec {
         }
     }
 
+    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
     public static final class InlineOptimizeBuilder<FT, IT, OT> {
 
         private final InlineSamplingState<FT, IT, OT> sampling;

--- a/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdicts.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/PerCriterionVerdicts.java
@@ -39,6 +39,7 @@ import java.util.Optional;
  *       per-criterion verdicts.</li>
  * </ul>
  */
+// javai-ref: JVI-ZCSHQ5K — do not remove (resolves in javai-orchestrator)
 public final class PerCriterionVerdicts {
 
     private PerCriterionVerdicts() {}

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ProbabilisticTest.java
@@ -458,6 +458,7 @@ public final class ProbabilisticTest implements Spec {
 
     // ── Builder ──────────────────────────────────────────────────────
 
+    // javai-ref: JVI-QRV7SYX — do not remove (resolves in javai-orchestrator)
     public static final class Builder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -575,6 +576,7 @@ public final class ProbabilisticTest implements Spec {
      * {@link #build()} time. Rejects empirical criteria at build time
      * with a diagnostic teaching the helper-extraction pattern.
      */
+    // javai-ref: JVI-QRV7SYX — do not remove (resolves in javai-orchestrator)
     public static final class InlineBuilder<FT, IT, OT> {
 
         private final Function<FT, ServiceContract<FT, IT, OT>> serviceContractFactory;

--- a/punit-core/src/main/java/org/javai/punit/api/spec/ResourceControls.java
+++ b/punit-core/src/main/java/org/javai/punit/api/spec/ResourceControls.java
@@ -35,6 +35,10 @@ import java.util.OptionalLong;
  *                       {@code ServiceContract.apply}; default ABORT_TEST
  * @param maxExampleFailures cap on retained failure detail; default 10
  */
+// javai-ref: JVI-9M5SBQZ — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-N0WK25H — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-W6A4WRA — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-T60D7VU — do not remove (resolves in javai-orchestrator)
 public record ResourceControls(
         Optional<Duration> timeBudget,
         OptionalLong tokenBudget,

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/Engine.java
@@ -316,6 +316,8 @@ public final class Engine {
          * same sample — it takes precedence over a (necessarily
          * stale) success-guaranteed reading.
          */
+        // javai-ref: JVI-BQTS77W — do not remove (resolves in javai-orchestrator)
+        // javai-ref: JVI-GZFMZXV — do not remove (resolves in javai-orchestrator)
         private void checkStatisticalEarlyTermination() {
             if (earlyTermination.isEmpty()) {
                 return;

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineIntegrity.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineIntegrity.java
@@ -41,6 +41,7 @@ import org.javai.punit.internal.util.HashUtils;
  * to (but excluding) the matched line — which is what the writer
  * hashes when it builds the file.
  */
+// javai-ref: JVI-CNDHE1$ — do not remove (resolves in javai-orchestrator)
 final class BaselineIntegrity {
 
     private BaselineIntegrity() { }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSelector.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/BaselineSelector.java
@@ -55,6 +55,7 @@ import org.javai.punit.api.covariate.CovariateProfile;
  * declared covariates; the candidate file alone (which only carries
  * key/value pairs in the {@code covariates:} block) is not enough.
  */
+// javai-ref: JVI-YN3BJ6U — do not remove (resolves in javai-orchestrator)
 final class BaselineSelector {
 
     /**

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/CovariateHashing.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/baseline/CovariateHashing.java
@@ -41,6 +41,7 @@ import org.javai.punit.internal.util.HashUtils;
  * preserves that order through resolution and round-trip, so the
  * implementation here just iterates the profile's value map.
  */
+// javai-ref: JVI-07HPCY* — do not remove (resolves in javai-orchestrator)
 final class CovariateHashing {
 
     static final int HASH_LENGTH = 4;

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/budget/DefaultTokenChargeRecorder.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/budget/DefaultTokenChargeRecorder.java
@@ -15,6 +15,7 @@ import org.javai.punit.api.TokenChargeRecorder;
  * 
  * <p>Not thread-safe - intended for use within a single test execution thread.
  */
+// javai-ref: JVI-76VA511 — do not remove (resolves in javai-orchestrator)
 public class DefaultTokenChargeRecorder implements TokenChargeRecorder {
 
     private final long tokenBudget;

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/covariate/CovariateResolver.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/covariate/CovariateResolver.java
@@ -64,6 +64,7 @@ import org.javai.punit.api.covariate.TimezoneCovariate;
  * mid-run (the clock advances, the system property could mutate),
  * defeating the purpose of recording a snapshot.
  */
+// javai-ref: JVI-GYHECWN — do not remove (resolves in javai-orchestrator)
 public final class CovariateResolver {
 
     static final String REGION_PROPERTY = "punit.region";

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/Feasibility.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/Feasibility.java
@@ -65,6 +65,7 @@ import org.javai.punit.statistics.VerificationFeasibilityEvaluator.FeasibilityRe
  * orchestrates. Diagnostic prose comes from
  * {@link InfeasibilityMessageRenderer}.
  */
+// javai-ref: JVI-RDWGWVV — do not remove (resolves in javai-orchestrator)
 public final class Feasibility {
 
     private Feasibility() { }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/criteria/PassRate.java
@@ -256,6 +256,8 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
     }
 
     @Override
+    // javai-ref: JVI-BQTS77W — do not remove (resolves in javai-orchestrator)
+    // javai-ref: JVI-GZFMZXV — do not remove (resolves in javai-orchestrator)
     public OptionalDouble earlyTerminationPassRate() {
         return contractualTarget();
     }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/emit/ResultProjections.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/emit/ResultProjections.java
@@ -39,6 +39,7 @@ import org.javai.punit.api.spec.Trial;
  * so the anchor line matches across the two files and acts as a
  * synchronisation point for the diff tool.
  */
+// javai-ref: JVI-G0R8DT$ — do not remove (resolves in javai-orchestrator)
 public final class ResultProjections {
 
     private ResultProjections() { }

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -36,6 +36,7 @@ import org.yaml.snakeyaml.Yaml;
  * projection metadata through, a {@code resultProjection:} block can
  * be appended additively.
  */
+// javai-ref: JVI-8CHB31R — do not remove (resolves in javai-orchestrator)
 public final class ExploreOutputWriter {
 
     /** Schema-version value carried in every emitted file. */

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/optimize/OptimizeOutputWriter.java
@@ -32,6 +32,7 @@ import org.yaml.snakeyaml.Yaml;
  * {@code {serviceContractId}/{experimentId}.yaml} — assembled by the
  * emitter, not the writer.
  */
+// javai-ref: JVI-FJK9SN9 — do not remove (resolves in javai-orchestrator)
 public final class OptimizeOutputWriter {
 
     /** Schema-version value carried in every emitted file. */

--- a/punit-core/src/main/java/org/javai/punit/internal/engine/spec/expiration/ExpirationEvaluator.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/engine/spec/expiration/ExpirationEvaluator.java
@@ -11,6 +11,7 @@ import org.javai.punit.internal.engine.spec.model.ExecutionSpecification;
  * <p>Provides convenient methods to evaluate expiration at the current time
  * or at a specified instant.
  */
+// javai-ref: JVI-09GQGN$ — do not remove (resolves in javai-orchestrator)
 public final class ExpirationEvaluator {
 
     private ExpirationEvaluator() {

--- a/punit-core/src/main/java/org/javai/punit/internal/reporting/ConsoleVerdictSink.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/reporting/ConsoleVerdictSink.java
@@ -19,6 +19,7 @@ import org.javai.punit.verdict.VerdictSink;
  * <p>Output uses the standard PUnit framing (header/footer dividers) and
  * label-value alignment provided by {@link PUnitReporter}.
  */
+// javai-ref: JVI-ZVX9J8V — do not remove (resolves in javai-orchestrator)
 public final class ConsoleVerdictSink implements VerdictSink {
 
     private final PrintStream out;

--- a/punit-core/src/main/java/org/javai/punit/internal/reporting/VerdictTextRenderer.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/reporting/VerdictTextRenderer.java
@@ -40,6 +40,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdict.Termination;
  *   <li>{@link #renderForReporter} — verbose box-drawn output for transparent stats console</li>
  * </ul>
  */
+// javai-ref: JVI-ZVX9J8V — do not remove (resolves in javai-orchestrator)
 public final class VerdictTextRenderer {
 
     private static final int LINE_WIDTH = 78;

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
@@ -64,6 +64,7 @@ import org.javai.punit.internal.engine.covariate.CovariateResolver;
  *   <li>{@code generatedAt} — {@code Instant.now()}</li>
  * </ul>
  */
+// javai-ref: JVI-EC8CPT3 — do not remove (resolves in javai-orchestrator)
 public final class BaselineEmitter {
 
     private BaselineEmitter() { }

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/ExploreEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/ExploreEmitter.java
@@ -38,6 +38,7 @@ import org.javai.punit.internal.engine.explore.ExploreOutputWriter;
  * overload; both share the same per-configuration logic so tests
  * exercise the same path production code drives.
  */
+// javai-ref: JVI-8CHB31R — do not remove (resolves in javai-orchestrator)
 public final class ExploreEmitter {
 
     private ExploreEmitter() { }

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/OptimizeEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/OptimizeEmitter.java
@@ -43,6 +43,7 @@ import org.javai.punit.internal.engine.optimize.OptimizeOutputWriter;
  * <p>The Path overload is a thin wrapper around the BiConsumer
  * overload; both share the same artefact-assembly logic.
  */
+// javai-ref: JVI-FJK9SN9 — do not remove (resolves in javai-orchestrator)
 public final class OptimizeEmitter {
 
     private OptimizeEmitter() { }

--- a/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/javai/punit/runtime/PUnit.java
@@ -100,6 +100,7 @@ public final class PUnit {
     // ── Sampling-bound factories ────────────────────────────────────
 
     /** Compose a contractual probabilistic test against a shared sampling. */
+    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
     public static <FT, IT, OT> TestBuilder<FT, IT, OT> testing(
             Sampling<FT, IT, OT> sampling, FT factors) {
         return new TestBuilder<>(
@@ -442,6 +443,7 @@ public final class PUnit {
     // ── Wrapper builders ────────────────────────────────────────────
 
     /** Wrapper around {@link Experiment.MeasureBuilder} adding {@link #run}. */
+    // javai-ref: JVI-315MNJX — do not remove (resolves in javai-orchestrator)
     public static final class MeasureBuilder<FT, IT, OT> {
         private final Experiment.MeasureBuilder<FT, IT, OT> delegate;
 
@@ -473,6 +475,7 @@ public final class PUnit {
     }
 
     /** Wrapper around {@link Experiment.ExploreBuilder} adding {@link #run}. */
+    // javai-ref: JVI-HGF78G* — do not remove (resolves in javai-orchestrator)
     public static final class ExploreBuilder<FT, IT, OT> {
         private final Experiment.ExploreBuilder<FT, IT, OT> delegate;
 
@@ -506,6 +509,7 @@ public final class PUnit {
     }
 
     /** Wrapper around {@link Experiment.OptimizeBuilder} adding {@link #run}. */
+    // javai-ref: JVI-PS5XC2C — do not remove (resolves in javai-orchestrator)
     public static final class OptimizeBuilder<FT, IT, OT> {
         private final Experiment.OptimizeBuilder<FT, IT, OT> delegate;
 

--- a/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/BinomialProportionEstimator.java
@@ -77,6 +77,7 @@ public class BinomialProportionEstimator {
      * @param confidenceLevel Confidence level (1-α), e.g., 0.95 for 95% CI
      * @return Proportion estimate with Wilson score confidence interval
      */
+    // javai-ref: JVI-58DBYP~ — do not remove (resolves in javai-orchestrator)
     public ProportionEstimate estimate(int successes, int trials, double confidenceLevel) {
         validateInputs(successes, trials);
         validateConfidenceLevel(confidenceLevel);
@@ -116,6 +117,7 @@ public class BinomialProportionEstimator {
      * @return One-sided lower confidence bound for p
      */
     // javai-ref: JVI-MNVWS4U — do not remove (resolves in javai-orchestrator)
+    // javai-ref: JVI-TX478RT — do not remove (resolves in javai-orchestrator)
     public double lowerBound(int successes, int trials, double confidenceLevel) {
         validateInputs(successes, trials);
         double pHat = (double) successes / trials;

--- a/punit-core/src/main/java/org/javai/punit/statistics/LatencyStatistics.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/LatencyStatistics.java
@@ -35,6 +35,7 @@ public final class LatencyStatistics {
      * @param p the percentile level in (0, 1]
      * @return the percentile value
      */
+    // javai-ref: JVI-CHSD1WP — do not remove (resolves in javai-orchestrator)
     public static double nearestRankPercentile(double[] latencies, double p) {
         Objects.requireNonNull(latencies, "latencies must not be null");
         if (latencies.length == 0) {

--- a/punit-core/src/main/java/org/javai/punit/statistics/LatencyThresholdDeriver.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/LatencyThresholdDeriver.java
@@ -35,6 +35,7 @@ import org.apache.commons.statistics.distribution.BinomialDistribution;
  * <p>This construction is non-parametric, distribution-free, and exact for any
  * continuous underlying latency distribution.
  */
+// javai-ref: JVI-QVNG2SX — do not remove (resolves in javai-orchestrator)
 public final class LatencyThresholdDeriver {
 
     private LatencyThresholdDeriver() {}

--- a/punit-core/src/main/java/org/javai/punit/statistics/SampleSizeCalculator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/SampleSizeCalculator.java
@@ -72,6 +72,8 @@ public class SampleSizeCalculator {
      * @param power The desired statistical power (1-β)
      * @return Sample size requirement with full context
      */
+    // javai-ref: JVI-2FYNHXX — do not remove (resolves in javai-orchestrator)
+    // javai-ref: JVI-EGMJ0MU — do not remove (resolves in javai-orchestrator)
     public SampleSizeRequirement calculateForPower(
             double baselineRate,
             double minDetectableEffect,

--- a/punit-core/src/main/java/org/javai/punit/statistics/TestVerdictEvaluator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/TestVerdictEvaluator.java
@@ -45,6 +45,7 @@ public class TestVerdictEvaluator {
      * @param threshold The derived threshold against which to compare
      * @return Verdict with full statistical context
      */
+    // javai-ref: JVI-T08PKZ6 — do not remove (resolves in javai-orchestrator)
     public VerdictWithConfidence evaluate(int testSuccesses, int testSamples, DerivedThreshold threshold) {
         validateInputs(testSuccesses, testSamples, threshold);
 

--- a/punit-core/src/main/java/org/javai/punit/statistics/ThresholdDeriver.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/ThresholdDeriver.java
@@ -70,6 +70,7 @@ public class ThresholdDeriver {
      * @param thresholdConfidence Desired confidence level (1-α)
      * @return Derived threshold with full context
      */
+    // javai-ref: JVI-9HJ92BC — do not remove (resolves in javai-orchestrator)
     public DerivedThreshold deriveSampleSizeFirst(
             int baselineSamples,
             int baselineSuccesses,
@@ -132,6 +133,7 @@ public class ThresholdDeriver {
      * @param explicitThreshold The explicitly specified threshold
      * @return Derived threshold with implied confidence and soundness flag
      */
+    // javai-ref: JVI-HHV7KT0 — do not remove (resolves in javai-orchestrator)
     public DerivedThreshold deriveThresholdFirst(
             int baselineSamples,
             int baselineSuccesses,

--- a/punit-core/src/main/java/org/javai/punit/statistics/VerificationFeasibilityEvaluator.java
+++ b/punit-core/src/main/java/org/javai/punit/statistics/VerificationFeasibilityEvaluator.java
@@ -77,6 +77,7 @@ public final class VerificationFeasibilityEvaluator {
      * @return the feasibility result including minimum required samples
      * @throws IllegalArgumentException if any parameter is out of range
      */
+    // javai-ref: JVI-M5YQ6RB — do not remove (resolves in javai-orchestrator)
     public static FeasibilityResult evaluate(int samples, double target, double confidence) {
         if (samples <= 0) {
             throw new IllegalArgumentException("samples must be > 0, got: " + samples);

--- a/punit-core/src/main/java/org/javai/punit/verdict/ExpirationPolicy.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ExpirationPolicy.java
@@ -28,6 +28,7 @@ import java.util.Optional;
  *
  * @see ExpirationStatus
  */
+// javai-ref: JVI-09GQGN$ — do not remove (resolves in javai-orchestrator)
 public record ExpirationPolicy(
     int expiresInDays,
     Instant baselineEndTime

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
@@ -25,6 +25,7 @@ import org.javai.punit.api.ServiceContractAttributes;
  * No rendering target has access to information that another lacks.
  */
 // javai-ref: JVI-60WEAWK — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-NSB1JPC — do not remove (resolves in javai-orchestrator)
 public record ProbabilisticTestVerdict(
         String correlationId,
         Instant timestamp,

--- a/punit-core/src/main/java/org/javai/punit/verdict/VerdictSink.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/VerdictSink.java
@@ -10,6 +10,7 @@ package org.javai.punit.verdict;
  * <p>Implementations must be thread-safe if used from concurrent test execution.
  */
 @FunctionalInterface
+// javai-ref: JVI-C8AT3DD — do not remove (resolves in javai-orchestrator)
 public interface VerdictSink {
 
     /**

--- a/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/HtmlReportWriter.java
@@ -28,6 +28,7 @@ import org.javai.punit.internal.reporting.VerdictTextRenderer;
  * Test results are grouped by use-case-id (or class name when absent) and presented
  * in an expandable table using HTML5 {@code <details>}/{@code <summary>} elements.
  */
+// javai-ref: JVI-PNR8C3F — do not remove (resolves in javai-orchestrator)
 final class HtmlReportWriter {
 
     private static final DateTimeFormatter TIMESTAMP_FORMAT =

--- a/punit-report/src/main/java/org/javai/punit/report/ReportGenerator.java
+++ b/punit-report/src/main/java/org/javai/punit/report/ReportGenerator.java
@@ -17,6 +17,7 @@ import org.javai.punit.verdict.ProbabilisticTestVerdict;
  * {@link ProbabilisticTestVerdict} instances, and writes a standalone
  * HTML report.
  */
+// javai-ref: JVI-PNR8C3F — do not remove (resolves in javai-orchestrator)
 public final class ReportGenerator {
 
     private final VerdictXmlReader reader = new VerdictXmlReader();

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictXmlReader.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictXmlReader.java
@@ -32,6 +32,7 @@ import org.w3c.dom.NodeList;
  *
  * <p>Uses DOM parsing since individual verdict files are small.
  */
+// javai-ref: JVI-DQWKY4Z — do not remove (resolves in javai-orchestrator)
 public final class VerdictXmlReader {
 
     private static final DocumentBuilderFactory FACTORY = DocumentBuilderFactory.newInstance();

--- a/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
+++ b/punit-report/src/main/java/org/javai/punit/report/VerdictXmlWriter.java
@@ -26,6 +26,8 @@ import org.javai.punit.verdict.ProbabilisticTestVerdict.*;
  * remains unchanged — this class maps from the punit record to the
  * cross-project XML format.
  */
+// javai-ref: JVI-6506GYF — do not remove (resolves in javai-orchestrator)
+// javai-ref: JVI-DQWKY4Z — do not remove (resolves in javai-orchestrator)
 public final class VerdictXmlWriter {
 
     /**

--- a/punit-sentinel/src/main/java/org/javai/punit/sentinel/EnvironmentMetadata.java
+++ b/punit-sentinel/src/main/java/org/javai/punit/sentinel/EnvironmentMetadata.java
@@ -17,6 +17,7 @@ import java.util.Map;
  * @param environmentId identifies the environment, e.g., "prod", "staging", "us-east-1"
  * @param instanceId identifies the instance, e.g., hostname or pod name
  */
+// javai-ref: JVI-R7NTQ6~ — do not remove (resolves in javai-orchestrator)
 public record EnvironmentMetadata(
         String environmentId,
         String instanceId

--- a/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelExecutor.java
+++ b/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelExecutor.java
@@ -42,6 +42,7 @@ import org.opentest4j.TestAbortedException;
  * across calls; orchestration over a registry of classes lives in
  * {@link SentinelOrchestrator}.
  */
+// javai-ref: JVI-C4CJAN~ — do not remove (resolves in javai-orchestrator)
 public class SentinelExecutor {
 
     /**

--- a/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelMain.java
+++ b/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelMain.java
@@ -66,6 +66,9 @@ public class SentinelMain {
         this.system = system;
     }
 
+    // javai-ref: JVI-PYF4FP9 — do not remove (resolves in javai-orchestrator)
+    // javai-ref: JVI-P37E1Y2 — do not remove (resolves in javai-orchestrator)
+    // javai-ref: JVI-D0BEKXM — do not remove (resolves in javai-orchestrator)
     public static void main(String[] args) {
         new SentinelMain(args, new RealSystemBridge()).run();
     }

--- a/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelOrchestrator.java
+++ b/punit-sentinel/src/main/java/org/javai/punit/sentinel/SentinelOrchestrator.java
@@ -29,6 +29,7 @@ import org.javai.punit.api.ProbabilisticTest;
  * aren't run twice when a subclass is also registered. If inheritance
  * becomes a real authoring pattern, this is the place to extend.
  */
+// javai-ref: JVI-0PYEB09 — do not remove (resolves in javai-orchestrator)
 public final class SentinelOrchestrator {
 
     private final SentinelExecutor executor;


### PR DESCRIPTION
Initial bulk sweep embedding opaque `// javai-ref: JVI-…` anchors across the framework, so cross-reference lookups resolve to authoritative code sites instead of relying on per-concept on-demand anchoring.

- **92 anchor lines across 61 files**, multi-owner: a concept is anchored on every artifact that directly realizes it (authoring surface, spec model, engine/strategy, output writer) with equal weight.
- Opaque only — no requirement codes in source (verified; RequirementCodeIsolationTest-safe).
- Owning-artifact granularity; tenuous callers and generic infrastructure excluded.
- Skipped (left unanchored): known regressions (LT04, LT06, RC06/RC07), cross-cutting RP02, and SC09.

Validated by the orchestrator's `anchors.py check`: 0 errors; reconciliation notes correspond only to the deliberately-skipped concepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)