### PR TITLE
Integer cutoff binds the empirical verdict, Wilson evidence the declared one; adopt the conformance manifest

### DIFF
--- a/docs/OPERATIONAL-FLOW.md
+++ b/docs/OPERATIONAL-FLOW.md
@@ -83,8 +83,8 @@ Regardless of which paradigm you use, you must decide **how to parameterize** yo
 
 > **Where the threshold comes from, and how the comparison is decided.** The pass-rate criterion has two modes, declared via `Criteria.meeting()` or `Criteria.empirical()` on the service contract's `criteria()`:
 >
-> - **Empirical** (`empirical().passRate()`) — the threshold is the observed pass rate read at runtime from the matched baseline spec (produced by a prior MEASURE experiment). The verdict applies a one-sided **Wilson score lower bound** to the run's observed rate at the configured confidence (default 0.95) and passes iff that lower bound clears the baseline rate. Approaches 1 and 2 below use this mode.
-> - **Contractual** (`meeting().passRate(threshold).contractRef(origin, ref)`) — the threshold is an externally-fixed number declared in code (an SLA, SLO, or policy figure). The verdict is a **deterministic** `observed >= threshold` comparison. No Wilson margin: an SLA is an external commitment to a specific number, not a statistical claim against a baseline. Approach 3 uses this mode.
+> - **Empirical** (`empirical().passRate()`) — the threshold is derived at runtime from the matched baseline spec (produced by a prior MEASURE experiment): the one-sided **Wilson score lower bound** of the baseline rate at the test's sample size and configured confidence (default 0.95). The binding decision is discrete — the derivation's **integer cutoff** `c = ⌈n·p*⌉` — and the run passes iff the raw observed success count `K ≥ c`. Approaches 1 and 2 below use this mode.
+> - **Contractual** (`meeting().passRate(threshold).contractRef(origin, ref)`) — the threshold is an externally-fixed number declared in code (an SLA, SLO, or policy figure). The verdict compares the **run's own Wilson lower bound** (at the default confidence) against the declared threshold: the commitment is met when the sample provides confidence-grade evidence for it, not when the point estimate happens to graze it. Approach 3 uses this mode.
 >
 > What the three approaches differ in is which knob the author fixes first.
 
