### PR TITLE
Normative judgement at experiment time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Normative judgement at experiment time.** A measure experiment over
+  a contract that declares normative criteria (`meeting().passRate(...)`)
+  now judges each one against its stipulated threshold using the run's
+  own samples — the Wilson one-sided lower confidence bound at the run's
+  sample count, at the criterion's confidence. The judgement (met /
+  failed / unsupportable-with-feasible-minimum) is rendered in the
+  experiment's console output and recorded per criterion in the baseline
+  file as an additive `normativeJudgement` marker that resolvers and
+  threshold derivation ignore; existing baseline files parse unchanged.
+  Empirical criteria remain unjudged at experiment time. `run()`'s
+  completion semantics are unchanged — it never fails on a failed
+  judgement; the new `assertMeets()` terminal (mutually exclusive with
+  `run()`) performs the same run and persistence, then throws
+  `AssertionFailedError` on a failed judgement and `TestAbortedException`
+  on an unsupportable one, with the baseline artefact on disk before any
+  throw.
 - **`PUNIT_BASELINE_DIR` environment variable** for baseline-directory
   resolution (`BaselineResolver.defaultDir()`), checked between the
   existing `punit.baseline.dir` system property and the fixed convention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   completion semantics are unchanged — it never fails on a failed
   judgement; the new `assertMeets()` terminal (mutually exclusive with
   `run()`) performs the same run and persistence, then throws
-  `AssertionFailedError` on a failed judgement and `TestAbortedException`
-  on an unsupportable one, with the baseline artefact on disk before any
+  `AssertionFailedError` on a failed judgement and
+  `UnsupportableJudgementException` (a `TestAbortedException` subtype,
+  identifying the cause for listeners and report tooling) on an
+  unsupportable one, with the baseline artefact on disk before any
   throw.
 - **`PUNIT_BASELINE_DIR` environment variable** for baseline-directory
   resolution (`BaselineResolver.defaultDir()`), checked between the

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -878,6 +878,23 @@ system property or the `PUNIT_BASELINE_DIR` environment variable
 (checked in that order — see Appendix A), or by setting the property
 in the project's `gradle.properties` for a Gradle-driven run.
 
