### PR TITLE
Verdict XML namespace: javai.org → mavai.org (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-08
+
+### Changed
+
+- **Verdict-XML namespace `http://javai.org/verdict/1.0` →
+  `http://mavai.org/verdict/1.0` (breaking interchange change).** The
+  verdict-XML wire namespace moves off `javai.org` to complete the family
+  rename. The writer emits, and the reader accepts, only the `mavai.org`
+  namespace — documents in the old namespace are no longer read. Only the
+  namespace host changes; the schema shape and all schema versions
+  (1.0 / 1.1 / 1.2) are unchanged. Consumers parsing the verdict XML by
+  namespace must update. (Released as a patch version by project decision
+  despite the breaking nature.)
+
 ## [0.9.0] - 2026-05-29
 
 ### Changed

--- a/docs/DEVELOPER-API.md
+++ b/docs/DEVELOPER-API.md
@@ -711,7 +711,7 @@ feotest, mavai.org sentinels and dashboards all read and write this
 format):
 
 - **XSD schema:** `punit-report/src/main/resources/org/mavai/punit/report/verdict-1.0.xsd`.
-- **Namespace:** `http://javai.org/verdict/1.0`.
+- **Namespace:** `http://mavai.org/verdict/1.0`.
 - **Root element:** `<verdict-record>`.
 
 The standard includes pacing, environment metadata, baseline

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1549,7 +1549,7 @@ Output: `build/reports/punit/index.html`. The report shows, per test:
 Every probabilistic test verdict serialises to an XML file conforming
 to the **RP07 javai verdict interchange standard**:
 
-- Namespace: `http://javai.org/verdict/1.0`
+- Namespace: `http://mavai.org/verdict/1.0`
 - Root: `<verdict-record>`
 - Schema: `verdict-1.0.xsd` (bundled in `punit-report`).
 

--- a/punit-core/src/test/java/org/mavai/punit/junit5/PUnitVerdictXmlEmissionIntegrationTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/junit5/PUnitVerdictXmlEmissionIntegrationTest.java
@@ -65,7 +65,7 @@ class PUnitVerdictXmlEmissionIntegrationTest {
 
         String xml = Files.readString(expected);
         assertThat(xml).contains("<verdict-record")
-                .contains("xmlns=\"http://javai.org/verdict/1.0\"")
+                .contains("xmlns=\"http://mavai.org/verdict/1.0\"")
                 .contains("test-name=\"passes\"")
                 .contains("value=\"PASS\"");
     }

--- a/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlReader.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlReader.java
@@ -26,7 +26,7 @@ import org.w3c.dom.NodeList;
 /**
  * Deserialises a {@link ProbabilisticTestVerdict} from verdict XML.
  *
- * <p>Reads the {@code http://javai.org/verdict/1.0} format and maps it back
+ * <p>Reads the {@code http://mavai.org/verdict/1.0} format and maps it back
  * to the punit verdict model. PUnit-specific fields not present in the verdict-XML standard
  * (pacing, environment, expiration, correlation ID) receive default values.
  *

--- a/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlWriter.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlWriter.java
@@ -16,7 +16,7 @@ import org.mavai.punit.verdict.ProbabilisticTestVerdict.*;
  * Serialises a {@link ProbabilisticTestVerdict} to the verdict XML
  * interchange format.
  *
- * <p>The output conforms to the {@code http://javai.org/verdict/1.0}
+ * <p>The output conforms to the {@code http://mavai.org/verdict/1.0}
  * namespace and the {@code verdict-1.0.xsd} schema bundled with this
  * module.
  *
@@ -33,7 +33,7 @@ public final class VerdictXmlWriter {
     /**
      * standard namespace.
      */
-    static final String NAMESPACE = "http://javai.org/verdict/1.0";
+    static final String NAMESPACE = "http://mavai.org/verdict/1.0";
     static final String VERSION_1_0 = "1.0";
     static final String VERSION_1_2 = "1.2";
 

--- a/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.0.xsd
+++ b/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.0.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:tns="http://javai.org/verdict/1.0"
-           targetNamespace="http://javai.org/verdict/1.0"
+           xmlns:tns="http://mavai.org/verdict/1.0"
+           targetNamespace="http://mavai.org/verdict/1.0"
            elementFormDefault="qualified">
 
   <!-- ===================================================================

