### PR TITLE
Use a Java 21 toolchain for the Gradle plugin (fix Kotlin bytecode)

### DIFF
--- a/punit-gradle-plugin/build.gradle.kts
+++ b/punit-gradle-plugin/build.gradle.kts
@@ -8,13 +8,19 @@ plugins {
 group = "org.mavai"
 version = property("punitVersion") as String
 
-// Target Java 21, matching the framework modules. Without this the plugin
-// compiles against whatever JDK the release machine defaults to and stamps
-// that version into the published Gradle Module Metadata (`org.gradle.jvm.version`),
-// which makes the plugin unresolvable for Java 21 consumers.
+// Pin a Java 21 toolchain. The plugin's logic is Kotlin, so a Java-only
+// sourceCompatibility/targetCompatibility pin is not enough: it sets the Java
+// target and the published Gradle Module Metadata (`org.gradle.jvm.version`) to
+// 21, but compileKotlin still follows the ambient JDK (25 on the release
+// machine) and emits Java 25 bytecode. The result is an artifact whose metadata
+// claims 21 while its classes are 25 — it resolves for a Java 21 consumer, then
+// fails at apply time with UnsupportedClassVersionError. A toolchain governs
+// both compileJava and compileKotlin (the Kotlin plugin reads the Java
+// toolchain), so all bytecode and the metadata agree on 21.
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 signing {


### PR DESCRIPTION
Follow-up to #223 — that fix was incomplete.

#223 added `sourceCompatibility/targetCompatibility = VERSION_21` to the plugin, which set the Java target and the published `org.gradle.jvm.version` metadata to 21. But the plugin's logic is **Kotlin**, and `compileKotlin` still followed the ambient JDK (25 on the release machine). So the jar's classes were Java 25 bytecode while the metadata claimed 21:

```
Inconsistent JVM-target compatibility detected for tasks 'compileJava' (21) and 'compileKotlin' (25).
```

A Java 21 consumer would **resolve** the plugin (metadata says 21) and then fail at apply-time with `UnsupportedClassVersionError`.

## Fix

Replace the Java-only pin with a **Java 21 toolchain**, which the Kotlin Gradle plugin also honours — so `compileJava`, `compileKotlin`, and the metadata all agree on 21.

## Verification

`publishToMavenLocal` at 0.9.1:
- **Bytecode:** all 31 plugin classes are major version 65 (Java 21) — previously 69 (Java 25).
- **Metadata:** `apiElements`/`runtimeElements` carry `jvm.version=21`.

## Note

This must merge **before** the plugin is published at 0.9.1. The prior 0.9.1 publish attempts never landed (they ran with `-PpunitVersion=0.9.0` and bounced off the existing 0.9.0), so no broken 0.9.1 exists on Central — the next publish will be the first and correct one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)