### PR TITLE
Conformance-lock percentile minimums; median needs five samples

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
@@ -145,7 +145,7 @@ public final class BaselineWriter {
         // indicator. Emitted top-level (not under statistics). The
         // block is omitted entirely when zero samples passed;
         // individual percentiles within it are omitted per the
-        // minimum-samples rule (1 / 10 / 20 / 100 for p50 / p90 /
+        // minimum-samples rule (5 / 10 / 20 / 100 for p50 / p90 /
         // p95 / p99).
         LatencyIndicator latency = record.latencyIndicator();
         if (latency.hasData()) {

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/LatencySection.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/LatencySection.java
@@ -33,8 +33,13 @@ public final class LatencySection {
     /** The only currently defined population basis. */
     public static final String BASIS_PASSING_SAMPLES = "passing-samples";
 
-    /** Minimum contributing samples required to emit each percentile. */
-    public static final int MIN_SAMPLES_P50 = 1;
+    /**
+     * Minimum contributing samples required to emit each percentile —
+     * the non-degeneracy gate of Statistical Companion §12.5.2,
+     * conformance-locked to the mavai-R
+     * {@code latency_percentile_minimums} fixture.
+     */
+    public static final int MIN_SAMPLES_P50 = 5;
     public static final int MIN_SAMPLES_P90 = 10;
     public static final int MIN_SAMPLES_P95 = 20;
     public static final int MIN_SAMPLES_P99 = 100;
@@ -127,7 +132,7 @@ public final class LatencySection {
         block.put("contributingSamples", contributingSamples);
         block.put("totalSamples", totalSamples);
         // Omit each percentile key when contributingSamples is below
-        // that percentile's minimum (1 / 10 / 20 / 100 for p50 / p90 /
+        // that percentile's minimum (5 / 10 / 20 / 100 for p50 / p90 /
         // p95 / p99). The artefact carries only the percentiles that
         // can be estimated reliably.
         if (isPercentileEmittable("p50", contributingSamples)) {

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/emit/LatencySectionTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/emit/LatencySectionTest.java
@@ -65,10 +65,27 @@ class LatencySectionTest {
                 18);
 
         Map<String, Object> block = LatencySection.blockFor(passing, 18, 20).orElseThrow();
-        // p50 needs ≥ 1, p90 needs ≥ 10 — both met at 18.
+        // p50 needs ≥ 5, p90 needs ≥ 10 — both met at 18.
         assertThat(block).containsKeys("p50Ms", "p90Ms");
         // p95 needs ≥ 20, p99 needs ≥ 100 — both unmet at 18.
         assertThat(block).doesNotContainKeys("p95Ms", "p99Ms");
+    }
+
+    @Test
+    @DisplayName("minimum-sample rule: 4 passing → no percentile keys at all")
+    void omitsMedianBelowNonDegeneracyMinimum() {
+        LatencyResult passing = new LatencyResult(
+                Duration.ofMillis(42),
+                Duration.ofMillis(78),
+                Duration.ofMillis(95),
+                Duration.ofMillis(150),
+                4);
+
+        Map<String, Object> block = LatencySection.blockFor(passing, 4, 10).orElseThrow();
+        // The indicator triple is still present — the block itself emits.
+        assertThat(block).containsEntry("contributingSamples", 4);
+        // p50 needs ≥ 5: below the non-degeneracy minimum nothing is emitted.
+        assertThat(block).doesNotContainKeys("p50Ms", "p90Ms", "p95Ms", "p99Ms");
     }
 
     @Test
@@ -89,9 +106,10 @@ class LatencySectionTest {
     }
 
     @Test
-    @DisplayName("isPercentileEmittable encodes the thresholds (1 / 10 / 20 / 100)")
+    @DisplayName("isPercentileEmittable encodes the thresholds (5 / 10 / 20 / 100)")
     void thresholdRule() {
-        assertThat(LatencySection.isPercentileEmittable("p50", 1)).isTrue();
+        assertThat(LatencySection.isPercentileEmittable("p50", 4)).isFalse();
+        assertThat(LatencySection.isPercentileEmittable("p50", 5)).isTrue();
         assertThat(LatencySection.isPercentileEmittable("p90", 9)).isFalse();
         assertThat(LatencySection.isPercentileEmittable("p90", 10)).isTrue();
         assertThat(LatencySection.isPercentileEmittable("p95", 19)).isFalse();

--- a/punit-core/src/test/java/org/mavai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -72,7 +72,7 @@ class LatencyEverywhereIntegrationTest {
                 .<F, String, Integer>builder()
                 .serviceContractFactory(f -> new EvenLengthServiceContract())
                 .inputs(MIXED_INPUTS)
-                .samples(6)
+                .samples(12)
                 .build();
         Experiment experiment = Experiment.exploring(sampling)
                 .grid(List.of(new F("only")))
@@ -90,18 +90,18 @@ class LatencyEverywhereIntegrationTest {
                 .as("EXPLORE row must carry latency block when at least one sample passed")
                 .isNotNull();
         assertThat(latency).containsEntry("basis", "passing-samples");
-        assertThat(latency).containsEntry("totalSamples", 6);
-        // 4 of 6 inputs are even-length → expect ~4 contributing samples.
+        assertThat(latency).containsEntry("totalSamples", 12);
+        // 4 of 6 inputs are even-length, cycled twice → 8 contributing.
         assertThat((Integer) latency.get("contributingSamples"))
                 .as("contributingSamples must be ≤ totalSamples and > 0")
                 .isPositive()
-                .isLessThanOrEqualTo(6);
-        // Minimum-samples rule: with ≤ 6 contributing samples,
-        // only p50Ms (needs ≥ 1) is emittable. p90 / p95 / p99 keys
-        // are correctly absent — explore is the canonical
-        // small-sample case the rule protects.
+                .isLessThanOrEqualTo(12);
+        // Minimum-samples rule: with 8 contributing samples, only
+        // p50Ms (needs ≥ 5) is emittable. p90 / p95 / p99 keys are
+        // correctly absent — explore is the canonical small-sample
+        // case the rule protects.
         assertThat(latency).containsKey("p50Ms");
-        assertThat(latency).doesNotContainKeys("p95Ms", "p99Ms");
+        assertThat(latency).doesNotContainKeys("p90Ms", "p95Ms", "p99Ms");
     }
 
     @Test
@@ -152,7 +152,7 @@ class LatencyEverywhereIntegrationTest {
                 .<F, String, Integer>builder()
                 .serviceContractFactory(f -> new EvenLengthServiceContract())
                 .inputs(MIXED_INPUTS)
-                .samples(6)
+                .samples(12)
                 .build();
         Experiment experiment = Experiment.measuring(sampling, new F("only")).build();
         new Engine().run(experiment);
@@ -170,9 +170,9 @@ class LatencyEverywhereIntegrationTest {
         assertThat(latency).containsEntry("basis", "passing-samples");
         assertThat(latency).containsKey("contributingSamples");
         assertThat(latency).containsKey("totalSamples");
-        // 6 samples, ≤ 6 contributing → only p50Ms emits.
+        // 12 samples, 8 contributing → only p50Ms (needs ≥ 5) emits.
         assertThat(latency).containsKey("p50Ms");
-        assertThat(latency).doesNotContainKeys("p95Ms", "p99Ms");
+        assertThat(latency).doesNotContainKeys("p90Ms", "p95Ms", "p99Ms");
     }
 
     @Test

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyConformanceTest.java
@@ -18,6 +18,7 @@ import org.mavai.punit.api.spec.PercentileLatency;
 import org.mavai.punit.api.spec.SampleSummary;
 import org.mavai.punit.api.spec.TerminationReason;
 import org.mavai.punit.api.spec.Verdict;
+import org.mavai.punit.internal.engine.emit.LatencySection;
 import org.mavai.punit.statistics.LatencyStatistics;
 import org.mavai.punit.statistics.LatencyThresholdDeriver;
 import org.junit.jupiter.api.DisplayName;
@@ -452,6 +453,74 @@ class LatencyConformanceTest {
                 out[i] = node.get(i).asLong();
             }
             return out;
+        }
+    }
+
+    @Nested
+    @DisplayName("latency_percentile_minimums — per-percentile minimum sample sizes")
+    class PercentileMinimums {
+
+        @TestFactory
+        @DisplayName("Emission non-degeneracy minimums match the published standard")
+        Collection<DynamicTest> emissionMinimums() {
+            JsonNode suite = loadSuite("latency_percentile_minimums.json");
+
+            var tests = new ArrayList<DynamicTest>();
+            for (JsonNode c : suite.get("cases")) {
+                if (!"emission_non_degeneracy".equals(c.get("approach").asText())) {
+                    continue;
+                }
+                String name = c.get("name").asText();
+                double p = c.get("inputs").get("percentile").asDouble();
+                int expected = c.get("expected").get("minimum_contributing_samples").asInt();
+
+                tests.add(DynamicTest.dynamicTest(name, () -> {
+                    String label = "p" + Math.round(p * 100);
+                    assertThat(LatencySection.minimumSamplesFor(label))
+                            .as("emission minimum for %s", label)
+                            .isEqualTo(expected);
+                }));
+            }
+            assertThat(tests).as("emission cases in the suite").hasSize(4);
+            return tests;
+        }
+
+        @TestFactory
+        @DisplayName("Bound-existence minimums mark the deriver's saturation boundary")
+        Collection<DynamicTest> boundExistenceMinimums() {
+            JsonNode suite = loadSuite("latency_percentile_minimums.json");
+
+            var tests = new ArrayList<DynamicTest>();
+            for (JsonNode c : suite.get("cases")) {
+                if (!"bound_existence".equals(c.get("approach").asText())) {
+                    continue;
+                }
+                String name = c.get("name").asText();
+                double p = c.get("inputs").get("percentile").asDouble();
+                double confidence = c.get("inputs").get("confidence").asDouble();
+                int minimum = c.get("expected").get("minimum_baseline_samples").asInt();
+
+                tests.add(DynamicTest.dynamicTest(name, () -> {
+                    assertThat(LatencyThresholdDeriver.derive(ascending(minimum), p, confidence)
+                            .saturated())
+                            .as("non-saturated bound at the published minimum n=%d", minimum)
+                            .isFalse();
+                    assertThat(LatencyThresholdDeriver.derive(ascending(minimum - 1), p, confidence)
+                            .saturated())
+                            .as("saturation just below the published minimum, n=%d", minimum - 1)
+                            .isTrue();
+                }));
+            }
+            assertThat(tests).as("bound-existence cases in the suite").hasSize(8);
+            return tests;
+        }
+
+        private double[] ascending(int n) {
+            double[] values = new double[n];
+            for (int i = 0; i < n; i++) {
+                values[i] = i + 1;
+            }
+            return values;
         }
     }
 

--- a/punit-report/src/test/java/org/mavai/punit/report/explore/ReportGeneratorTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/explore/ReportGeneratorTest.java
@@ -200,11 +200,15 @@ class ReportGeneratorTest {
         @DisplayName("marks equally-reliable variants within the latency margin as too close to call")
         void nearTieMarksAdjacentVariants() throws IOException {
             Path service = tempDir.resolve("explorations").resolve("svc");
-            // Both all-pass; p50 1010 vs 1040 -> ~2.9% apart, within the 5% margin.
+            // Both all-pass; p50 1010 vs 1040 -> ~2.9% apart, within the 5%
+            // margin. Five passing samples each: a median needs >= 5
+            // contributing samples to be reported at all.
             writeVariant(service, "a.yaml",
-                    allPassVariant("svc", "model-a", new long[]{1000, 1010, 1020}, 1010));
+                    allPassVariant("svc", "model-a",
+                            new long[]{1000, 1005, 1010, 1015, 1020}, 1010));
             writeVariant(service, "b.yaml",
-                    allPassVariant("svc", "model-b", new long[]{1030, 1040, 1050}, 1040));
+                    allPassVariant("svc", "model-b",
+                            new long[]{1030, 1035, 1040, 1045, 1050}, 1040));
 
             String html = generate(tempDir.resolve("explorations"));
 
@@ -221,9 +225,11 @@ class ReportGeneratorTest {
             Path service = tempDir.resolve("explorations").resolve("svc");
             // p50 1010 vs 1510 -> ~33% apart, well beyond 5%.
             writeVariant(service, "a.yaml",
-                    allPassVariant("svc", "model-a", new long[]{1000, 1010, 1020}, 1010));
+                    allPassVariant("svc", "model-a",
+                            new long[]{1000, 1005, 1010, 1015, 1020}, 1010));
             writeVariant(service, "c.yaml",
-                    allPassVariant("svc", "model-c", new long[]{1500, 1510, 1520}, 1510));
+                    allPassVariant("svc", "model-c",
+                            new long[]{1500, 1505, 1510, 1515, 1520}, 1510));
 
             String html = generate(tempDir.resolve("explorations"));
 
@@ -236,9 +242,11 @@ class ReportGeneratorTest {
             Path service = tempDir.resolve("explorations").resolve("svc");
             // Close medians, but different pass rates: not a near-tie (no proportion test).
             writeVariant(service, "a.yaml",
-                    allPassVariant("svc", "model-a", new long[]{1000, 1010, 1020}, 1010));
+                    allPassVariant("svc", "model-a",
+                            new long[]{1000, 1005, 1010, 1015, 1020}, 1010));
             writeVariant(service, "d.yaml", variant("svc", factors("model-d"),
-                    0.667, 2, 1, "COMPLETED", new long[]{1005, 1015, 1025}, 1015));
+                    0.833, 5, 1, "COMPLETED",
+                    new long[]{1005, 1010, 1015, 1020, 1025}, 1015));
 
             String html = generate(tempDir.resolve("explorations"));
 


### PR DESCRIPTION
Executes the family alignment of per-percentile minimum sample sizes (orchestrator directive `DIR-PERCENTILE-MINIMUMS-family`).

mavai-R v0.8.3 publishes `latency_percentile_minimums.json` — the Statistical Companion's non-degeneracy emission minimums (§12.5.2) and the Wilks bound-existence minimums (§12.5.2.1) — as an exact-equality conformance suite.

**Commit 1 (red)**: a new conformance section asserts the emission gate equals the fixture and that the threshold deriver's saturation flag flips precisely at the published bound-existence minimum. The median emission case fails at that commit: the code gated p50 at 1 contributing sample, while the companion — and this repo's own USER-GUIDE Part 7 — say 5. The eight bound-existence cases pass immediately, confirming the deriver sits exactly on the Wilks boundary.

**Commit 2 (green)**: `LatencySection.MIN_SAMPLES_P50` rises 1 → 5. All artefact paths (baseline, exploration, optimization, verdict record) route through this one gating table, verified. Consequence: artefacts and verdicts from runs with fewer than five passing samples no longer carry `p50Ms`; renderers already show a dash. Integration and exploration-report tests that relied on 3–4-passing-sample medians now use five or more.

The conformance test consumes the fixture through the standard `fetchConformanceData` fetch-latest path; v0.8.3 is released, and the suite passes end-to-end against it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgDQDXMkp5TQGfYFKVvtgv