### PR TITLE
Scrub leaked requirement codes from source; close two isolation-guard gaps

### DIFF
--- a/punit-core/src/main/java/org/javai/punit/api/Sampling.java
+++ b/punit-core/src/main/java/org/javai/punit/api/Sampling.java
@@ -42,7 +42,7 @@ import org.javai.punit.api.spec.ExceptionPolicy;
  * {@code ProbabilisticTest.testing(sampling, factors)}, etc.). For
  * the measure / test pair, both call sites pass the same factors;
  * the framework's empirical-baseline resolver then matches the
- * test's factors against the measure's stored baseline (CR02).
+ * test's factors against the measure's stored baseline.
  *
  * <h2>The pair pattern at the call site</h2>
  *

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/BaselineEmitter.java
@@ -43,8 +43,8 @@ import org.javai.punit.internal.engine.covariate.CovariateResolver;
  * <p>Called from {@link PUnit.MeasureBuilder#run} after the engine
  * finishes its sampling loop. The record carries both
  * {@link PassRateStatistics} and {@link LatencyStatistics} so any
- * future empirical criterion (CR02 or CR03 today, future kinds
- * additively) can read what it needs from the same baseline file.
+ * empirical criterion — today's kinds and future ones, additively —
+ * can read what it needs from the same baseline file.
  *
  * <p>Identity fields:
  *

--- a/punit-core/src/main/java/org/javai/punit/internal/runtime/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/javai/punit/internal/runtime/VerdictAdapter.java
@@ -174,7 +174,8 @@ public final class VerdictAdapter {
         // field is only meaningful inside the JUnit context).
         b.junitPassed(true);
 
-        // Per-criterion structural decomposition (CR07 / CR09). The
+        // Per-criterion structural decomposition: the per-criterion verdict
+        // rows and the composite over them. The
         // in-memory PerCriterionEvaluation translates row-for-row into
         // the persistence-layer PerCriterionStructure. Empty
         // evaluations leave the field absent.

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdict.java
@@ -59,8 +59,9 @@ public record ProbabilisticTestVerdict(
 
     /**
      * Backward-compatible constructor for the 17-component shape that
-     * predates the per-criterion structural surface (CR09 / CR01 in
-     * the verdict XML). Defaults the per-criterion component to empty.
+     * predates the per-criterion structural surface (the composite
+     * verdict and its per-criterion rows in the verdict XML). Defaults
+     * the per-criterion component to empty.
      */
     public ProbabilisticTestVerdict(
             String correlationId,

--- a/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/javai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -115,7 +115,7 @@ public class ProbabilisticTestVerdictBuilder {
     // ── Postcondition failure histogram ───────────────────────────────────
     private Map<String, FailureCount> postconditionFailures = Map.of();
 
-    // ── Per-criterion structural decomposition (CR07 / CR09) ──────────────
+    // ── Per-criterion structural decomposition (rows + composite) ─────────
     // Optional. Populated by VerdictAdapter from
     // ProbabilisticTestResult.perCriterionEvaluation() on every normal
     // run; empty for apply-level-failure paths.

--- a/punit-core/src/test/java/org/javai/punit/architecture/RequirementCodeIsolationTest.java
+++ b/punit-core/src/test/java/org/javai/punit/architecture/RequirementCodeIsolationTest.java
@@ -29,11 +29,15 @@ import org.junit.jupiter.api.Test;
  * by its domain name, not by its tracking code.
  *
  * <p>This test walks every Java source file under the project's
- * <code>src/main/java</code> AND <code>src/test/java</code> trees and
- * asserts no requirement-style code appears anywhere - neither in code
- * nor in comments. Earlier iterations only guarded production source;
- * test sources were a back door through which codes kept leaking back
- * in, defeating the rule. The guard now scans both.
+ * <code>src/main/java</code> AND <code>src/test/java</code> trees, plus
+ * the published text resources (<code>.xsd</code> / <code>.xslt</code> /
+ * <code>.xml</code>) under <code>src/main/resources</code> and
+ * <code>src/test/resources</code>, and asserts no requirement-style code
+ * appears anywhere - neither in code, comments, nor schema/resource
+ * files. Earlier iterations only guarded production Java source; test
+ * sources, then resource files (the verdict XSDs in particular), were
+ * back doors through which codes kept leaking back in, defeating the
+ * rule. The guard now scans Java and text resources, production and test.
  *
  * <p>The one exception: this file itself necessarily mentions the
  * prefixes (in its docstring above and in the regex below) so it can
@@ -53,6 +57,7 @@ class RequirementCodeIsolationTest {
      * Letters cover every prefix currently in use across the
      * orchestrator catalog and design docs:
      * <ul>
+     *   <li>CR - criterion decomposition</li>
      *   <li>CT - conformance testing</li>
      *   <li>EX - experiments</li>
      *   <li>LT - latency dimension</li>
@@ -73,7 +78,7 @@ class RequirementCodeIsolationTest {
      * wire-format constants.
      */
     private static final Pattern REQUIREMENT_CODE = Pattern.compile(
-            "\\b(CT|EX|LT|PT|RC|RP|SC|SN|TH|UC|XM|DG)\\d{2}\\b");
+            "\\b(CR|CT|EX|LT|PT|RC|RP|SC|SN|TH|UC|XM|DG)\\d{2}\\b");
 
     /**
      * Filenames that legitimately mention the prefixes - this test
@@ -89,22 +94,43 @@ class RequirementCodeIsolationTest {
      * its CWD is .../punit/punit-core). Walk up one level to reach the
      * project root, then descend per-module.
      *
-     * <p>Both <code>src/main/java</code> and <code>src/test/java</code>
-     * are scanned. Test sources are not exempt: an orchestrator code
-     * in a {@code @DisplayName} or javadoc surfaces in build reports
-     * and IDE test panes, where an open-source reader meets it without
-     * any catalog access. The earlier production-only scope let codes
-     * leak back in through test files; the rule is now uniform.
+     * <p>Both <code>src/main</code> and <code>src/test</code> are scanned,
+     * for Java and for text resources. Neither test sources nor resource
+     * files are exempt: an orchestrator code in a {@code @DisplayName}, a
+     * javadoc, or an XSD comment surfaces in build reports, IDE test
+     * panes, and the published repository, where an open-source reader
+     * meets it without any catalog access. Earlier scopes (production
+     * only, then Java only) let codes leak back in through test files and
+     * the verdict XSDs; the rule is now uniform.
      */
     private static final List<Path> SOURCE_ROOTS = List.of(
             Paths.get("..", "punit-core", "src", "main", "java"),
             Paths.get("..", "punit-core", "src", "test", "java"),
+            Paths.get("..", "punit-core", "src", "main", "resources"),
+            Paths.get("..", "punit-core", "src", "test", "resources"),
             Paths.get("..", "punit-junit5", "src", "main", "java"),
             Paths.get("..", "punit-junit5", "src", "test", "java"),
+            Paths.get("..", "punit-junit5", "src", "main", "resources"),
+            Paths.get("..", "punit-junit5", "src", "test", "resources"),
             Paths.get("..", "punit-report", "src", "main", "java"),
             Paths.get("..", "punit-report", "src", "test", "java"),
+            Paths.get("..", "punit-report", "src", "main", "resources"),
+            Paths.get("..", "punit-report", "src", "test", "resources"),
             Paths.get("..", "punit-sentinel", "src", "main", "java"),
-            Paths.get("..", "punit-sentinel", "src", "test", "java"));
+            Paths.get("..", "punit-sentinel", "src", "test", "java"),
+            Paths.get("..", "punit-sentinel", "src", "main", "resources"),
+            Paths.get("..", "punit-sentinel", "src", "test", "resources"));
+
+    /**
+     * File extensions scanned for leaked codes: Java source plus the
+     * published text-resource formats that carry human-readable comments
+     * (the verdict XSDs, the report XSLT, and any bundled XML). Binary
+     * resources and data formats (YAML specs, {@code .properties},
+     * service files) are not scanned - lowercase wire-format constants do
+     * not match the two-uppercase-letter pattern anyway.
+     */
+    private static final List<String> SCANNED_EXTENSIONS =
+            List.of(".java", ".xsd", ".xslt", ".xml");
 
     @Test
     @DisplayName("no orchestrator-internal requirement codes appear in production or test source")
@@ -116,7 +142,7 @@ class RequirementCodeIsolationTest {
             }
             try (Stream<Path> stream = Files.walk(root)) {
                 stream
-                        .filter(p -> p.toString().endsWith(".java"))
+                        .filter(RequirementCodeIsolationTest::isScannable)
                         .filter(p -> !isSelfReferencing(p))
                         .forEach(file -> scanFile(file, hits));
             }
@@ -131,6 +157,11 @@ class RequirementCodeIsolationTest {
                         + "earlier iterations only scanned production, and codes kept "
                         + "leaking back in through test files.")
                 .isEmpty();
+    }
+
+    private static boolean isScannable(Path file) {
+        String name = file.toString();
+        return SCANNED_EXTENSIONS.stream().anyMatch(name::endsWith);
     }
 
     private static boolean isSelfReferencing(Path file) {

--- a/punit-report/src/main/resources/org/javai/punit/report/verdict-1.0.xsd
+++ b/punit-report/src/main/resources/org/javai/punit/report/verdict-1.0.xsd
@@ -84,7 +84,7 @@
 
   <!-- ===================================================================
        Factor bundle (FT instance the test ran under; shape-symmetric
-       with EX04 baseline factors:)
+       with the baseline factors block)
        =================================================================== -->
 
   <xs:complexType name="FactorsType">

--- a/punit-report/src/main/resources/org/javai/punit/report/verdict-1.1.xsd
+++ b/punit-report/src/main/resources/org/javai/punit/report/verdict-1.1.xsd
@@ -89,7 +89,7 @@
 
   <!-- ===================================================================
        Factor bundle (FT instance the test ran under; shape-symmetric
-       with EX04 baseline factors:)
+       with the baseline factors block)
        =================================================================== -->
 
   <xs:complexType name="FactorsType">
@@ -422,8 +422,8 @@
   <!-- ===================================================================
        Per-criterion methodology-level decomposition (1.1 addition)
 
-       Carries the per-criterion three-valued aggregate verdicts (CR07),
-       the composite verdict over them (CR09), and — during the
+       Carries each criterion's three-valued aggregate verdict,
+       the composite verdict over them, and — during the
        cutover's transitional window — the pre-cutover legacy aggregate.
 
        The bundle is optional under <verdict-record>. Present when the

--- a/punit-report/src/main/resources/org/javai/punit/report/verdict-1.2.xsd
+++ b/punit-report/src/main/resources/org/javai/punit/report/verdict-1.2.xsd
@@ -96,7 +96,7 @@
 
   <!-- ===================================================================
        Factor bundle (FT instance the test ran under; shape-symmetric
-       with EX04 baseline factors:)
+       with the baseline factors block)
        =================================================================== -->
 
   <xs:complexType name="FactorsType">
@@ -430,8 +430,8 @@
        Per-criterion methodology-level decomposition (1.1 addition,
        1.2 refinement)
 
-       Carries the per-criterion three-valued aggregate verdicts (CR07)
-       and the composite verdict over them (CR09).
+       Carries each criterion's three-valued aggregate verdict
+       and the composite verdict over them.
 
        The bundle is optional under <verdict-record>. Present when the
        producing run had per-criterion data (every normal run on every


### PR DESCRIPTION
`RequirementCodeIsolationTest` had **two blind spots** that let orchestrator-internal tracking codes sit in published source undetected:

1. **The regex omitted the `CR` prefix.** The alternation was `(CT|EX|LT|PT|RC|RP|SC|SN|TH|UC|XM|DG)` — no `CR` (criterion-decomposition). So every `CR0x` reference was invisible *everywhere*, including in `.java`.
2. **It never scanned resources.** Only `.java` under `src/main/java`/`src/test/java` was walked, so the verdict XSD comments were unchecked.

## Scrub (domain language, no codes)
- **`.java`**: `BaselineEmitter`, `VerdictAdapter`, `ProbabilisticTestVerdictBuilder`, `ProbabilisticTestVerdict`, `Sampling` — `CR0x` mentions in comments/javadoc reworded to plain description.
- **`verdict-1.0/1.1/1.2.xsd`**: `EX04` in the factor-bundle comment; `CR07`/`CR09` in the per-criterion comment block. The surrounding prose already names the concepts.

Each concept remains bound to its **owning** artifact via its existing opaque `// javai-ref:` anchor (verified with `anchors.py report`) — `CriterionRow`, `ProbabilisticTestVerdict`, `NamedPostcondition`, `CriterionDecl`, `BaselineEmitter`, `VerdictXmlWriter`/`Reader`. The scrubbed lines were *secondary* mentions, not owning sites, so no anchors move (owning-artifact granularity = one opaque line per owner, not per mention).

## Harden the guard
- Add `CR` to the prefix regex.
- Scan `src/main/resources` + `src/test/resources` for `.xsd`/`.xslt`/`.xml` as well as `.java`.

`./gradlew :punit-core:test --tests "*RequirementCodeIsolationTest"` → **PASSED** (the hardened guard is green against the scrubbed tree, and would now fail on either leak class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)