--- a/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.1.xsd
+++ b/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.1.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:tns="http://javai.org/verdict/1.0"
-           targetNamespace="http://javai.org/verdict/1.0"
+           xmlns:tns="http://mavai.org/verdict/1.0"
+           targetNamespace="http://mavai.org/verdict/1.0"
            elementFormDefault="qualified">
 
   <!-- ===================================================================

--- a/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.2.xsd
+++ b/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.2.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:tns="http://javai.org/verdict/1.0"
-           targetNamespace="http://javai.org/verdict/1.0"
+           xmlns:tns="http://mavai.org/verdict/1.0"
+           targetNamespace="http://mavai.org/verdict/1.0"
            elementFormDefault="qualified">
 
   <!-- ===================================================================

--- a/punit-report/src/test/java/org/mavai/punit/report/VerdictXmlReaderTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/VerdictXmlReaderTest.java
@@ -451,7 +451,7 @@ class VerdictXmlReaderTest {
             // bundle without surprise; the legacy element is silently
             // discarded.
             String xml = """
-                    <verdict-record xmlns="http://javai.org/verdict/1.0"
+                    <verdict-record xmlns="http://mavai.org/verdict/1.0"
                                     version="1.1"
                                     timestamp="2026-03-11T14:30:00Z"
                                     generator="test">

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/README.md
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/README.md
@@ -37,7 +37,7 @@ don't must canonicalise first.
 - Each element starts on its own line; attributes after the first
   are indented to align with the first attribute on the opening
   tag's continuation line.
-- The default namespace `http://javai.org/verdict/1.0` is declared
+- The default namespace `http://mavai.org/verdict/1.0` is declared
   on the root `<verdict-record>` element only; no prefix
   declarations on descendant elements.
 - Attributes appear in schema declaration order (the order they

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/fail_with_statistical_analysis/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/fail_with_statistical_analysis/expected.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<verdict-record xmlns="http://javai.org/verdict/1.0"
+<verdict-record xmlns="http://mavai.org/verdict/1.0"
                 version="1.0"
                 timestamp="2026-05-11T12:00:00Z"
                 generator="punit"

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/inconclusive_covariate_misalignment/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/inconclusive_covariate_misalignment/expected.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<verdict-record xmlns="http://javai.org/verdict/1.0"
+<verdict-record xmlns="http://mavai.org/verdict/1.0"
                 version="1.0"
                 timestamp="2026-05-11T12:00:00Z"
                 generator="punit"

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/pass_baseline_derived_threshold/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/pass_baseline_derived_threshold/expected.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<verdict-record xmlns="http://javai.org/verdict/1.0"
+<verdict-record xmlns="http://mavai.org/verdict/1.0"
                 version="1.0"
                 timestamp="2026-05-11T12:00:00Z"
                 generator="punit"

--- a/punit-report/src/test/resources/rp07-conformance-fixtures/pass_functional_and_latency/expected.xml
+++ b/punit-report/src/test/resources/rp07-conformance-fixtures/pass_functional_and_latency/expected.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<verdict-record xmlns="http://javai.org/verdict/1.0"
+<verdict-record xmlns="http://mavai.org/verdict/1.0"
                 version="1.0"
                 timestamp="2026-05-11T12:00:00Z"
                 generator="punit"


### PR DESCRIPTION
Implements **DIR-VERDICT-NAMESPACE-MAVAI-family** for punit — the deferred verdict-XML namespace carve-out from the family rename.

## What

Hard cutover of the verdict-XML wire namespace:

```
http://javai.org/verdict/1.0  →  http://mavai.org/verdict/1.0
```

Host swap only — schema shape and all schema versions (1.0 / 1.1 / 1.2) unchanged.

- `VerdictXmlWriter.NAMESPACE` (the reader follows it via `getElementsByTagNameNS`)
- the three XSDs' `targetNamespace` + `xmlns:tns`
- `VerdictXmlReaderTest` inline XML + the four rp07 conformance fixtures + the emission integration test
- USER-GUIDE / DEVELOPER-API namespace lines
- CHANGELOG `[0.9.1]` breaking entry (the `[0.9.0]` historical "namespace deliberately unchanged" note is preserved)

**Hard cutover**: documents in the old namespace are no longer read. Breaking for any consumer parsing the verdict XML by namespace.

## Versioning

Released as **0.9.1** (patch) by project decision, despite the breaking nature — see the CHANGELOG note. Ships in lockstep with feotest's equivalent change.

## Verification

`./gradlew publishToMavenLocal -Psigning.skip=true && ./gradlew build` — green (verdict-XML reader, rp07 conformance, and emission integration tests all pass against the new namespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)