### PR TITLE
Publish punit-gradle-plugin to Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -317,6 +317,12 @@ tasks.register("release") {
         logger.lifecycle("Publishing $ver to Maven Central...")
         try {
             runCommand("./gradlew", "publishAndReleaseToMavenCentral")
+            // The Gradle plugin lives in a standalone includeBuild, so the root
+            // publish above never reaches it. Publish it explicitly so the
+            // org.mavai.punit plugin and its marker ship with every release —
+            // otherwise a standalone consumer cannot resolve the plugin.
+            logger.lifecycle("Publishing punit-gradle-plugin $ver to Maven Central...")
+            runCommand("./gradlew", ":punit-gradle-plugin:publishAndReleaseToMavenCentral")
         } catch (e: Exception) {
             logger.lifecycle("Publishing failed — removing local tag $tag")
             runCommand("git", "tag", "-d", tag)

--- a/punit-gradle-plugin/build.gradle.kts
+++ b/punit-gradle-plugin/build.gradle.kts
@@ -1,10 +1,22 @@
 plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
+    id("signing")
+    id("com.vanniktech.maven.publish") version "0.36.0"
 }
 
 group = "org.mavai"
 version = property("punitVersion") as String
+
+signing {
+    useGpgCmd()
+}
+
+if (project.hasProperty("signing.skip")) {
+    tasks.matching { it.name.startsWith("sign") }.configureEach {
+        enabled = false
+    }
+}
 
 repositories {
     mavenCentral()
@@ -17,6 +29,44 @@ gradlePlugin {
             implementationClass = "org.mavai.punit.gradle.PUnitPlugin"
             displayName = "PUnit Gradle Plugin"
             description = "Configures test and experiment tasks for PUnit probabilistic testing"
+        }
+    }
+}
+
+// Publish the plugin (and its auto-generated `org.mavai.punit.gradle.plugin`
+// marker) to Maven Central, so a standalone consumer can resolve the plugin
+// without a sibling `../punit` checkout. The `java-gradle-plugin` plugin
+// creates the marker publication; vanniktech signs and uploads both.
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    coordinates("org.mavai", "punit-gradle-plugin", version.toString())
+
+    pom {
+        name.set("PUnit Gradle Plugin")
+        description.set("Configures test and experiment tasks for PUnit probabilistic testing")
+        url.set("https://github.com/mavai-org/punit")
+
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("mikemannion")
+                name.set("Michael Franz Mannion")
+                email.set("michaelmannion@me.com")
+            }
+        }
+
+        scm {
+            url.set("https://github.com/mavai-org/punit")
+            connection.set("scm:git:git://github.com/mavai-org/punit.git")
+            developerConnection.set("scm:git:ssh://github.com/mavai-org/punit.git")
         }
     }
 }


### PR DESCRIPTION
## Problem

The `org.mavai.punit` Gradle plugin was never published anywhere. A standalone clone of a consumer (e.g. `punitexamples`) cannot resolve it: the plugin marker 404s on both the Gradle Plugin Portal and Maven Central, and the composite-build fallback in `settings.gradle.kts` only works inside the multi-repo workspace where `../punit` exists. Outside contributors hit "Plugin not found" on a fresh clone.

Every other framework artifact (`punit-core`, `punit-report`, `punit-sentinel`, `punit`, `outcome`) is already on Maven Central at 0.9.0/0.9.1 — the plugin was the only gap.

## Root cause

`punit-gradle-plugin` is a standalone `includeBuild` with no publishing configuration, so the root `publishAndReleaseToMavenCentral` never reached it.

## Changes

- Add vanniktech Central publishing + GPG signing to `punit-gradle-plugin/build.gradle.kts`, mirroring the root pattern. For a `java-gradle-plugin` project this ships **both** `org.mavai:punit-gradle-plugin` and the `org.mavai.punit.gradle.plugin` marker (the artifact that was 404ing).
- Wire `:punit-gradle-plugin:publishAndReleaseToMavenCentral` into the root `release` task so the plugin ships with every release and cannot silently fall behind again.

## Validation

`:punit-gradle-plugin:publishToMavenLocal` at `-PpunitVersion=0.9.0` succeeds, producing both the plugin and marker publications with `PUnitVersion=0.9.0` baked into the jar.

## Follow-up (manual, irreversible)

A one-time backfill is still needed to put 0.9.0 on Central so existing clones build now:
`./gradlew -PpunitVersion=0.9.0 :punit-gradle-plugin:publishAndReleaseToMavenCentral`

🤖 Generated with [Claude Code](https://claude.com/claude-code)