@@ -159,14 +159,14 @@ void thresholdFirst() {
 
 **What happens:**
 - The threshold and its provenance (`SLA`, `SLO`, or `POLICY`) are declared in code; no baseline is involved.
-- PUnit runs the chosen samples and applies a **deterministic** `observed >= threshold` comparison — no Wilson margin.
+- PUnit runs the chosen samples and passes iff the **run's own Wilson lower bound** clears the declared threshold — the sample must provide confidence-grade evidence for the commitment.
 - The threshold's provenance and the optional `contractRef` are recorded on the verdict for audit traceability.
 
-**Trade-off:** No statistical buffer. With a small N relative to a strict threshold, declare `.intent(TestIntent.SMOKE)` to mark the run as a sentinel rather than a verification claim; otherwise PUnit's pre-flight feasibility gate may reject the configuration as undersized for verification.
+**Trade-off:** Evidence costs samples. The Wilson comparison means a strict threshold needs a sample size that can actually support it (even a perfect run of 30 samples only evidences ≈ 0.917); with a small N relative to a strict threshold, declare `.intent(TestIntent.SMOKE)` to mark the run as a sentinel rather than a verification claim; otherwise PUnit's pre-flight feasibility gate rejects the configuration as undersized for verification.
 
 **Best for:** SLA-style verification of services with externally-committed reliability targets.
 
-> **Antipattern: pinning a contractual threshold to a baseline's observed rate.** Reading a baseline file by eye and pasting its observed rate into `meeting().passRate(0.935).contractRef(EMPIRICAL, ...)` looks like the empirical-pair pattern but isn't. The contractual path is deterministic — `observed >= 0.935` — and natural sampling variance puts the next run's observed rate below 0.935 roughly half the time even when the SUT is performing exactly at baseline. Result: ~50% false-fail rate. The proper baseline-comparison path is `empirical().passRate()`, which resolves the baseline at runtime, applies the Wilson lower bound at the configured confidence, and gives the test the statistical buffer that the hardcoded contractual approach is missing.
+> **Antipattern: pinning a contractual threshold to a baseline's observed rate.** Reading a baseline file by eye and pasting its observed rate into `meeting().passRate(0.935).contractRef(EMPIRICAL, ...)` looks like the empirical-pair pattern but isn't. The contractual path demands confidence-grade evidence *for that number*: the run's Wilson lower bound must clear 0.935, which a service performing exactly at the 0.935 baseline essentially never provides at test-scale sample counts. Result: near-permanent false-fail. The proper baseline-comparison path is `empirical().passRate()`, which resolves the baseline at runtime, derives the sample-size-aware threshold and integer cutoff from it, and gives the test the statistical margin that the hardcoded contractual approach is missing.
 
 ### Choosing Your Approach
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -527,17 +527,20 @@ A criterion's threshold comes from one of two places, selected by the
 factory that opens its declaration on the contract:
 
 - **Contractual** (`meeting().passRate(...)`, `meeting().atMost(...)`)
-  — a fixed value declared by an SLA, SLO, or policy. PUnit applies a
-  deterministic `observed >= threshold` comparison. No baseline is
-  consulted; no statistical margin is applied.
+  — a fixed value declared by an SLA, SLO, or policy. No baseline is
+  consulted; PUnit passes the run iff its own Wilson-95% lower bound
+  clears the declared threshold — the sample must provide
+  confidence-grade evidence for the commitment, not merely a point
+  estimate that grazes it.
   ```java
   return meeting().passRate(0.99).contractRef(SLA, "Acme SLA v3 §2.1")
           .satisfies(...);
   ```
 - **Empirical** (`empirical().passRate()`, `empirical().atMost(...)`)
-  — derived at runtime from a recorded baseline file. PUnit applies
-  the Wilson-95% lower bound to the run's observed rate and passes
-  if that bound clears the baseline rate.
+  — derived at runtime from a recorded baseline file. PUnit derives
+  the threshold as the Wilson-95% lower bound of the baseline rate at
+  the test's sample size, and passes iff the raw observed success
+  count meets the derivation's integer cutoff `c = ⌈n·p*⌉`.
   ```java
   return empirical().<O>passRate().satisfies(...);
   ```

--- a/punit-core/build.gradle.kts
+++ b/punit-core/build.gradle.kts
@@ -98,7 +98,30 @@ val fetchConformanceData by tasks.registering {
     outputs.dir(conformanceResourcesDir)
     outputs.upToDateWhen { false }
 
+    // Local-directory override: -PconformanceCasesDir=/path/to/mavai-R/inst/cases
+    // sources the fixture JSON from a local checkout instead of the latest
+    // GitHub release. Intended for working against fixture content that is
+    // merged upstream but not yet tagged/released; the default fetch-latest
+    // behaviour is unchanged when the property is absent.
+    val conformanceCasesDirOverride = providers.gradleProperty("conformanceCasesDir")
+
     doLast {
+        val overrideDir = conformanceCasesDirOverride.orNull
+        if (overrideDir != null) {
+            val srcDir = file(overrideDir)
+            require(srcDir.isDirectory) {
+                "conformanceCasesDir does not resolve to a directory: $srcDir"
+            }
+            val destDir = conformanceResourcesDir.get().asFile.resolve("conformance")
+            if (destDir.exists()) destDir.deleteRecursively()
+            destDir.mkdirs()
+            copy {
+                from(srcDir) { include("*.json") }
+                into(destDir)
+            }
+            logger.lifecycle("Using local mavai-R conformance fixtures: $srcDir")
+            return@doLast
+        }
         val latestUrl = URI(
             "https://github.com/mavai-org/mavai-R/releases/latest"
         ).toURL()

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionPosture.java
@@ -246,8 +246,9 @@ public final class CriterionPosture {
      * Returns a copy of this posture with the given confidence floor.
      * Rejects composition with zero-failures (explicit or implicit)
      * — the statistical math is undefined at the threshold boundary.
-     * Rejects composition with {@code .meeting(...)} — threshold-first
-     * is deterministic and accepts no rigour adjuncts.
+     * Rejects composition with {@code .meeting(...)} — a declared
+     * threshold is judged at the framework's default confidence and
+     * accepts no per-criterion rigour adjuncts.
      */
     public CriterionPosture withConfidenceFloor(double confidence) {
         rejectRigourAdjunct("atConfidence");
@@ -360,8 +361,9 @@ public final class CriterionPosture {
                             + "statistical math is undefined at the threshold boundary");
             case STATISTICAL_CONTRACTUAL -> throw new IllegalStateException(
                     "." + methodName + "(...) cannot compose with .meeting(...) — "
-                            + "threshold-first is deterministic and accepts no rigour adjuncts; "
-                            + "switch to .empirical() if you want a statistical comparison");
+                            + "a declared threshold is judged at the framework's default "
+                            + "confidence and accepts no per-criterion rigour adjuncts; "
+                            + "switch to .empirical() if you want a baseline-derived comparison");
             case LATENCY_CONTRACTUAL -> throw new IllegalStateException(
                     "." + methodName + "(...) does not apply to contractual latency — "
                             + "the ceiling is the threshold; nothing to estimate");

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/Criterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/Criterion.java
@@ -105,4 +105,20 @@ public interface Criterion<OT, S extends BaselineStatistics> {
     default OptionalDouble earlyTerminationPassRate() {
         return OptionalDouble.empty();
     }
+
+    /**
+     * The confidence of the declared-threshold comparison backing
+     * {@link #earlyTerminationPassRate()}, if any. The engine's
+     * guaranteed-success short-circuit derives its required success
+     * count from the same statistical rule the criterion will apply at
+     * evaluate time — the Wilson lower bound at this confidence
+     * clearing the threshold — so a short-circuited run can never lock
+     * in a verdict the full run would have refused.
+     *
+     * @return the comparison confidence in (0, 1), or empty when the
+     *         criterion exposes no up-front threshold
+     */
+    default OptionalDouble earlyTerminationConfidence() {
+        return OptionalDouble.empty();
+    }
 }

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/EarlyTerminationContext.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/EarlyTerminationContext.java
@@ -19,10 +19,17 @@ package org.mavai.punit.api.spec;
  *                              until the normal approximation is meaningful.
  *                              Zero disables the floor (failure-inevitable
  *                              termination never needs it).
+ * @param confidence            the confidence of the criterion's declared-
+ *                              threshold Wilson comparison (companion
+ *                              §3.2/§3.6). The engine derives the guaranteed-
+ *                              success count from it: a success count is only
+ *                              "locked in" when its Wilson lower bound at this
+ *                              confidence already clears {@code minPassRate}.
  */
 public record EarlyTerminationContext(
         double minPassRate,
-        int minSamplesForValidity) {
+        int minSamplesForValidity,
+        double confidence) {
 
     public EarlyTerminationContext {
         if (Double.isNaN(minPassRate) || minPassRate < 0.0 || minPassRate > 1.0) {
@@ -32,6 +39,10 @@ public record EarlyTerminationContext(
         if (minSamplesForValidity < 0) {
             throw new IllegalArgumentException(
                     "minSamplesForValidity must be non-negative, got: " + minSamplesForValidity);
+        }
+        if (Double.isNaN(confidence) || confidence <= 0.0 || confidence >= 1.0) {
+            throw new IllegalArgumentException(
+                    "confidence must be in (0, 1), got: " + confidence);
         }
     }
 }

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/PerCriterionVerdicts.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/PerCriterionVerdicts.java
@@ -8,15 +8,18 @@ import java.util.Optional;
  * Derives a per-criterion three-valued verdict for every methodology-
  * level criterion the contract declared on a run.
  *
- * <p>This is glue, not statistics: it reuses the threshold the
- * legacy verdict path already resolved (via {@code PassRate.evaluate})
- * and applies the same {@code observed >= threshold} decision rule to
- * each criterion's marginal-policy observed pass-rate. Any new
- * statistical arithmetic belongs in
- * {@code org.mavai.punit.statistics}; this helper performs no such
- * arithmetic.
+ * <p>This is glue, not statistics: it reuses the verdicts and
+ * thresholds the criterion evaluation already produced (via
+ * {@code PassRate.evaluate}). The decision rule itself — integer
+ * cutoff on the empirical path, test-side Wilson lower bound on the
+ * declared path (statistical companion §3.4 / §3.2) — is applied
+ * exactly once, inside the criterion; this helper consumes the
+ * criterion's published {@code verdictsByCriterion} rather than
+ * re-deriving a verdict of its own. Any new statistical arithmetic
+ * belongs in {@code org.mavai.punit.statistics}; this helper performs
+ * no such arithmetic.
  *
- * <p>Step-3 behavioural contract:
+ * <p>Behavioural contract:
  *
  * <ul>
  *   <li>The legacy spec-layer evaluation (the list of
@@ -27,12 +30,12 @@ import java.util.Optional;
  *       per-criterion verdict is INCONCLUSIVE too. The framework has
  *       judged the entire run statistically inconclusive; a
  *       per-criterion verdict cannot meaningfully be PASS or FAIL.</li>
- *   <li>Otherwise: per-criterion verdict =
- *       {@code observed >= threshold ? PASS : FAIL}, where
- *       {@code observed} is the criterion's marginal-policy observed
- *       pass-rate (PASS count over PASS+FAIL+INCONCLUSIVE) and
- *       {@code threshold} is the contract-inherited resolved
- *       threshold. A criterion with zero samples (only reachable on a
+ *   <li>Otherwise: per-criterion verdict = the criterion evaluation's
+ *       own published verdict for that methodology criterion. For
+ *       results from evaluators that publish no per-criterion verdict
+ *       map (hand-built fixtures, older evaluators) the legacy
+ *       {@code observed >= threshold} comparison remains as the
+ *       fallback. A criterion with zero samples (only reachable on a
  *       zero-sample run, in which case the feasibility gate has
  *       independently refused the test) maps to INCONCLUSIVE.</li>
  *   <li>The composite is {@link Verdict#aggregate(List)} over the
@@ -52,6 +55,7 @@ public final class PerCriterionVerdicts {
         }
         java.util.Map<String, Double> perCriterionThresholds =
                 scanPerCriterionThresholds(legacyEvaluated);
+        java.util.Map<String, Verdict> judgedVerdicts = scanJudgedVerdicts(legacyEvaluated);
         Optional<Double> sharedThreshold = scanThreshold(legacyEvaluated);
         Verdict legacyComposed = Verdict.compose(legacyEvaluated);
         boolean propagateInconclusive = legacyComposed == Verdict.INCONCLUSIVE;
@@ -69,9 +73,14 @@ public final class PerCriterionVerdicts {
                     : sharedThreshold.orElse(Double.NaN);
             Verdict v;
             double observed = counts.observedPassRate();
-            if (propagateInconclusive
-                    || Double.isNaN(resolvedThreshold)
-                    || counts.total() == 0) {
+            if (propagateInconclusive || counts.total() == 0) {
+                v = Verdict.INCONCLUSIVE;
+            } else if (judgedVerdicts.containsKey(counts.criterionId())) {
+                // The criterion evaluation already judged this criterion
+                // under the companion's decision rule — reuse it; do not
+                // re-derive a second verdict from observed vs threshold.
+                v = judgedVerdicts.get(counts.criterionId());
+            } else if (Double.isNaN(resolvedThreshold)) {
                 v = Verdict.INCONCLUSIVE;
             } else {
                 v = observed >= resolvedThreshold ? Verdict.PASS : Verdict.FAIL;
@@ -81,6 +90,32 @@ public final class PerCriterionVerdicts {
             verdicts.add(v);
         }
         return new PerCriterionEvaluation(derived, Verdict.aggregate(verdicts));
+    }
+
+    /**
+     * Lifts the criterion evaluation's own per-methodology-criterion
+     * verdicts from the legacy {@link EvaluatedCriterion} list. The
+     * {@code PassRate} evaluator publishes {@code verdictsByCriterion}
+     * ({@code Map<String, String>} of verdict names) on its result
+     * detail; results that carry no such map (hand-built fixtures,
+     * non-pass-rate criteria) contribute nothing and fall back to the
+     * threshold comparison.
+     */
+    private static java.util.Map<String, Verdict> scanJudgedVerdicts(
+            List<EvaluatedCriterion> evaluated) {
+        java.util.LinkedHashMap<String, Verdict> out = new java.util.LinkedHashMap<>();
+        for (EvaluatedCriterion ec : evaluated) {
+            Object v = ec.result().detail().get("verdictsByCriterion");
+            if (v instanceof java.util.Map<?, ?> raw) {
+                for (java.util.Map.Entry<?, ?> e : raw.entrySet()) {
+                    if (e.getKey() instanceof String key
+                            && e.getValue() instanceof String name) {
+                        out.put(key, Verdict.valueOf(name));
+                    }
+                }
+            }
+        }
+        return out;
     }
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTest.java
@@ -449,7 +449,13 @@ public final class ProbabilisticTest implements Spec {
                     double rate = threshold.getAsDouble();
                     int floor = new org.mavai.punit.statistics.BinomialProportionEstimator()
                             .minSamplesForNormalApproximation(rate);
-                    return Optional.of(new EarlyTerminationContext(rate, floor));
+                    // The confidence of the criterion's Wilson comparison —
+                    // the guaranteed-success count must be derived under the
+                    // same rule the criterion applies at evaluate time.
+                    double confidence = entry.criterion().earlyTerminationConfidence()
+                            .orElse(org.mavai.punit.statistics.StatisticalDefaults
+                                    .DEFAULT_CONFIDENCE);
+                    return Optional.of(new EarlyTerminationContext(rate, floor, confidence));
                 }
             }
             return Optional.empty();

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
@@ -215,14 +215,26 @@ public final class Engine {
             this.tracker = tracker;
             this.plannedSamples = plannedSamples;
             this.earlyTermination = earlyTermination;
-            // Cached once: required-successes = ceil(plannedSamples * minPassRate),
-            // and the statistical-validity floor below which a guaranteed-success
-            // short-circuit must not fire. Both zero when no context is supplied
-            // (measure / explore / optimize / empirical / opt-out paths).
+            // Cached once: required-successes = the smallest success count
+            // whose Wilson lower bound at the context's confidence clears
+            // the declared threshold — the same rule the criterion applies
+            // at evaluate time (companion §3.2/§3.6), so neither
+            // short-circuit can disagree with the eventual verdict:
+            // success-guaranteed fires only on a count the criterion will
+            // pass; failure-inevitable fires when even all-remaining-pass
+            // stays below it. plannedSamples + 1 (never guaranteed;
+            // failure inevitable from the outset) when a perfect run
+            // cannot clear the threshold at this sample count. Also cached:
+            // the statistical-validity floor below which a guaranteed-
+            // success short-circuit must not fire. Both zero when no
+            // context is supplied (measure / explore / optimize /
+            // empirical / opt-out paths).
             if (earlyTermination.isPresent()) {
                 EarlyTerminationContext ctx = earlyTermination.get();
                 this.requiredSuccesses =
-                        (int) Math.ceil(plannedSamples * ctx.minPassRate());
+                        new org.mavai.punit.statistics.BinomialProportionEstimator()
+                                .minimumSuccessesToClear(
+                                        ctx.minPassRate(), plannedSamples, ctx.confidence());
                 this.minSamplesForValidity = ctx.minSamplesForValidity();
             } else {
                 this.requiredSuccesses = 0;

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
@@ -45,17 +45,20 @@ import org.mavai.punit.statistics.ThresholdDeriver;
  * <p>The empirical paths derive a threshold by applying the one-sided
  * Wilson lower bound at the test sample size to the baseline rate
  * (with a perfect-baseline two-step refinement when {@code k = n};
- * statistical companion §3.4 / §4.3.2), and PASS iff the observed
- * pass rate respects that derived threshold (§5.1). The underlying
- * statistical machinery is {@link BinomialProportionEstimator}; this
- * criterion holds no statistical code of its own — that's the punit
- * design rule (statistics live only in
- * {@code org.mavai.punit.statistics}). See {@code CLAUDE.md}
- * §"Statistics isolation rule".
+ * statistical companion §3.4 / §4.3.2), and PASS iff the raw observed
+ * success count meets the derivation's integer cutoff
+ * {@code c = ⌈n_test · p*⌉} — the companion's binding decision
+ * artefact. The underlying statistical machinery is
+ * {@link BinomialProportionEstimator}; this criterion holds no
+ * statistical code of its own — that's the punit design rule
+ * (statistics live only in {@code org.mavai.punit.statistics}). See
+ * {@code CLAUDE.md} §"Statistics isolation rule".
  *
- * <p>The contractual path keeps a deterministic
- * {@code observed >= threshold} check: an SLA-style threshold is an
- * external commitment, not a statistical claim against a baseline.
+ * <p>The contractual (declared-threshold) path judges the test
+ * sample's own one-sided Wilson lower bound against the declared
+ * threshold (companion §3.2/§3.6): a declared commitment is met when
+ * the sample provides confidence-grade evidence for it, not when the
+ * point estimate happens to graze it.
  *
  * <p>Lives in {@code punit-core} rather than {@code api package} because
  * the empirical path needs {@code BinomialProportionEstimator} and
@@ -69,6 +72,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
     private static final String NAME = "bernoulli-pass-rate";
     private static final double DEFAULT_CONFIDENCE = 0.95;
     private static final ThresholdDeriver DERIVER = new ThresholdDeriver();
+    private static final BinomialProportionEstimator ESTIMATOR = new BinomialProportionEstimator();
 
     private enum Mode { CONTRACTUAL, EMPIRICAL_DEFAULT, EMPIRICAL_PINNED, ZERO_FAILURES }
 
@@ -263,6 +267,13 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
     }
 
     @Override
+    public OptionalDouble earlyTerminationConfidence() {
+        return mode == Mode.CONTRACTUAL
+                ? OptionalDouble.of(confidence)
+                : OptionalDouble.empty();
+    }
+
+    @Override
     public Map<String, Object> empiricalDetail() {
         if (mode == Mode.CONTRACTUAL || mode == Mode.ZERO_FAILURES) {
             return Map.of();
@@ -345,6 +356,17 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
         Map<String, Double> thresholdsByCriterion = new LinkedHashMap<>();
         Map<String, Double> observedByCriterion = new LinkedHashMap<>();
         Map<String, PassRateStatistics> resolvedBaselineByCriterion = new LinkedHashMap<>();
+        // The judged three-valued verdict per methodology criterion —
+        // published on the result detail so downstream aggregation
+        // (PerCriterionVerdicts) reuses the criterion's own judgement
+        // instead of re-deriving one from observed vs threshold.
+        Map<String, String> verdictsByCriterion = new LinkedHashMap<>();
+        // Declared-threshold path: the test sample's Wilson lower bound
+        // per criterion (companion §3.2/§3.6 decision artefact).
+        Map<String, Double> wilsonLowerByCriterion = new LinkedHashMap<>();
+        // Empirical path: the derivation carrying the integer cutoff and
+        // achieved size (companion §3.4 decision artefacts).
+        Map<String, DerivedThreshold> decisionByCriterion = new LinkedHashMap<>();
         List<String> perCriterionExplanations = new ArrayList<>();
         ThresholdOrigin resolvedOrigin = isEmpirical()
                 ? ThresholdOrigin.EMPIRICAL
@@ -395,13 +417,25 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                 double pThreshold = posture.threshold().getAsDouble();
                 ThresholdOrigin pOrigin = posture.origin().orElseThrow();
                 thresholdsByCriterion.put(counts.criterionId(), pThreshold);
-                Verdict pv = criterionTotal == 0
-                        ? Verdict.INCONCLUSIVE
-                        : (observed >= pThreshold ? Verdict.PASS : Verdict.FAIL);
+                Verdict pv;
+                if (criterionTotal == 0) {
+                    pv = Verdict.INCONCLUSIVE;
+                } else {
+                    // Declared threshold (companion §3.2/§3.6): the test
+                    // sample's own Wilson lower bound must clear it.
+                    double wilsonLower = ESTIMATOR.lowerBound(
+                            counts.pass(), criterionTotal, confidence);
+                    wilsonLowerByCriterion.put(counts.criterionId(), wilsonLower);
+                    pv = wilsonLower >= pThreshold ? Verdict.PASS : Verdict.FAIL;
+                }
                 perCriterionVerdicts.add(pv);
+                verdictsByCriterion.put(counts.criterionId(), pv.name());
                 perCriterionExplanations.add(String.format(
-                        "%s: observed=%.4f vs threshold=%.4f (origin=%s) over %d samples → %s",
-                        counts.criterionId(), observed, pThreshold, pOrigin, criterionTotal, pv));
+                        "%s: observed=%.4f, Wilson-%.0f%% lower=%.4f vs threshold=%.4f "
+                                + "(origin=%s) over %d samples → %s",
+                        counts.criterionId(), observed, confidence * 100.0,
+                        wilsonLowerByCriterion.getOrDefault(counts.criterionId(), Double.NaN),
+                        pThreshold, pOrigin, criterionTotal, pv));
                 continue;
             }
             // zero-failures fires when the contract committed explicitly
@@ -427,6 +461,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                     pv = Verdict.FAIL;
                 }
                 perCriterionVerdicts.add(pv);
+                verdictsByCriterion.put(counts.criterionId(), pv.name());
                 perCriterionExplanations.add(String.format(
                         "%s: zero-failures (origin=%s); failures=%d "
                                 + "(of which transform/no-value=%d) over %d samples → %s",
@@ -439,6 +474,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
             double criterionThreshold;
             Double baselineRate = null;
             Integer baselineSampleCount = null;
+            DerivedThreshold derived = null;
             if (mode == Mode.CONTRACTUAL) {
                 criterionThreshold = threshold;
             } else {
@@ -460,6 +496,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                         return EmpiricalChecks.noBaseline(NAME, empiricalDetail());
                     }
                     perCriterionVerdicts.add(Verdict.INCONCLUSIVE);
+                    verdictsByCriterion.put(counts.criterionId(), Verdict.INCONCLUSIVE.name());
                     perCriterionExplanations.add(String.format(
                             "%s: INCONCLUSIVE (no baseline entry for this criterion)",
                             counts.criterionId()));
@@ -475,6 +512,8 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                         return sizeViolation.get();
                     }
                     perCriterionVerdicts.add(sizeViolation.get().verdict());
+                    verdictsByCriterion.put(
+                            counts.criterionId(), sizeViolation.get().verdict().name());
                     perCriterionExplanations.add(
                             counts.criterionId() + ": " + sizeViolation.get().explanation());
                     thresholdsByCriterion.put(counts.criterionId(), Double.NaN);
@@ -483,8 +522,9 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                 resolvedBaselineByCriterion.put(counts.criterionId(), criterionBaseline);
                 int baselineSuccesses = (int) Math.round(
                         criterionBaseline.observedPassRate() * criterionBaseline.sampleCount());
-                DerivedThreshold derived = DERIVER.deriveSampleSizeFirst(
+                derived = DERIVER.deriveSampleSizeFirst(
                         criterionBaseline.sampleCount(), baselineSuccesses, criterionTotal, confidence);
+                decisionByCriterion.put(counts.criterionId(), derived);
                 criterionThreshold = derived.value();
                 baselineRate = criterionBaseline.observedPassRate();
                 baselineSampleCount = criterionBaseline.sampleCount();
@@ -494,19 +534,36 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
             Verdict v;
             if (criterionTotal == 0) {
                 v = Verdict.INCONCLUSIVE;
+            } else if (mode == Mode.CONTRACTUAL) {
+                // Declared threshold (companion §3.2/§3.6): the test
+                // sample's own Wilson lower bound must clear it.
+                double wilsonLower = ESTIMATOR.lowerBound(
+                        counts.pass(), criterionTotal, confidence);
+                wilsonLowerByCriterion.put(counts.criterionId(), wilsonLower);
+                v = wilsonLower >= criterionThreshold ? Verdict.PASS : Verdict.FAIL;
             } else {
-                v = observed >= criterionThreshold ? Verdict.PASS : Verdict.FAIL;
+                // Baseline-derived threshold (companion §3.4): the binding
+                // decision artefact is the derivation's integer cutoff —
+                // PASS iff the raw observed success count K meets it.
+                v = counts.pass() >= derived.cutoff().orElseThrow()
+                        ? Verdict.PASS : Verdict.FAIL;
             }
             perCriterionVerdicts.add(v);
+            verdictsByCriterion.put(counts.criterionId(), v.name());
             if (mode == Mode.CONTRACTUAL) {
                 perCriterionExplanations.add(String.format(
-                        "%s: observed=%.4f vs threshold=%.4f over %d samples → %s",
-                        counts.criterionId(), observed, criterionThreshold, criterionTotal, v));
+                        "%s: observed=%.4f, Wilson-%.0f%% lower=%.4f vs threshold=%.4f "
+                                + "over %d samples → %s",
+                        counts.criterionId(), observed, confidence * 100.0,
+                        wilsonLowerByCriterion.getOrDefault(counts.criterionId(), Double.NaN),
+                        criterionThreshold, criterionTotal, v));
             } else {
                 perCriterionExplanations.add(String.format(
-                        "%s: observed=%.4f vs threshold=%.4f "
-                                + "(Wilson-%.0f%% lower of baseline rate %.4f at n=%d) → %s",
-                        counts.criterionId(), observed, criterionThreshold,
+                        "%s: successes=%d vs cutoff=%d (threshold=%.4f, "
+                                + "Wilson-%.0f%% lower of baseline rate %.4f at n=%d) → %s",
+                        counts.criterionId(), counts.pass(),
+                        derived == null ? -1 : derived.cutoff().orElse(-1),
+                        criterionThreshold,
                         confidence * 100.0, baselineRate, criterionTotal, v));
             }
         }
@@ -536,6 +593,23 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                 detail.put("confidence", confidence);
                 detail.put("baselineSampleCount", b == null ? null : b.sampleCount());
                 detail.put("baselineRate", b == null ? null : b.observedPassRate());
+                DerivedThreshold decision = decisionByCriterion.get(only.criterionId());
+                if (decision != null) {
+                    // Companion §3.4 report obligations: the integer cutoff
+                    // is the decision artefact; the displayed rate (c/n) and
+                    // achieved size accompany it.
+                    decision.cutoff().ifPresent(c -> detail.put("cutoff", c));
+                    decision.displayedRate().ifPresent(r -> detail.put("displayedRate", r));
+                    decision.achievedSize().ifPresent(a -> detail.put("achievedSize", a));
+                }
+            } else {
+                Double wilsonLower = wilsonLowerByCriterion.get(only.criterionId());
+                if (wilsonLower != null) {
+                    // Companion §3.2/§3.6: the declared-threshold decision
+                    // artefact is the test sample's Wilson lower bound.
+                    detail.put("wilsonLower", wilsonLower);
+                    detail.put("confidence", confidence);
+                }
             }
             CriterionPosture onlyPosture = ctx.criterionPostures().getOrDefault(
                     only.criterionId(), CriterionPosture.implicit());
@@ -550,7 +624,14 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
             }
             detail.put("thresholdsByCriterion", Map.copyOf(thresholdsByCriterion));
             detail.put("observedByCriterion", Map.copyOf(observedByCriterion));
+            if (!wilsonLowerByCriterion.isEmpty()) {
+                detail.put("wilsonLowerByCriterion", Map.copyOf(wilsonLowerByCriterion));
+            }
         }
+        // The criterion's own judged verdicts — consumed by the spec
+        // layer's per-criterion aggregation so the decision rule is
+        // applied exactly once, here.
+        detail.put("verdictsByCriterion", Map.copyOf(verdictsByCriterion));
 
         String explanation;
         if (methodologyCriteria.size() == 1) {

--- a/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
@@ -247,6 +247,79 @@ public class BinomialProportionEstimator {
         return (int) Math.ceil(5.0 / tighter);
     }
 
+    /**
+     * The exact binomial cumulative distribution function
+     * {@code P(K ≤ k)} for {@code trials} Bernoulli trials at success
+     * probability {@code p}. Used for the achieved size of the
+     * integer-cutoff decision rule (statistical companion §3.4):
+     * {@code achievedSize = P(K < c) = binomialCdf(c − 1, n, p)}.
+     *
+     * @param k      the (inclusive) upper success count; {@code k < 0}
+     *               yields {@code 0.0}, {@code k ≥ trials} yields {@code 1.0}
+     * @param trials the number of trials, positive
+     * @param p      the per-trial success probability in [0, 1]
+     * @return {@code P(K ≤ k)}
+     */
+    public double binomialCdf(int k, int trials, double p) {
+        if (trials <= 0) {
+            throw new IllegalArgumentException("Trials must be positive, got: " + trials);
+        }
+        if (Double.isNaN(p) || p < 0.0 || p > 1.0) {
+            throw new IllegalArgumentException("Probability must be in [0, 1], got: " + p);
+        }
+        if (k < 0) {
+            return 0.0;
+        }
+        if (k >= trials) {
+            return 1.0;
+        }
+        return org.apache.commons.statistics.distribution.BinomialDistribution
+                .of(trials, p)
+                .cumulativeProbability(k);
+    }
+
+    /**
+     * The smallest success count {@code K} whose one-sided Wilson lower
+     * bound at the given confidence clears the threshold — the
+     * declared-threshold (compliance) analogue of the empirical
+     * procedure's integer cutoff. The Wilson lower bound is monotone in
+     * the success count, so the answer is found by binary search.
+     *
+     * <p>Used by the engine's guaranteed-success early termination: a
+     * run whose success count has reached this value cannot fail the
+     * declared-threshold comparison however the remaining samples land.
+     *
+     * @param threshold       the declared threshold in [0, 1]
+     * @param trials          the planned sample count, positive
+     * @param confidenceLevel the confidence of the Wilson comparison, in (0, 1)
+     * @return the minimal clearing success count in {@code [0, trials]},
+     *         or {@code trials + 1} when even a perfect run cannot clear
+     *         the threshold at this sample count
+     */
+    public int minimumSuccessesToClear(double threshold, int trials, double confidenceLevel) {
+        if (trials <= 0) {
+            throw new IllegalArgumentException("Trials must be positive, got: " + trials);
+        }
+        if (Double.isNaN(threshold) || threshold < 0.0 || threshold > 1.0) {
+            throw new IllegalArgumentException("Threshold must be in [0, 1], got: " + threshold);
+        }
+        validateConfidenceLevel(confidenceLevel);
+        if (lowerBound(trials, trials, confidenceLevel) < threshold) {
+            return trials + 1;
+        }
+        int lo = 0;
+        int hi = trials;
+        while (lo < hi) {
+            int mid = (lo + hi) >>> 1;
+            if (lowerBound(mid, trials, confidenceLevel) >= threshold) {
+                hi = mid;
+            } else {
+                lo = mid + 1;
+            }
+        }
+        return lo;
+    }
+
     private void validateInputs(int successes, int trials) {
         if (trials <= 0) {
             throw new IllegalArgumentException("Trials must be positive, got: " + trials);

--- a/punit-core/src/main/java/org/mavai/punit/statistics/DerivedThreshold.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/DerivedThreshold.java
@@ -1,33 +1,54 @@
 package org.mavai.punit.statistics;
 
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
 /**
  * Represents a statistically-derived threshold for probabilistic testing.
- * 
+ *
  * <p>The threshold p_threshold is the minimum observed pass rate required for a test
  * to pass. It is derived from the baseline experimental data using one of three
  * {@link OperationalApproach}es.
- * 
+ *
  * <p>For the Sample-Size-First approach (most common):
  * <pre>
  *   p_threshold = Wilson one-sided lower bound at confidence (1-α)
  * </pre>
- * 
+ *
  * <p>This ensures that if the true rate has not degraded from the baseline,
  * the probability of a false positive (test failing when system is fine) is at most α.
- * 
+ *
+ * <p><b>The binding decision artefact</b> (statistical companion §3.4): for a
+ * baseline-derived test the decision is discrete — the integer cutoff
+ * {@code c = ⌈n_test · p_threshold⌉}, with PASS iff the raw observed success
+ * count {@code K ≥ c}. The real-valued threshold, the displayed rate
+ * {@code c / n_test}, and the achieved size (the exact probability, under the
+ * effective baseline rate, of a false degradation signal:
+ * {@code P(K < c)}) are the report obligations that accompany a conformant
+ * verdict. Sample-size-first derivations carry all three; threshold-first
+ * derivations answer a different question (the implied confidence of a given
+ * threshold) and carry none.
+ *
  * @param value The derived threshold value p_threshold ∈ [0, 1]
  * @param approach The operational approach used for derivation
  * @param context The derivation context (baseline data, sample sizes, confidence)
  * @param isStatisticallySound True if the derivation produces a reliable threshold;
  *                              false if the implied confidence is too low (&lt; 80%)
- * 
+ * @param cutoff The integer cutoff {@code c = ⌈n_test · value⌉} — the binding
+ *               decision artefact; present on sample-size-first derivations
+ * @param achievedSize The exact achieved size {@code P(K < c)} under the
+ *                     effective baseline rate; present on sample-size-first
+ *                     derivations
+ *
  * @see OperationalApproach
  */
 public record DerivedThreshold(
     double value,
     OperationalApproach approach,
     DerivationContext context,
-    boolean isStatisticallySound
+    boolean isStatisticallySound,
+    OptionalInt cutoff,
+    OptionalDouble achievedSize
 ) {
     /**
      * Validates the threshold parameters.
@@ -43,29 +64,54 @@ public record DerivedThreshold(
         if (context == null) {
             throw new IllegalArgumentException("Context must not be null");
         }
+        if (cutoff == null || achievedSize == null) {
+            throw new IllegalArgumentException("Decision artefacts must not be null");
+        }
     }
-    
+
+    /**
+     * Convenience constructor for thresholds carrying no discrete decision
+     * artefacts (threshold-first derivations, hand-built values).
+     */
+    public DerivedThreshold(
+            double value, OperationalApproach approach, DerivationContext context,
+            boolean isStatisticallySound) {
+        this(value, approach, context, isStatisticallySound,
+                OptionalInt.empty(), OptionalDouble.empty());
+    }
+
     /**
      * Convenience constructor for statistically sound thresholds.
      */
     public DerivedThreshold(double value, OperationalApproach approach, DerivationContext context) {
         this(value, approach, context, true);
     }
-    
+
+    /**
+     * The displayed rate {@code c / n_test} — the integer cutoff expressed
+     * as a rate, the figure a conformant report shows alongside the cutoff
+     * (companion §3.4). Present exactly when {@link #cutoff()} is.
+     */
+    public OptionalDouble displayedRate() {
+        if (cutoff.isEmpty()) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of((double) cutoff.getAsInt() / context.testSamples());
+    }
+
     /**
      * Returns the gap between the baseline rate and the derived threshold.
-     * 
+     *
      * <p>This gap accounts for:
      * <ul>
      *   <li>Uncertainty in the baseline estimate</li>
      *   <li>Increased variance with smaller test sample</li>
      *   <li>Desired confidence level</li>
      * </ul>
-     * 
+     *
      * @return baselineRate - threshold (positive if threshold is below baseline)
      */
     public double gapFromBaseline() {
         return context.baselineRate() - value;
     }
 }
-

--- a/punit-core/src/main/java/org/mavai/punit/statistics/LatencyThresholdDeriver.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/LatencyThresholdDeriver.java
@@ -99,7 +99,7 @@ public final class LatencyThresholdDeriver {
 
         double baselinePercentile = LatencyStatistics.nearestRankPercentile(sorted, p);
 
-        return new Threshold(k, threshold, baselinePercentile, n, saturated);
+        return new Threshold(k, threshold, baselinePercentile, n, saturated, kRaw);
     }
 
     /**
@@ -112,9 +112,19 @@ public final class LatencyThresholdDeriver {
      * @param saturated          {@code true} when {@code k_raw > n} — the
      *                           {@code threshold} is the advisory {@code t_{(n)}},
      *                           not an exact bound at the configured confidence
+     * @param kRaw               the unclamped confidence rank
+     *                           {@code qbinom(1 − α; n, p) + 1}; exceeds
+     *                           {@code n} exactly when {@code saturated}
      */
     public record Threshold(
-            int rank, double threshold, double baselinePercentile, int n, boolean saturated) {
+            int rank, double threshold, double baselinePercentile, int n, boolean saturated,
+            int kRaw) {
+
+        /** Back-compat constructor: the unclamped rank defaults to the clamped one. */
+        public Threshold(
+                int rank, double threshold, double baselinePercentile, int n, boolean saturated) {
+            this(rank, threshold, baselinePercentile, n, saturated, rank);
+        }
 
         /** Back-compat constructor: non-saturated form. */
         public Threshold(int rank, double threshold, double baselinePercentile, int n) {

--- a/punit-core/src/main/java/org/mavai/punit/statistics/ThresholdDeriver.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/ThresholdDeriver.java
@@ -88,7 +88,19 @@ public class ThresholdDeriver {
         DerivationContext context = new DerivationContext(
             baselineRate, baselineSamples, testSamples, thresholdConfidence);
 
-        return new DerivedThreshold(threshold, OperationalApproach.SAMPLE_SIZE_FIRST, context, true);
+        // The binding decision artefacts (companion §3.4): the integer
+        // cutoff c = ⌈n_test · p_threshold⌉ — PASS iff the raw observed
+        // success count K ≥ c — and the achieved size, the exact
+        // probability of a false degradation signal under the effective
+        // baseline rate: P(K < c) = BinomialCDF(c − 1; n_test, p_eff).
+        int cutoff = (int) Math.ceil(testSamples * threshold);
+        double achievedSize = estimator.binomialCdf(
+                cutoff - 1, testSamples, effectiveBaselineRate);
+
+        return new DerivedThreshold(
+                threshold, OperationalApproach.SAMPLE_SIZE_FIRST, context, true,
+                java.util.OptionalInt.of(cutoff),
+                java.util.OptionalDouble.of(achievedSize));
     }
 
     /**

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/AutoInjectionFromPostureTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/AutoInjectionFromPostureTest.java
@@ -40,7 +40,11 @@ class AutoInjectionFromPostureTest {
                 return Outcome.ok(true);
             }
             @Override public Criteria<Boolean> criteria() {
-                return meeting().passRate(0.95);
+                // 0.8 is clearable at n=20: the declared-threshold rule
+                // judges the sample's Wilson lower bound (20/20 at 95%
+                // ≈ 0.88) against the threshold; 0.95 would need n ≥ 52
+                // even from a perfect run.
+                return meeting().passRate(0.8);
             }
         };
 

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/EarlyTerminationIntegrationTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/EarlyTerminationIntegrationTest.java
@@ -47,10 +47,10 @@ class EarlyTerminationIntegrationTest {
         }
     }
 
-    /** Always-pass variant whose contract posture is meeting(0.20, SLA). */
+    /** Always-pass variant whose contract posture is meeting(0.05, SLA). */
     private static class AlwaysPassLowThreshold implements ServiceContract<Factors, Integer, Boolean> {
         @Override public Criteria<Boolean> criteria() {
-            return meeting().passRate(0.20);
+            return meeting().passRate(0.05);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return Outcome.ok(Boolean.TRUE);
@@ -87,7 +87,7 @@ class EarlyTerminationIntegrationTest {
         private int seen = 0;
         FailsThenPasses(int failsFirst) { this.failsFirst = failsFirst; }
         @Override public Criteria<Boolean> criteria() {
-            return meeting().passRate(0.80);
+            return meeting().passRate(0.5);
         }
         @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
             return ++seen <= failsFirst
@@ -109,7 +109,7 @@ class EarlyTerminationIntegrationTest {
     // ── Failure-inevitable short-circuit ─────────────────────────────
 
     @Test
-    @DisplayName("failure-inevitable: all-fail with 0.95 threshold terminates at sample 6 of 100")
+    @DisplayName("failure-inevitable: all-fail with 0.95 threshold terminates at sample 2 of 100")
     void failureInevitableTerminatesEarly() {
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling(f -> new AlwaysFail(), 100), new Factors())
@@ -117,9 +117,10 @@ class EarlyTerminationIntegrationTest {
 
         var result = (ProbabilisticTestResult) new Engine().run(spec);
 
-        // requiredSuccesses = ceil(100 * 0.95) = 95. After sample 6 the
-        // failure count is 6 → max-possible-successes = 94 < 95 → fire.
-        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(6);
+        // requiredSuccesses = the smallest K whose Wilson lower bound at
+        // 95% confidence clears 0.95 at n=100 → 99. After sample 2 the
+        // failure count is 2 → max-possible-successes = 98 < 99 → fire.
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(2);
         assertThat(result.engineSummary().terminationReason())
                 .isEqualTo(TerminationReason.IMPOSSIBILITY);
         assertThat(result.verdict()).isEqualTo(Verdict.FAIL);
@@ -128,12 +129,15 @@ class EarlyTerminationIntegrationTest {
     @Test
     @DisplayName("failure-inevitable: mixed mid-run failures that remain recoverable do not terminate")
     void failureInevitableNoFireWhenRecoverable() {
-        // threshold 0.80, samples 20, three failures up front. Required =
-        // ceil(16) = 16; after 3 failures the max-possible-successes is
-        // 17 ≥ 16, so the failure-inevitable shortcut never fires and the
-        // run completes. Verdict is PASS (17 successes / 20 = 85%).
+        // threshold 0.5, samples 20 → required = 14 (smallest K whose
+        // Wilson lower bound at 95% clears 0.5 at n=20). Six failures up
+        // front leave max-possible-successes at 14 ≥ 14, so the
+        // failure-inevitable shortcut never fires; the 14th success only
+        // lands on the final sample, so the success-guaranteed shortcut
+        // (which needs remaining > 0) never fires either, and the run
+        // completes. Verdict is PASS (Wilson lower of 14/20 ≈ 0.52 ≥ 0.5).
         ProbabilisticTest spec = ProbabilisticTest
-                .testing(sampling(f -> new FailsThenPasses(3), 20), new Factors())
+                .testing(sampling(f -> new FailsThenPasses(6), 20), new Factors())
                 .build();
 
         var result = (ProbabilisticTestResult) new Engine().run(spec);
@@ -149,17 +153,18 @@ class EarlyTerminationIntegrationTest {
     @Test
     @DisplayName("success-guaranteed: all-pass at 0.5 threshold with floor met terminates early")
     void successGuaranteedTerminatesAtThresholdCross() {
-        // threshold 0.5, samples 100 → required = 50, validity floor =
-        // ceil(5 / min(0.5, 0.5)) = 10. With all-pass, both conditions
+        // threshold 0.5, samples 100 → required = 59 (smallest K whose
+        // Wilson lower bound at 95% clears 0.5 at n=100), validity floor
+        // = ceil(5 / min(0.5, 0.5)) = 10. With all-pass, both conditions
         // (successes >= required AND total >= floor) become true at
-        // sample 50 → fire.
+        // sample 59 → fire.
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling(f -> new AlwaysPass(), 100), new Factors())
                 .build();
 
         var result = (ProbabilisticTestResult) new Engine().run(spec);
 
-        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(50);
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(59);
         assertThat(result.engineSummary().terminationReason())
                 .isEqualTo(TerminationReason.SUCCESS_GUARANTEED);
         assertThat(result.verdict()).isEqualTo(Verdict.PASS);
@@ -168,17 +173,18 @@ class EarlyTerminationIntegrationTest {
     @Test
     @DisplayName("success-guaranteed: validity floor delays termination past threshold-cross")
     void successGuaranteedFloorDelaysTermination() {
-        // threshold 0.20, samples 100 → required = 20, validity floor =
-        // ceil(5 / min(0.20, 0.80)) = 25. With all-pass, successes >=
-        // required at sample 20 but total < floor; the run continues to
-        // sample 25 where the floor is met and the short-circuit fires.
+        // threshold 0.05, samples 200 → required = 16 (smallest K whose
+        // Wilson lower bound at 95% clears 0.05 at n=200), validity floor
+        // = ceil(5 / min(0.05, 0.95)) = 100. With all-pass, successes >=
+        // required at sample 16 but total < floor; the run continues to
+        // sample 100 where the floor is met and the short-circuit fires.
         ProbabilisticTest spec = ProbabilisticTest
-                .testing(sampling(f -> new AlwaysPassLowThreshold(), 100), new Factors())
+                .testing(sampling(f -> new AlwaysPassLowThreshold(), 200), new Factors())
                 .build();
 
         var result = (ProbabilisticTestResult) new Engine().run(spec);
 
-        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(25);
+        assertThat(result.engineSummary().samplesExecuted()).isEqualTo(100);
         assertThat(result.engineSummary().terminationReason())
                 .isEqualTo(TerminationReason.SUCCESS_GUARANTEED);
         assertThat(result.verdict()).isEqualTo(Verdict.PASS);

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/EngineIntegrationTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/EngineIntegrationTest.java
@@ -72,11 +72,16 @@ class EngineIntegrationTest {
     @Test
     @DisplayName("ProbabilisticTest with PassRate.meeting() produces PASS when observed beats threshold")
     void contractualProducesPass() {
+        // 100 samples: the declared-threshold rule judges the test
+        // sample's Wilson lower bound against 0.95, and a perfect run
+        // only supports 0.95 from n = 52 upward (Wilson lower of
+        // 100/100 at 95% ≈ 0.974). 30 perfect samples support ≈ 0.917 —
+        // not confidence-grade evidence for the declared 0.95.
         Sampling<LlmFactors, Integer, Boolean> sampling = Sampling
                 .<LlmFactors, Integer, Boolean>builder()
                 .serviceContractFactory(f -> new AlwaysPassesServiceContract())
                 .inputs(1, 2, 3)
-                .samples(30)
+                .samples(100)
                 .build();
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling, new LlmFactors("gpt-4o", 0.3))
@@ -91,17 +96,21 @@ class EngineIntegrationTest {
         var detail = result.criterionResults().get(0).result().detail();
         assertThat(detail).containsEntry("origin", "SLA");
         assertThat(detail).containsEntry("threshold", 0.95);
-        assertThat(detail).containsEntry("total", 30);
+        assertThat(detail).containsEntry("total", 100);
     }
 
     @Test
     @DisplayName("ProbabilisticTestResult carries engine-run summary populated from SampleSummary")
     void engineSummaryPopulated() {
+        // 100 samples: feasible for the declared 0.95 under the Wilson
+        // comparison, and the validity floor for 0.95 (= 100) keeps the
+        // guaranteed-success short-circuit from firing before the final
+        // sample, so all 100 planned samples execute → COMPLETED.
         Sampling<LlmFactors, Integer, Boolean> sampling = Sampling
                 .<LlmFactors, Integer, Boolean>builder()
                 .serviceContractFactory(f -> new AlwaysPassesServiceContract())
                 .inputs(1, 2, 3)
-                .samples(30)
+                .samples(100)
                 .build();
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling, new LlmFactors("gpt-4o", 0.3))
@@ -110,16 +119,14 @@ class EngineIntegrationTest {
         var result = (ProbabilisticTestResult) new Engine().run(spec);
 
         var summary = result.engineSummary();
-        assertThat(summary.plannedSamples()).isEqualTo(30);
-        assertThat(summary.samplesExecuted()).isEqualTo(30);
-        assertThat(summary.successes()).isEqualTo(30);
+        assertThat(summary.plannedSamples()).isEqualTo(100);
+        assertThat(summary.samplesExecuted()).isEqualTo(100);
+        assertThat(summary.successes()).isEqualTo(100);
         assertThat(summary.failures()).isZero();
         assertThat(summary.elapsedMs()).isGreaterThanOrEqualTo(0L);
         assertThat(summary.terminationReason())
                 .isEqualTo(TerminationReason.COMPLETED);
-        // Contractual mode: confidence falls back to default 0.95 since
-        // PassRate's contractual path doesn't surface confidence
-        // in detail map.
+        // Contractual mode runs at the framework's default confidence.
         assertThat(summary.confidence()).isEqualTo(0.95);
         assertThat(summary.baselineFilename()).isEmpty();
     }

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/EngineResourceControlsAndLatencyIntegrationTest.java
@@ -456,7 +456,10 @@ class EngineResourceControlsAndLatencyIntegrationTest {
     void reportOnlyLatencyExcludedFromComposition() {
         ServiceContract<Factors, Integer, Boolean> slow = new ServiceContract<>() {
             @Override public Criteria<Boolean> criteria() {
-                return meeting().passRate(0.95);
+                // 0.5 is clearable at n=5: the declared-threshold rule
+                // judges the sample's Wilson lower bound (5/5 at 95%
+                // ≈ 0.65) against the threshold.
+                return meeting().passRate(0.5);
             }
             @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
                 sleep(50);

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/criteria/CriterionResultDetailTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/criteria/CriterionResultDetailTest.java
@@ -119,16 +119,19 @@ class CriterionResultDetailTest {
     }
 
     @Test
-    @DisplayName("PassRate's contractual detail carries observed/threshold/origin/successes/failures/total")
+    @DisplayName("PassRate's contractual detail carries observed/threshold/origin/successes/failures/total"
+            + " plus the Wilson decision artefacts")
     void bernoulliContractualDetailKeys() {
         var result = PassRate.<Integer>meeting(ThresholdOrigin.SLA, 0.5)
                 .evaluate(ctx(summaryWithLatency(LatencyResult.empty()), Optional.empty()));
 
         assertThat(result.detail()).containsKeys(
                 "observed", "threshold", "origin", "successes", "failures", "total");
-        // Contractual variants do not record the confidence — that knob is only meaningful
-        // for the empirical Wilson-score-aware comparison Stage 4 will wire in.
-        assertThat(result.detail()).doesNotContainKey("confidence");
+        // The declared-threshold comparison is the test sample's Wilson
+        // lower bound clearing the threshold (companion §3.2/§3.6); the
+        // bound and the confidence it was computed at are the decision
+        // artefacts a conformant result surfaces.
+        assertThat(result.detail()).containsKeys("wilsonLower", "confidence");
     }
 
     @Test

--- a/punit-core/src/test/java/org/mavai/punit/runtime/LatencyEverywhereIntegrationTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/runtime/LatencyEverywhereIntegrationTest.java
@@ -186,6 +186,13 @@ class LatencyEverywhereIntegrationTest {
                 .build();
         ProbabilisticTest spec = ProbabilisticTest
                 .testing(sampling, new F("only"))
+                // Every declared sample must run: this test asserts the
+                // descriptive latency block over the full mixed pass/fail
+                // population, and under the Wilson-based declared-threshold
+                // rule the two scripted failures make 0.5 unreachable at
+                // n=6, which would otherwise trip the failure-inevitable
+                // short-circuit before the last sample.
+                .disableEarlyTermination()
                 .build();
         ProbabilisticTestResult result = (ProbabilisticTestResult) new Engine().run(spec);
         ProbabilisticTestVerdict verdict = VerdictAdapter.adapt(

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
@@ -1,0 +1,601 @@
+package org.mavai.punit.statistics.conformance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.mavai.punit.api.PercentileKey;
+import org.mavai.punit.api.TestIntent;
+import org.mavai.punit.api.spec.CriterionResult;
+import org.mavai.punit.api.spec.PercentileLatency;
+import org.mavai.punit.api.spec.Verdict;
+import org.mavai.punit.internal.engine.emit.LatencySection;
+import org.mavai.punit.statistics.BinomialProportionEstimator;
+import org.mavai.punit.statistics.DerivationContext;
+import org.mavai.punit.statistics.DerivedThreshold;
+import org.mavai.punit.statistics.LatencyStatistics;
+import org.mavai.punit.statistics.LatencyThresholdDeriver;
+import org.mavai.punit.statistics.OperationalApproach;
+import org.mavai.punit.statistics.SampleSizeCalculator;
+import org.mavai.punit.statistics.SampleSizeRequirement;
+import org.mavai.punit.statistics.TestVerdictEvaluator;
+import org.mavai.punit.statistics.ThresholdDeriver;
+import org.mavai.punit.statistics.VerdictWithConfidence;
+import org.mavai.punit.statistics.VerificationFeasibilityEvaluator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mavai.punit.statistics.conformance.OracleAssert.assertOracle;
+
+/**
+ * The registry of every conformance check punit runs against the mavai-R
+ * fixtures — one {@link CaseCheck} per fixture case (occasionally two,
+ * when a case is verified on both a component surface and the production
+ * verdict path).
+ *
+ * <p>Two consumers execute the same checks:
+ *
+ * <ul>
+ *   <li>the per-suite display tests ({@code ProportionConformanceTest},
+ *       {@code LatencyConformanceTest}, {@code DecisionRuleConformanceTest})
+ *       turn each check into a {@code DynamicTest} for per-case reporting;</li>
+ *   <li>{@code ConformanceCoverageTest} re-runs the whole catalog with a
+ *       collecting {@link ConformanceRecorder} and diffs the recorded
+ *       {@code (suite, case, binding-field)} triples against the
+ *       manifest's obligations. Because the coverage test re-executes the
+ *       checks itself, its verdict is deterministic regardless of test
+ *       ordering, filtering, or Gradle fork configuration — there is no
+ *       shared mutable ledger to lose.</li>
+ * </ul>
+ */
+final class ConformanceCatalog {
+
+    @FunctionalInterface
+    interface Check {
+        void run(ConformanceRecorder recorder) throws Exception;
+    }
+
+    record CaseCheck(String suite, String caseName, Check check) { }
+
+    private static final BinomialProportionEstimator ESTIMATOR = new BinomialProportionEstimator();
+    private static final ThresholdDeriver THRESHOLD_DERIVER = new ThresholdDeriver();
+    private static final SampleSizeCalculator SAMPLE_SIZE_CALCULATOR = new SampleSizeCalculator();
+    private static final TestVerdictEvaluator VERDICT_EVALUATOR = new TestVerdictEvaluator();
+
+    private ConformanceCatalog() { }
+
+    /** Every check in the catalog — the coverage test's execution plan. */
+    static List<CaseCheck> all() {
+        List<CaseCheck> checks = new ArrayList<>();
+        checks.addAll(wilsonCi());
+        checks.addAll(wilsonLower());
+        checks.addAll(thresholdDerivation());
+        checks.addAll(powerAnalysis());
+        checks.addAll(feasibility());
+        checks.addAll(verdict());
+        checks.addAll(latencyPercentileValues());
+        checks.addAll(latencyPercentileSummaries());
+        checks.addAll(latencyThreshold());
+        checks.addAll(latencyThresholdBootstrap());
+        checks.addAll(latencyThresholdBootstrapProductionPath());
+        checks.addAll(latencyPercentileEmissionMinimums());
+        checks.addAll(latencyBoundExistenceMinimums());
+        checks.addAll(regressionDecisionDerivation());
+        checks.addAll(regressionDecisionProductionVerdicts());
+        return checks;
+    }
+
+    // ── wilson_ci ───────────────────────────────────────────────────
+
+    static List<CaseCheck> wilsonCi() {
+        JsonNode suite = ConformanceFixtures.load("wilson_ci.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("wilson_ci", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                var result = ESTIMATOR.estimate(
+                        inputs.get("successes").asInt(),
+                        inputs.get("trials").asInt(),
+                        inputs.get("confidence").asDouble());
+                assertOracle(recorder, "wilson_ci", c, "lower", result.lowerBound(), tolerance);
+                assertOracle(recorder, "wilson_ci", c, "upper", result.upperBound(), tolerance);
+                assertOracle(recorder, "wilson_ci", c, "point", result.pointEstimate(), tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    // ── wilson_lower ────────────────────────────────────────────────
+
+    static List<CaseCheck> wilsonLower() {
+        JsonNode suite = ConformanceFixtures.load("wilson_lower.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("wilson_lower", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                double result = ESTIMATOR.lowerBound(
+                        inputs.get("successes").asInt(),
+                        inputs.get("trials").asInt(),
+                        inputs.get("confidence").asDouble());
+                assertOracle(recorder, "wilson_lower", c, "lower_bound", result, tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    // ── threshold_derivation ────────────────────────────────────────
+
+    static List<CaseCheck> thresholdDerivation() {
+        JsonNode suite = ConformanceFixtures.load("threshold_derivation.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            String approach = c.get("approach").asText();
+            checks.add(new CaseCheck("threshold_derivation", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                int baselineSuccesses = inputs.get("baseline_successes").asInt();
+                int baselineTrials = inputs.get("baseline_trials").asInt();
+
+                if ("sample_size_first".equals(approach)) {
+                    DerivedThreshold result = THRESHOLD_DERIVER.deriveSampleSizeFirst(
+                            baselineTrials, baselineSuccesses,
+                            inputs.get("test_samples").asInt(),
+                            inputs.get("confidence").asDouble());
+                    assertOracle(recorder, "threshold_derivation", c, "threshold",
+                            result.value(), tolerance);
+                    // The real-valued Wilson lower bound at n_test IS the
+                    // derived threshold in the sample-size-first construction.
+                    assertOracle(recorder, "threshold_derivation", c, "wilson_lower_real",
+                            result.value(), tolerance);
+                    // The integer cutoff and achieved size are the binding
+                    // decision artefacts of the regression procedure; the
+                    // derivation must produce them alongside the real-valued
+                    // threshold. Looked up reflectively so this check compiles
+                    // (and fails red, not red-compile) while the deriver does
+                    // not yet expose them — the Java analogue of baseltest's
+                    // getattr(result, "cutoff", None).
+                    assertOracle(recorder, "threshold_derivation", c, "cutoff_integer",
+                            derivedArtefact(result, "cutoff"));
+                    assertOracle(recorder, "threshold_derivation", c, "achieved_size",
+                            derivedArtefact(result, "achievedSize"), tolerance);
+                } else if ("threshold_first".equals(approach)) {
+                    // testSamples is not used in the threshold-first implied
+                    // confidence computation but is required by the API; use
+                    // baseline trials as a reasonable value.
+                    DerivedThreshold result = THRESHOLD_DERIVER.deriveThresholdFirst(
+                            baselineTrials, baselineSuccesses, baselineTrials,
+                            inputs.get("threshold").asDouble());
+                    assertOracle(recorder, "threshold_derivation", c, "implied_confidence",
+                            result.context().confidence(), tolerance);
+                    assertOracle(recorder, "threshold_derivation", c, "is_sound",
+                            result.isStatisticallySound());
+                }
+            }));
+        }
+        return checks;
+    }
+
+    // ── power_analysis ──────────────────────────────────────────────
+
+    static List<CaseCheck> powerAnalysis() {
+        JsonNode suite = ConformanceFixtures.load("power_analysis.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("power_analysis", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                double baselineRate = inputs.get("baseline_rate").asDouble();
+                double minDetectableEffect = inputs.get("min_detectable_effect").asDouble();
+                double confidence = inputs.get("confidence").asDouble();
+
+                SampleSizeRequirement result = SAMPLE_SIZE_CALCULATOR.calculateForPower(
+                        baselineRate, minDetectableEffect, confidence,
+                        inputs.get("power").asDouble());
+                assertOracle(recorder, "power_analysis", c, "required_samples",
+                        result.requiredSamples());
+
+                double achievedPower = SAMPLE_SIZE_CALCULATOR.calculateAchievedPower(
+                        result.requiredSamples(), baselineRate, minDetectableEffect, confidence);
+                assertOracle(recorder, "power_analysis", c, "achieved_power",
+                        achievedPower, tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    // ── feasibility ─────────────────────────────────────────────────
+
+    static List<CaseCheck> feasibility() {
+        JsonNode suite = ConformanceFixtures.load("feasibility.json");
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("feasibility", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                var result = VerificationFeasibilityEvaluator.evaluate(
+                        inputs.get("sample_size").asInt(),
+                        inputs.get("target_proportion").asDouble(),
+                        inputs.get("confidence").asDouble());
+                assertOracle(recorder, "feasibility", c, "feasible", result.feasible());
+                assertOracle(recorder, "feasibility", c, "minimum_samples", result.minimumSamples());
+                assertOracle(recorder, "feasibility", c, "criterion",
+                        result.criterion().toLowerCase().replaceAll("[\\s-]+", "_"));
+            }));
+        }
+        return checks;
+    }
+
+    // ── verdict ─────────────────────────────────────────────────────
+
+    static List<CaseCheck> verdict() {
+        JsonNode suite = ConformanceFixtures.load("verdict.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("verdict", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                int successes = inputs.get("successes").asInt();
+                int trials = inputs.get("trials").asInt();
+                double threshold = inputs.get("threshold").asDouble();
+                double confidence = inputs.get("confidence").asDouble();
+
+                var context = new DerivationContext(threshold, trials, trials, confidence);
+                var derivedThreshold = new DerivedThreshold(
+                        threshold, OperationalApproach.SAMPLE_SIZE_FIRST, context);
+
+                VerdictWithConfidence verdict = VERDICT_EVALUATOR.evaluate(
+                        successes, trials, derivedThreshold);
+                assertOracle(recorder, "verdict", c, "passed", verdict.passed());
+                assertOracle(recorder, "verdict", c, "observed_rate",
+                        verdict.observedRate(), tolerance);
+
+                double observedRate = (double) successes / trials;
+                double z = ESTIMATOR.zTestStatistic(observedRate, threshold, trials);
+                assertOracle(recorder, "verdict", c, "test_statistic", z, tolerance);
+                assertOracle(recorder, "verdict", c, "p_value",
+                        ESTIMATOR.oneSidedPValue(z), tolerance);
+                // false_positive_probability in the reference data is alpha = 1 - confidence.
+                assertOracle(recorder, "verdict", c, "false_positive_probability",
+                        1.0 - confidence, tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    // ── latency_percentile ──────────────────────────────────────────
+
+    static List<CaseCheck> latencyPercentileValues() {
+        JsonNode suite = ConformanceFixtures.load("latency_percentile.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            if (!c.get("inputs").has("percentile")) {
+                continue; // summary case
+            }
+            checks.add(new CaseCheck("latency_percentile", c.get("name").asText(), recorder -> {
+                double[] latencies = ConformanceFixtures.toDoubleArray(c.get("inputs").get("latencies"));
+                double result = LatencyStatistics.nearestRankPercentile(
+                        latencies, c.get("inputs").get("percentile").asDouble());
+                assertOracle(recorder, "latency_percentile", c, "value", result, tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    static List<CaseCheck> latencyPercentileSummaries() {
+        JsonNode suite = ConformanceFixtures.load("latency_percentile.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            if (c.get("inputs").has("percentile")) {
+                continue; // percentile case
+            }
+            checks.add(new CaseCheck("latency_percentile", c.get("name").asText(), recorder -> {
+                double[] latencies = ConformanceFixtures.toDoubleArray(c.get("inputs").get("latencies"));
+                assertOracle(recorder, "latency_percentile", c, "mean",
+                        LatencyStatistics.mean(latencies), tolerance);
+                assertOracle(recorder, "latency_percentile", c, "max",
+                        LatencyStatistics.max(latencies), tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    // ── latency_threshold ───────────────────────────────────────────
+
+    static List<CaseCheck> latencyThreshold() {
+        JsonNode suite = ConformanceFixtures.load("latency_threshold.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("latency_threshold", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                LatencyThresholdDeriver.Threshold result = LatencyThresholdDeriver.derive(
+                        ConformanceFixtures.toDoubleArray(inputs.get("baseline_latencies")),
+                        inputs.get("p").asDouble(),
+                        inputs.get("confidence").asDouble());
+                assertOracle(recorder, "latency_threshold", c, "rank", result.rank());
+                assertOracle(recorder, "latency_threshold", c, "threshold",
+                        result.threshold(), tolerance);
+                assertOracle(recorder, "latency_threshold", c, "baseline_percentile",
+                        result.baselinePercentile(), tolerance);
+                assertOracle(recorder, "latency_threshold", c, "n", result.n());
+            }));
+        }
+        return checks;
+    }
+
+    // ── latency_threshold_bootstrap (binomial side) ─────────────────
+
+    /**
+     * Conformance against the bootstrap-comparison suite's binding
+     * fields. The conformance fields are integer-valued or specific
+     * elements of the integer-valued baseline array, so the suite
+     * carries {@code tolerance: 0} and equality is exact. The
+     * {@code bootstrap_upper} / {@code point_estimate} / {@code diff}
+     * fields are manifest-classified informational (no bootstrap method
+     * is implemented, deliberately) and are not conformance targets.
+     */
+    static List<CaseCheck> latencyThresholdBootstrap() {
+        JsonNode suite = ConformanceFixtures.load("latency_threshold_bootstrap.json");
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("latency_threshold_bootstrap", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                LatencyThresholdDeriver.Threshold result = LatencyThresholdDeriver.derive(
+                        ConformanceFixtures.toDoubleArray(inputs.get("baseline_latencies")),
+                        inputs.get("p").asDouble(),
+                        inputs.get("confidence").asDouble());
+                assertOracle(recorder, "latency_threshold_bootstrap", c, "rank", result.rank());
+                assertOracle(recorder, "latency_threshold_bootstrap", c, "threshold", result.threshold());
+                assertOracle(recorder, "latency_threshold_bootstrap", c, "baseline_percentile",
+                        result.baselinePercentile());
+                assertOracle(recorder, "latency_threshold_bootstrap", c, "n", result.n());
+                assertOracle(recorder, "latency_threshold_bootstrap", c, "saturated", result.saturated());
+                // The unclamped rank k_raw is a binding field the deriver
+                // does not yet expose — reflective lookup, red until it does.
+                assertOracle(recorder, "latency_threshold_bootstrap", c, "k_raw",
+                        reflectiveAccessor(result, "kRaw"));
+            }));
+        }
+        return checks;
+    }
+
+    /**
+     * End-to-end conformance against the bootstrap fixture, driven
+     * through the production evaluation path
+     * ({@code PercentileLatency.evaluate} reading a baseline
+     * {@code LatencyStatistics}) rather than calling
+     * {@code LatencyThresholdDeriver} in isolation. Guards against a
+     * class of regression where the deriver remains correct on its own
+     * but a refactor detaches it from the hot path or rewires the
+     * detail-map value.
+     */
+    static List<CaseCheck> latencyThresholdBootstrapProductionPath() {
+        JsonNode suite = ConformanceFixtures.load("latency_threshold_bootstrap.json");
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            checks.add(new CaseCheck("latency_threshold_bootstrap", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                var expected = c.get("expected");
+                long[] baselineLatenciesMs = ConformanceFixtures.toLongArray(inputs.get("baseline_latencies"));
+                double confidence = inputs.get("confidence").asDouble();
+                long expectedThreshold = expected.get("threshold").asLong();
+                boolean saturated = expected.get("saturated").asBoolean();
+                PercentileKey key = LatencyProductionPath.percentileKeyFor(inputs.get("p").asDouble());
+
+                var baseline = LatencyProductionPath.buildBaseline(baselineLatenciesMs);
+                PercentileLatency<String> criterion = PercentileLatency.empirical(confidence, key);
+
+                CriterionResult verification = criterion.evaluate(
+                        LatencyProductionPath.evaluationContext(baseline, TestIntent.VERIFICATION));
+                if (saturated) {
+                    assertThat(verification.verdict())
+                            .as("VERIFICATION verdict (saturated)")
+                            .isEqualTo(Verdict.INCONCLUSIVE);
+                    assertThat(verification.detail())
+                            .as("saturated.%s flag", key.detailKey())
+                            .containsEntry("saturated." + key.detailKey(), true);
+                } else {
+                    assertThat(verification.verdict())
+                            .as("VERIFICATION verdict (non-saturated)")
+                            .isEqualTo(Verdict.PASS);
+                    assertThat(verification.detail())
+                            .as("threshold.%s on production path", key.detailKey())
+                            .containsEntry("threshold." + key.detailKey(), expectedThreshold);
+                }
+
+                if (saturated) {
+                    CriterionResult smoke = criterion.evaluate(
+                            LatencyProductionPath.evaluationContext(baseline, TestIntent.SMOKE));
+                    assertThat(smoke.verdict())
+                            .as("SMOKE verdict (saturated, advisory)")
+                            .isEqualTo(Verdict.PASS);
+                    assertThat(smoke.detail())
+                            .as("SMOKE threshold.%s (advisory)", key.detailKey())
+                            .containsEntry("threshold." + key.detailKey(), expectedThreshold);
+                    assertThat(smoke.detail())
+                            .as("SMOKE saturated.%s flag", key.detailKey())
+                            .containsEntry("saturated." + key.detailKey(), true);
+                }
+            }));
+        }
+        return checks;
+    }
+
+    // ── latency_percentile_minimums ─────────────────────────────────
+
+    static List<CaseCheck> latencyPercentileEmissionMinimums() {
+        JsonNode suite = ConformanceFixtures.load("latency_percentile_minimums.json");
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            if (!"emission_non_degeneracy".equals(c.get("approach").asText())) {
+                continue;
+            }
+            checks.add(new CaseCheck("latency_percentile_minimums", c.get("name").asText(), recorder -> {
+                double p = c.get("inputs").get("percentile").asDouble();
+                String label = "p" + Math.round(p * 100);
+                assertOracle(recorder, "latency_percentile_minimums", c,
+                        "minimum_contributing_samples", LatencySection.minimumSamplesFor(label));
+            }));
+        }
+        return checks;
+    }
+
+    /**
+     * The bound-existence minimums mark the deriver's saturation
+     * boundary: non-saturated at the published minimum, saturated just
+     * below it. The flip assertions are the semantic check that the
+     * published {@code minimum_baseline_samples} equals the deriver's
+     * own floor, so the field is recorded here.
+     */
+    static List<CaseCheck> latencyBoundExistenceMinimums() {
+        JsonNode suite = ConformanceFixtures.load("latency_percentile_minimums.json");
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            if (!"bound_existence".equals(c.get("approach").asText())) {
+                continue;
+            }
+            checks.add(new CaseCheck("latency_percentile_minimums", c.get("name").asText(), recorder -> {
+                recorder.record("latency_percentile_minimums", c.get("name").asText(),
+                        "minimum_baseline_samples");
+                double p = c.get("inputs").get("percentile").asDouble();
+                double confidence = c.get("inputs").get("confidence").asDouble();
+                int minimum = c.get("expected").get("minimum_baseline_samples").asInt();
+                assertThat(LatencyThresholdDeriver.derive(ascending(minimum), p, confidence)
+                        .saturated())
+                        .as("non-saturated bound at the published minimum n=%d", minimum)
+                        .isFalse();
+                assertThat(LatencyThresholdDeriver.derive(ascending(minimum - 1), p, confidence)
+                        .saturated())
+                        .as("saturation just below the published minimum, n=%d", minimum - 1)
+                        .isTrue();
+            }));
+        }
+        return checks;
+    }
+
+    // ── regression_decision ─────────────────────────────────────────
+
+    /**
+     * The derivation the framework performs on the empirical path must
+     * produce the binding decision artefacts: the real-valued threshold
+     * is a report obligation, the integer cutoff and achieved size are
+     * the decision; the displayed rate is §-mandated {@code c/n}.
+     */
+    static List<CaseCheck> regressionDecisionDerivation() {
+        JsonNode suite = ConformanceFixtures.load("regression_decision.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            if (!"REGRESSION".equals(c.get("procedure").asText())) {
+                continue;
+            }
+            checks.add(new CaseCheck("regression_decision", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                DerivedThreshold derived = THRESHOLD_DERIVER.deriveSampleSizeFirst(
+                        inputs.get("baseline_trials").asInt(),
+                        inputs.get("baseline_successes").asInt(),
+                        inputs.get("test_samples").asInt(),
+                        inputs.get("confidence").asDouble());
+                assertOracle(recorder, "regression_decision", c, "threshold_real",
+                        derived.value(), tolerance);
+                assertOracle(recorder, "regression_decision", c, "cutoff_integer",
+                        derivedArtefact(derived, "cutoff"));
+                assertOracle(recorder, "regression_decision", c, "displayed_rate",
+                        derivedArtefact(derived, "displayedRate"), tolerance);
+                assertOracle(recorder, "regression_decision", c, "achieved_size",
+                        derivedArtefact(derived, "achievedSize"), tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    /**
+     * The scenario suite through the production verdict path — a real
+     * probabilistic test driven the way a user would drive it (baseline
+     * resolution, threshold derivation inside the framework, engine
+     * sampling, criterion evaluation), not a test-side recomposition of
+     * the formulae. See {@link DecisionRuleProductionPath}.
+     */
+    static List<CaseCheck> regressionDecisionProductionVerdicts() {
+        JsonNode suite = ConformanceFixtures.load("regression_decision.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            String procedure = c.get("procedure").asText();
+            checks.add(new CaseCheck("regression_decision", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                int testSamples = inputs.get("test_samples").asInt();
+                double confidence = inputs.get("confidence").asDouble();
+                int observedSuccesses = inputs.get("observed_successes").asInt();
+                if ("REGRESSION".equals(procedure)) {
+                    var judged = DecisionRuleProductionPath.judgeRegression(
+                            inputs.get("baseline_successes").asInt(),
+                            inputs.get("baseline_trials").asInt(),
+                            testSamples, confidence, observedSuccesses);
+                    assertOracle(recorder, "regression_decision", c, "verdict",
+                            judged.verdict().name());
+                } else {
+                    var judged = DecisionRuleProductionPath.judgeCompliance(
+                            inputs.get("threshold").asDouble(),
+                            testSamples, confidence, observedSuccesses);
+                    assertOracle(recorder, "regression_decision", c, "verdict",
+                            judged.verdict().name());
+                    // §3.2/§3.6: the test sample's own Wilson lower bound is
+                    // the compliance decision artefact; a conformant verdict
+                    // surfaces it. Absent from the production detail today →
+                    // a red missing-capability assertion.
+                    assertOracle(recorder, "regression_decision", c, "wilson_lower",
+                            judged.detail().get("wilsonLower"), tolerance);
+                }
+            }));
+        }
+        return checks;
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Reflective lookup of a decision artefact the statistics package
+     * does not yet expose — returns {@code null} (→ a clear red
+     * missing-capability assertion) instead of failing to compile. The
+     * Java analogue of baseltest's {@code getattr(result, name, None)}:
+     * the red-then-green discipline wants these tests on the branch
+     * before any production change exists for them to call.
+     */
+    private static Object derivedArtefact(DerivedThreshold derived, String accessor) {
+        return reflectiveAccessor(derived, accessor);
+    }
+
+    private static Object reflectiveAccessor(Object target, String accessor) {
+        try {
+            var method = target.getClass().getMethod(accessor);
+            Object value = method.invoke(target);
+            if (value instanceof OptionalInt oi) {
+                return oi.isPresent() ? oi.getAsInt() : null;
+            }
+            if (value instanceof OptionalDouble od) {
+                return od.isPresent() ? od.getAsDouble() : null;
+            }
+            if (value instanceof java.util.Optional<?> o) {
+                return o.orElse(null);
+            }
+            return value;
+        } catch (NoSuchMethodException e) {
+            return null;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static double[] ascending(int n) {
+        double[] values = new double[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = i + 1;
+        }
+        return values;
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCoverageTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCoverageTest.java
@@ -1,0 +1,81 @@
+package org.mavai.punit.statistics.conformance;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The manifest-driven coverage obligation: every
+ * {@code (suite, case, binding-field)} triple demanded by the oracle's
+ * family-mandatory tier plus punit's committed scope
+ * ({@code conformance-scope.json}) must actually be asserted by the
+ * conformance catalog. A binding field that is loaded but never asserted
+ * is a gap, not a pass — the failure mode that let the empirical
+ * decision-rule deviation ship undetected in the family.
+ *
+ * <p>This test <em>re-executes</em> the catalog's checks with its own
+ * collecting recorder rather than reading a ledger populated by the
+ * other test classes. That makes its verdict deterministic under any
+ * test ordering, {@code --tests} filtering, or Gradle fork/parallel
+ * configuration: there is no shared mutable state to lose. Assertion
+ * failures inside re-run checks are tolerated here (the per-suite
+ * display tests report them); a check records each triple before
+ * asserting it, so an attempted-and-failed assertion still counts as
+ * addressed while fields after the failure point in the same case
+ * surface as gaps until the case is green.
+ */
+@DisplayName("Conformance coverage (mavai-R manifest)")
+class ConformanceCoverageTest {
+
+    private static final Path REPORT_PATH = Path.of("build", "conformance-report.json");
+
+    @Test
+    @DisplayName("Fetched fixture files match the manifest's content hashes")
+    void fixtureFilesMatchManifestHashes() {
+        ConformanceLedger ledger = ConformanceLedger.load();
+        for (String suite : ledger.inScopeSuites()) {
+            assertThat(ledger.fetchedMd5(suite))
+                    .as("suite %s: fetched fixture must be byte-identical to the file the "
+                            + "manifest describes — fetch/vendor drift is a conformance failure",
+                            suite)
+                    .isEqualTo(ledger.manifestMd5(suite));
+        }
+    }
+
+    @Test
+    @DisplayName("Every binding assertion the manifest and scope demand is made")
+    void coverageMeetsManifestObligations() {
+        ConformanceLedger ledger = ConformanceLedger.load();
+        int failedChecks = 0;
+        for (ConformanceCatalog.CaseCheck check : ConformanceCatalog.all()) {
+            try {
+                check.check().run(ledger::record);
+            } catch (AssertionError e) {
+                // Red checks are reported by the per-suite display tests;
+                // coverage accounts for what was *attempted*. Triples
+                // recorded before the failure point count as addressed.
+                failedChecks++;
+            } catch (Exception e) {
+                throw new IllegalStateException(
+                        "conformance check crashed (not an assertion failure): "
+                                + check.suite() + "/" + check.caseName(), e);
+            }
+        }
+
+        ledger.writeReport(REPORT_PATH);
+        System.out.println(ledger.standing());
+        if (failedChecks > 0) {
+            System.out.println("conformance coverage: " + failedChecks
+                    + " re-run check(s) currently red — see the conformance suite tests");
+        }
+
+        assertThat(ledger.gaps())
+                .as("binding assertions required by the manifest (family-mandatory tier + "
+                        + "committed scope) that were never made — report written to %s",
+                        REPORT_PATH)
+                .isEmpty();
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceFixtures.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceFixtures.java
@@ -1,0 +1,109 @@
+package org.mavai.punit.statistics.conformance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Classpath access to the mavai-R conformance fixtures fetched by the
+ * {@code fetchConformanceData} Gradle task into {@code /conformance/}.
+ *
+ * <p>Suites added in newer oracle releases may be absent when the fetched
+ * release predates them; {@link #load(String)} converts that absence into
+ * a clear test failure naming the required release rather than an
+ * initialisation crash.
+ */
+final class ConformanceFixtures {
+
+    static final String CONFORMANCE_DIR = "/conformance/";
+
+    /**
+     * The oracle release that introduced {@code manifest.json} and
+     * {@code regression_decision.json}. Named in the missing-fixture
+     * diagnostic so the corrective action is obvious.
+     */
+    static final String MINIMUM_RELEASE = "v0.8.4";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ConformanceFixtures() { }
+
+    static Optional<JsonNode> tryLoad(String filename) {
+        try (InputStream is = ConformanceFixtures.class.getResourceAsStream(CONFORMANCE_DIR + filename)) {
+            if (is == null) {
+                return Optional.empty();
+            }
+            return Optional.of(MAPPER.readTree(is));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read conformance suite: " + filename, e);
+        }
+    }
+
+    /**
+     * Loads a fixture file, failing (as a test assertion, not a crash)
+     * with a corrective diagnostic when the fetched release does not
+     * carry it.
+     */
+    static JsonNode load(String filename) {
+        return tryLoad(filename).orElseGet(() -> fail(missingMessage(filename)));
+    }
+
+    static String missingMessage(String filename) {
+        return "Conformance fixture " + CONFORMANCE_DIR + filename + " is absent from the fetched "
+                + "mavai-R release. This suite requires mavai-R " + MINIMUM_RELEASE + " or later; "
+                + "the fetchConformanceData task pulls the latest tagged release. Until that release "
+                + "is tagged, run against a local checkout: "
+                + "./gradlew test -PconformanceCasesDir=/path/to/mavai-R/inst/cases";
+    }
+
+    /** MD5 of the fixture file's bytes as fetched — for manifest drift checks. */
+    static String md5(String filename) {
+        try (InputStream is = ConformanceFixtures.class.getResourceAsStream(CONFORMANCE_DIR + filename)) {
+            if (is == null) {
+                return fail(missingMessage(filename));
+            }
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+            return String.format("%032x", new BigInteger(1, digest.digest()));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to hash conformance suite: " + filename, e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 unavailable", e);
+        }
+    }
+
+    static double[] toDoubleArray(JsonNode node) {
+        if (node.isArray()) {
+            double[] values = new double[node.size()];
+            for (int i = 0; i < node.size(); i++) {
+                values[i] = node.get(i).asDouble();
+            }
+            return values;
+        }
+        // The oracle's serialiser unboxes single-element vectors to scalars.
+        return new double[] { node.asDouble() };
+    }
+
+    static long[] toLongArray(JsonNode node) {
+        if (!node.isArray()) {
+            throw new IllegalArgumentException("expected a JSON array");
+        }
+        long[] out = new long[node.size()];
+        for (int i = 0; i < node.size(); i++) {
+            out[i] = node.get(i).asLong();
+        }
+        return out;
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceLedger.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceLedger.java
@@ -1,0 +1,262 @@
+package org.mavai.punit.statistics.conformance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Manifest-driven conformance coverage accounting.
+ *
+ * <p>The mavai-R oracle publishes {@code manifest.json} alongside its
+ * fixture suites: per-suite case rosters, a binding-vs-informational
+ * classification of every expected field, per-suite content hashes, and
+ * a family-mandatory suite tier. The obligation on a consumer is the set
+ * of {@code (suite, case, binding-field)} triples across the
+ * family-mandatory tier plus this repository's committed scope file
+ * ({@code conformance-scope.json}) — and the obligation is
+ * <em>self-verified</em>: every conformance assertion records the triple
+ * it asserted, and the coverage check diffs the recorded set against the
+ * manifest. A binding field that is loaded but never asserted is a gap,
+ * not a pass.
+ */
+final class ConformanceLedger {
+
+    record Triple(String suite, String caseName, String field) implements Comparable<Triple> {
+        @Override
+        public int compareTo(Triple o) {
+            int c = suite.compareTo(o.suite);
+            if (c != 0) return c;
+            c = caseName.compareTo(o.caseName);
+            if (c != 0) return c;
+            return field.compareTo(o.field);
+        }
+
+        @Override
+        public String toString() {
+            return suite + "/" + caseName + "/" + field;
+        }
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String SCOPE_RESOURCE = "conformance-scope.json";
+
+    private final JsonNode manifest;
+    private final List<String> scopeSuites;
+    private final List<String> mandatorySuites;
+    private final Set<Triple> asserted = new LinkedHashSet<>();
+
+    private ConformanceLedger(JsonNode manifest, List<String> scopeSuites) {
+        this.manifest = manifest;
+        this.scopeSuites = List.copyOf(scopeSuites);
+        List<String> mandatory = new ArrayList<>();
+        manifest.get("familyMandatory").forEach(n -> mandatory.add(n.asText()));
+        this.mandatorySuites = List.copyOf(mandatory);
+    }
+
+    /**
+     * Loads the fetched manifest plus the committed scope file. Fails
+     * (as a test assertion) with the corrective release diagnostic when
+     * the fetched oracle release predates the manifest.
+     */
+    static ConformanceLedger load() {
+        JsonNode manifest = ConformanceFixtures.load("manifest.json");
+        try (InputStream is = ConformanceLedger.class.getResourceAsStream(SCOPE_RESOURCE)) {
+            if (is == null) {
+                return fail("committed scope file %s is missing next to the conformance tests",
+                        SCOPE_RESOURCE);
+            }
+            JsonNode scope = MAPPER.readTree(is);
+            List<String> scopeSuites = new ArrayList<>();
+            scope.get("suites").forEach(n -> scopeSuites.add(n.asText()));
+            return new ConformanceLedger(manifest, scopeSuites);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to read " + SCOPE_RESOURCE, e);
+        }
+    }
+
+    // ── recording ───────────────────────────────────────────────────
+
+    void record(String suite, String caseName, String field) {
+        asserted.add(new Triple(suite, caseName, field));
+    }
+
+    // ── the obligation ──────────────────────────────────────────────
+
+    String fixtureVersion() {
+        return manifest.get("fixtureVersion").asText();
+    }
+
+    List<String> mandatorySuites() {
+        return mandatorySuites;
+    }
+
+    List<String> scopeSuites() {
+        return scopeSuites;
+    }
+
+    /** Family-mandatory plus committed scope, deduplicated, manifest order. */
+    List<String> inScopeSuites() {
+        Set<String> wanted = new LinkedHashSet<>();
+        wanted.addAll(mandatorySuites);
+        wanted.addAll(scopeSuites);
+        List<String> ordered = new ArrayList<>();
+        manifest.get("suites").fieldNames().forEachRemaining(name -> {
+            if (wanted.contains(name)) {
+                ordered.add(name);
+            }
+        });
+        return ordered;
+    }
+
+    /**
+     * The manifest's binding-field roster for a suite. The oracle's
+     * serialiser unboxes single-element vectors to scalars, so the
+     * value may be a lone JSON string rather than an array.
+     */
+    Set<String> bindingFields(String suite) {
+        JsonNode fields = suiteEntry(suite).get("bindingFields");
+        Set<String> out = new LinkedHashSet<>();
+        if (fields.isTextual()) {
+            out.add(fields.asText());
+        } else {
+            fields.forEach(n -> out.add(n.asText()));
+        }
+        return out;
+    }
+
+    /**
+     * Every {@code (suite, case, binding-field)} triple the given suites
+     * demand. A case owes exactly the binding fields present in its own
+     * {@code expected} block — suites whose case groups carry different
+     * expected shapes (e.g. threshold_derivation's two approaches) owe
+     * per-case, not the suite-wide union.
+     */
+    Set<Triple> obligations(List<String> suites) {
+        Set<Triple> out = new LinkedHashSet<>();
+        for (String suite : suites) {
+            Set<String> binding = bindingFields(suite);
+            JsonNode suiteFile = ConformanceFixtures.load(suiteEntry(suite).get("file").asText());
+            for (JsonNode c : suiteFile.get("cases")) {
+                String caseName = c.get("name").asText();
+                c.get("expected").fieldNames().forEachRemaining(field -> {
+                    if (binding.contains(field)) {
+                        out.add(new Triple(suite, caseName, field));
+                    }
+                });
+            }
+        }
+        return out;
+    }
+
+    Set<Triple> gaps() {
+        Set<Triple> gaps = new TreeSet<>(obligations(inScopeSuites()));
+        gaps.removeAll(asserted);
+        return gaps;
+    }
+
+    /** Manifest suites outside scope, with case counts — reported, never silently skipped. */
+    Map<String, Integer> unaddressedSuites() {
+        Set<String> inScope = new LinkedHashSet<>(inScopeSuites());
+        Map<String, Integer> out = new LinkedHashMap<>();
+        manifest.get("suites").fieldNames().forEachRemaining(name -> {
+            if (!inScope.contains(name)) {
+                out.put(name, manifest.get("suites").get(name).get("caseCount").asInt());
+            }
+        });
+        return out;
+    }
+
+    // ── fetch / vendor drift ────────────────────────────────────────
+
+    String manifestMd5(String suite) {
+        return suiteEntry(suite).get("md5").asText();
+    }
+
+    String fetchedMd5(String suite) {
+        return ConformanceFixtures.md5(suiteEntry(suite).get("file").asText());
+    }
+
+    // ── the standing ────────────────────────────────────────────────
+
+    /** The one-line summary every coverage run prints. */
+    String standing() {
+        Set<Triple> mandatory = obligations(mandatorySuites);
+        Set<Triple> scoped = obligations(scopeSuites);
+        long mandatoryHit = mandatory.stream().filter(asserted::contains).count();
+        long scopedHit = scoped.stream().filter(asserted::contains).count();
+        StringBuilder sb = new StringBuilder("conformance standing: ")
+                .append("fixtures v").append(fixtureVersion())
+                .append("; mandatory ").append(mandatoryHit).append('/').append(mandatory.size())
+                .append(" binding assertions over ").append(mandatorySuites.size()).append(" suites")
+                .append("; scope ").append(scopedHit).append('/').append(scoped.size())
+                .append(" over ").append(scopeSuites.size()).append(" suites");
+        Map<String, Integer> unaddressed = unaddressedSuites();
+        if (!unaddressed.isEmpty()) {
+            sb.append("; unaddressed: ");
+            boolean first = true;
+            for (var e : unaddressed.entrySet()) {
+                if (!first) sb.append(", ");
+                sb.append(e.getKey()).append(" (").append(e.getValue()).append(')');
+                first = false;
+            }
+        }
+        return sb.toString();
+    }
+
+    /** The machine-readable per-run report, for CI surfacing. */
+    void writeReport(Path path) {
+        ObjectNode report = MAPPER.createObjectNode();
+        report.put("fixtureVersion", fixtureVersion());
+        report.put("manifestVersion", manifest.get("manifestVersion").asInt());
+        ArrayNode mandatory = report.putArray("mandatorySuites");
+        mandatorySuites.forEach(mandatory::add);
+        ArrayNode scope = report.putArray("scopeSuites");
+        scopeSuites.forEach(scope::add);
+        report.put("assertedTriples", asserted.size());
+        report.put("obligedTriples", obligations(inScopeSuites()).size());
+        ArrayNode gapsNode = report.putArray("gaps");
+        for (Triple gap : gaps()) {
+            ObjectNode g = gapsNode.addObject();
+            g.put("suite", gap.suite());
+            g.put("case", gap.caseName());
+            g.put("field", gap.field());
+        }
+        ArrayNode unaddressed = report.putArray("unaddressedSuites");
+        for (var e : unaddressedSuites().entrySet()) {
+            ObjectNode u = unaddressed.addObject();
+            u.put("suite", e.getKey());
+            u.put("caseCount", e.getValue());
+        }
+        report.put("standing", standing());
+        try {
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, report.toPrettyString() + System.lineSeparator());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to write conformance report to " + path, e);
+        }
+    }
+
+    private JsonNode suiteEntry(String suite) {
+        JsonNode entry = manifest.get("suites").get(suite);
+        if (entry == null) {
+            throw new IllegalStateException("suite '" + suite + "' is not in the manifest");
+        }
+        return entry;
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceRecorder.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceRecorder.java
@@ -1,0 +1,17 @@
+package org.mavai.punit.statistics.conformance;
+
+/**
+ * Receives the {@code (suite, case, binding-field)} triple of every
+ * oracle assertion a conformance check makes. The coverage check
+ * ({@code ConformanceCoverageTest}) re-runs the catalog's checks with a
+ * collecting recorder and diffs the recorded set against the manifest's
+ * obligations; the per-suite display tests run the same checks with
+ * {@link #NO_OP}.
+ */
+@FunctionalInterface
+interface ConformanceRecorder {
+
+    void record(String suite, String caseName, String field);
+
+    ConformanceRecorder NO_OP = (suite, caseName, field) -> { };
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/DecisionRuleConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/DecisionRuleConformanceTest.java
@@ -1,0 +1,67 @@
+package org.mavai.punit.statistics.conformance;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Conformance against the composed decision rules (statistical companion
+ * §3.4 regression procedure, §3.2/§3.6 compliance procedure) — the
+ * {@code regression_decision} scenario suite, evaluated through the
+ * production verdict path rather than a test-side recomposition of the
+ * formulae.
+ *
+ * <p>For a baseline-derived test the binding decision artefact is the
+ * integer cutoff: {@code p* = WilsonLower(baseline rate, n_test, α)},
+ * {@code c = ⌈n_test · p*⌉}, PASS iff the raw observed success count
+ * {@code K ≥ c}; the real-valued threshold, displayed rate {@code c/n},
+ * and achieved size are report obligations. For a declared threshold the
+ * test sample's own Wilson lower bound must clear it. The suite's
+ * conflation-detector pair shares one observation across both procedures
+ * with opposite verdicts, so applying either procedure's rule on the
+ * other's path fails the suite even when every component computation is
+ * arithmetically conformant.
+ *
+ * <p>The check bodies live in {@link ConformanceCatalog}, shared with the
+ * manifest-driven coverage check ({@code ConformanceCoverageTest}); this
+ * class provides the per-case test reporting.
+ *
+ * @see <a href="https://github.com/mavai-org/mavai-R">mavai-R</a>
+ */
+@DisplayName("Decision-rule conformance (mavai-R regression_decision)")
+class DecisionRuleConformanceTest {
+
+    private static Collection<DynamicTest> dynamicTests(List<ConformanceCatalog.CaseCheck> checks) {
+        return checks.stream()
+                .map(check -> DynamicTest.dynamicTest(
+                        check.caseName(),
+                        () -> check.check().run(ConformanceRecorder.NO_OP)))
+                .toList();
+    }
+
+    @Nested
+    @DisplayName("regression_decision — binding decision artefacts from the production deriver")
+    class DerivationArtefacts {
+
+        @TestFactory
+        @DisplayName("Threshold, integer cutoff, displayed rate, and achieved size")
+        Collection<DynamicTest> cases() {
+            return dynamicTests(ConformanceCatalog.regressionDecisionDerivation());
+        }
+    }
+
+    @Nested
+    @DisplayName("regression_decision — verdicts through the production verdict path")
+    class ProductionVerdicts {
+
+        @TestFactory
+        @DisplayName("Engine-judged verdict equals the oracle's, per procedure")
+        Collection<DynamicTest> cases() {
+            return dynamicTests(ConformanceCatalog.regressionDecisionProductionVerdicts());
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/DecisionRuleProductionPath.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/DecisionRuleProductionPath.java
@@ -1,0 +1,189 @@
+package org.mavai.punit.statistics.conformance;
+
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.FactorBundle;
+import org.mavai.punit.api.Sampling;
+import org.mavai.punit.api.ServiceContract;
+import org.mavai.punit.api.TokenTracker;
+import org.mavai.punit.api.criterion.Criteria;
+import org.mavai.punit.api.spec.BaselineStatistics;
+import org.mavai.punit.api.spec.CriterionResult;
+import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
+import org.mavai.punit.api.spec.ProbabilisticTest;
+import org.mavai.punit.api.spec.ProbabilisticTestResult;
+import org.mavai.punit.api.spec.Verdict;
+import org.mavai.punit.internal.engine.Engine;
+import org.mavai.punit.internal.engine.baseline.BaselineRecord;
+import org.mavai.punit.internal.engine.baseline.BaselineWriter;
+import org.mavai.punit.internal.engine.baseline.FactorsFingerprint;
+import org.mavai.punit.internal.engine.baseline.YamlBaselineProvider;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.mavai.punit.api.criterion.Criteria.empirical;
+import static org.mavai.punit.api.criterion.Criteria.meeting;
+
+/**
+ * Drives one {@code regression_decision} fixture case through punit's
+ * production verdict path — the code path a real probabilistic test
+ * takes from threshold to verdict — and returns the judged criterion
+ * result.
+ *
+ * <p><b>REGRESSION procedure</b>: a baseline with exactly the case's
+ * {@code (baseline_successes, baseline_trials)} is written to disk the
+ * way a measure run persists one, an empirical pass-rate contract at
+ * the case's confidence is sampled {@code test_samples} times against a
+ * scripted service delivering exactly {@code observed_successes}
+ * passes, and the engine resolves the baseline, derives the threshold
+ * inside the framework, and judges. Nothing statistical is recomputed
+ * on the test side.
+ *
+ * <p><b>COMPLIANCE procedure</b>: the same drive with a declared
+ * (contractual) pass-rate threshold and no baseline.
+ *
+ * <p>Early termination is disabled on the spec so the scripted sample
+ * schedule always runs to its full count — the fixture's {@code K} and
+ * {@code n} must reach the criterion untruncated.
+ */
+final class DecisionRuleProductionPath {
+
+    record Judged(Verdict verdict, Map<String, Object> detail) { }
+
+    private static final String USE_CASE_ID = "decision-rule-conformance-use-case";
+
+    record Factors(String scenario) { }
+
+    private static final Factors FACTORS = new Factors("oracle-scenario");
+
+    private DecisionRuleProductionPath() { }
+
+    static Judged judgeRegression(
+            int baselineSuccesses, int baselineTrials,
+            int testSamples, double confidence, int observedSuccesses) throws IOException {
+        Path baselineDir = Files.createTempDirectory("punit-conformance-baseline");
+        try {
+            writeBaseline(baselineDir, baselineSuccesses, baselineTrials);
+            var sampling = sampling(testSamples, scriptedContract(
+                    observedSuccesses,
+                    empirical().<String>passRate().atConfidence(confidence)
+                            .where("scripted response is ok", "ok"::equals)));
+            ProbabilisticTest spec = ProbabilisticTest.testing(sampling, FACTORS)
+                    .disableEarlyTermination()
+                    .build();
+            var result = (ProbabilisticTestResult)
+                    new Engine(new YamlBaselineProvider(baselineDir)).run(spec);
+            return judgedFrom(result);
+        } finally {
+            deleteRecursively(baselineDir);
+        }
+    }
+
+    static Judged judgeCompliance(
+            double threshold, int testSamples, double confidence, int observedSuccesses) {
+        // punit's authoring surface accepts no confidence adjunct on a
+        // declared threshold (`.atConfidence(...) cannot compose with
+        // .meeting(...)`) — the criterion runs at the framework default.
+        // Every compliance fixture case is published at that default, so
+        // nothing is lost; a future fixture at another confidence would
+        // need the authoring surface extended first.
+        if (confidence != 0.95) {
+            throw new IllegalArgumentException(
+                    "compliance fixture case at confidence " + confidence
+                            + " is not expressible on punit's declared-threshold "
+                            + "authoring surface (fixed at the 0.95 default)");
+        }
+        var sampling = sampling(testSamples, scriptedContract(
+                observedSuccesses,
+                meeting().<String>passRate(threshold)
+                        .where("scripted response is ok", "ok"::equals)));
+        ProbabilisticTest spec = ProbabilisticTest.testing(sampling, FACTORS)
+                .disableEarlyTermination()
+                .build();
+        var result = (ProbabilisticTestResult) new Engine().run(spec);
+        return judgedFrom(result);
+    }
+
+    private static Judged judgedFrom(ProbabilisticTestResult result) {
+        CriterionResult criterion = result.criterionResults().get(0).result();
+        return new Judged(result.verdict(), criterion.detail());
+    }
+
+    /**
+     * A service delivering exactly {@code successes} passing responses
+     * first, then failing ones. The scripted failure is a postcondition
+     * failure (the response fails the criterion's {@code where} clause),
+     * the shape a typical stochastic-service test produces — the sample
+     * is counted as a failure on both the run-level and the
+     * per-criterion accounting bases.
+     *
+     * <p>Deliberately NOT an {@code Outcome.fail} apply-level failure:
+     * punit's per-criterion verdict derivation excludes apply-level
+     * failures from its counting basis, which is a separate accounting
+     * question from the decision rule this suite pins. See the
+     * decision-rule conformance findings.
+     */
+    private static ServiceContract<Factors, Integer, String> scriptedContract(
+            int successes, Criteria<String> criteria) {
+        AtomicInteger invocation = new AtomicInteger();
+        return new ServiceContract<>() {
+            @Override public String id() { return USE_CASE_ID; }
+            @Override public Criteria<String> criteria() { return criteria; }
+            @Override public Outcome<String> invoke(Integer input, TokenTracker tracker) {
+                return invocation.incrementAndGet() <= successes
+                        ? Outcome.ok("ok")
+                        : Outcome.ok("scripted failing response");
+            }
+        };
+    }
+
+    private static Sampling<Factors, Integer, String> sampling(
+            int samples, ServiceContract<Factors, Integer, String> contract) {
+        return Sampling.<Factors, Integer, String>builder()
+                .serviceContractFactory(f -> contract)
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    /**
+     * Persists the case's baseline exactly as a measure run would: the
+     * observed pass rate and sample count under the pass-rate criterion
+     * key, with an inputs identity matching the paired test's sampling.
+     */
+    private static void writeBaseline(
+            Path baselineDir, int baselineSuccesses, int baselineTrials) throws IOException {
+        double passRate = (double) baselineSuccesses / baselineTrials;
+        var probeSampling = sampling(1, scriptedContract(1, empirical().<String>passRate()));
+        BaselineRecord record = new BaselineRecord(
+                USE_CASE_ID, "measureBaseline",
+                FactorsFingerprint.of(FactorBundle.of(FACTORS)),
+                probeSampling.inputsIdentity(), baselineTrials,
+                Instant.parse("2026-07-10T00:00:00Z"),
+                Map.<String, BaselineStatistics>of(
+                        "bernoulli-pass-rate",
+                        PerCriterionPassRateStatistics.of("contract", passRate, baselineTrials)));
+        new BaselineWriter().write(record, baselineDir);
+    }
+
+    private static void deleteRecursively(Path dir) {
+        try (Stream<Path> paths = Files.walk(dir)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyConformanceTest.java
@@ -1,79 +1,36 @@
 package org.mavai.punit.statistics.conformance;
 
-import static org.mavai.punit.api.criterion.Criteria.meeting;
-import org.mavai.punit.api.criterion.Criteria;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.mavai.outcome.Outcome;
-import org.mavai.punit.api.Contract;
-import org.mavai.punit.api.FactorBundle;
-import org.mavai.punit.api.LatencyResult;
-import org.mavai.punit.api.PercentileKey;
-import org.mavai.punit.api.ServiceContractOutcome;
-import org.mavai.punit.api.TestIntent;
-import org.mavai.punit.api.TokenTracker;
-import org.mavai.punit.api.spec.CriterionResult;
-import org.mavai.punit.api.spec.EvaluationContext;
-import org.mavai.punit.api.spec.PercentileLatency;
-import org.mavai.punit.api.spec.SampleSummary;
-import org.mavai.punit.api.spec.TerminationReason;
-import org.mavai.punit.api.spec.Verdict;
-import org.mavai.punit.internal.engine.emit.LatencySection;
-import org.mavai.punit.statistics.LatencyStatistics;
-import org.mavai.punit.statistics.LatencyThresholdDeriver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 
 /**
  * Conformance tests for latency statistics: empirical percentile estimation,
  * summary statistics, and threshold derivation from baseline data.
+ *
+ * <p>The check bodies live in {@link ConformanceCatalog}, shared with the
+ * manifest-driven coverage check ({@code ConformanceCoverageTest}); this
+ * class provides the per-case test reporting.
  *
  * @see <a href="https://github.com/mavai-org/mavai-R">mavai-R</a>
  */
 @DisplayName("Latency conformance (mavai-R)")
 class LatencyConformanceTest {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String CONFORMANCE_DIR = "/conformance/";
-
-    private static JsonNode loadSuite(String filename) {
-        try (InputStream is = LatencyConformanceTest.class.getResourceAsStream(CONFORMANCE_DIR + filename)) {
-            if (is == null) {
-                throw new IllegalStateException(
-                        "Conformance data not found: " + CONFORMANCE_DIR + filename
-                                + ". Run the Gradle downloadConformanceData task or check the checked-in fallback files.");
-            }
-            return MAPPER.readTree(is);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to read conformance suite: " + filename, e);
-        }
-    }
-
-    private static double[] toDoubleArray(JsonNode node) {
-        if (node.isArray()) {
-            double[] values = new double[node.size()];
-            for (int i = 0; i < node.size(); i++) {
-                values[i] = node.get(i).asDouble();
-            }
-            return values;
-        }
-        // Single scalar value
-        return new double[]{ node.asDouble() };
+    private static Collection<DynamicTest> dynamicTests(List<ConformanceCatalog.CaseCheck> checks) {
+        return checks.stream()
+                .map(check -> DynamicTest.dynamicTest(
+                        check.caseName(),
+                        () -> check.check().run(ConformanceRecorder.NO_OP)))
+                .toList();
     }
 
     @Nested
@@ -83,31 +40,7 @@ class LatencyConformanceTest {
         @TestFactory
         @DisplayName("Nearest-rank (ceiling) percentile estimation")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("latency_percentile.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                var inputs = c.get("inputs");
-                if (!inputs.has("percentile")) {
-                    continue; // summary case, handled by the Summary nested class
-                }
-
-                String name = c.get("name").asText();
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    double[] latencies = toDoubleArray(inputs.get("latencies"));
-                    double p = inputs.get("percentile").asDouble();
-
-                    double result = LatencyStatistics.nearestRankPercentile(latencies, p);
-
-                    assertThat(result)
-                            .as("percentile value")
-                            .isCloseTo(expected.get("value").asDouble(), within(tolerance));
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.latencyPercentileValues());
         }
     }
 
@@ -118,32 +51,7 @@ class LatencyConformanceTest {
         @TestFactory
         @DisplayName("Mean and maximum")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("latency_percentile.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                var inputs = c.get("inputs");
-                if (inputs.has("percentile")) {
-                    continue; // percentile case, handled by the Percentile nested class
-                }
-
-                String name = c.get("name").asText();
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    double[] latencies = toDoubleArray(inputs.get("latencies"));
-
-                    assertThat(LatencyStatistics.mean(latencies))
-                            .as("mean")
-                            .isCloseTo(expected.get("mean").asDouble(), within(tolerance));
-
-                    assertThat(LatencyStatistics.max(latencies))
-                            .as("max")
-                            .isCloseTo(expected.get("max").asDouble(), within(tolerance));
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.latencyPercentileSummaries());
         }
     }
 
@@ -154,54 +62,10 @@ class LatencyConformanceTest {
         @TestFactory
         @DisplayName("Exact binomial order-statistic upper bound on the baseline percentile")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("latency_threshold.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    double[] baselineLatencies = toDoubleArray(inputs.get("baseline_latencies"));
-                    double p = inputs.get("p").asDouble();
-                    double confidence = inputs.get("confidence").asDouble();
-
-                    LatencyThresholdDeriver.Threshold result =
-                            LatencyThresholdDeriver.derive(baselineLatencies, p, confidence);
-
-                    assertThat(result.rank())
-                            .as("rank (k)")
-                            .isEqualTo(expected.get("rank").asInt());
-                    assertThat(result.threshold())
-                            .as("threshold (t_{(k)})")
-                            .isCloseTo(expected.get("threshold").asDouble(), within(tolerance));
-                    assertThat(result.baselinePercentile())
-                            .as("baseline percentile (Q(p))")
-                            .isCloseTo(expected.get("baseline_percentile").asDouble(), within(tolerance));
-                    assertThat(result.n())
-                            .as("n")
-                            .isEqualTo(expected.get("n").asInt());
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.latencyThreshold());
         }
     }
 
-    /**
-     * Conformance against the bootstrap-comparison suite — the one whose
-     * `expected` section publishes the binomial fields alongside the
-     * informational bootstrap fields. Per the suite's own description, the
-     * conformance fields ({@code rank}, {@code threshold},
-     * {@code baseline_percentile}, {@code n}) are integer-valued or are
-     * specific elements of the integer-valued {@code baseline_latencies}
-     * array, so the suite carries {@code tolerance: 0} and we check exact
-     * equality. The fields {@code bootstrap_upper}, {@code point_estimate},
-     * and {@code diff} are informational and are not asserted as
-     * conformance targets here — they are exercised separately by the
-     * conservatism sanity check below.
-     */
     @Nested
     @DisplayName("latency_threshold_bootstrap (binomial side; bootstrap fields informational)")
     class BootstrapComparison {
@@ -209,37 +73,7 @@ class LatencyConformanceTest {
         @TestFactory
         @DisplayName("Exact binomial order-statistic bound matches across the bootstrap-comparison baselines")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("latency_threshold_bootstrap.json");
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    double[] baselineLatencies = toDoubleArray(inputs.get("baseline_latencies"));
-                    double p = inputs.get("p").asDouble();
-                    double confidence = inputs.get("confidence").asDouble();
-
-                    LatencyThresholdDeriver.Threshold result =
-                            LatencyThresholdDeriver.derive(baselineLatencies, p, confidence);
-
-                    assertThat(result.rank())
-                            .as("rank (k) — exact equality")
-                            .isEqualTo(expected.get("rank").asInt());
-                    assertThat(result.threshold())
-                            .as("threshold (t_{(k)}) — exact equality")
-                            .isEqualTo(expected.get("threshold").asDouble());
-                    assertThat(result.baselinePercentile())
-                            .as("baseline percentile (Q(p)) — exact equality")
-                            .isEqualTo(expected.get("baseline_percentile").asDouble());
-                    assertThat(result.n())
-                            .as("n — exact equality")
-                            .isEqualTo(expected.get("n").asInt());
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.latencyThresholdBootstrap());
         }
 
         /**
@@ -252,13 +86,13 @@ class LatencyConformanceTest {
          * case signals either a fixture defect or a methodology drift —
          * fail loudly so neither slips past silently.
          *
-         * This is a property check on the oracle's own publication, not
+         * <p>This is a property check on the oracle's own publication, not
          * a check against {@code LatencyThresholdDeriver}.
          */
         @Test
         @DisplayName("Binomial-conservatism sanity: threshold >= bootstrap_upper holds for every published case")
         void binomialBoundIsAtLeastBootstrapUpper() {
-            JsonNode suite = loadSuite("latency_threshold_bootstrap.json");
+            JsonNode suite = ConformanceFixtures.load("latency_threshold_bootstrap.json");
             for (JsonNode c : suite.get("cases")) {
                 String name = c.get("name").asText();
                 double threshold = c.get("expected").get("threshold").asDouble();
@@ -271,27 +105,6 @@ class LatencyConformanceTest {
         }
     }
 
-    /**
-     * End-to-end conformance against the bootstrap fixture, driven
-     * through the production evaluation path
-     * ({@code PercentileLatency.evaluate} reading a baseline
-     * {@code LatencyStatistics}) rather than calling
-     * {@code LatencyThresholdDeriver} in isolation. Guards against
-     * a class of regression where the deriver remains correct on its
-     * own but a refactor detaches it from the hot path or rewires the
-     * detail-map value.
-     *
-     * <p>For non-saturated cases the test asserts exact equality of
-     * the {@code threshold.<p>} detail-map entry against the fixture's
-     * {@code expected.threshold}, and verdict PASS (the synthetic
-     * observed latencies are well below threshold).
-     *
-     * <p>For saturated cases (companion §12.4.2) the test exercises
-     * both intents: under VERIFICATION → INCONCLUSIVE with
-     * {@code saturated.<p>=true}; under SMOKE → advisory PASS with
-     * the same flag set and the threshold equal to the fixture's
-     * advisory value at the saturation ceiling.
-     */
     @Nested
     @DisplayName("latency_threshold_bootstrap (production path: PercentileLatency.evaluate)")
     class ProductionPath {
@@ -299,160 +112,7 @@ class LatencyConformanceTest {
         @TestFactory
         @DisplayName("Threshold derived on the production path matches the fixture, per intent")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("latency_threshold_bootstrap.json");
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    long[] baselineLatenciesMs = toLongArray(inputs.get("baseline_latencies"));
-                    double p = inputs.get("p").asDouble();
-                    double confidence = inputs.get("confidence").asDouble();
-                    long expectedThreshold = expected.get("threshold").asLong();
-                    boolean saturated = expected.get("saturated").asBoolean();
-                    PercentileKey key = percentileKeyFor(p);
-
-                    org.mavai.punit.api.spec.LatencyStatistics baseline =
-                            buildBaseline(baselineLatenciesMs);
-                    PercentileLatency<String> criterion =
-                            PercentileLatency.empirical(confidence, key);
-
-                    // VERIFICATION: saturated → INCONCLUSIVE with the
-                    // saturation flag; non-saturated → PASS with
-                    // threshold.<p> equal to fixture's expected.threshold.
-                    CriterionResult verification = criterion.evaluate(
-                            evaluationContext(baseline, TestIntent.VERIFICATION));
-                    if (saturated) {
-                        assertThat(verification.verdict())
-                                .as("case=%s VERIFICATION verdict (saturated)", name)
-                                .isEqualTo(Verdict.INCONCLUSIVE);
-                        assertThat(verification.detail())
-                                .as("case=%s saturated.%s flag", name, key.detailKey())
-                                .containsEntry("saturated." + key.detailKey(), true);
-                    } else {
-                        assertThat(verification.verdict())
-                                .as("case=%s VERIFICATION verdict (non-saturated)", name)
-                                .isEqualTo(Verdict.PASS);
-                        assertThat(verification.detail())
-                                .as("case=%s threshold.%s on production path", name, key.detailKey())
-                                .containsEntry("threshold." + key.detailKey(), expectedThreshold);
-                    }
-
-                    // SMOKE on the saturated case: advisory PASS on
-                    // t_{(n)}, threshold.<p> present and equal to the
-                    // fixture's published threshold, saturated flag
-                    // still surfaced.
-                    if (saturated) {
-                        CriterionResult smoke = criterion.evaluate(
-                                evaluationContext(baseline, TestIntent.SMOKE));
-                        assertThat(smoke.verdict())
-                                .as("case=%s SMOKE verdict (saturated, advisory)", name)
-                                .isEqualTo(Verdict.PASS);
-                        assertThat(smoke.detail())
-                                .as("case=%s SMOKE threshold.%s (advisory)", name, key.detailKey())
-                                .containsEntry("threshold." + key.detailKey(), expectedThreshold);
-                        assertThat(smoke.detail())
-                                .as("case=%s SMOKE saturated.%s flag", name, key.detailKey())
-                                .containsEntry("saturated." + key.detailKey(), true);
-                    }
-                }));
-            }
-            return tests;
-        }
-
-        private PercentileKey percentileKeyFor(double p) {
-            if (p == 0.95) return PercentileKey.P95;
-            if (p == 0.99) return PercentileKey.P99;
-            throw new IllegalArgumentException(
-                    "fixture case asserts percentile " + p
-                            + ", which has no PercentileKey on the production surface");
-        }
-
-        private org.mavai.punit.api.spec.LatencyStatistics buildBaseline(long[] sortedAscMs) {
-            // sortedLatenciesMs is the only field the deriver reads;
-            // percentile point estimates are reporting metadata. Fill
-            // them honestly from the sorted vector so the baseline
-            // object is internally consistent.
-            LatencyResult percentiles = new LatencyResult(
-                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.50)),
-                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.90)),
-                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.95)),
-                    Duration.ofMillis(nearestRankMs(sortedAscMs, 0.99)),
-                    sortedAscMs.length);
-            return new org.mavai.punit.api.spec.LatencyStatistics(
-                    percentiles, sortedAscMs, sortedAscMs.length);
-        }
-
-        private long nearestRankMs(long[] sortedAsc, double p) {
-            int index = (int) Math.ceil(p * sortedAsc.length) - 1;
-            index = Math.max(0, Math.min(index, sortedAsc.length - 1));
-            return sortedAsc[index];
-        }
-
-        private EvaluationContext<String, org.mavai.punit.api.spec.LatencyStatistics>
-                evaluationContext(
-                        org.mavai.punit.api.spec.LatencyStatistics baseline,
-                        TestIntent intent) {
-            int testSampleCount = Math.max(1, baseline.sampleCount() / 2);
-            SampleSummary<String> summary = buildSummary(testSampleCount);
-            String identity = "sha256:test-fixed-identity";
-            return new EvaluationContext<>() {
-                @Override public SampleSummary<String> summary() { return summary; }
-                @Override public Optional<org.mavai.punit.api.spec.LatencyStatistics> baseline() {
-                    return Optional.of(baseline);
-                }
-                @Override public FactorBundle factors() {
-                    return FactorBundle.of(new Object());
-                }
-                @Override public String testInputsIdentity() { return identity; }
-                @Override public Optional<String> baselineInputsIdentity() {
-                    return Optional.of(identity);
-                }
-                @Override public TestIntent intent() { return intent; }
-            };
-        }
-
-        private SampleSummary<String> buildSummary(int sampleCount) {
-            // Synthetic observed latencies safely below every published
-            // bootstrap-case threshold (smallest threshold across the
-            // four cases is 419 ms); the test asserts on the deriver's
-            // threshold value flowing through evaluate, not on the
-            // observation-vs-threshold comparison.
-            LatencyResult observed = new LatencyResult(
-                    Duration.ofMillis(1),
-                    Duration.ofMillis(1),
-                    Duration.ofMillis(1),
-                    Duration.ofMillis(1),
-                    sampleCount);
-            var outcomes = new ArrayList<ServiceContractOutcome<?, String>>(sampleCount);
-            for (int i = 0; i < sampleCount; i++) {
-                outcomes.add(new ServiceContractOutcome<>(
-                        Outcome.ok("ok"), STUB_CONTRACT, List.of(),
-                        0L, Duration.ofMillis(1)));
-            }
-            return new SampleSummary<>(
-                    outcomes,
-                    Duration.ofMillis(1),
-                    sampleCount, 0, 0L, 0,
-                    observed,
-                    TerminationReason.COMPLETED,
-                    List.of(),
-                    Map.of(), LatencyResult.empty(), List.of());
-        }
-
-        private long[] toLongArray(JsonNode node) {
-            if (!node.isArray()) {
-                throw new IllegalArgumentException(
-                        "baseline_latencies must be a JSON array");
-            }
-            long[] out = new long[node.size()];
-            for (int i = 0; i < node.size(); i++) {
-                out[i] = node.get(i).asLong();
-            }
-            return out;
+            return dynamicTests(ConformanceCatalog.latencyThresholdBootstrapProductionPath());
         }
     }
 
@@ -463,24 +123,7 @@ class LatencyConformanceTest {
         @TestFactory
         @DisplayName("Emission non-degeneracy minimums match the published standard")
         Collection<DynamicTest> emissionMinimums() {
-            JsonNode suite = loadSuite("latency_percentile_minimums.json");
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                if (!"emission_non_degeneracy".equals(c.get("approach").asText())) {
-                    continue;
-                }
-                String name = c.get("name").asText();
-                double p = c.get("inputs").get("percentile").asDouble();
-                int expected = c.get("expected").get("minimum_contributing_samples").asInt();
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    String label = "p" + Math.round(p * 100);
-                    assertThat(LatencySection.minimumSamplesFor(label))
-                            .as("emission minimum for %s", label)
-                            .isEqualTo(expected);
-                }));
-            }
+            var tests = dynamicTests(ConformanceCatalog.latencyPercentileEmissionMinimums());
             assertThat(tests).as("emission cases in the suite").hasSize(4);
             return tests;
         }
@@ -488,49 +131,9 @@ class LatencyConformanceTest {
         @TestFactory
         @DisplayName("Bound-existence minimums mark the deriver's saturation boundary")
         Collection<DynamicTest> boundExistenceMinimums() {
-            JsonNode suite = loadSuite("latency_percentile_minimums.json");
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                if (!"bound_existence".equals(c.get("approach").asText())) {
-                    continue;
-                }
-                String name = c.get("name").asText();
-                double p = c.get("inputs").get("percentile").asDouble();
-                double confidence = c.get("inputs").get("confidence").asDouble();
-                int minimum = c.get("expected").get("minimum_baseline_samples").asInt();
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    assertThat(LatencyThresholdDeriver.derive(ascending(minimum), p, confidence)
-                            .saturated())
-                            .as("non-saturated bound at the published minimum n=%d", minimum)
-                            .isFalse();
-                    assertThat(LatencyThresholdDeriver.derive(ascending(minimum - 1), p, confidence)
-                            .saturated())
-                            .as("saturation just below the published minimum, n=%d", minimum - 1)
-                            .isTrue();
-                }));
-            }
+            var tests = dynamicTests(ConformanceCatalog.latencyBoundExistenceMinimums());
             assertThat(tests).as("bound-existence cases in the suite").hasSize(8);
             return tests;
         }
-
-        private double[] ascending(int n) {
-            double[] values = new double[n];
-            for (int i = 0; i < n; i++) {
-                values[i] = i + 1;
-            }
-            return values;
-        }
     }
-
-    private static final Contract<Object, String> STUB_CONTRACT = new Contract<>() {
-        @Override public Outcome<String> invoke(Object input, TokenTracker tracker) {
-            return Outcome.ok("ok");
-        }
-        @Override public Criteria<String> criteria() {
-            return meeting().<String>zeroFailures();
-        }
-
-    };
 }

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyProductionPath.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/LatencyProductionPath.java
@@ -1,0 +1,119 @@
+package org.mavai.punit.statistics.conformance;
+
+import static org.mavai.punit.api.criterion.Criteria.meeting;
+
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.Contract;
+import org.mavai.punit.api.FactorBundle;
+import org.mavai.punit.api.LatencyResult;
+import org.mavai.punit.api.PercentileKey;
+import org.mavai.punit.api.ServiceContractOutcome;
+import org.mavai.punit.api.TestIntent;
+import org.mavai.punit.api.TokenTracker;
+import org.mavai.punit.api.criterion.Criteria;
+import org.mavai.punit.api.spec.EvaluationContext;
+import org.mavai.punit.api.spec.LatencyStatistics;
+import org.mavai.punit.api.spec.SampleSummary;
+import org.mavai.punit.api.spec.TerminationReason;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Scaffolding for driving the latency bootstrap fixture through the
+ * production evaluation path ({@code PercentileLatency.evaluate}
+ * reading a baseline {@code LatencyStatistics}).
+ */
+final class LatencyProductionPath {
+
+    private LatencyProductionPath() { }
+
+    static PercentileKey percentileKeyFor(double p) {
+        if (p == 0.95) return PercentileKey.P95;
+        if (p == 0.99) return PercentileKey.P99;
+        throw new IllegalArgumentException(
+                "fixture case asserts percentile " + p
+                        + ", which has no PercentileKey on the production surface");
+    }
+
+    static LatencyStatistics buildBaseline(long[] sortedAscMs) {
+        // sortedLatenciesMs is the only field the deriver reads;
+        // percentile point estimates are reporting metadata. Fill them
+        // honestly from the sorted vector so the baseline object is
+        // internally consistent.
+        LatencyResult percentiles = new LatencyResult(
+                Duration.ofMillis(nearestRankMs(sortedAscMs, 0.50)),
+                Duration.ofMillis(nearestRankMs(sortedAscMs, 0.90)),
+                Duration.ofMillis(nearestRankMs(sortedAscMs, 0.95)),
+                Duration.ofMillis(nearestRankMs(sortedAscMs, 0.99)),
+                sortedAscMs.length);
+        return new LatencyStatistics(percentiles, sortedAscMs, sortedAscMs.length);
+    }
+
+    private static long nearestRankMs(long[] sortedAsc, double p) {
+        int index = (int) Math.ceil(p * sortedAsc.length) - 1;
+        index = Math.max(0, Math.min(index, sortedAsc.length - 1));
+        return sortedAsc[index];
+    }
+
+    static EvaluationContext<String, LatencyStatistics> evaluationContext(
+            LatencyStatistics baseline, TestIntent intent) {
+        int testSampleCount = Math.max(1, baseline.sampleCount() / 2);
+        SampleSummary<String> summary = buildSummary(testSampleCount);
+        String identity = "sha256:test-fixed-identity";
+        return new EvaluationContext<>() {
+            @Override public SampleSummary<String> summary() { return summary; }
+            @Override public Optional<LatencyStatistics> baseline() {
+                return Optional.of(baseline);
+            }
+            @Override public FactorBundle factors() {
+                return FactorBundle.of(new Object());
+            }
+            @Override public String testInputsIdentity() { return identity; }
+            @Override public Optional<String> baselineInputsIdentity() {
+                return Optional.of(identity);
+            }
+            @Override public TestIntent intent() { return intent; }
+        };
+    }
+
+    private static SampleSummary<String> buildSummary(int sampleCount) {
+        // Synthetic observed latencies safely below every published
+        // bootstrap-case threshold (smallest threshold across the four
+        // cases is 419 ms); the check asserts on the deriver's threshold
+        // value flowing through evaluate, not on the
+        // observation-vs-threshold comparison.
+        LatencyResult observed = new LatencyResult(
+                Duration.ofMillis(1),
+                Duration.ofMillis(1),
+                Duration.ofMillis(1),
+                Duration.ofMillis(1),
+                sampleCount);
+        var outcomes = new ArrayList<ServiceContractOutcome<?, String>>(sampleCount);
+        for (int i = 0; i < sampleCount; i++) {
+            outcomes.add(new ServiceContractOutcome<>(
+                    Outcome.ok("ok"), STUB_CONTRACT, List.of(),
+                    0L, Duration.ofMillis(1)));
+        }
+        return new SampleSummary<>(
+                outcomes,
+                Duration.ofMillis(1),
+                sampleCount, 0, 0L, 0,
+                observed,
+                TerminationReason.COMPLETED,
+                List.of(),
+                Map.of(), LatencyResult.empty(), List.of());
+    }
+
+    private static final Contract<Object, String> STUB_CONTRACT = new Contract<>() {
+        @Override public Outcome<String> invoke(Object input, TokenTracker tracker) {
+            return Outcome.ok("ok");
+        }
+        @Override public Criteria<String> criteria() {
+            return meeting().<String>zeroFailures();
+        }
+    };
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/OracleAssert.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/OracleAssert.java
@@ -1,0 +1,59 @@
+package org.mavai.punit.statistics.conformance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Asserts one binding expected field of one fixture case against the
+ * oracle, recording the {@code (suite, case, field)} triple <em>before</em>
+ * asserting — an attempted-and-failed assertion is a red test, not a
+ * coverage gap. A {@code null} actual value fails with a
+ * missing-capability diagnostic: the production surface produced nothing
+ * for a field the manifest classifies as binding.
+ */
+final class OracleAssert {
+
+    private OracleAssert() { }
+
+    /** Exact-equality form: booleans, strings, integer-valued fields. */
+    static void assertOracle(
+            ConformanceRecorder recorder, String suite, JsonNode fixtureCase,
+            String field, Object actual) {
+        assertOracle(recorder, suite, fixtureCase, field, actual, null);
+    }
+
+    static void assertOracle(
+            ConformanceRecorder recorder, String suite, JsonNode fixtureCase,
+            String field, Object actual, Double tolerance) {
+        String caseName = fixtureCase.get("name").asText();
+        recorder.record(suite, caseName, field);
+        JsonNode expected = fixtureCase.get("expected").get(field);
+        String label = suite + "/" + caseName + "/" + field;
+        if (expected == null) {
+            throw new IllegalStateException(
+                    label + ": the fixture case carries no such expected field — check the assertion");
+        }
+        if (actual == null) {
+            fail("%s: the oracle expects %s, but the production surface produced nothing "
+                    + "for this binding field", label, expected);
+        }
+        if (expected.isBoolean()) {
+            assertThat(actual).as(label).isEqualTo(expected.asBoolean());
+        } else if (expected.isTextual()) {
+            assertThat(String.valueOf(actual)).as(label).isEqualTo(expected.asText());
+        } else if (tolerance == null || tolerance == 0.0) {
+            if (expected.isIntegralNumber()) {
+                assertThat(((Number) actual).longValue()).as(label).isEqualTo(expected.asLong());
+            } else {
+                assertThat(((Number) actual).doubleValue()).as(label).isEqualTo(expected.asDouble());
+            }
+        } else {
+            assertThat(((Number) actual).doubleValue())
+                    .as(label)
+                    .isCloseTo(expected.asDouble(), within(tolerance));
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ProportionConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ProportionConformanceTest.java
@@ -1,59 +1,32 @@
 package org.mavai.punit.statistics.conformance;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.mavai.punit.statistics.BinomialProportionEstimator;
-import org.mavai.punit.statistics.DerivationContext;
-import org.mavai.punit.statistics.DerivedThreshold;
-import org.mavai.punit.statistics.OperationalApproach;
-import org.mavai.punit.statistics.ProportionEstimate;
-import org.mavai.punit.statistics.SampleSizeCalculator;
-import org.mavai.punit.statistics.SampleSizeRequirement;
-import org.mavai.punit.statistics.TestVerdictEvaluator;
-import org.mavai.punit.statistics.ThresholdDeriver;
-import org.mavai.punit.statistics.VerdictWithConfidence;
-import org.mavai.punit.statistics.VerificationFeasibilityEvaluator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
+import java.util.List;
 
 /**
  * Conformance tests for binomial proportion statistics: Wilson score intervals,
  * threshold derivation, power analysis, feasibility, and verdict evaluation.
+ *
+ * <p>The check bodies live in {@link ConformanceCatalog}, shared with the
+ * manifest-driven coverage check ({@code ConformanceCoverageTest}); this
+ * class provides the per-case test reporting.
  *
  * @see <a href="https://github.com/mavai-org/mavai-R">mavai-R</a>
  */
 @DisplayName("Proportion conformance (mavai-R)")
 class ProportionConformanceTest {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String CONFORMANCE_DIR = "/conformance/";
-
-    private static final BinomialProportionEstimator ESTIMATOR = new BinomialProportionEstimator();
-    private static final ThresholdDeriver THRESHOLD_DERIVER = new ThresholdDeriver();
-    private static final SampleSizeCalculator SAMPLE_SIZE_CALCULATOR = new SampleSizeCalculator();
-    private static final TestVerdictEvaluator VERDICT_EVALUATOR = new TestVerdictEvaluator();
-
-    private static JsonNode loadSuite(String filename) {
-        try (InputStream is = ProportionConformanceTest.class.getResourceAsStream(CONFORMANCE_DIR + filename)) {
-            if (is == null) {
-                throw new IllegalStateException(
-                        "Conformance data not found: " + CONFORMANCE_DIR + filename
-                                + ". Run the Gradle downloadConformanceData task or check the checked-in fallback files.");
-            }
-            return MAPPER.readTree(is);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to read conformance suite: " + filename, e);
-        }
+    private static Collection<DynamicTest> dynamicTests(List<ConformanceCatalog.CaseCheck> checks) {
+        return checks.stream()
+                .map(check -> DynamicTest.dynamicTest(
+                        check.caseName(),
+                        () -> check.check().run(ConformanceRecorder.NO_OP)))
+                .toList();
     }
 
     @Nested
@@ -63,34 +36,7 @@ class ProportionConformanceTest {
         @TestFactory
         @DisplayName("Two-sided Wilson score confidence intervals")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("wilson_ci.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    int successes = inputs.get("successes").asInt();
-                    int trials = inputs.get("trials").asInt();
-                    double confidence = inputs.get("confidence").asDouble();
-
-                    ProportionEstimate result = ESTIMATOR.estimate(successes, trials, confidence);
-
-                    assertThat(result.lowerBound())
-                            .as("lower bound")
-                            .isCloseTo(expected.get("lower").asDouble(), within(tolerance));
-                    assertThat(result.upperBound())
-                            .as("upper bound")
-                            .isCloseTo(expected.get("upper").asDouble(), within(tolerance));
-                    assertThat(result.pointEstimate())
-                            .as("point estimate")
-                            .isCloseTo(expected.get("point").asDouble(), within(tolerance));
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.wilsonCi());
         }
     }
 
@@ -101,28 +47,7 @@ class ProportionConformanceTest {
         @TestFactory
         @DisplayName("One-sided Wilson score lower bound")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("wilson_lower.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    int successes = inputs.get("successes").asInt();
-                    int trials = inputs.get("trials").asInt();
-                    double confidence = inputs.get("confidence").asDouble();
-
-                    double result = ESTIMATOR.lowerBound(successes, trials, confidence);
-
-                    assertThat(result)
-                            .as("lower bound")
-                            .isCloseTo(expected.get("lower_bound").asDouble(), within(tolerance));
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.wilsonLower());
         }
     }
 
@@ -131,51 +56,9 @@ class ProportionConformanceTest {
     class ThresholdDerivation {
 
         @TestFactory
-        @DisplayName("Sample-size-first and threshold-first derivation")
+        @DisplayName("Sample-size-first (with binding decision artefacts) and threshold-first derivation")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("threshold_derivation.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                String approach = c.get("approach").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    int baselineSuccesses = inputs.get("baseline_successes").asInt();
-                    int baselineTrials = inputs.get("baseline_trials").asInt();
-
-                    if ("sample_size_first".equals(approach)) {
-                        int testSamples = inputs.get("test_samples").asInt();
-                        double confidence = inputs.get("confidence").asDouble();
-
-                        DerivedThreshold result = THRESHOLD_DERIVER.deriveSampleSizeFirst(
-                                baselineTrials, baselineSuccesses, testSamples, confidence);
-
-                        assertThat(result.value())
-                                .as("threshold")
-                                .isCloseTo(expected.get("threshold").asDouble(), within(tolerance));
-
-                    } else if ("threshold_first".equals(approach)) {
-                        double threshold = inputs.get("threshold").asDouble();
-
-                        // testSamples is not used in the threshold-first implied confidence computation
-                        // but is required by the API; use baseline trials as a reasonable value
-                        DerivedThreshold result = THRESHOLD_DERIVER.deriveThresholdFirst(
-                                baselineTrials, baselineSuccesses, baselineTrials, threshold);
-
-                        assertThat(result.context().confidence())
-                                .as("implied confidence")
-                                .isCloseTo(expected.get("implied_confidence").asDouble(), within(tolerance));
-                        assertThat(result.isStatisticallySound())
-                                .as("is sound")
-                                .isEqualTo(expected.get("is_sound").asBoolean());
-                    }
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.thresholdDerivation());
         }
     }
 
@@ -186,37 +69,7 @@ class ProportionConformanceTest {
         @TestFactory
         @DisplayName("Sample size calculation via power analysis")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("power_analysis.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    double baselineRate = inputs.get("baseline_rate").asDouble();
-                    double minDetectableEffect = inputs.get("min_detectable_effect").asDouble();
-                    double confidence = inputs.get("confidence").asDouble();
-                    double power = inputs.get("power").asDouble();
-
-                    SampleSizeRequirement result = SAMPLE_SIZE_CALCULATOR.calculateForPower(
-                            baselineRate, minDetectableEffect, confidence, power);
-
-                    assertThat(result.requiredSamples())
-                            .as("required samples")
-                            .isEqualTo(expected.get("required_samples").asInt());
-
-                    double achievedPower = SAMPLE_SIZE_CALCULATOR.calculateAchievedPower(
-                            result.requiredSamples(), baselineRate, minDetectableEffect, confidence);
-
-                    assertThat(achievedPower)
-                            .as("achieved power")
-                            .isCloseTo(expected.get("achieved_power").asDouble(), within(tolerance));
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.powerAnalysis());
         }
     }
 
@@ -227,34 +80,7 @@ class ProportionConformanceTest {
         @TestFactory
         @DisplayName("Verification feasibility checking")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("feasibility.json");
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    double targetProportion = inputs.get("target_proportion").asDouble();
-                    int sampleSize = inputs.get("sample_size").asInt();
-                    double confidence = inputs.get("confidence").asDouble();
-
-                    var result = VerificationFeasibilityEvaluator.evaluate(
-                            sampleSize, targetProportion, confidence);
-
-                    assertThat(result.feasible())
-                            .as("feasible")
-                            .isEqualTo(expected.get("feasible").asBoolean());
-                    assertThat(result.minimumSamples())
-                            .as("minimum samples")
-                            .isEqualTo(expected.get("minimum_samples").asInt());
-                    assertThat(result.criterion().toLowerCase().replaceAll("[\\s-]+", "_"))
-                            .as("criterion")
-                            .isEqualTo(expected.get("criterion").asText());
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.feasibility());
         }
     }
 
@@ -265,55 +91,7 @@ class ProportionConformanceTest {
         @TestFactory
         @DisplayName("Pass/fail verdict evaluation with z-test statistics")
         Collection<DynamicTest> cases() {
-            JsonNode suite = loadSuite("verdict.json");
-            double tolerance = suite.get("tolerance").asDouble();
-
-            var tests = new ArrayList<DynamicTest>();
-            for (JsonNode c : suite.get("cases")) {
-                String name = c.get("name").asText();
-                var inputs = c.get("inputs");
-                var expected = c.get("expected");
-
-                tests.add(DynamicTest.dynamicTest(name, () -> {
-                    int successes = inputs.get("successes").asInt();
-                    int trials = inputs.get("trials").asInt();
-                    double threshold = inputs.get("threshold").asDouble();
-                    double confidence = inputs.get("confidence").asDouble();
-
-                    // Build a DerivedThreshold to pass to the evaluator
-                    var context = new DerivationContext(threshold, trials, trials, confidence);
-                    var derivedThreshold = new DerivedThreshold(
-                            threshold, OperationalApproach.SAMPLE_SIZE_FIRST, context);
-
-                    VerdictWithConfidence verdict = VERDICT_EVALUATOR.evaluate(
-                            successes, trials, derivedThreshold);
-
-                    assertThat(verdict.passed())
-                            .as("passed")
-                            .isEqualTo(expected.get("passed").asBoolean());
-                    assertThat(verdict.observedRate())
-                            .as("observed rate")
-                            .isCloseTo(expected.get("observed_rate").asDouble(), within(tolerance));
-
-                    // z-test statistic and p-value via BinomialProportionEstimator
-                    double observedRate = (double) successes / trials;
-                    double z = ESTIMATOR.zTestStatistic(observedRate, threshold, trials);
-                    double pValue = ESTIMATOR.oneSidedPValue(z);
-
-                    assertThat(z)
-                            .as("test statistic")
-                            .isCloseTo(expected.get("test_statistic").asDouble(), within(tolerance));
-                    assertThat(pValue)
-                            .as("p-value")
-                            .isCloseTo(expected.get("p_value").asDouble(), within(tolerance));
-
-                    // false_positive_probability in the reference data is alpha = 1 - confidence
-                    assertThat(1.0 - confidence)
-                            .as("false positive probability (alpha)")
-                            .isCloseTo(expected.get("false_positive_probability").asDouble(), within(tolerance));
-                }));
-            }
-            return tests;
+            return dynamicTests(ConformanceCatalog.verdict());
         }
     }
 }

--- a/punit-core/src/test/resources/org/mavai/punit/statistics/conformance/conformance-scope.json
+++ b/punit-core/src/test/resources/org/mavai/punit/statistics/conformance/conformance-scope.json
@@ -1,0 +1,9 @@
+{
+  "description": "punit's conformance scope beyond the oracle's family-mandatory tier. Extend-only: suites listed here are additional obligations; nothing here can subtract from the manifest's familyMandatory roster. A suite absent from both tiers is reported as unaddressed by every conformance run, never silently skipped.",
+  "suites": [
+    "feasibility",
+    "power_analysis",
+    "latency_percentile_minimums",
+    "latency_threshold_bootstrap"
+  ]
+}


### PR DESCRIPTION
## Summary

Two commits, red-then-green, enforcing the composed decision rules against the mavai-R v0.8.4 fixtures.

**Red (first commit)** — punit's true standing, established and demonstrated:
- `regression_decision` scenario suite + conformance manifest wired into the conformance machinery. `fetchConformanceData` keeps fetch-latest (now resolving v0.8.4) and gains an opt-in `-PconformanceCasesDir` local override; absent fixtures fail as clear assertions, not crashes.
- `ConformanceCatalog` + `ConformanceLedger` + `ConformanceCoverageTest`: the coverage test re-executes the catalog with its own recorder (deterministic under any ordering/filtering/forking), diffs against family-mandatory ∪ the committed scope file, prints the standing, writes `punit-core/build/conformance-report.json`, MD5-checks each in-scope suite.
- Demonstrated: the empirical rule was conformant (observed rate ≥ p* ⟺ K ≥ ⌈n·p*⌉; §4.3.2 perfect-baseline guard present) but produced none of the binding decision artefacts. The declared-threshold path was **anti-conservative** — point rate where the methodology mandates the test-side Wilson lower bound — and documented as deliberate; fixed per the owner ruling. Red set: 26 of 1709.

**Green (second commit)** — the fix, plus two structural findings it forced:
- Threshold derivation produces cutoff / achieved size / displayed rate; declared thresholds are judged by the test sample's Wilson lower bound.
- **Second verdict path closed:** `PerCriterionVerdicts.derive` had re-derived verdicts by point rate and substituted them over `PassRate`'s judgement, on a counting basis excluding apply-level (`Outcome.fail`) failures — a 90-of-100 run scripted via `Outcome.fail` produced composite PASS while PassRate said FAIL. The aggregation now reuses PassRate's verdicts; the rule is applied exactly once.
- Early termination's `SUCCESS_GUARANTEED` is now confidence-aware (it could lock in PASSes the Wilson rule refuses).
- USER-GUIDE / OPERATIONAL-FLOW passages describing the deterministic contractual rule rewritten. Several integration tests re-parameterised where their configurations were only passing under the anti-conservative rule (details in the commit message).

Open question for a family ruling (noted, not resolved here): whether apply-level failures belong in the pass-rate denominator (punit counts them; per-criterion rows display criterion-basis counts). Deferred by design: the verdict-XML cutoff attribute (verdict-1.2 → 1.3 schema evolution — punit owns the XSD; to be its own coordinated step). Known limitation: `.atConfidence(...)` does not compose with `.meeting(...)`; all published compliance fixtures are at the 0.95 default.

Final state: `./gradlew clean build` fully green with the default fetch — 1709 punit-core tests + punit-report + punit-sentinel + ArchUnit guards. Standing `mandatory 217/217 over 7 suites; scope 69/69 over 4 suites`. Mark the conformance CI job required after merge.

Tracked by DIR-DECISION-RULE-CONFORMANCE-family (orchestrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
