### PR TITLE
Flip residual javai→mavai references

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@ PUnit
 Copyright 2026 Mike Mannion
 
 This product includes software developed by Mike Mannion and the
-javai project contributors (https://javai.org).
+mavai project contributors (https://mavai.org).
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This runs 100 samples against the contract's declared criteria — a 95% pass-ra
 
 ## Examples
 
-Find many examples in the [punitexamples repository](https://github.com/javai-org/punitexamples).
+Find many examples in the [punitexamples repository](https://github.com/mavai-org/punitexamples).
 
 ## Documentation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,7 +155,7 @@ tasks.jar {
         attributes(
             "Implementation-Title" to "PUNIT - Probabilistic Unit Testing Framework",
             "Implementation-Version" to project.version,
-            "Implementation-Vendor" to "javai.org",
+            "Implementation-Vendor" to "mavai.org",
             "Automatic-Module-Name" to "org.mavai.punit"
         )
     }

--- a/docs/DEVELOPER-API.md
+++ b/docs/DEVELOPER-API.md
@@ -705,9 +705,9 @@ feotest the equivalent is idiomatic `Result<T, E>`.
 
 ## Verdict XML wire format
 
-punit serialises every Verdict to XML using the javai.org family's
+punit serialises every Verdict to XML using the mavai.org family's
 **verdict-XML interchange standard** (cross-language: punit,
-feotest, javai.org sentinels and dashboards all read and write this
+feotest, mavai.org sentinels and dashboards all read and write this
 format):
 
 - **XSD schema:** `punit-report/src/main/resources/org/mavai/punit/report/verdict-1.0.xsd`.
@@ -722,7 +722,7 @@ context).
 
 When modifying the XML format:
 
-- Schema semantics are shared across the javai.org framework
+- Schema semantics are shared across the mavai.org framework
   family — coordinate cross-framework before changing punit's
   copy in isolation.
 - `<statistics>` carries `wilson-lower` only — the one-sided Wilson

--- a/docs/DISTRIBUTIONAL-CONTRACTS.md
+++ b/docs/DISTRIBUTIONAL-CONTRACTS.md
@@ -3,7 +3,7 @@
 > **This document has moved.**
 >
 > The Distributional Contracts paper is now maintained as part of the
-> [javai-R](https://github.com/javai-org/javai-R) project, where it serves as
-> the theoretical foundation for the entire javai methodology — not just punit.
+> [mavai-R](https://github.com/mavai-org/mavai-R) project, where it serves as
+> the theoretical foundation for the entire mavai methodology — not just punit.
 >
-> **New location**: https://r.javai.org/
+> **New location**: https://r.mavai.org/

--- a/docs/DOMAIN-ONTOLOGY.md
+++ b/docs/DOMAIN-ONTOLOGY.md
@@ -1,6 +1,6 @@
 # punit Domain Ontology
 
-This document maps the javai.org framework family's shared domain
+This document maps the mavai.org framework family's shared domain
 concepts onto punit's Java idioms, packages, and types. It is the
 conceptual counterpart to [`DEVELOPER-API.md`](DEVELOPER-API.md) —
 together they form punit's spec for "what the framework looks like
@@ -86,9 +86,9 @@ ArchUnit-style architecture test).
   gotchas:
     - Drop the `with_` prefix on builder/fluent factor methods
       (project-wide rule — see cross-framework ontology assistant guidance).
-    - **Term to avoid: "factor level".** The canonical javai term
+    - **Term to avoid: "factor level".** The canonical mavai term
       is "factor value". "Factor level" survives only in
-      `javai-R/docs/GLOSSARY.md` as a Design-of-Experiments nod.
+      `mavai-R/docs/GLOSSARY.md` as a Design-of-Experiments nod.
       Two javadoc surfaces in `Factor.java` and `Config.java` still
       use "factor levels" — sweep when next editing those files.
 
@@ -484,7 +484,7 @@ ArchUnit-style architecture test).
     `punit-report` module. XSD shipped at
     `punit-report/src/main/resources/.../verdict-1.0.xsd`. Must
     diff clean against the cross-framework canonical XSD shared
-    with feotest and javai.org sentinels / dashboards.
+    with feotest and mavai.org sentinels / dashboards.
   gotchas:
     - Emits `wilson-lower` only on `<statistics>`; the upper bound
       is not emitted (the verdict path is left-tailed). Aligned to
@@ -718,7 +718,7 @@ lands, current violations are captured in `archunit_store/` via
     - punit-core/.../api/Factor.java:13
     - punit-core/.../api/Config.java:8
   fix: |
-    Replace with "factor values". The canonical javai term is
+    Replace with "factor values". The canonical mavai term is
     "factor value" (family ambiguous-terms entry "Factor Level").
   scope: editorial; sweep when next editing those files.
 
@@ -760,7 +760,7 @@ lands, current violations are captured in `archunit_store/` via
   are owned upstream. This document records *how punit enforces*
   each invariant, not what each invariant says.
 - **It does not duplicate the glossary.** Concept definitions live
-  in `javai-R/docs/GLOSSARY.md`. This document maps each
+  in `mavai-R/docs/GLOSSARY.md`. This document maps each
   glossary-defined concept onto a Java type / package / idiom.
 - **It does not restate methodology.** Statistical formulae live
   in the Statistical Companion; this document references the

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -3,13 +3,13 @@
 > **This document has moved.**
 >
 > The Glossary is now maintained as part of the
-> [javai-R](https://github.com/javai-org/javai-R) project, where it serves as
-> the shared terminology reference for the entire javai methodology — not just
+> [mavai-R](https://github.com/mavai-org/mavai-R) project, where it serves as
+> the shared terminology reference for the entire mavai methodology — not just
 > punit.
 >
-> **New location**: https://r.javai.org/
+> **New location**: https://r.mavai.org/
 >
-> **Source**: https://github.com/javai-org/javai-R/blob/main/docs/GLOSSARY.md
+> **Source**: https://github.com/mavai-org/mavai-R/blob/main/docs/GLOSSARY.md
 >
 > The glossary has been generalised to use framework-agnostic terminology.
 > PUnit-specific annotations and class names are documented in punit's own

--- a/docs/OPERATIONAL-FLOW.md
+++ b/docs/OPERATIONAL-FLOW.md
@@ -176,7 +176,7 @@ void thresholdFirst() {
 | Minimizing risk (safety, compliance) | Confidence-First  | "We need to detect this regression at this power. How many samples?"           |
 | Honouring a contractual target       | Threshold-First   | "The SLA says 0.99. Pass iff observed beats it."                               |
 
-> **Working example:** See [`ShoppingBasketThresholdApproachesTest`](https://github.com/javai-org/punitexamples/blob/main/src/test/java/org/javai/punit/examples/probabilistictests/ShoppingBasketThresholdApproachesTest.java) in punitexamples for a complete demonstration of all three approaches.
+> **Working example:** See [`ShoppingBasketThresholdApproachesTest`](https://github.com/mavai-org/punitexamples/blob/main/src/test/java/org/mavai/punit/examples/probabilistictests/ShoppingBasketThresholdApproachesTest.java) in punitexamples for a complete demonstration of all three approaches.
 
 ---
 

--- a/docs/STATISTICAL-COMPANION.md
+++ b/docs/STATISTICAL-COMPANION.md
@@ -3,8 +3,8 @@
 > **This document has moved.**
 >
 > The Statistical Companion is now maintained as part of the
-> [javai-R](https://github.com/javai-org/javai-R) project, where it serves as
-> the formal statistical foundation for the entire javai methodology — not just
+> [mavai-R](https://github.com/mavai-org/mavai-R) project, where it serves as
+> the formal statistical foundation for the entire mavai methodology — not just
 > punit.
 >
-> **New location**: https://r.javai.org/
+> **New location**: https://r.mavai.org/

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -95,7 +95,7 @@ It provides:
    power analysis for sample sizing, qualified verdicts.
 
 The mathematical foundations live in the
-[Statistical Companion Document](https://r.javai.org/statistical-companion.pdf);
+[Statistical Companion Document](https://r.mavai.org/statistical-companion.pdf);
 this guide stays at the engineering level, with pointers into the
 companion where a reader wants the proof.
 
@@ -1097,7 +1097,7 @@ are not comparable with successful ones (a fast validation rejection
 and a slow timeout both reflect *error paths*, not the latency of
 successful operation), so latency is conditioned on `X = 1` —
 successful samples only. This is the **tripartite-contract
-decomposition** the [statistical companion §12.2.1](https://r.javai.org/statistical-companion.pdf)
+decomposition** the [statistical companion §12.2.1](https://r.mavai.org/statistical-companion.pdf)
 formalises: correctness, availability, and latency-given-success are
 three orthogonal sub-contracts evaluated independently.
 
@@ -1176,7 +1176,7 @@ Three properties matter:
 - **Integer-millisecond** — the threshold is an observed value,
   aligning with how SLA targets are written and compared.
 
-[Statistical companion §12.4](https://r.javai.org/statistical-companion.pdf)
+[Statistical companion §12.4](https://r.mavai.org/statistical-companion.pdf)
 develops the construction with proofs; the implementation lives in
 `org.mavai.punit.statistics.LatencyThresholdDeriver`.
 
@@ -1556,7 +1556,7 @@ to the **RP07 javai verdict interchange standard**:
 The schema covers identity, verdict, criterion results, sample
 counts, latency percentiles, baseline expiration, environment
 metadata, contract reference, and correlation id. The verdict XML is
-the one format that flows between punit, feotest, and javai.org —
+the one format that flows between punit, feotest, and mavai.org —
 sentinels and dashboards consume it without caring which framework
 produced it.
 
@@ -1569,7 +1569,7 @@ Configuration: set the output directory via system property
 
 This section is a brief tour of what PUnit computes and where it
 lives. The comprehensive treatment is the
-[Statistical Companion Document](https://r.javai.org/statistical-companion.pdf);
+[Statistical Companion Document](https://r.mavai.org/statistical-companion.pdf);
 the implementation lives in the ArchUnit-isolated
 `org.mavai.punit.statistics` package, which has no dependencies on
 any other punit package so the statistical core can be audited
@@ -1595,7 +1595,7 @@ p_lower  =  ──────────────────────�
 Wilson is used everywhere — small samples, extreme proportions, the
 boundary case `p̂ = 1`. There is no method-switching: the same
 formula handles every case correctly. Conformance against the
-R-generated reference data (`javai-R/inst/cases/wilson_*.json`) is
+R-generated reference data (`mavai-R/inst/cases/wilson_*.json`) is
 verified on every build.
 
 For empirical thresholds: the test passes iff the run's Wilson lower
@@ -1679,12 +1679,12 @@ author can either bump samples or rethink the threshold.
 ### Further reading
 
 Mathematical foundations:
-[Statistical Companion Document](https://r.javai.org/statistical-companion.pdf).
+[Statistical Companion Document](https://r.mavai.org/statistical-companion.pdf).
 
-Cross-language conformance: every javai framework (punit, feotest,
+Cross-language conformance: every mavai framework (punit, feotest,
 baseltest) reproduces the R-generated reference data within stated
 tolerances. The conformance machinery is documented in the
-`javai-R` project README.
+`mavai-R` project README.
 
 ---
 
@@ -1841,5 +1841,5 @@ boundary `p̂ = 1`.
 
 *Last reviewed: 2026-05-03. The mathematical foundations are
 maintained separately as the
-[Statistical Companion Document](https://r.javai.org/statistical-companion.pdf);
+[Statistical Companion Document](https://r.mavai.org/statistical-companion.pdf);
 this guide stays at the engineering level.*

--- a/punit-core/build.gradle.kts
+++ b/punit-core/build.gradle.kts
@@ -83,8 +83,8 @@ dependencies {
     testImplementation(project(":punit-report"))
 }
 
-// --- javai-R conformance reference data ----------------------------------------
-// Fetches the latest javai-R release (resolved via the GitHub /releases/latest
+// --- mavai-R conformance reference data ----------------------------------------
+// Fetches the latest mavai-R release (resolved via the GitHub /releases/latest
 // redirect, which costs no API-rate-limit quota), downloads its cases-<tag>.zip
 // asset, caches it keyed by tag, and extracts into a directory on the test
 // classpath so that /conformance/*.json resolves.
@@ -92,7 +92,7 @@ dependencies {
 val conformanceResourcesDir = layout.buildDirectory.dir("generated/conformance")
 
 val fetchConformanceData by tasks.registering {
-    description = "Fetches the latest javai-R conformance reference data release"
+    description = "Fetches the latest mavai-R conformance reference data release"
     group = "verification"
 
     outputs.dir(conformanceResourcesDir)
@@ -135,7 +135,7 @@ val fetchConformanceData by tasks.registering {
             from(zipTree(cacheZip))
             into(destDir)
         }
-        logger.lifecycle("Fetched javai-R conformance fixtures: $tag")
+        logger.lifecycle("Fetched mavai-R conformance fixtures: $tag")
     }
 }
 
@@ -154,7 +154,7 @@ tasks.jar {
         attributes(
             "Implementation-Title" to "PUnit",
             "Implementation-Version" to project.version,
-            "Implementation-Vendor" to "javai.org",
+            "Implementation-Vendor" to "mavai.org",
             "Automatic-Module-Name" to "org.mavai.punit.core"
         )
     }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/LatencyPercentileComputer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/LatencyPercentileComputer.java
@@ -14,7 +14,7 @@ import org.mavai.punit.statistics.LatencyStatistics;
  * <p>Computation delegates to
  * {@link LatencyStatistics#nearestRankPercentile(double[], double)}
  * — the R-compatible nearest-rank percentile, so conformance with
- * the javai-R oracle is preserved.
+ * the mavai-R oracle is preserved.
  *
  * <p>This bridge lives in {@code punit-core} rather than
  * {@code api package} to keep the {@code commons-statistics} dependency

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/spec/model/LatencyBaseline.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/spec/model/LatencyBaseline.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * <p>This record carries the full sorted vector of successful-response latencies
  * (in milliseconds) alongside the mean and maximum for reporting. The sorted
  * vector is the canonical storage format required by the exact binomial
- * order-statistic threshold derivation (javai-R STATISTICAL-COMPANION v1.1
+ * order-statistic threshold derivation (mavai-R STATISTICAL-COMPANION v1.1
  * &sect;12.4): thresholds are the {@code k}-th order statistic of this vector
  * for a rank {@code k} computed from the binomial upper confidence bound on
  * the baseline percentile.

--- a/punit-core/src/main/java/org/mavai/punit/statistics/LatencyStatistics.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/LatencyStatistics.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * <p>This class provides the fundamental statistical operations for latency
  * analysis at full floating-point precision: nearest-rank percentile, mean,
  * and maximum. These operations underpin the framework's latency dimension
- * and are validated against javai-R reference data in the conformance test
+ * and are validated against mavai-R reference data in the conformance test
  * suite.
  *
  * <p>Percentiles use the nearest-rank (ceiling) method to match R's

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyConformanceTest.java
@@ -42,9 +42,9 @@ import static org.assertj.core.api.Assertions.within;
  * Conformance tests for latency statistics: empirical percentile estimation,
  * summary statistics, and threshold derivation from baseline data.
  *
- * @see <a href="https://github.com/javai-org/javai-R">javai-R</a>
+ * @see <a href="https://github.com/mavai-org/mavai-R">mavai-R</a>
  */
-@DisplayName("Latency conformance (javai-R)")
+@DisplayName("Latency conformance (mavai-R)")
 class LatencyConformanceTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ProportionConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ProportionConformanceTest.java
@@ -30,9 +30,9 @@ import static org.assertj.core.api.Assertions.within;
  * Conformance tests for binomial proportion statistics: Wilson score intervals,
  * threshold derivation, power analysis, feasibility, and verdict evaluation.
  *
- * @see <a href="https://github.com/javai-org/javai-R">javai-R</a>
+ * @see <a href="https://github.com/mavai-org/mavai-R">mavai-R</a>
  */
-@DisplayName("Proportion conformance (javai-R)")
+@DisplayName("Proportion conformance (mavai-R)")
 class ProportionConformanceTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/package-info.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/package-info.java
@@ -1,21 +1,21 @@
 /**
  * Conformance tests validating punit's statistics engine against canonical
- * reference data published by javai-R.
+ * reference data published by mavai-R.
  *
- * <p>javai-R generates expected outputs using R's well-vetted statistical
+ * <p>mavai-R generates expected outputs using R's well-vetted statistical
  * functions. The tests in this package ensure that punit's Java implementations
  * produce identical results within stated tolerances, guaranteeing statistical
- * equivalence across all javai framework implementations (punit, feotest,
+ * equivalence across all mavai framework implementations (punit, feotest,
  * and future frameworks).
  *
  * <p>Each JSON suite declares its own tolerance. Tests use the declared
  * tolerance — not a hardcoded value — so that tolerance decisions are owned
- * by javai-R, not by individual frameworks.
+ * by mavai-R, not by individual frameworks.
  *
- * <p>This package is the foundation of javai's statistical integrity. If a
+ * <p>This package is the foundation of mavai's statistical integrity. If a
  * conformance test fails, the framework's statistical guarantees are in question
  * and the failure must be resolved before release.
  *
- * @see <a href="https://github.com/javai-org/javai-R">javai-R — the statistical oracle</a>
+ * @see <a href="https://github.com/mavai-org/mavai-R">mavai-R — the statistical oracle</a>
  */
 package org.mavai.punit.statistics.conformance;

--- a/punit-report/build.gradle.kts
+++ b/punit-report/build.gradle.kts
@@ -19,7 +19,7 @@ tasks.jar {
         attributes(
             "Implementation-Title" to "PUnit Report",
             "Implementation-Version" to project.version,
-            "Implementation-Vendor" to "javai.org",
+            "Implementation-Vendor" to "mavai.org",
             "Automatic-Module-Name" to "org.mavai.punit.report"
         )
     }

--- a/punit-report/src/test/java/org/mavai/punit/report/conformance/VerdictXmlConformanceTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/conformance/VerdictXmlConformanceTest.java
@@ -49,7 +49,7 @@ import org.xmlunit.diff.DifferenceEvaluators;
 /**
  * Cross-framework conformance test for the verdict-XML interchange
  * wire format. For each canonical fixture case published by the
- * javai.org product family's verdict-XML reference suite, builds a
+ * mavai.org product family's verdict-XML reference suite, builds a
  * verdict matching the case's semantics, serialises it via
  * {@link VerdictXmlWriter}, and asserts the result is structurally
  * equivalent to the case's canonical {@code expected.xml}.

--- a/punit-sentinel/build.gradle.kts
+++ b/punit-sentinel/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.jar {
         attributes(
             "Implementation-Title" to "PUnit Sentinel",
             "Implementation-Version" to project.version,
-            "Implementation-Vendor" to "javai.org",
+            "Implementation-Vendor" to "mavai.org",
             "Automatic-Module-Name" to "org.mavai.punit.sentinel"
         )
     }


### PR DESCRIPTION
Tail of the javai→mavai brand rename — residuals missed by earlier waves.

**Changed**
- jar-manifest `Implementation-Vendor` → `mavai.org` (4 build files)
- `NOTICE` → mavai project / mavai.org
- oracle references → `mavai-R` (build comments, conformance tests, package-info, Latency* javadoc)
- `r.javai.org` doc links → `r.mavai.org`; brand prose across 8 docs
- fixed a broken source deep-link (`org/javai/punit/examples` → `org/mavai/punit/examples`)

**Retained (separate decisions, untouched)**
- `http://javai.org/verdict/1.0` XML namespace
- the `// javai-ref:` anchor token
- the `RP07 javai verdict` line (coupled to the namespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)