### PR TITLE
Pin punit-gradle-plugin to Java 21

### DIFF
--- a/punit-gradle-plugin/build.gradle.kts
+++ b/punit-gradle-plugin/build.gradle.kts
@@ -8,6 +8,15 @@ plugins {
 group = "org.mavai"
 version = property("punitVersion") as String
 
+// Target Java 21, matching the framework modules. Without this the plugin
+// compiles against whatever JDK the release machine defaults to and stamps
+// that version into the published Gradle Module Metadata (`org.gradle.jvm.version`),
+// which makes the plugin unresolvable for Java 21 consumers.
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
 signing {
     useGpgCmd()
 }


### PR DESCRIPTION
Follow-up to #222.

#222 added Maven Central publishing for the Gradle plugin, but the plugin subproject has no Java target pin (unlike the framework modules). Built on a JDK 25 release machine, it stamped `org.gradle.jvm.version=25` into the published Gradle Module Metadata, so the published `org.mavai:punit-gradle-plugin:0.9.0` is **unresolvable for Java 21 consumers** — punitexamples CI fails with:

> Dependency requires at least JVM runtime version 25. This build uses a Java 21 JVM.

## Fix

Add `java { sourceCompatibility/targetCompatibility = VERSION_21 }` to `punit-gradle-plugin/build.gradle.kts`, mirroring the framework modules.

## Verification

`publishToMavenLocal` at 0.9.1 → `apiElements`/`runtimeElements` now carry `jvm.version=21`.

## Note

The already-published `0.9.0` plugin on Central is immutable and cannot be fixed in place. After this merges, the plugin will be republished at **0.9.1** (whose injected library set already exists on Central) and punitexamples re-pinned to 0.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)