+### Normative judgement at experiment time
+
+When the measured contract declares normative criteria (`meeting().passRate(...)`), the measure experiment judges each one against its stipulated threshold using the run's own samples: the criterion is **met** when the Wilson one-sided lower confidence bound of its observed rate — at the run's sample count, at the criterion's confidence — clears the stipulation, **failed** when it does not, and **unsupportable** when the run's sample count cannot support the stipulated threshold at that confidence even with a perfect observation (the output states the feasible minimum sample count). Empirical criteria are never judged at experiment time — their bar does not exist until a baseline supplies it.
+
+The judgement is rendered in the experiment's console output alongside the measured characterisation, and recorded per criterion in the baseline file as an additive `normativeJudgement` marker (state, stipulated threshold, confidence) inside the criterion's statistics row. Baseline resolution and threshold derivation ignore the marker entirely — it is a durable record for later readers of the file. The judgement states a relation to the stipulation, nothing more: a failed judgement at measure time can be entirely expected — an aspirational bar measured mid-development, a fresh configuration characterised before tuning.
+
+`run()` never fails on a failed judgement. To make the stipulations binding, finish the builder with `assertMeets()` instead of `run()` — the two are mutually exclusive terminals:
+
+```java
+@Experiment
+void measurePaymentGatewayGated() {
+    PUnit.measuring(PaymentGatewayServiceContract.sampling(1000)).assertMeets();
+}
+```
+
+`assertMeets()` performs the same run and the same baseline persistence — the artefact is on disk before any throw — then translates the judgements with the same opentest4j mapping `assertPasses()` uses: a failed judgement throws `AssertionFailedError`, an unsupportable one throws `TestAbortedException` (stating the feasible minimum). Calling it on a contract with no normative criteria is a configuration defect (`IllegalStateException`), detected before any sampling.
+
 ### Asymmetric sampling
 
 The standard pattern measures with high statistical power and tests

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -893,7 +893,7 @@ void measurePaymentGatewayGated() {
 }
 ```
 
-`assertMeets()` performs the same run and the same baseline persistence — the artefact is on disk before any throw — then translates the judgements with the same opentest4j mapping `assertPasses()` uses: a failed judgement throws `AssertionFailedError`, an unsupportable one throws `TestAbortedException` (stating the feasible minimum). Calling it on a contract with no normative criteria is a configuration defect (`IllegalStateException`), detected before any sampling.
+`assertMeets()` performs the same run and the same baseline persistence — the artefact is on disk before any throw — then translates the judgements with the same opentest4j mapping `assertPasses()` uses: a failed judgement throws `AssertionFailedError`, an unsupportable one throws `UnsupportableJudgementException` — a `TestAbortedException` subtype, so the harness aborts rather than fails — stating the feasible minimum. Calling it on a contract with no normative criteria is a configuration defect (`IllegalStateException`), detected before any sampling.
 
 ### Asymmetric sampling
 

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/MeasuredBaseline.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/MeasuredBaseline.java
@@ -1,0 +1,43 @@
+package org.mavai.punit.api.spec;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The emission summary of a completed measure run — what the
+ * framework's baseline emission hands back to the experiment
+ * terminals once the baseline artefact has been written.
+ *
+ * <p>Carries the artefact's identity (service contract, sample
+ * count, filename) plus the run's normative judgements: one
+ * {@link NormativeJudgement} per normative criterion the contract
+ * declared, empty for a purely empirical contract. The terminals
+ * render and — under the gating terminal — assert on the judgements
+ * strictly after the artefact is on disk.
+ *
+ * @param serviceContractId   the measured service contract's identifier
+ * @param sampleCount         the run's total sample count
+ * @param filename            the baseline artefact's canonical filename
+ * @param normativeJudgements the run's normative judgements, in
+ *                            contract declaration order; empty when the
+ *                            contract declares no normative criteria
+ * @param judgementRendering  the judgements' console rendering — the
+ *                            characterisation-plus-judgement block the
+ *                            experiment prints; empty exactly when
+ *                            {@code normativeJudgements} is empty
+ */
+public record MeasuredBaseline(
+        String serviceContractId,
+        int sampleCount,
+        String filename,
+        List<NormativeJudgement> normativeJudgements,
+        String judgementRendering) {
+
+    public MeasuredBaseline {
+        Objects.requireNonNull(serviceContractId, "serviceContractId");
+        Objects.requireNonNull(filename, "filename");
+        Objects.requireNonNull(normativeJudgements, "normativeJudgements");
+        Objects.requireNonNull(judgementRendering, "judgementRendering");
+        normativeJudgements = List.copyOf(normativeJudgements);
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/NormativeJudgement.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/NormativeJudgement.java
@@ -1,4 +1,4 @@
-package org.mavai.punit.internal.engine.baseline;
+package org.mavai.punit.api.spec;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -21,7 +21,7 @@ import org.mavai.punit.statistics.NormativeJudgementEvaluator.Judgement;
  * later reader of the file sees not only what was measured but how
  * the measurement stood relative to a stipulation in force at
  * measure time. The marker is additive and purely documentary:
- * {@link BaselineResolver} and threshold derivation ignore it.
+ * baseline resolution and threshold derivation ignore it.
  *
  * @param criterionId    the judged criterion's stable identifier
  * @param judgement      the statistical judgement

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/UnsupportableJudgementException.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/UnsupportableJudgementException.java
@@ -1,0 +1,32 @@
+package org.mavai.punit.api.spec;
+
+import org.opentest4j.TestAbortedException;
+
+/**
+ * Thrown by the measure builder's gating terminal when a normative
+ * judgement is unsupportable at the run's sample size — the sample
+ * count cannot support the stipulated threshold at the criterion's
+ * confidence, even with a perfect observation, so no met/failed
+ * judgement can be rendered.
+ *
+ * <p>A subtype of {@link TestAbortedException}: the host harness
+ * treats the run as aborted, not failed — an underpowered run is a
+ * configuration inadequacy, not evidence against the service. The
+ * type identifies the cause for listeners and report tooling; the
+ * message states the feasible minimum sample count at which the
+ * judgement becomes supportable.
+ *
+ * <p>Thrown only after the baseline artefact is on disk — the
+ * gating terminal's persistence-before-assertion obligation applies
+ * to the unsupportable case exactly as to a failed judgement, and
+ * the artefact records the criterion's marker with its
+ * unsupportable state.
+ */
+public class UnsupportableJudgementException extends TestAbortedException {
+
+    private static final long serialVersionUID = 1L;
+
+    public UnsupportableJudgementException(String message) {
+        super(message);
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineRecord.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineRecord.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import org.mavai.punit.api.covariate.CovariateProfile;
 import org.mavai.punit.api.spec.BaselineStatistics;
+import org.mavai.punit.api.spec.NormativeJudgement;
 
 /**
  * In-memory shape of a baseline file. Carries the identity keys the

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineRecord.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineRecord.java
@@ -2,6 +2,7 @@ package org.mavai.punit.internal.engine.baseline;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -43,6 +44,13 @@ import org.mavai.punit.api.spec.BaselineStatistics;
  *        declared {@code .expiresInDays(n)}; the writer emits it and the
  *        derived {@code expiresAt} into the baseline so a paired test can
  *        evaluate staleness.
+ * @param normativeJudgements the measure run's judgement of each
+ *        normative criterion against its stipulated threshold, in
+ *        contract declaration order. Empty when the contract declares
+ *        no normative criteria. Serialised as an additive per-criterion
+ *        marker in the baseline YAML; documentary only — the
+ *        {@link BaselineResolver} and threshold derivation ignore it,
+ *        and {@link BaselineReader} does not reconstitute it on load.
  */
 public record BaselineRecord(
         String serviceContractId,
@@ -54,7 +62,8 @@ public record BaselineRecord(
         Map<String, BaselineStatistics> statisticsByCriterionName,
         CovariateProfile covariateProfile,
         LatencyIndicator latencyIndicator,
-        int expiresInDays) {
+        int expiresInDays,
+        List<NormativeJudgement> normativeJudgements) {
 
     public BaselineRecord {
         Objects.requireNonNull(serviceContractId, "serviceContractId");
@@ -65,6 +74,7 @@ public record BaselineRecord(
         Objects.requireNonNull(statisticsByCriterionName, "statisticsByCriterionName");
         Objects.requireNonNull(covariateProfile, "covariateProfile");
         Objects.requireNonNull(latencyIndicator, "latencyIndicator");
+        Objects.requireNonNull(normativeJudgements, "normativeJudgements");
         if (serviceContractId.isBlank()) {
             throw new IllegalArgumentException("serviceContractId must not be blank");
         }
@@ -88,6 +98,28 @@ public record BaselineRecord(
                             + "criterion entries is not consumable by any empirical criterion");
         }
         statisticsByCriterionName = Map.copyOf(new LinkedHashMap<>(statisticsByCriterionName));
+        normativeJudgements = List.copyOf(normativeJudgements);
+    }
+
+    /**
+     * Convenience constructor matching the pre-normative-judgement
+     * canonical signature; defaults {@link #normativeJudgements()} to
+     * an empty list (no normative criteria judged).
+     */
+    public BaselineRecord(
+            String serviceContractId,
+            String methodName,
+            String factorsFingerprint,
+            String inputsIdentity,
+            int sampleCount,
+            Instant generatedAt,
+            Map<String, BaselineStatistics> statisticsByCriterionName,
+            CovariateProfile covariateProfile,
+            LatencyIndicator latencyIndicator,
+            int expiresInDays) {
+        this(serviceContractId, methodName, factorsFingerprint, inputsIdentity,
+                sampleCount, generatedAt, statisticsByCriterionName,
+                covariateProfile, latencyIndicator, expiresInDays, List.of());
     }
 
     /**
@@ -107,7 +139,7 @@ public record BaselineRecord(
             LatencyIndicator latencyIndicator) {
         this(serviceContractId, methodName, factorsFingerprint, inputsIdentity,
                 sampleCount, generatedAt, statisticsByCriterionName,
-                covariateProfile, latencyIndicator, 0);
+                covariateProfile, latencyIndicator, 0, List.of());
     }
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineSchema.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineSchema.java
@@ -50,6 +50,17 @@ final class BaselineSchema {
     // PassRate / PassRateStatistics
     static final String FIELD_OBSERVED_PASS_RATE = "observedPassRate";
 
+    // Normative judgement at experiment time — additive per-criterion
+    // marker under statistics.bernoulli-pass-rate.criteria.<id>.
+    // Documentary only: records how the measure run's evidence stood
+    // relative to the criterion's stipulated threshold at measure
+    // time. The reader ignores it (resolvers and threshold derivation
+    // never consume it); files without it parse identically.
+    static final String FIELD_NORMATIVE_JUDGEMENT = "normativeJudgement";
+    static final String FIELD_JUDGEMENT_STATE = "state";
+    static final String FIELD_STIPULATED_THRESHOLD = "stipulatedThreshold";
+    static final String FIELD_JUDGEMENT_CONFIDENCE = "confidence";
+
     // PercentileLatency / LatencyStatistics
     static final String FIELD_PERCENTILES = "percentiles";
     static final String PERCENTILE_KEY_P50 = "p50";

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import org.mavai.punit.api.LatencyResult;
 import org.mavai.punit.api.spec.BaselineStatistics;
 import org.mavai.punit.api.spec.LatencyStatistics;
+import org.mavai.punit.api.spec.NormativeJudgement;
 import org.mavai.punit.api.spec.PassRateStatistics;
 import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.yaml.snakeyaml.DumperOptions;

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
@@ -121,11 +121,15 @@ public final class BaselineWriter {
         // PercentileLatency criterion's lookup; the reader
         // re-synthesises it from the top-level block on load.
         Map<String, Object> stats = new LinkedHashMap<>();
+        Map<String, NormativeJudgement> judgementsByCriterionId = new LinkedHashMap<>();
+        for (NormativeJudgement judgement : record.normativeJudgements()) {
+            judgementsByCriterionId.put(judgement.criterionId(), judgement);
+        }
         record.statisticsByCriterionName().forEach((name, value) -> {
             if (value instanceof LatencyStatistics) {
                 return; // suppressed; lives in the latency: block instead
             }
-            stats.put(name, serialiseStatisticsEntry(name, value));
+            stats.put(name, serialiseStatisticsEntry(name, value, judgementsByCriterionId));
         });
         root.put(FIELD_STATISTICS, stats);
 
@@ -155,9 +159,10 @@ public final class BaselineWriter {
     }
 
     private Map<String, Object> serialiseStatisticsEntry(
-            String criterionName, BaselineStatistics statistics) {
+            String criterionName, BaselineStatistics statistics,
+            Map<String, NormativeJudgement> judgementsByCriterionId) {
         if (statistics instanceof PerCriterionPassRateStatistics perCriterion) {
-            return serialisePerCriterionPassRate(perCriterion);
+            return serialisePerCriterionPassRate(perCriterion, judgementsByCriterionId);
         }
         if (statistics instanceof LatencyStatistics latency) {
             return serialiseLatency(latency);
@@ -169,17 +174,41 @@ public final class BaselineWriter {
     }
 
     private Map<String, Object> serialisePerCriterionPassRate(
-            PerCriterionPassRateStatistics stats) {
+            PerCriterionPassRateStatistics stats,
+            Map<String, NormativeJudgement> judgementsByCriterionId) {
         Map<String, Object> criteriaBlock = new LinkedHashMap<>();
         for (Map.Entry<String, PassRateStatistics> e : stats.byCriterion().entrySet()) {
             Map<String, Object> entry = new LinkedHashMap<>();
             entry.put(FIELD_OBSERVED_PASS_RATE, e.getValue().observedPassRate());
             entry.put(FIELD_SAMPLE_COUNT, e.getValue().sampleCount());
+            // Additive, documentary marker: the measure run's
+            // judgement of this criterion against its stipulated
+            // threshold. Emitted only for normative criteria; the
+            // reader (and thus every resolver / derivation consumer)
+            // ignores it. Positioned inside the criterion row, before
+            // the appended contentFingerprint, so it falls under the
+            // integrity hash like every other written field.
+            NormativeJudgement judgement = judgementsByCriterionId.get(e.getKey());
+            if (judgement != null) {
+                entry.put(BaselineSchema.FIELD_NORMATIVE_JUDGEMENT,
+                        serialiseNormativeJudgement(judgement));
+            }
             criteriaBlock.put(e.getKey(), entry);
         }
         Map<String, Object> outer = new LinkedHashMap<>();
         outer.put(BaselineSchema.FIELD_CRITERIA, criteriaBlock);
         return outer;
+    }
+
+    private Map<String, Object> serialiseNormativeJudgement(NormativeJudgement judgement) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put(BaselineSchema.FIELD_JUDGEMENT_STATE,
+                judgement.judgement().state().name().toLowerCase(java.util.Locale.ROOT));
+        entry.put(BaselineSchema.FIELD_STIPULATED_THRESHOLD,
+                judgement.judgement().stipulatedThreshold());
+        entry.put(BaselineSchema.FIELD_JUDGEMENT_CONFIDENCE,
+                judgement.judgement().confidence());
+        return entry;
     }
 
     private Map<String, Object> serialiseLatency(LatencyStatistics stats) {

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/NormativeJudgement.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/NormativeJudgement.java
@@ -1,0 +1,44 @@
+package org.mavai.punit.internal.engine.baseline;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.mavai.punit.statistics.NormativeJudgementEvaluator.Judgement;
+
+/**
+ * A measure run's judgement of one normative criterion against its
+ * stipulated threshold — the experiment-time verdict for normative
+ * criteria.
+ *
+ * <p>Pairs the statistical {@link Judgement} (state, stipulated
+ * threshold, confidence, observed rate, lower bound, feasible
+ * minimum) with the criterion's identity and its author-supplied
+ * contract reference (the audit pointer to the stipulation's source
+ * document), which is diagnostic context rather than statistics.
+ *
+ * <p>The baseline artefact records the judgement's state, stipulated
+ * threshold, and confidence per criterion — a durable marker that a
+ * later reader of the file sees not only what was measured but how
+ * the measurement stood relative to a stipulation in force at
+ * measure time. The marker is additive and purely documentary:
+ * {@link BaselineResolver} and threshold derivation ignore it.
+ *
+ * @param criterionId    the judged criterion's stable identifier
+ * @param judgement      the statistical judgement
+ * @param stipulationRef the author-supplied contract reference for
+ *                       the stipulation, when declared
+ */
+public record NormativeJudgement(
+        String criterionId,
+        Judgement judgement,
+        Optional<String> stipulationRef) {
+
+    public NormativeJudgement {
+        Objects.requireNonNull(criterionId, "criterionId");
+        Objects.requireNonNull(judgement, "judgement");
+        Objects.requireNonNull(stipulationRef, "stipulationRef");
+        if (criterionId.isBlank()) {
+            throw new IllegalArgumentException("criterionId must not be blank");
+        }
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
@@ -6,10 +6,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.mavai.punit.api.spec.BaselineStatistics;
+import org.mavai.punit.api.spec.NormativeJudgement;
 import org.mavai.punit.api.spec.PassRateStatistics;
 import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.mavai.punit.internal.engine.baseline.BaselineRecord;
-import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
 import org.mavai.punit.statistics.NormativeJudgementEvaluator;
 
 /**

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
@@ -48,23 +48,29 @@ public final class NormativeJudgementRenderer {
             return "";
         }
         Map<String, PassRateStatistics> characterisation = passRateByCriterion(record);
-        StringBuilder sb = new StringBuilder();
-        sb.append("[PUNIT-MEASURE] ").append(record.serviceContractId())
-                .append(": ").append(record.sampleCount()).append(" samples\n");
+        StringBuilder sb = new StringBuilder(String.format(
+                "[PUNIT-MEASURE] %s: %d samples%n",
+                record.serviceContractId(), record.sampleCount()));
         for (NormativeJudgement judgement : record.normativeJudgements()) {
-            PassRateStatistics observed = characterisation.get(judgement.criterionId());
-            sb.append("  criterion \"").append(judgement.criterionId()).append("\": ");
-            if (observed != null) {
-                sb.append("observed ").append(rate(observed.observedPassRate()))
-                        .append(" (").append(observed.sampleCount()).append(" samples)");
-            } else {
-                sb.append("observed ").append(rate(judgement.judgement().observedRate()));
-            }
-            sb.append('\n');
-            sb.append("  ").append(judgementLine(judgement)).append('\n');
+            sb.append(criterionBlock(
+                    judgement, characterisation.get(judgement.criterionId())));
         }
-        sb.append("  baseline: ").append(record.filename());
+        sb.append(String.format("  baseline: %s", record.filename()));
         return sb.toString();
+    }
+
+    /**
+     * One criterion's two-line block: the measured characterisation,
+     * then the judgement rendered against it.
+     */
+    private static String criterionBlock(
+            NormativeJudgement judgement, PassRateStatistics observed) {
+        String characterisation = observed != null
+                ? String.format("observed %s (%d samples)",
+                        rate(observed.observedPassRate()), observed.sampleCount())
+                : String.format("observed %s", rate(judgement.judgement().observedRate()));
+        return String.format("  criterion \"%s\": %s%n  %s%n",
+                judgement.criterionId(), characterisation, judgementLine(judgement));
     }
 
     private static String judgementLine(NormativeJudgement entry) {
@@ -73,19 +79,18 @@ public final class NormativeJudgementRenderer {
                 .map(ref -> " (" + ref + ")")
                 .orElse("");
         return switch (j.state()) {
-            case MET -> "normative judgement: met — "
-                    + confidencePercent(j.confidence()) + "-confident lower bound "
-                    + rate(j.lowerBound()) + " clears the stipulated "
-                    + rate(j.stipulatedThreshold()) + source;
-            case FAILED -> "NORMATIVE JUDGEMENT: FAILED — stipulated "
-                    + rate(j.stipulatedThreshold()) + source + "; "
-                    + confidencePercent(j.confidence()) + "-confident lower bound "
-                    + rate(j.lowerBound()) + " does not clear the stipulation";
-            case UNSUPPORTABLE -> "NORMATIVE JUDGEMENT: UNSUPPORTABLE at this sample size — "
-                    + "judging the stipulated " + rate(j.stipulatedThreshold()) + source
-                    + " at " + confidencePercent(j.confidence())
-                    + " confidence requires at least " + j.feasibleMinimumSamples()
-                    + " samples; no judgement rendered";
+            case MET -> String.format(
+                    "normative judgement: met — %s-confident lower bound %s clears the stipulated %s%s",
+                    confidencePercent(j.confidence()), rate(j.lowerBound()),
+                    rate(j.stipulatedThreshold()), source);
+            case FAILED -> String.format(
+                    "NORMATIVE JUDGEMENT: FAILED — stipulated %s%s; %s-confident lower bound %s does not clear the stipulation",
+                    rate(j.stipulatedThreshold()), source,
+                    confidencePercent(j.confidence()), rate(j.lowerBound()));
+            case UNSUPPORTABLE -> String.format(
+                    "NORMATIVE JUDGEMENT: UNSUPPORTABLE at this sample size — judging the stipulated %s%s at %s confidence requires at least %d samples; no judgement rendered",
+                    rate(j.stipulatedThreshold()), source,
+                    confidencePercent(j.confidence()), j.feasibleMinimumSamples());
         };
     }
 

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
@@ -1,0 +1,113 @@
+package org.mavai.punit.internal.reporting;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import org.mavai.punit.api.spec.BaselineStatistics;
+import org.mavai.punit.api.spec.PassRateStatistics;
+import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
+import org.mavai.punit.internal.engine.baseline.BaselineRecord;
+import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator;
+
+/**
+ * Renders a measure run's normative judgements for the experiment's
+ * console output — the experiment-time verdict for normative
+ * criteria, displayed against (never instead of) the measured
+ * characterisation.
+ *
+ * <p>Wording discipline: every judgement line states the run's
+ * relation to the stipulation — observed rate, confidence bound,
+ * stipulated threshold, source reference — and implies nothing about
+ * the service's validity. A failed judgement at measure time can be
+ * entirely normal (an aspirational bar measured mid-development, a
+ * fresh configuration characterised before tuning), so the language
+ * is "does not clear the stipulation", never "the service is
+ * broken". A failed or unsupportable judgement is rendered in
+ * upper case for prominence; a met judgement in lower case.
+ *
+ * <p>This class formats pre-computed data only; the judgement itself
+ * is computed upstream (statistics package) before the record
+ * reaches this renderer.
+ */
+public final class NormativeJudgementRenderer {
+
+    private NormativeJudgementRenderer() { }
+
+    /**
+     * Render the record's characterisation-plus-judgement block.
+     * Returns an empty string when the record carries no normative
+     * judgements — a measure over a purely empirical contract prints
+     * nothing new.
+     */
+    public static String render(BaselineRecord record) {
+        Objects.requireNonNull(record, "record");
+        if (record.normativeJudgements().isEmpty()) {
+            return "";
+        }
+        Map<String, PassRateStatistics> characterisation = passRateByCriterion(record);
+        StringBuilder sb = new StringBuilder();
+        sb.append("[PUNIT-MEASURE] ").append(record.serviceContractId())
+                .append(": ").append(record.sampleCount()).append(" samples\n");
+        for (NormativeJudgement judgement : record.normativeJudgements()) {
+            PassRateStatistics observed = characterisation.get(judgement.criterionId());
+            sb.append("  criterion \"").append(judgement.criterionId()).append("\": ");
+            if (observed != null) {
+                sb.append("observed ").append(rate(observed.observedPassRate()))
+                        .append(" (").append(observed.sampleCount()).append(" samples)");
+            } else {
+                sb.append("observed ").append(rate(judgement.judgement().observedRate()));
+            }
+            sb.append('\n');
+            sb.append("  ").append(judgementLine(judgement)).append('\n');
+        }
+        sb.append("  baseline: ").append(record.filename());
+        return sb.toString();
+    }
+
+    private static String judgementLine(NormativeJudgement entry) {
+        NormativeJudgementEvaluator.Judgement j = entry.judgement();
+        String source = entry.stipulationRef()
+                .map(ref -> " (" + ref + ")")
+                .orElse("");
+        return switch (j.state()) {
+            case MET -> "normative judgement: met — "
+                    + confidencePercent(j.confidence()) + "-confident lower bound "
+                    + rate(j.lowerBound()) + " clears the stipulated "
+                    + rate(j.stipulatedThreshold()) + source;
+            case FAILED -> "NORMATIVE JUDGEMENT: FAILED — stipulated "
+                    + rate(j.stipulatedThreshold()) + source + "; "
+                    + confidencePercent(j.confidence()) + "-confident lower bound "
+                    + rate(j.lowerBound()) + " does not clear the stipulation";
+            case UNSUPPORTABLE -> "NORMATIVE JUDGEMENT: UNSUPPORTABLE at this sample size — "
+                    + "judging the stipulated " + rate(j.stipulatedThreshold()) + source
+                    + " at " + confidencePercent(j.confidence())
+                    + " confidence requires at least " + j.feasibleMinimumSamples()
+                    + " samples; no judgement rendered";
+        };
+    }
+
+    private static Map<String, PassRateStatistics> passRateByCriterion(BaselineRecord record) {
+        Map<String, PassRateStatistics> byCriterion = new LinkedHashMap<>();
+        for (BaselineStatistics statistics : record.statisticsByCriterionName().values()) {
+            if (statistics instanceof PerCriterionPassRateStatistics perCriterion) {
+                byCriterion.putAll(perCriterion.byCriterion());
+            }
+        }
+        return byCriterion;
+    }
+
+    private static String rate(double value) {
+        return String.format(Locale.ROOT, "%.4f", value);
+    }
+
+    private static String confidencePercent(double confidence) {
+        double percent = confidence * 100.0;
+        if (percent == Math.rint(percent)) {
+            return String.format(Locale.ROOT, "%.0f%%", percent);
+        }
+        return String.format(Locale.ROOT, "%s%%", percent);
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
@@ -32,12 +32,14 @@ import org.mavai.punit.api.spec.SampleSummary;
 import org.mavai.punit.api.spec.Spec;
 import org.mavai.punit.api.spec.TypedSpec;
 import org.mavai.punit.api.criterion.CriterionPosture;
+import org.mavai.punit.api.spec.MeasuredBaseline;
+import org.mavai.punit.api.spec.NormativeJudgement;
 import org.mavai.punit.internal.engine.baseline.BaselineRecord;
 import org.mavai.punit.internal.engine.baseline.BaselineWriter;
 import org.mavai.punit.internal.engine.baseline.FactorsFingerprint;
 import org.mavai.punit.internal.engine.baseline.LatencyIndicator;
-import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
 import org.mavai.punit.internal.engine.covariate.CovariateResolver;
+import org.mavai.punit.internal.reporting.NormativeJudgementRenderer;
 import org.mavai.punit.statistics.NormativeJudgementEvaluator;
 import org.mavai.punit.statistics.StatisticalDefaults;
 
@@ -75,9 +77,17 @@ public final class BaselineEmitter {
 
     private BaselineEmitter() { }
 
-    public static BaselineRecord emit(Experiment experiment, Path baselineDir) {
+    /**
+     * Emit the baseline artefact to {@code baselineDir} and return the
+     * emission summary the measure terminals consume: artefact
+     * identity, the run's normative judgements, and their console
+     * rendering. The artefact is on disk before this method returns —
+     * the terminals render and, under the gating terminal, assert
+     * strictly after persistence.
+     */
+    public static MeasuredBaseline emit(Experiment experiment, Path baselineDir) {
         Objects.requireNonNull(baselineDir, "baselineDir");
-        return emit(experiment, (relativePath, content) -> {
+        BaselineRecord record = emit(experiment, (relativePath, content) -> {
             try {
                 Files.createDirectories(baselineDir);
                 Path target = baselineDir.resolve(relativePath);
@@ -87,6 +97,12 @@ public final class BaselineEmitter {
                         "Failed to write baseline " + relativePath + " under " + baselineDir, e);
             }
         });
+        return new MeasuredBaseline(
+                record.serviceContractId(),
+                record.sampleCount(),
+                record.filename(),
+                record.normativeJudgements(),
+                NormativeJudgementRenderer.render(record));
     }
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
@@ -6,11 +6,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import org.mavai.punit.api.FactorBundle;
@@ -29,11 +31,15 @@ import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.mavai.punit.api.spec.SampleSummary;
 import org.mavai.punit.api.spec.Spec;
 import org.mavai.punit.api.spec.TypedSpec;
+import org.mavai.punit.api.criterion.CriterionPosture;
 import org.mavai.punit.internal.engine.baseline.BaselineRecord;
 import org.mavai.punit.internal.engine.baseline.BaselineWriter;
 import org.mavai.punit.internal.engine.baseline.FactorsFingerprint;
 import org.mavai.punit.internal.engine.baseline.LatencyIndicator;
+import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
 import org.mavai.punit.internal.engine.covariate.CovariateResolver;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator;
+import org.mavai.punit.statistics.StatisticalDefaults;
 
 /**
  * Translates a completed MEASURE {@link Experiment} into a
@@ -69,9 +75,9 @@ public final class BaselineEmitter {
 
     private BaselineEmitter() { }
 
-    public static void emit(Experiment experiment, Path baselineDir) {
+    public static BaselineRecord emit(Experiment experiment, Path baselineDir) {
         Objects.requireNonNull(baselineDir, "baselineDir");
-        emit(experiment, (relativePath, content) -> {
+        return emit(experiment, (relativePath, content) -> {
             try {
                 Files.createDirectories(baselineDir);
                 Path target = baselineDir.resolve(relativePath);
@@ -88,8 +94,13 @@ public final class BaselineEmitter {
      * scrutinise the YAML without touching disk. The sink receives a
      * single {@code (relativePath, yamlContent)} pair where
      * {@code relativePath} is the canonical baseline filename.
+     *
+     * @return the composed {@link BaselineRecord}, including the run's
+     *         normative judgements — the caller (the measure terminal)
+     *         renders and, under the gating terminal, asserts on them
+     *         strictly after the artefact has been handed to the sink.
      */
-    public static void emit(Experiment experiment, BiConsumer<String, String> sink) {
+    public static BaselineRecord emit(Experiment experiment, BiConsumer<String, String> sink) {
         Objects.requireNonNull(experiment, "experiment");
         Objects.requireNonNull(sink, "sink");
         if (experiment.kind() != Experiment.Kind.MEASURE) {
@@ -121,6 +132,7 @@ public final class BaselineEmitter {
             }
         });
         sink.accept(record.filename(), new BaselineWriter().toYaml(record));
+        return record;
     }
 
     @SuppressWarnings("unchecked")
@@ -191,7 +203,69 @@ public final class BaselineEmitter {
                 stats,
                 profile,
                 latencyIndicator,
-                expiresInDays);
+                expiresInDays,
+                judgeNormativeCriteria(serviceContract, summary));
+    }
+
+    /**
+     * Normative judgement at experiment time: for each normative
+     * criterion the contract declares (the {@code meeting(...)}
+     * pass-rate posture — a stipulated minimum acceptable rate whose
+     * validity does not depend on any baseline), judge the run's own
+     * evidence against the stipulated threshold at the criterion's
+     * confidence. The judgement machinery — Wilson lower bound at the
+     * run's sample count plus the supportability gate — lives in
+     * {@link NormativeJudgementEvaluator}; this method only routes
+     * counts and posture metadata into it.
+     *
+     * <p>Empirical criteria are never judged at experiment time: their
+     * bar does not exist until a baseline supplies it. Zero-failures
+     * and latency postures are likewise out of scope — the judgement
+     * is defined over the stipulated pass-rate form only.
+     */
+    private static <FT, IT, OT> List<NormativeJudgement> judgeNormativeCriteria(
+            ServiceContract<FT, IT, OT> serviceContract, SampleSummary<?> summary) {
+        Map<String, CriterionSampleCounts> countsByCriterionId = new LinkedHashMap<>();
+        for (CriterionSampleCounts counts : summary.criterionSampleCounts()) {
+            countsByCriterionId.put(counts.criterionId(), counts);
+        }
+        List<NormativeJudgement> judgements = new ArrayList<>();
+        for (org.mavai.punit.api.criterion.Criterion<OT> criterion
+                : serviceContract.effectiveCriteria()) {
+            CriterionPosture posture = criterion.posture();
+            if (posture.kind() != CriterionPosture.Kind.STATISTICAL_CONTRACTUAL
+                    || posture.threshold().isEmpty()) {
+                continue;
+            }
+            CriterionSampleCounts counts = countsByCriterionId.get(criterion.id());
+            if (counts == null || counts.total() == 0) {
+                // No per-criterion evidence recorded for this criterion —
+                // nothing to judge. Unreachable in practice: the zero-sample
+                // guard above rejects empty runs before composition.
+                continue;
+            }
+            double confidence = posture.confidenceFloor()
+                    .orElse(StatisticalDefaults.DEFAULT_CONFIDENCE);
+            NormativeJudgementEvaluator.Judgement judgement =
+                    NormativeJudgementEvaluator.judge(
+                            counts.pass(),
+                            counts.total(),
+                            posture.threshold().getAsDouble(),
+                            confidence);
+            judgements.add(new NormativeJudgement(
+                    criterion.id(), judgement, contractRefFor(posture)));
+        }
+        return judgements;
+    }
+
+    private static Optional<String> contractRefFor(CriterionPosture posture) {
+        Optional<String> ref = posture.contractRef();
+        Optional<String> originName = posture.origin().map(Enum::name);
+        if (ref.isPresent() && originName.isPresent()
+                && !"UNSPECIFIED".equals(originName.get())) {
+            return Optional.of(originName.get() + ", " + ref.get());
+        }
+        return ref.isPresent() ? ref : Optional.empty();
     }
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
@@ -241,37 +241,55 @@ public final class BaselineEmitter {
      */
     private static <FT, IT, OT> List<NormativeJudgement> judgeNormativeCriteria(
             ServiceContract<FT, IT, OT> serviceContract, SampleSummary<?> summary) {
-        Map<String, CriterionSampleCounts> countsByCriterionId = new LinkedHashMap<>();
-        for (CriterionSampleCounts counts : summary.criterionSampleCounts()) {
-            countsByCriterionId.put(counts.criterionId(), counts);
-        }
+        Map<String, CriterionSampleCounts> countsByCriterionId =
+                countsByCriterionId(summary);
         List<NormativeJudgement> judgements = new ArrayList<>();
         for (org.mavai.punit.api.criterion.Criterion<OT> criterion
                 : serviceContract.effectiveCriteria()) {
-            CriterionPosture posture = criterion.posture();
-            if (posture.kind() != CriterionPosture.Kind.STATISTICAL_CONTRACTUAL
-                    || posture.threshold().isEmpty()) {
-                continue;
-            }
-            CriterionSampleCounts counts = countsByCriterionId.get(criterion.id());
-            if (counts == null || counts.total() == 0) {
-                // No per-criterion evidence recorded for this criterion —
-                // nothing to judge. Unreachable in practice: the zero-sample
-                // guard above rejects empty runs before composition.
-                continue;
-            }
-            double confidence = posture.confidenceFloor()
-                    .orElse(StatisticalDefaults.DEFAULT_CONFIDENCE);
-            NormativeJudgementEvaluator.Judgement judgement =
-                    NormativeJudgementEvaluator.judge(
-                            counts.pass(),
-                            counts.total(),
-                            posture.threshold().getAsDouble(),
-                            confidence);
-            judgements.add(new NormativeJudgement(
-                    criterion.id(), judgement, contractRefFor(posture)));
+            judgeCriterion(criterion, countsByCriterionId)
+                    .ifPresent(judgements::add);
         }
         return judgements;
+    }
+
+    private static Map<String, CriterionSampleCounts> countsByCriterionId(
+            SampleSummary<?> summary) {
+        Map<String, CriterionSampleCounts> byCriterionId = new LinkedHashMap<>();
+        for (CriterionSampleCounts counts : summary.criterionSampleCounts()) {
+            byCriterionId.put(counts.criterionId(), counts);
+        }
+        return byCriterionId;
+    }
+
+    /**
+     * Judge one criterion, or return empty when there is nothing to
+     * judge: the criterion is not normative (no stipulated pass-rate
+     * posture), or no per-criterion evidence was recorded for it —
+     * the latter unreachable in practice, since the zero-sample guard
+     * rejects empty runs before composition.
+     */
+    private static <OT> Optional<NormativeJudgement> judgeCriterion(
+            org.mavai.punit.api.criterion.Criterion<OT> criterion,
+            Map<String, CriterionSampleCounts> countsByCriterionId) {
+        CriterionPosture posture = criterion.posture();
+        if (posture.kind() != CriterionPosture.Kind.STATISTICAL_CONTRACTUAL
+                || posture.threshold().isEmpty()) {
+            return Optional.empty();
+        }
+        CriterionSampleCounts counts = countsByCriterionId.get(criterion.id());
+        if (counts == null || counts.total() == 0) {
+            return Optional.empty();
+        }
+        double confidence = posture.confidenceFloor()
+                .orElse(StatisticalDefaults.DEFAULT_CONFIDENCE);
+        NormativeJudgementEvaluator.Judgement judgement =
+                NormativeJudgementEvaluator.judge(
+                        counts.pass(),
+                        counts.total(),
+                        posture.threshold().getAsDouble(),
+                        confidence);
+        return Optional.of(new NormativeJudgement(
+                criterion.id(), judgement, contractRefFor(posture)));
     }
 
     private static Optional<String> contractRefFor(CriterionPosture posture) {

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -568,11 +568,11 @@ public final class PUnit {
                 }
             });
             if (!anyNormative) {
-                throw new IllegalStateException(
-                        "assertMeets() requires at least one normative criterion — "
-                                + "a stipulated pass rate declared via meeting().passRate(...). "
-                                + "This contract declares none, so there is nothing to "
-                                + "assert; use run() to characterise without gating.");
+                throw new IllegalStateException("""
+                        assertMeets() requires at least one normative criterion — \
+                        a stipulated pass rate declared via meeting().passRate(...). \
+                        This contract declares none, so there is nothing to \
+                        assert; use run() to characterise without gating.""");
             }
         }
 
@@ -606,33 +606,44 @@ public final class PUnit {
                 MeasuredBaseline emission,
                 List<NormativeJudgement> failed,
                 List<NormativeJudgement> unsupportable) {
-            StringBuilder sb = new StringBuilder();
-            sb.append(emission.serviceContractId())
-                    .append(": ").append(emission.sampleCount()).append(" samples");
-            for (NormativeJudgement judgement : failed) {
-                NormativeJudgementEvaluator.Judgement j = judgement.judgement();
-                sb.append("\n  criterion \"").append(judgement.criterionId())
-                        .append("\" did not clear its stipulated ")
-                        .append(j.stipulatedThreshold());
-                judgement.stipulationRef().ifPresent(ref ->
-                        sb.append(" (").append(ref).append(')'));
-                sb.append(": observed ").append(j.observedRate())
-                        .append(", lower bound ").append(j.lowerBound())
-                        .append(" at confidence ").append(j.confidence());
-            }
-            for (NormativeJudgement judgement : unsupportable) {
-                NormativeJudgementEvaluator.Judgement j = judgement.judgement();
-                sb.append("\n  criterion \"").append(judgement.criterionId())
-                        .append("\" is unsupportable at ").append(emission.sampleCount())
-                        .append(" samples: judging the stipulated ")
-                        .append(j.stipulatedThreshold())
-                        .append(" at confidence ").append(j.confidence())
-                        .append(" requires at least ").append(j.feasibleMinimumSamples())
-                        .append(" samples");
-            }
-            sb.append("\n  baseline persisted before this assertion: ")
-                    .append(emission.filename());
+            StringBuilder sb = new StringBuilder(String.format(
+                    "%s: %d samples",
+                    emission.serviceContractId(), emission.sampleCount()));
+            failed.forEach(judgement -> sb.append(failedLine(judgement)));
+            unsupportable.forEach(judgement ->
+                    sb.append(unsupportableLine(judgement, emission.sampleCount())));
+            sb.append(String.format(
+                    "%n  baseline persisted before this assertion: %s",
+                    emission.filename()));
             return sb.toString();
+        }
+
+        private static String failedLine(NormativeJudgement judgement) {
+            NormativeJudgementEvaluator.Judgement j = judgement.judgement();
+            return String.format(
+                    "%n  criterion \"%s\" did not clear its stipulated %s%s: "
+                            + "observed %s, lower bound %s at confidence %s",
+                    judgement.criterionId(), j.stipulatedThreshold(),
+                    stipulationSource(judgement),
+                    j.observedRate(), j.lowerBound(), j.confidence());
+        }
+
+        private static String unsupportableLine(
+                NormativeJudgement judgement, int sampleCount) {
+            NormativeJudgementEvaluator.Judgement j = judgement.judgement();
+            return String.format(
+                    "%n  criterion \"%s\" is unsupportable at %d samples: "
+                            + "judging the stipulated %s at confidence %s "
+                            + "requires at least %d samples",
+                    judgement.criterionId(), sampleCount,
+                    j.stipulatedThreshold(), j.confidence(),
+                    j.feasibleMinimumSamples());
+        }
+
+        private static String stipulationSource(NormativeJudgement judgement) {
+            return judgement.stipulationRef()
+                    .map(ref -> " (" + ref + ")")
+                    .orElse("");
         }
     }
 

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -36,6 +36,8 @@ import org.mavai.punit.api.spec.Experiment;
 import org.mavai.punit.api.spec.FactorsStepper;
 import org.mavai.punit.api.spec.FailureCount;
 import org.mavai.punit.api.spec.FailureExemplar;
+import org.mavai.punit.api.spec.MeasuredBaseline;
+import org.mavai.punit.api.spec.NormativeJudgement;
 import org.mavai.punit.api.spec.PerCriterionEvaluation;
 import org.mavai.punit.api.spec.ProbabilisticTest;
 import org.mavai.punit.api.spec.ProbabilisticTestResult;
@@ -44,13 +46,10 @@ import org.mavai.punit.api.spec.Verdict;
 import org.mavai.punit.api.covariate.Covariate;
 import org.mavai.punit.api.covariate.CovariateProfile;
 import org.mavai.punit.internal.engine.Engine;
-import org.mavai.punit.internal.engine.baseline.BaselineRecord;
-import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
 import org.mavai.punit.internal.engine.baseline.ProfileBoundBaselineProvider;
 import org.mavai.punit.internal.engine.covariate.CovariateResolver;
 import org.mavai.punit.internal.engine.criteria.Feasibility;
 import org.mavai.punit.internal.engine.criteria.PassRate;
-import org.mavai.punit.internal.reporting.NormativeJudgementRenderer;
 import org.mavai.punit.internal.reporting.TransparentStatsRenderer;
 import org.mavai.punit.statistics.NormativeJudgementEvaluator;
 import org.mavai.punit.statistics.transparent.TransparentStatsConfig;
@@ -176,19 +175,18 @@ public final class PUnit {
     /**
      * Drive a MEASURE experiment, persist its baseline artefact, and
      * render its normative judgements (when the contract declares
-     * normative criteria). Returns the composed baseline record so a
-     * gating terminal can assert on the judgements — strictly after
-     * the artefact is on disk.
+     * normative criteria). Returns the emission summary so a gating
+     * terminal can assert on the judgements — strictly after the
+     * artefact is on disk.
      */
-    private static BaselineRecord driveAndEmit(Experiment experiment) {
+    private static MeasuredBaseline driveAndEmit(Experiment experiment) {
         drive(experiment);
-        BaselineRecord record =
+        MeasuredBaseline emission =
                 BaselineEmitter.emit(experiment, BaselineProviderResolver.resolveDir());
-        String judgements = NormativeJudgementRenderer.render(record);
-        if (!judgements.isEmpty()) {
-            System.out.println(judgements);
+        if (!emission.judgementRendering().isEmpty()) {
+            System.out.println(emission.judgementRendering());
         }
-        return record;
+        return emission;
     }
 
     private static void driveAndEmitExplore(Experiment experiment) {
@@ -534,8 +532,8 @@ public final class PUnit {
         public void assertMeets() {
             Experiment experiment = build();
             requireNormativeCriteria(experiment);
-            BaselineRecord record = driveAndEmit(experiment);
-            translateJudgements(record);
+            MeasuredBaseline emission = driveAndEmit(experiment);
+            translateJudgements(emission);
         }
 
         /**
@@ -581,10 +579,10 @@ public final class PUnit {
          * are present the run is a failure, and the message carries
          * the unsupportable criteria as context.
          */
-        private static void translateJudgements(BaselineRecord record) {
+        private static void translateJudgements(MeasuredBaseline emission) {
             List<NormativeJudgement> failed = new ArrayList<>();
             List<NormativeJudgement> unsupportable = new ArrayList<>();
-            for (NormativeJudgement judgement : record.normativeJudgements()) {
+            for (NormativeJudgement judgement : emission.normativeJudgements()) {
                 switch (judgement.judgement().state()) {
                     case FAILED -> failed.add(judgement);
                     case UNSUPPORTABLE -> unsupportable.add(judgement);
@@ -593,21 +591,21 @@ public final class PUnit {
             }
             if (!failed.isEmpty()) {
                 throw new AssertionFailedError(
-                        judgementMessage(record, failed, unsupportable));
+                        judgementMessage(emission, failed, unsupportable));
             }
             if (!unsupportable.isEmpty()) {
                 throw new TestAbortedException(
-                        judgementMessage(record, failed, unsupportable));
+                        judgementMessage(emission, failed, unsupportable));
             }
         }
 
         private static String judgementMessage(
-                BaselineRecord record,
+                MeasuredBaseline emission,
                 List<NormativeJudgement> failed,
                 List<NormativeJudgement> unsupportable) {
             StringBuilder sb = new StringBuilder();
-            sb.append(record.serviceContractId())
-                    .append(": ").append(record.sampleCount()).append(" samples");
+            sb.append(emission.serviceContractId())
+                    .append(": ").append(emission.sampleCount()).append(" samples");
             for (NormativeJudgement judgement : failed) {
                 NormativeJudgementEvaluator.Judgement j = judgement.judgement();
                 sb.append("\n  criterion \"").append(judgement.criterionId())
@@ -622,7 +620,7 @@ public final class PUnit {
             for (NormativeJudgement judgement : unsupportable) {
                 NormativeJudgementEvaluator.Judgement j = judgement.judgement();
                 sb.append("\n  criterion \"").append(judgement.criterionId())
-                        .append("\" is unsupportable at ").append(record.sampleCount())
+                        .append("\" is unsupportable at ").append(emission.sampleCount())
                         .append(" samples: judging the stipulated ")
                         .append(j.stipulatedThreshold())
                         .append(" at confidence ").append(j.confidence())
@@ -630,7 +628,7 @@ public final class PUnit {
                         .append(" samples");
             }
             sb.append("\n  baseline persisted before this assertion: ")
-                    .append(record.filename());
+                    .append(emission.filename());
             return sb.toString();
         }
     }

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -44,11 +44,15 @@ import org.mavai.punit.api.spec.Verdict;
 import org.mavai.punit.api.covariate.Covariate;
 import org.mavai.punit.api.covariate.CovariateProfile;
 import org.mavai.punit.internal.engine.Engine;
+import org.mavai.punit.internal.engine.baseline.BaselineRecord;
+import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
 import org.mavai.punit.internal.engine.baseline.ProfileBoundBaselineProvider;
 import org.mavai.punit.internal.engine.covariate.CovariateResolver;
 import org.mavai.punit.internal.engine.criteria.Feasibility;
 import org.mavai.punit.internal.engine.criteria.PassRate;
+import org.mavai.punit.internal.reporting.NormativeJudgementRenderer;
 import org.mavai.punit.internal.reporting.TransparentStatsRenderer;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator;
 import org.mavai.punit.statistics.transparent.TransparentStatsConfig;
 import org.mavai.punit.verdict.ProbabilisticTestVerdict;
 import org.mavai.punit.verdict.RunMetadata;
@@ -169,9 +173,22 @@ public final class PUnit {
         return new Engine(provider).run(spec);
     }
 
-    private static void driveAndEmit(Experiment experiment) {
+    /**
+     * Drive a MEASURE experiment, persist its baseline artefact, and
+     * render its normative judgements (when the contract declares
+     * normative criteria). Returns the composed baseline record so a
+     * gating terminal can assert on the judgements — strictly after
+     * the artefact is on disk.
+     */
+    private static BaselineRecord driveAndEmit(Experiment experiment) {
         drive(experiment);
-        BaselineEmitter.emit(experiment, BaselineProviderResolver.resolveDir());
+        BaselineRecord record =
+                BaselineEmitter.emit(experiment, BaselineProviderResolver.resolveDir());
+        String judgements = NormativeJudgementRenderer.render(record);
+        if (!judgements.isEmpty()) {
+            System.out.println(judgements);
+        }
+        return record;
     }
 
     private static void driveAndEmitExplore(Experiment experiment) {
@@ -465,12 +482,156 @@ public final class PUnit {
             return delegate.build();
         }
 
+        /**
+         * The neutral terminal. Runs the measure, persists the
+         * baseline artefact (normative-judgement markers included),
+         * and renders any normative judgements prominently in the
+         * experiment's output — but never fails on a failed
+         * judgement. A measure characterises; whether a stipulation
+         * in force at measure time was cleared is reported, not
+         * enforced. Use {@link #assertMeets()} to make the
+         * stipulations binding.
+         */
         public void run() {
             // Measure runs and emits a baseline file when a baseline directory
             // is configured (system property or project convention). The
             // emission is silent when no directory resolves — the run itself
             // succeeded; the artefact just has nowhere to land.
             driveAndEmit(build());
+        }
+
+        /**
+         * The gating terminal — normative judgement at experiment
+         * time, made binding. Mutually exclusive alternative to
+         * {@link #run()}: same run, same persistence, then asserts.
+         * Mirrors {@link TestBuilder#assertPasses()}'s fused
+         * run-and-assert convention — asserting terminals imply
+         * running.
+         *
+         * <p>Judgement-to-outcome mapping (the same opentest4j
+         * mapping {@code assertPasses()} uses):
+         *
+         * <ul>
+         *   <li>every normative criterion met — returns normally;</li>
+         *   <li>any normative criterion failed — throws
+         *       {@link AssertionFailedError};</li>
+         *   <li>any judgement unsupportable at this sample size —
+         *       throws {@link TestAbortedException}, stating the
+         *       feasible minimum sample count.</li>
+         * </ul>
+         *
+         * <p>Persistence strictly precedes assertion: the baseline
+         * artefact is on disk before any throw — a failed stipulation
+         * never costs the baseline. A failed judgement states the
+         * run's relation to the stipulation, not a claim about the
+         * service's validity; opting into this terminal is what makes
+         * that relation binding for the host harness.
+         *
+         * @throws IllegalStateException when the contract declares no
+         *         normative criteria — there is nothing to assert;
+         *         use {@link #run()}. Thrown before any sampling.
+         */
+        public void assertMeets() {
+            Experiment experiment = build();
+            requireNormativeCriteria(experiment);
+            BaselineRecord record = driveAndEmit(experiment);
+            translateJudgements(record);
+        }
+
+        /**
+         * Configuration-defect gate for {@link #assertMeets()}: a
+         * contract with no normative (stipulated pass-rate) criteria
+         * has nothing to assert. Checked before sampling so the
+         * defect surfaces without spending the run's samples.
+         */
+        private static void requireNormativeCriteria(Experiment experiment) {
+            boolean anyNormative = experiment.dispatch(new Spec.Dispatcher<Boolean>() {
+                @Override
+                public <F, I, O> Boolean apply(TypedSpec<F, I, O> typed) {
+                    var configs = typed.configurations();
+                    if (!configs.hasNext()) {
+                        return false;
+                    }
+                    F factors = configs.next().factors();
+                    ServiceContract<F, I, O> serviceContract =
+                            typed.serviceContractFactory().apply(factors);
+                    for (org.mavai.punit.api.criterion.Criterion<O> criterion
+                            : serviceContract.effectiveCriteria()) {
+                        if (criterion.posture().kind()
+                                == org.mavai.punit.api.criterion.CriterionPosture
+                                        .Kind.STATISTICAL_CONTRACTUAL) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            });
+            if (!anyNormative) {
+                throw new IllegalStateException(
+                        "assertMeets() requires at least one normative criterion — "
+                                + "a stipulated pass rate declared via meeting().passRate(...). "
+                                + "This contract declares none, so there is nothing to "
+                                + "assert; use run() to characterise without gating.");
+            }
+        }
+
+        /**
+         * Translate the run's normative judgements into the host
+         * harness's outcome. Failed dominates unsupportable: when both
+         * are present the run is a failure, and the message carries
+         * the unsupportable criteria as context.
+         */
+        private static void translateJudgements(BaselineRecord record) {
+            List<NormativeJudgement> failed = new ArrayList<>();
+            List<NormativeJudgement> unsupportable = new ArrayList<>();
+            for (NormativeJudgement judgement : record.normativeJudgements()) {
+                switch (judgement.judgement().state()) {
+                    case FAILED -> failed.add(judgement);
+                    case UNSUPPORTABLE -> unsupportable.add(judgement);
+                    case MET -> { /* nothing to translate */ }
+                }
+            }
+            if (!failed.isEmpty()) {
+                throw new AssertionFailedError(
+                        judgementMessage(record, failed, unsupportable));
+            }
+            if (!unsupportable.isEmpty()) {
+                throw new TestAbortedException(
+                        judgementMessage(record, failed, unsupportable));
+            }
+        }
+
+        private static String judgementMessage(
+                BaselineRecord record,
+                List<NormativeJudgement> failed,
+                List<NormativeJudgement> unsupportable) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(record.serviceContractId())
+                    .append(": ").append(record.sampleCount()).append(" samples");
+            for (NormativeJudgement judgement : failed) {
+                NormativeJudgementEvaluator.Judgement j = judgement.judgement();
+                sb.append("\n  criterion \"").append(judgement.criterionId())
+                        .append("\" did not clear its stipulated ")
+                        .append(j.stipulatedThreshold());
+                judgement.stipulationRef().ifPresent(ref ->
+                        sb.append(" (").append(ref).append(')'));
+                sb.append(": observed ").append(j.observedRate())
+                        .append(", lower bound ").append(j.lowerBound())
+                        .append(" at confidence ").append(j.confidence());
+            }
+            for (NormativeJudgement judgement : unsupportable) {
+                NormativeJudgementEvaluator.Judgement j = judgement.judgement();
+                sb.append("\n  criterion \"").append(judgement.criterionId())
+                        .append("\" is unsupportable at ").append(record.sampleCount())
+                        .append(" samples: judging the stipulated ")
+                        .append(j.stipulatedThreshold())
+                        .append(" at confidence ").append(j.confidence())
+                        .append(" requires at least ").append(j.feasibleMinimumSamples())
+                        .append(" samples");
+            }
+            sb.append("\n  baseline persisted before this assertion: ")
+                    .append(record.filename());
+            return sb.toString();
         }
     }
 

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -42,6 +42,7 @@ import org.mavai.punit.api.spec.PerCriterionEvaluation;
 import org.mavai.punit.api.spec.ProbabilisticTest;
 import org.mavai.punit.api.spec.ProbabilisticTestResult;
 import org.mavai.punit.api.spec.Scorer;
+import org.mavai.punit.api.spec.UnsupportableJudgementException;
 import org.mavai.punit.api.spec.Verdict;
 import org.mavai.punit.api.covariate.Covariate;
 import org.mavai.punit.api.covariate.CovariateProfile;
@@ -514,8 +515,10 @@ public final class PUnit {
          *   <li>any normative criterion failed — throws
          *       {@link AssertionFailedError};</li>
          *   <li>any judgement unsupportable at this sample size —
-         *       throws {@link TestAbortedException}, stating the
-         *       feasible minimum sample count.</li>
+         *       throws {@link UnsupportableJudgementException} (a
+         *       {@link TestAbortedException}, so the harness aborts
+         *       rather than fails), stating the feasible minimum
+         *       sample count.</li>
          * </ul>
          *
          * <p>Persistence strictly precedes assertion: the baseline
@@ -594,7 +597,7 @@ public final class PUnit {
                         judgementMessage(emission, failed, unsupportable));
             }
             if (!unsupportable.isEmpty()) {
-                throw new TestAbortedException(
+                throw new UnsupportableJudgementException(
                         judgementMessage(emission, failed, unsupportable));
             }
         }

--- a/punit-core/src/main/java/org/mavai/punit/statistics/NormativeJudgementEvaluator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/NormativeJudgementEvaluator.java
@@ -1,0 +1,139 @@
+package org.mavai.punit.statistics;
+
+/**
+ * Judges a measure run's evidence against a stipulated (contractual)
+ * pass-rate threshold — the experiment-time verdict for normative
+ * criteria.
+ *
+ * <h2>Method</h2>
+ * <p>Composes two existing constructs; it introduces no new
+ * statistical machinery:
+ *
+ * <ol>
+ *   <li><strong>Supportability gate</strong> — delegates to
+ *       {@link VerificationFeasibilityEvaluator}: when even a perfect
+ *       observation at the run's sample count could not place the
+ *       Wilson one-sided lower confidence bound at or above the
+ *       stipulated threshold, no judgement can be rendered at this
+ *       sample size. The result is
+ *       {@link State#UNSUPPORTABLE} with the feasible minimum sample
+ *       count stated.</li>
+ *   <li><strong>Judgement</strong> — the Wilson score one-sided lower
+ *       confidence bound at the run's own sample count
+ *       ({@link BinomialProportionEstimator#lowerBound}), at the
+ *       criterion's confidence level, compared against the stipulated
+ *       threshold: bound &ge; threshold is {@link State#MET},
+ *       otherwise {@link State#FAILED}.</li>
+ * </ol>
+ *
+ * <h2>Interpretation</h2>
+ * <p>A {@link State#FAILED} judgement states one fact: this run's
+ * evidence did not clear a stipulation in force at measure time. It
+ * does <em>not</em> invalidate the service under measurement — an
+ * aspirational bar measured mid-development, or a service measured
+ * precisely because it is suspected to be below its bar, fails its
+ * stipulation as a matter of course. Consumers of this result must
+ * word it as a relation to the stipulation, never as a claim about
+ * the service's validity.
+ */
+public final class NormativeJudgementEvaluator {
+
+    private static final BinomialProportionEstimator ESTIMATOR =
+            new BinomialProportionEstimator();
+
+    private NormativeJudgementEvaluator() {
+        // utility class
+    }
+
+    /** The three possible judgement states. */
+    public enum State {
+        /** The run's lower confidence bound clears the stipulated threshold. */
+        MET,
+        /** The run's lower confidence bound does not clear the stipulated threshold. */
+        FAILED,
+        /**
+         * The run's sample count cannot support the stipulated
+         * threshold at the stated confidence — even a perfect
+         * observation would leave the bound below the threshold. No
+         * met/failed judgement is rendered.
+         */
+        UNSUPPORTABLE
+    }
+
+    /**
+     * Result of judging a run against a stipulated threshold.
+     *
+     * @param state                  the judgement state
+     * @param stipulatedThreshold    the threshold the run was judged against
+     * @param confidence             the confidence level the bound was computed at
+     * @param observedRate           the run's observed pass rate (successes / samples)
+     * @param lowerBound             the Wilson one-sided lower confidence bound at the
+     *                               run's sample count; {@code NaN} when the judgement
+     *                               is {@link State#UNSUPPORTABLE} (no bound is asserted)
+     * @param feasibleMinimumSamples the minimum sample count at which a judgement
+     *                               against this threshold becomes supportable at
+     *                               this confidence
+     */
+    public record Judgement(
+            State state,
+            double stipulatedThreshold,
+            double confidence,
+            double observedRate,
+            double lowerBound,
+            int feasibleMinimumSamples) {
+    }
+
+    /**
+     * Judge a run's evidence against a stipulated threshold.
+     *
+     * @param successes           number of passing samples (k); must be in [0, samples]
+     * @param samples             the run's sample count (N); must be &gt; 0
+     * @param stipulatedThreshold the stipulated minimum acceptable rate (p₀); must be in [0, 1)
+     * @param confidence          the confidence level (1 − α); must be in (0, 1) exclusive
+     * @return the judgement with its full statistical context
+     * @throws IllegalArgumentException if any parameter is out of range
+     */
+    public static Judgement judge(
+            int successes, int samples, double stipulatedThreshold, double confidence) {
+        validate(successes, samples, stipulatedThreshold, confidence);
+        double observedRate = (double) successes / samples;
+        if (stipulatedThreshold <= 0.0) {
+            // A zero threshold is degenerate: any evidence clears it,
+            // and the feasibility machinery (which requires a target in
+            // (0, 1) exclusive) has nothing to gate. Trivially met.
+            return new Judgement(State.MET, stipulatedThreshold, confidence,
+                    observedRate, ESTIMATOR.lowerBound(successes, samples, confidence), 1);
+        }
+        VerificationFeasibilityEvaluator.FeasibilityResult feasibility =
+                VerificationFeasibilityEvaluator.evaluate(
+                        samples, stipulatedThreshold, confidence);
+        if (!feasibility.feasible()) {
+            return new Judgement(State.UNSUPPORTABLE, stipulatedThreshold, confidence,
+                    observedRate, Double.NaN, feasibility.minimumSamples());
+        }
+        double lowerBound = ESTIMATOR.lowerBound(successes, samples, confidence);
+        State state = lowerBound >= stipulatedThreshold ? State.MET : State.FAILED;
+        return new Judgement(state, stipulatedThreshold, confidence,
+                observedRate, lowerBound, feasibility.minimumSamples());
+    }
+
+    private static void validate(
+            int successes, int samples, double stipulatedThreshold, double confidence) {
+        if (samples <= 0) {
+            throw new IllegalArgumentException("samples must be > 0, got: " + samples);
+        }
+        if (successes < 0 || successes > samples) {
+            throw new IllegalArgumentException(
+                    "successes must be in [0, " + samples + "], got: " + successes);
+        }
+        if (Double.isNaN(stipulatedThreshold)
+                || stipulatedThreshold < 0.0 || stipulatedThreshold >= 1.0) {
+            throw new IllegalArgumentException(
+                    "stipulatedThreshold must be in [0, 1), got: " + stipulatedThreshold);
+        }
+        if (Double.isNaN(confidence) || confidence <= 0.0 || confidence >= 1.0) {
+            throw new IllegalArgumentException(
+                    "confidence must be in (0, 1) exclusive, got: " + confidence);
+        }
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/statistics/NormativeJudgementEvaluator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/NormativeJudgementEvaluator.java
@@ -36,6 +36,7 @@ package org.mavai.punit.statistics;
  * word it as a relation to the stipulation, never as a claim about
  * the service's validity.
  */
+// javai-ref: JVI-305FCX1 — do not remove (resolves in javai-orchestrator)
 public final class NormativeJudgementEvaluator {
 
     private static final BinomialProportionEstimator ESTIMATOR =

--- a/punit-core/src/test/java/org/mavai/punit/internal/reporting/NormativeJudgementRendererTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/reporting/NormativeJudgementRendererTest.java
@@ -1,0 +1,102 @@
+package org.mavai.punit.internal.reporting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mavai.punit.api.spec.BaselineStatistics;
+import org.mavai.punit.api.spec.PassRateStatistics;
+import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
+import org.mavai.punit.internal.engine.baseline.BaselineRecord;
+import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator.Judgement;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator.State;
+
+/**
+ * Console wording for normative judgement at experiment time. The
+ * judgement is rendered against the characterisation, visually
+ * distinguished from it, prominent on failure — and always worded as
+ * the run's relation to the stipulation, never as a claim about the
+ * service's validity.
+ */
+@DisplayName("Normative judgement rendering — relation to the stipulation, never a verdict on the service")
+class NormativeJudgementRendererTest {
+
+    private static BaselineRecord record(List<NormativeJudgement> judgements) {
+        Map<String, BaselineStatistics> stats = Map.of(
+                "bernoulli-pass-rate",
+                new PerCriterionPassRateStatistics(Map.of(
+                        "transaction-succeeds", new PassRateStatistics(0.983, 1000))));
+        return new BaselineRecord(
+                "payment-gateway", "measure", "a1b2c3d4", "deadbeef",
+                1000, Instant.parse("2026-07-05T00:00:00Z"), stats,
+                org.mavai.punit.api.covariate.CovariateProfile.empty(),
+                org.mavai.punit.internal.engine.baseline.LatencyIndicator.empty(),
+                0, judgements);
+    }
+
+    private static NormativeJudgement judgement(State state) {
+        return new NormativeJudgement(
+                "transaction-succeeds",
+                new Judgement(state, 0.99, 0.95, 0.983,
+                        state == State.UNSUPPORTABLE ? Double.NaN : 0.9744, 268),
+                Optional.of("SLA, Payment Provider SLA v2.0 §4.1"));
+    }
+
+    @Test
+    @DisplayName("renders a met judgement in measured tones, with bound, stipulation, "
+            + "and source")
+    void rendersMetJudgement() {
+        String out = NormativeJudgementRenderer.render(
+                record(List.of(judgement(State.MET))));
+
+        assertThat(out)
+                .contains("[PUNIT-MEASURE] payment-gateway: 1000 samples")
+                .contains("criterion \"transaction-succeeds\": observed 0.9830 (1000 samples)")
+                .contains("normative judgement: met")
+                .contains("95%-confident lower bound 0.9744 clears the stipulated 0.9900")
+                .contains("(SLA, Payment Provider SLA v2.0 §4.1)");
+    }
+
+    @Test
+    @DisplayName("renders a failed judgement prominently, as a relation to the "
+            + "stipulation — the wording never condemns the service")
+    void rendersFailedJudgementProminently() {
+        String out = NormativeJudgementRenderer.render(
+                record(List.of(judgement(State.FAILED))));
+
+        assertThat(out)
+                .contains("NORMATIVE JUDGEMENT: FAILED")
+                .contains("stipulated 0.9900 (SLA, Payment Provider SLA v2.0 §4.1)")
+                .contains("95%-confident lower bound 0.9744 does not clear the stipulation");
+        assertThat(out)
+                .as("the judgement states the relation to the stipulation and "
+                        + "implies nothing about the service's validity")
+                .doesNotContain("invalid", "broken", "degraded", "violat");
+    }
+
+    @Test
+    @DisplayName("renders an unsupportable judgement with the feasible minimum, "
+            + "instead of silently omitting it or rendering a bound anyway")
+    void rendersUnsupportableJudgementWithFeasibleMinimum() {
+        String out = NormativeJudgementRenderer.render(
+                record(List.of(judgement(State.UNSUPPORTABLE))));
+
+        assertThat(out)
+                .contains("NORMATIVE JUDGEMENT: UNSUPPORTABLE at this sample size")
+                .contains("requires at least 268 samples")
+                .contains("no judgement rendered");
+    }
+
+    @Test
+    @DisplayName("renders nothing for a record with no normative judgements — a "
+            + "purely empirical measure's output is unchanged")
+    void rendersNothingWithoutJudgements() {
+        assertThat(NormativeJudgementRenderer.render(record(List.of()))).isEmpty();
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/internal/reporting/NormativeJudgementRendererTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/reporting/NormativeJudgementRendererTest.java
@@ -13,7 +13,7 @@ import org.mavai.punit.api.spec.BaselineStatistics;
 import org.mavai.punit.api.spec.PassRateStatistics;
 import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.mavai.punit.internal.engine.baseline.BaselineRecord;
-import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
+import org.mavai.punit.api.spec.NormativeJudgement;
 import org.mavai.punit.statistics.NormativeJudgementEvaluator.Judgement;
 import org.mavai.punit.statistics.NormativeJudgementEvaluator.State;
 

--- a/punit-core/src/test/java/org/mavai/punit/internal/runtime/MeasureNormativeJudgementTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/runtime/MeasureNormativeJudgementTest.java
@@ -22,7 +22,7 @@ import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.mavai.punit.internal.engine.Engine;
 import org.mavai.punit.internal.engine.baseline.BaselineReader;
 import org.mavai.punit.internal.engine.baseline.BaselineRecord;
-import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
+import org.mavai.punit.api.spec.NormativeJudgement;
 import org.mavai.punit.statistics.NormativeJudgementEvaluator.State;
 import org.yaml.snakeyaml.Yaml;
 

--- a/punit-core/src/test/java/org/mavai/punit/internal/runtime/MeasureNormativeJudgementTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/runtime/MeasureNormativeJudgementTest.java
@@ -1,0 +1,241 @@
+package org.mavai.punit.internal.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mavai.punit.api.criterion.Criteria.empirical;
+import static org.mavai.punit.api.criterion.Criteria.meeting;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.NoFactors;
+import org.mavai.punit.api.Sampling;
+import org.mavai.punit.api.ServiceContract;
+import org.mavai.punit.api.ThresholdOrigin;
+import org.mavai.punit.api.TokenTracker;
+import org.mavai.punit.api.criterion.Criteria;
+import org.mavai.punit.api.spec.Experiment;
+import org.mavai.punit.api.spec.PassRateStatistics;
+import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
+import org.mavai.punit.internal.engine.Engine;
+import org.mavai.punit.internal.engine.baseline.BaselineReader;
+import org.mavai.punit.internal.engine.baseline.BaselineRecord;
+import org.mavai.punit.internal.engine.baseline.NormativeJudgement;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator.State;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Normative judgement at experiment time, at the baseline-artefact
+ * seam: the measure path judges each normative (meeting) criterion
+ * against its stipulated threshold using the run's own evidence, and
+ * records an additive, documentary marker per judged criterion in the
+ * baseline YAML. Empirical criteria are never judged. Resolvers and
+ * threshold derivation ignore the marker; files without it parse
+ * exactly as before.
+ */
+@DisplayName("Normative judgement at experiment time — baseline artefact marker")
+class MeasureNormativeJudgementTest {
+
+    /** Postcondition passes for even inputs, fails for odd ones. */
+    private static ServiceContract<NoFactors, Integer, String> contractWith(
+            Criteria<String> criteria, String id) {
+        return new ServiceContract<>() {
+            @Override public String id() { return id; }
+            @Override public Criteria<String> criteria() { return criteria; }
+            @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok("value-" + input);
+            }
+        };
+    }
+
+    private static Outcome<?> even(String value) {
+        int n = Integer.parseInt(value.substring("value-".length()));
+        return n % 2 == 0 ? Outcome.ok(null) : Outcome.fail("odd", "odd input " + n);
+    }
+
+    private static BaselineRecord measure(
+            ServiceContract<NoFactors, Integer, String> contract,
+            Map<String, String> yamlSink,
+            Integer... inputs) {
+        Sampling<NoFactors, Integer, String> sampling = Sampling
+                .<NoFactors, Integer, String>builder()
+                .serviceContractFactory(f -> contract)
+                .inputs(inputs)
+                .samples(8)
+                .build();
+        Experiment measure = Experiment.measuring(sampling, new NoFactors()).build();
+        new Engine().run(measure);
+        return BaselineEmitter.emit(measure, yamlSink::put);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> criterionRow(String yaml, String criterionId) {
+        Map<String, Object> root = new Yaml().load(yaml);
+        Map<String, Object> stats = (Map<String, Object>) root.get("statistics");
+        Map<String, Object> passRate = (Map<String, Object>) stats.get("bernoulli-pass-rate");
+        Map<String, Object> criteria = (Map<String, Object>) passRate.get("criteria");
+        return (Map<String, Object>) criteria.get(criterionId);
+    }
+
+    @Test
+    @DisplayName("records a met judgement with the stipulated threshold and confidence "
+            + "when the run's evidence clears the stipulation")
+    void recordsMetJudgement() {
+        ServiceContract<NoFactors, Integer, String> contract = contractWith(
+                meeting().<String>passRate(0.5)
+                        .contractRef(ThresholdOrigin.SLA, "Payments SLA v2 §4.1")
+                        .satisfies("value is even", MeasureNormativeJudgementTest::even),
+                "AllEvensMeasure");
+        Map<String, String> sink = new LinkedHashMap<>();
+        BaselineRecord record = measure(contract, sink, 2, 4); // all pass
+
+        assertThat(record.normativeJudgements()).hasSize(1);
+        NormativeJudgement judgement = record.normativeJudgements().get(0);
+        assertThat(judgement.judgement().state()).isEqualTo(State.MET);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> marker = (Map<String, Object>)
+                criterionRow(sink.values().iterator().next(), judgement.criterionId())
+                        .get("normativeJudgement");
+        assertThat(marker)
+                .containsEntry("state", "met")
+                .containsEntry("stipulatedThreshold", 0.5)
+                .containsEntry("confidence", 0.95);
+    }
+
+    @Test
+    @DisplayName("records a failed judgement — the marker is a durable record of a "
+            + "stipulation in force at measure time, not a run failure")
+    void recordsFailedJudgement() {
+        ServiceContract<NoFactors, Integer, String> contract = contractWith(
+                meeting().<String>passRate(0.5)
+                        .satisfies("value is even", MeasureNormativeJudgementTest::even),
+                "HalfEvensMeasure");
+        Map<String, String> sink = new LinkedHashMap<>();
+        BaselineRecord record = measure(contract, sink, 2, 3); // half pass
+
+        assertThat(record.normativeJudgements()).hasSize(1);
+        assertThat(record.normativeJudgements().get(0).judgement().state())
+                .isEqualTo(State.FAILED);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> marker = (Map<String, Object>)
+                criterionRow(sink.values().iterator().next(),
+                        record.normativeJudgements().get(0).criterionId())
+                        .get("normativeJudgement");
+        assertThat(marker).containsEntry("state", "failed");
+    }
+
+    @Test
+    @DisplayName("records an unsupportable judgement when the run's sample count cannot "
+            + "support the stipulated threshold at the criterion's confidence")
+    void recordsUnsupportableJudgement() {
+        ServiceContract<NoFactors, Integer, String> contract = contractWith(
+                meeting().<String>passRate(0.99)
+                        .satisfies("value is even", MeasureNormativeJudgementTest::even),
+                "UndersizedMeasure");
+        Map<String, String> sink = new LinkedHashMap<>();
+        BaselineRecord record = measure(contract, sink, 2, 4); // 8 samples, all pass
+
+        assertThat(record.normativeJudgements()).hasSize(1);
+        NormativeJudgement judgement = record.normativeJudgements().get(0);
+        assertThat(judgement.judgement().state()).isEqualTo(State.UNSUPPORTABLE);
+        assertThat(judgement.judgement().feasibleMinimumSamples()).isGreaterThan(8);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> marker = (Map<String, Object>)
+                criterionRow(sink.values().iterator().next(), judgement.criterionId())
+                        .get("normativeJudgement");
+        assertThat(marker).containsEntry("state", "unsupportable");
+    }
+
+    @Test
+    @DisplayName("judges only the normative criteria of a mixed contract — the "
+            + "empirical criterion is characterised with no judgement marker")
+    void mixedContractJudgesOnlyNormativeCriteria() {
+        ServiceContract<NoFactors, Integer, String> contract = contractWith(
+                Criteria.of(
+                        meeting().<String>passRate(0.5)
+                                .name("stipulated-evenness")
+                                .satisfies("value is even", MeasureNormativeJudgementTest::even),
+                        empirical().<String>passRate()
+                                .name("observed-evenness")
+                                .satisfies("value is even", MeasureNormativeJudgementTest::even)),
+                "MixedPostureMeasure");
+        Map<String, String> sink = new LinkedHashMap<>();
+        BaselineRecord record = measure(contract, sink, 2, 4);
+
+        assertThat(record.normativeJudgements())
+                .extracting(NormativeJudgement::criterionId)
+                .containsExactly("stipulated-evenness");
+
+        String yaml = sink.values().iterator().next();
+        assertThat(criterionRow(yaml, "stipulated-evenness"))
+                .containsKey("normativeJudgement");
+        assertThat(criterionRow(yaml, "observed-evenness"))
+                .as("empirical criteria are never judged at experiment time — "
+                        + "their bar does not exist until a baseline supplies it")
+                .doesNotContainKey("normativeJudgement")
+                .containsKeys("observedPassRate", "sampleCount");
+    }
+
+    @Test
+    @DisplayName("emits no judgement vocabulary at all for a purely empirical contract")
+    void purelyEmpiricalContractCarriesNoJudgementVocabulary() {
+        ServiceContract<NoFactors, Integer, String> contract = contractWith(
+                empirical().<String>passRate()
+                        .satisfies("value is even", MeasureNormativeJudgementTest::even),
+                "EmpiricalOnlyMeasure");
+        Map<String, String> sink = new LinkedHashMap<>();
+        BaselineRecord record = measure(contract, sink, 2, 4);
+
+        assertThat(record.normativeJudgements()).isEmpty();
+        assertThat(sink.values().iterator().next())
+                .doesNotContain("normativeJudgement", "stipulatedThreshold");
+    }
+
+    @Test
+    @DisplayName("the marker is additive: the file round-trips through BaselineReader, "
+            + "the marker precedes the content fingerprint, and the parsed statistics "
+            + "are identical to a marker-free file's")
+    void markerIsAdditiveAndIgnoredByTheReader() {
+        Map<String, String> judged = new LinkedHashMap<>();
+        measure(contractWith(
+                meeting().<String>passRate(0.5)
+                        .satisfies("value is even", MeasureNormativeJudgementTest::even),
+                "AdditivityMeasure"), judged, 2, 3);
+        Map<String, String> unjudged = new LinkedHashMap<>();
+        measure(contractWith(
+                empirical().<String>passRate()
+                        .satisfies("value is even", MeasureNormativeJudgementTest::even),
+                "AdditivityMeasure"), unjudged, 2, 3);
+
+        String judgedYaml = judged.values().iterator().next();
+        String unjudgedYaml = unjudged.values().iterator().next();
+
+        // The marker falls under the integrity hash like every other field.
+        assertThat(judgedYaml.indexOf("normativeJudgement"))
+                .isGreaterThan(-1)
+                .isLessThan(judgedYaml.indexOf("contentFingerprint"));
+
+        BaselineRecord fromJudged = new BaselineReader().parse(judgedYaml);
+        BaselineRecord fromUnjudged = new BaselineReader().parse(unjudgedYaml);
+
+        // The reader does not reconstitute the marker: it is documentary.
+        assertThat(fromJudged.normativeJudgements()).isEmpty();
+
+        // Derivation-relevant content is identical with or without the
+        // marker — resolvers and threshold derivation see the same statistics.
+        PassRateStatistics judgedStats =
+                ((PerCriterionPassRateStatistics) fromJudged
+                        .statisticsByCriterionName().get("bernoulli-pass-rate"))
+                        .byCriterion().get("default");
+        PassRateStatistics unjudgedStats =
+                ((PerCriterionPassRateStatistics) fromUnjudged
+                        .statisticsByCriterionName().get("bernoulli-pass-rate"))
+                        .byCriterion().get("default");
+        assertThat(judgedStats).isEqualTo(unjudgedStats);
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/runtime/MeasureGatingTerminalTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/runtime/MeasureGatingTerminalTest.java
@@ -26,6 +26,7 @@ import org.mavai.punit.api.TokenTracker;
 import org.mavai.punit.api.criterion.Criteria;
 import org.mavai.punit.internal.engine.baseline.BaselineResolver;
 import org.opentest4j.AssertionFailedError;
+import org.mavai.punit.api.spec.UnsupportableJudgementException;
 import org.opentest4j.TestAbortedException;
 
 /**
@@ -122,15 +123,17 @@ class MeasureGatingTerminalTest {
     }
 
     @Test
-    @DisplayName("throws TestAbortedException, stating the feasible minimum, on an "
-            + "unsupportable judgement — after the baseline artefact is on disk")
+    @DisplayName("throws UnsupportableJudgementException (aborting the harness), stating "
+            + "the feasible minimum, on an unsupportable judgement — after the baseline "
+            + "artefact is on disk")
     void abortsOnUnsupportableJudgementWithBaselinePersisted() throws IOException {
         var uc = contract("GatedUndersizedMeasure",
                 meeting().<String>passRate(0.99)
                         .satisfies("value is even", MeasureGatingTerminalTest::even));
 
-        assertThatExceptionOfType(TestAbortedException.class)
+        assertThatExceptionOfType(UnsupportableJudgementException.class)
                 .isThrownBy(() -> PUnit.measuring(sampling(uc, 2, 4)).assertMeets())
+                .isInstanceOf(TestAbortedException.class)
                 .withMessageContaining("unsupportable at 8 samples")
                 .withMessageContaining("requires at least");
         assertThat(baselineFileCount()).isEqualTo(1);

--- a/punit-core/src/test/java/org/mavai/punit/runtime/MeasureGatingTerminalTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/runtime/MeasureGatingTerminalTest.java
@@ -1,0 +1,228 @@
+package org.mavai.punit.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mavai.punit.api.criterion.Criteria.empirical;
+import static org.mavai.punit.api.criterion.Criteria.meeting;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.NoFactors;
+import org.mavai.punit.api.Sampling;
+import org.mavai.punit.api.ServiceContract;
+import org.mavai.punit.api.TokenTracker;
+import org.mavai.punit.api.criterion.Criteria;
+import org.mavai.punit.internal.engine.baseline.BaselineResolver;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.TestAbortedException;
+
+/**
+ * The measure builder's gating terminal — normative judgement at
+ * experiment time, made binding. The neutral {@code run()} terminal
+ * never fails on a failed judgement; the gating terminal performs the
+ * same run and the same persistence, then asserts with the same
+ * opentest4j mapping {@code assertPasses()} uses. Persistence
+ * strictly precedes assertion: the baseline artefact is on disk
+ * before any throw.
+ */
+@DisplayName("Measure gating terminal — run-and-assert over normative judgements")
+class MeasureGatingTerminalTest {
+
+    @TempDir
+    Path baselineDir;
+
+    private String savedProperty;
+
+    @BeforeEach
+    void pointBaselineDirAtTempDir() {
+        savedProperty = System.getProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, baselineDir.toString());
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        if (savedProperty == null) {
+            System.clearProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        } else {
+            System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY, savedProperty);
+        }
+    }
+
+    private static Outcome<?> even(String value) {
+        int n = Integer.parseInt(value.substring("value-".length()));
+        return n % 2 == 0 ? Outcome.ok(null) : Outcome.fail("odd", "odd input " + n);
+    }
+
+    private static ServiceContract<NoFactors, Integer, String> contract(
+            String id, Criteria<String> criteria) {
+        return new ServiceContract<>() {
+            @Override public String id() { return id; }
+            @Override public Criteria<String> criteria() { return criteria; }
+            @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+                return Outcome.ok("value-" + input);
+            }
+        };
+    }
+
+    private static Sampling<NoFactors, Integer, String> sampling(
+            ServiceContract<NoFactors, Integer, String> contract, Integer... inputs) {
+        return Sampling.<NoFactors, Integer, String>builder()
+                .serviceContractFactory(f -> contract)
+                .inputs(inputs)
+                .samples(8)
+                .build();
+    }
+
+    private long baselineFileCount() throws IOException {
+        try (Stream<Path> files = Files.list(baselineDir)) {
+            return files.filter(p -> p.toString().endsWith(".yaml")).count();
+        }
+    }
+
+    @Test
+    @DisplayName("completes normally when every normative criterion is met, with the "
+            + "baseline artefact on disk")
+    void completesWhenAllNormativeCriteriaMet() throws IOException {
+        var uc = contract("GatedMetMeasure",
+                meeting().<String>passRate(0.5)
+                        .satisfies("value is even", MeasureGatingTerminalTest::even));
+
+        assertThatCode(() -> PUnit.measuring(sampling(uc, 2, 4)).assertMeets())
+                .doesNotThrowAnyException();
+        assertThat(baselineFileCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("throws AssertionFailedError on a failed judgement — after the "
+            + "baseline artefact is on disk")
+    void failsOnFailedJudgementWithBaselinePersisted() throws IOException {
+        var uc = contract("GatedFailedMeasure",
+                meeting().<String>passRate(0.5)
+                        .satisfies("value is even", MeasureGatingTerminalTest::even));
+
+        assertThatExceptionOfType(AssertionFailedError.class)
+                .isThrownBy(() -> PUnit.measuring(sampling(uc, 2, 3)).assertMeets())
+                .withMessageContaining("did not clear its stipulated 0.5");
+        assertThat(baselineFileCount())
+                .as("persistence strictly precedes assertion — a failed "
+                        + "stipulation never costs the baseline")
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("throws TestAbortedException, stating the feasible minimum, on an "
+            + "unsupportable judgement — after the baseline artefact is on disk")
+    void abortsOnUnsupportableJudgementWithBaselinePersisted() throws IOException {
+        var uc = contract("GatedUndersizedMeasure",
+                meeting().<String>passRate(0.99)
+                        .satisfies("value is even", MeasureGatingTerminalTest::even));
+
+        assertThatExceptionOfType(TestAbortedException.class)
+                .isThrownBy(() -> PUnit.measuring(sampling(uc, 2, 4)).assertMeets())
+                .withMessageContaining("unsupportable at 8 samples")
+                .withMessageContaining("requires at least");
+        assertThat(baselineFileCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("run() keeps its neutral completion semantics — it never fails on a "
+            + "failed judgement")
+    void runCompletesOnFailedJudgement() throws IOException {
+        var uc = contract("NeutralFailedMeasure",
+                meeting().<String>passRate(0.5)
+                        .satisfies("value is even", MeasureGatingTerminalTest::even));
+
+        assertThatCode(() -> PUnit.measuring(sampling(uc, 2, 3)).run())
+                .doesNotThrowAnyException();
+        assertThat(baselineFileCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("run() also completes normally on an unsupportable judgement")
+    void runCompletesOnUnsupportableJudgement() throws IOException {
+        var uc = contract("NeutralUndersizedMeasure",
+                meeting().<String>passRate(0.99)
+                        .satisfies("value is even", MeasureGatingTerminalTest::even));
+
+        assertThatCode(() -> PUnit.measuring(sampling(uc, 2, 4)).run())
+                .doesNotThrowAnyException();
+        assertThat(baselineFileCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("judges only the normative criteria of a mixed contract — an "
+            + "empirical criterion cannot fail the gating terminal")
+    void mixedContractGatesOnNormativeCriteriaOnly() throws IOException {
+        var uc = contract("GatedMixedMeasure",
+                Criteria.of(
+                        meeting().<String>passRate(0.5)
+                                .name("stipulated-evenness")
+                                .satisfies("value is even", MeasureGatingTerminalTest::even),
+                        empirical().<String>passRate()
+                                .name("observed-evenness")
+                                .satisfies("value is even", MeasureGatingTerminalTest::even)));
+
+        assertThatCode(() -> PUnit.measuring(sampling(uc, 2, 4)).assertMeets())
+                .doesNotThrowAnyException();
+        assertThat(baselineFileCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("rejects a contract with no normative criteria as a configuration "
+            + "defect, before spending any samples")
+    void rejectsContractWithNoNormativeCriteriaBeforeSampling() throws IOException {
+        AtomicInteger invocations = new AtomicInteger();
+        ServiceContract<NoFactors, Integer, String> uc = new ServiceContract<>() {
+            @Override public String id() { return "GatedEmpiricalOnlyMeasure"; }
+            @Override public Criteria<String> criteria() {
+                return empirical().<String>passRate()
+                        .satisfies("value is even", MeasureGatingTerminalTest::even);
+            }
+            @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+                invocations.incrementAndGet();
+                return Outcome.ok("value-" + input);
+            }
+        };
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> PUnit.measuring(sampling(uc, 2, 4)).assertMeets())
+                .withMessageContaining("nothing to")
+                .withMessageContaining("run()");
+        assertThat(invocations)
+                .as("the configuration defect surfaces before sampling")
+                .hasValue(0);
+        assertThat(baselineFileCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("gating and neutral terminals are alternatives over the same run and "
+            + "the same artefact — the gated artefact carries the judgement marker")
+    void gatedRunPersistsTheJudgementMarker() throws IOException {
+        var uc = contract("GatedMarkerMeasure",
+                meeting().<String>passRate(0.5)
+                        .satisfies("value is even", MeasureGatingTerminalTest::even));
+
+        assertThatExceptionOfType(AssertionFailedError.class)
+                .isThrownBy(() -> PUnit.measuring(sampling(uc, 2, 3)).assertMeets());
+
+        try (Stream<Path> files = Files.list(baselineDir)) {
+            List<Path> yamls = files.filter(p -> p.toString().endsWith(".yaml")).toList();
+            assertThat(yamls).hasSize(1);
+            assertThat(Files.readString(yamls.get(0)))
+                    .contains("normativeJudgement")
+                    .contains("state: failed");
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/NormativeJudgementEvaluatorTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/NormativeJudgementEvaluatorTest.java
@@ -1,0 +1,108 @@
+package org.mavai.punit.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator.Judgement;
+import org.mavai.punit.statistics.NormativeJudgementEvaluator.State;
+
+@DisplayName("Normative judgement at experiment time — statistical evaluation")
+class NormativeJudgementEvaluatorTest {
+
+    private static final BinomialProportionEstimator ESTIMATOR =
+            new BinomialProportionEstimator();
+
+    @Test
+    @DisplayName("judges met when the Wilson lower bound at the run's sample count "
+            + "clears the stipulated threshold")
+    void metWhenBoundClearsThreshold() {
+        Judgement judgement = NormativeJudgementEvaluator.judge(980, 1000, 0.9, 0.95);
+
+        assertThat(judgement.state()).isEqualTo(State.MET);
+        assertThat(judgement.observedRate()).isEqualTo(0.98);
+        assertThat(judgement.stipulatedThreshold()).isEqualTo(0.9);
+        assertThat(judgement.confidence()).isEqualTo(0.95);
+        assertThat(judgement.lowerBound())
+                .as("the bound is the estimator's Wilson one-sided lower bound — "
+                        + "no parallel arithmetic")
+                .isEqualTo(ESTIMATOR.lowerBound(980, 1000, 0.95))
+                .isGreaterThanOrEqualTo(0.9);
+    }
+
+    @Test
+    @DisplayName("judges failed when the bound does not clear the threshold, even "
+            + "though the observed rate does — the judgement is bound-based")
+    void failedWhenBoundDoesNotClearThreshold() {
+        // Observed 0.91 exceeds the stipulated 0.9, but the 95%-confident
+        // lower bound at n=1000 sits below it: evidence, not point estimate.
+        Judgement judgement = NormativeJudgementEvaluator.judge(910, 1000, 0.9, 0.95);
+
+        assertThat(judgement.state()).isEqualTo(State.FAILED);
+        assertThat(judgement.observedRate()).isGreaterThan(0.9);
+        assertThat(judgement.lowerBound())
+                .isEqualTo(ESTIMATOR.lowerBound(910, 1000, 0.95))
+                .isLessThan(0.9);
+    }
+
+    @Test
+    @DisplayName("judges unsupportable, with the feasible minimum stated, when even a "
+            + "perfect observation could not clear the threshold at this sample count")
+    void unsupportableWhenSampleCountCannotSupportThreshold() {
+        Judgement judgement = NormativeJudgementEvaluator.judge(50, 50, 0.99, 0.95);
+
+        assertThat(judgement.state()).isEqualTo(State.UNSUPPORTABLE);
+        assertThat(judgement.feasibleMinimumSamples())
+                .as("the feasible minimum comes from the existing feasibility machinery")
+                .isEqualTo(VerificationFeasibilityEvaluator
+                        .evaluate(50, 0.99, 0.95).minimumSamples())
+                .isGreaterThan(50);
+        assertThat(judgement.lowerBound())
+                .as("no bound is asserted for an unsupportable judgement")
+                .isNaN();
+    }
+
+    @Test
+    @DisplayName("agrees with the feasibility machinery about where supportability begins")
+    void supportabilityBoundaryMatchesFeasibilityEvaluator() {
+        int minimum = VerificationFeasibilityEvaluator
+                .evaluate(1, 0.95, 0.95).minimumSamples();
+
+        assertThat(NormativeJudgementEvaluator
+                .judge(minimum, minimum, 0.95, 0.95).state())
+                .isEqualTo(State.MET);
+        assertThat(NormativeJudgementEvaluator
+                .judge(minimum - 1, minimum - 1, 0.95, 0.95).state())
+                .isEqualTo(State.UNSUPPORTABLE);
+    }
+
+    @Test
+    @DisplayName("a zero threshold is degenerate and trivially met")
+    void zeroThresholdTriviallyMet() {
+        Judgement judgement = NormativeJudgementEvaluator.judge(0, 10, 0.0, 0.95);
+
+        assertThat(judgement.state()).isEqualTo(State.MET);
+        assertThat(judgement.observedRate()).isZero();
+    }
+
+    @Test
+    @DisplayName("rejects out-of-range inputs as defects")
+    void rejectsOutOfRangeInputs() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> NormativeJudgementEvaluator.judge(1, 0, 0.9, 0.95))
+                .withMessageContaining("samples");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> NormativeJudgementEvaluator.judge(11, 10, 0.9, 0.95))
+                .withMessageContaining("successes");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> NormativeJudgementEvaluator.judge(-1, 10, 0.9, 0.95))
+                .withMessageContaining("successes");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> NormativeJudgementEvaluator.judge(5, 10, 1.0, 0.95))
+                .withMessageContaining("stipulatedThreshold");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> NormativeJudgementEvaluator.judge(5, 10, 0.9, 1.0))
+                .withMessageContaining("confidence");
+    }
+}


### PR DESCRIPTION
A measure experiment over a contract that declares normative criteria (`meeting().passRate(...)`) now judges each one against its stipulated threshold using the run's own samples — the Wilson one-sided lower confidence bound at the run's sample count, at the criterion's confidence, gated by the existing supportability check. Empirical criteria remain unjudged at experiment time: their bar does not exist until a baseline supplies it.

## What's in here

- **Judgement computation** — `NormativeJudgementEvaluator` (statistics package) composes the existing Wilson-bound and feasibility machinery into the three-state judgement: met / failed / unsupportable-with-feasible-minimum. No new statistical constructs.
- **Experiment output** — the judgement is rendered in the experiment's console output against the measured characterisation, worded strictly as a relation to the stipulation and prominent on failure. `run()`'s completion semantics are unchanged: it never fails on a failed judgement.
- **Baseline marker** — an additive, documentary `normativeJudgement` marker (state, stipulated threshold, confidence) per judged criterion row in the baseline YAML. Resolvers and threshold derivation ignore it; existing baseline files parse unchanged; the marker falls under the content fingerprint like every other written field.
- **Gating terminal** — `PUnit.measuring(...).assertMeets()`, mutually exclusive with `run()`, mirroring `assertPasses()`'s fused run-and-assert convention: same run, same persistence (baseline on disk before any throw), then `AssertionFailedError` on a failed judgement, `UnsupportableJudgementException` — a `TestAbortedException` subtype identifying the cause for tooling — (stating the feasible minimum) on an unsupportable one, `IllegalStateException` before sampling when the contract declares no normative criteria.
- **Namespace discipline** — `NormativeJudgement` lives in `api.spec` as outward result vocabulary, and the new `api.spec.MeasuredBaseline` carries what the measure terminals consume, so `PUnit` touches no internal types and the internal-namespace freeze store gains no new violations.
- **Docs** — user-guide section under Part 4 (Measuring) and a changelog entry.

## Verification

Full `./gradlew build` green: 1671+ tests including the ArchUnit guards (statistics isolation, requirement-code isolation, internal-namespace freeze, abstraction levels) and the mavai-R conformance suite (no fixture changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
