### PR TITLE
Adopt the risk-driven sizing statistics, oracle-locked to the sizing suite

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/statistics/RiskDrivenSizingCalculator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/RiskDrivenSizingCalculator.java
@@ -1,0 +1,204 @@
+package org.mavai.punit.statistics;
+
+import org.apache.commons.statistics.distribution.NormalDistribution;
+
+/**
+ * Sizes a regression-procedure test against its own moving acceptance floor.
+ *
+ * <h2>The Moving Floor</h2>
+ * <p>A test whose threshold is derived from a measured baseline does not apply
+ * a fixed bar: the acceptance floor is the baseline rate's one-sided Wilson
+ * lower bound evaluated at the test's own sample size. As the sample size
+ * shrinks, the floor falls — a small sample proves less, so less is demanded
+ * of it. Fixed-threshold power formulas therefore overstate the power of small
+ * designs: the bar the small test will actually apply is lower than the one
+ * they price.
+ *
+ * <p>This calculator puts the moving floor inside the power calculation.
+ * Given a declared <em>minimum acceptable rate</em> — the worst true rate the
+ * operator is willing to tolerate; a declared tolerance, not a measured
+ * estimate — the self-consistent power at a candidate sample size n is
+ * <pre>
+ *   floor(n) = WilsonLower(p₀, n, 1−α)
+ *   Power(n) = Φ((floor(n) − p_min) / √(p_min(1−p_min)/n))
+ * </pre>
+ * read as: the probability that a service whose true rate is exactly the
+ * tolerated minimum fails the test — that degradation at least this severe is
+ * detected. The floor reuses the package's existing Wilson machinery
+ * ({@link BinomialProportionEstimator#lowerBoundFromRate}) so the z inside the
+ * Wilson bound and the Φ of the power form share one normal-distribution
+ * convention.
+ *
+ * <h2>Domain</h2>
+ * <p>The construction is defined for a minimum acceptable rate strictly below
+ * the baseline rate. When the tolerated minimum sits at or above the measured
+ * baseline, the floor lies below the tolerated rate at every sample size,
+ * power falls as n grows, and no sample size achieves a useful target power —
+ * such a design asks the test to detect a "degradation" the baseline already
+ * exceeds. That regime is rejected as misuse.
+ *
+ * <h2>What This Class Offers</h2>
+ * <ul>
+ *   <li>{@link #powerAt}: self-consistent power at a candidate sample size</li>
+ *   <li>{@link #requiredSamples}: smallest sample size meeting a target power</li>
+ *   <li>{@link #detectableRate}: the inversion — the largest tolerable rate
+ *       detectable at target power with a fixed, affordable sample size</li>
+ * </ul>
+ *
+ * <p>Within the domain, increasing n both raises the floor toward the baseline
+ * rate and shrinks the standard error, so power is increasing in n and the
+ * required sample size is well defined.
+ */
+public class RiskDrivenSizingCalculator {
+
+    /**
+     * The standard normal distribution N(0, 1) — the same implementation the
+     * rest of the statistics package uses, so the Wilson bound's z and the
+     * power form's Φ share one convention.
+     */
+    private static final NormalDistribution STANDARD_NORMAL = NormalDistribution.of(0, 1);
+
+    /**
+     * Search ceiling for {@link #requiredSamples}: beyond this the declared
+     * tolerance is too tight for the baseline to be sized at all.
+     */
+    private static final int MAX_REQUIRED_SAMPLES = 10_000_000;
+
+    private final BinomialProportionEstimator estimator = new BinomialProportionEstimator();
+
+    /**
+     * Self-consistent power at a candidate sample size: the probability that
+     * a service whose true rate is exactly the minimum acceptable rate fails
+     * a test whose acceptance floor is derived from the baseline rate at this
+     * very sample size.
+     *
+     * @param sampleSize            the candidate test sample size n, positive
+     * @param baselineRate          the effective baseline rate p₀, in (0, 1)
+     * @param minimumAcceptableRate the declared tolerance, in (0, baselineRate)
+     * @param confidence            one-sided confidence level (1 − α), in (0, 1)
+     * @return the probability that degradation to the tolerated minimum is detected
+     */
+    public double powerAt(
+            int sampleSize,
+            double baselineRate,
+            double minimumAcceptableRate,
+            double confidence) {
+        validateSampleSize(sampleSize);
+        validateSizingInputs(baselineRate, minimumAcceptableRate, confidence);
+
+        double floor = estimator.lowerBoundFromRate(baselineRate, sampleSize, confidence);
+        double standardError = Math.sqrt(
+                minimumAcceptableRate * (1.0 - minimumAcceptableRate) / sampleSize);
+        return STANDARD_NORMAL.cumulativeProbability(
+                (floor - minimumAcceptableRate) / standardError);
+    }
+
+    /**
+     * The smallest sample size whose self-consistent power meets the target.
+     *
+     * <p>Power is increasing in the sample size within the domain (the floor
+     * rises toward the baseline rate and the standard error shrinks), so the
+     * minimum is well defined; it is found by doubling until the target is
+     * met, then bisecting.
+     *
+     * @param baselineRate          the effective baseline rate p₀, in (0, 1)
+     * @param minimumAcceptableRate the declared tolerance, in (0, baselineRate)
+     * @param confidence            one-sided confidence level (1 − α), in (0, 1)
+     * @param targetPower           the required detection probability, in (0, 1)
+     * @return the minimal sample size at which the target power is achieved
+     */
+    public int requiredSamples(
+            double baselineRate,
+            double minimumAcceptableRate,
+            double confidence,
+            double targetPower) {
+        validateSizingInputs(baselineRate, minimumAcceptableRate, confidence);
+        validateProbability(targetPower, "Target power");
+
+        int hi = 2;
+        while (powerAt(hi, baselineRate, minimumAcceptableRate, confidence) < targetPower) {
+            hi *= 2;
+            if (hi > MAX_REQUIRED_SAMPLES) {
+                throw new IllegalArgumentException(
+                        "Required sample size exceeds " + MAX_REQUIRED_SAMPLES
+                                + "; the declared tolerance is too tight for this baseline");
+            }
+        }
+        int lo = Math.max(1, hi / 2);
+        while (lo + 1 < hi) {
+            int mid = (lo + hi) >>> 1;
+            if (powerAt(mid, baselineRate, minimumAcceptableRate, confidence) >= targetPower) {
+                hi = mid;
+            } else {
+                lo = mid;
+            }
+        }
+        return hi;
+    }
+
+    /**
+     * The inversion: for a fixed, affordable sample size, the largest
+     * tolerable rate (the smallest drop from the baseline) at which the
+     * self-consistent power still meets the target. Found by bisection over
+     * the open interval below the baseline rate, to an absolute tolerance
+     * of 1e-10.
+     *
+     * @param sampleSize   the affordable test sample size N, positive
+     * @param baselineRate the effective baseline rate p₀, in (0, 1)
+     * @param confidence   one-sided confidence level (1 − α), in (0, 1)
+     * @param targetPower  the required detection probability, in (0, 1)
+     * @return the largest minimum acceptable rate detectable at target power
+     */
+    public double detectableRate(
+            int sampleSize,
+            double baselineRate,
+            double confidence,
+            double targetPower) {
+        validateSampleSize(sampleSize);
+        validateProbability(baselineRate, "Baseline rate");
+        validateProbability(confidence, "Confidence");
+        validateProbability(targetPower, "Target power");
+
+        double lo = 1e-9;
+        double hi = baselineRate - 1e-9;
+        while (hi - lo > 1e-10) {
+            double mid = (lo + hi) / 2.0;
+            if (powerAt(sampleSize, baselineRate, mid, confidence) >= targetPower) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+
+    private void validateSampleSize(int sampleSize) {
+        if (sampleSize < 1) {
+            throw new IllegalArgumentException(
+                    "Sample size must be positive, got: " + sampleSize);
+        }
+    }
+
+    private void validateSizingInputs(
+            double baselineRate, double minimumAcceptableRate, double confidence) {
+        validateProbability(baselineRate, "Baseline rate");
+        validateProbability(minimumAcceptableRate, "Minimum acceptable rate");
+        validateProbability(confidence, "Confidence");
+        if (minimumAcceptableRate >= baselineRate) {
+            throw new IllegalArgumentException(
+                    "Minimum acceptable rate (" + minimumAcceptableRate
+                            + ") must sit below the measured baseline rate (" + baselineRate
+                            + "): the moving-floor construction sizes the detection of a "
+                            + "degradation below the baseline. To assert a rate at or above "
+                            + "the baseline, re-measure the baseline rather than asserting "
+                            + "improvement through the tolerance.");
+        }
+    }
+
+    private void validateProbability(double value, String name) {
+        if (Double.isNaN(value) || value <= 0.0 || value >= 1.0) {
+            throw new IllegalArgumentException(
+                    name + " must be in (0, 1), got: " + value);
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/RiskDrivenSizingCalculatorTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/RiskDrivenSizingCalculatorTest.java
@@ -1,0 +1,146 @@
+package org.mavai.punit.statistics;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+@DisplayName("RiskDrivenSizingCalculator")
+class RiskDrivenSizingCalculatorTest {
+
+    private final RiskDrivenSizingCalculator calculator = new RiskDrivenSizingCalculator();
+
+    @Nested
+    @DisplayName("Required sample size")
+    class RequiredSampleSize {
+
+        @Test
+        @DisplayName("returns the smallest size meeting the target power for the worked example")
+        void returnsTheSmallestSizeMeetingTheTargetPowerForTheWorkedExample() {
+            assertThat(calculator.requiredSamples(0.87, 0.84, 0.95, 0.80)).isEqualTo(891);
+        }
+
+        @Test
+        @DisplayName("is minimal: the target power holds at the required size and fails one below")
+        void isMinimalTargetPowerHoldsAtRequiredSizeAndFailsOneBelow() {
+            assertThat(calculator.powerAt(891, 0.87, 0.84, 0.95))
+                    .isGreaterThanOrEqualTo(0.80);
+            assertThat(calculator.powerAt(890, 0.87, 0.84, 0.95))
+                    .isLessThan(0.80);
+        }
+
+        @Test
+        @DisplayName("sizes the scenario walkthrough tuple")
+        void sizesTheScenarioWalkthroughTuple() {
+            assertThat(calculator.requiredSamples(0.96, 0.93, 0.95, 0.80)).isEqualTo(405);
+        }
+
+        @Test
+        @DisplayName("rejects a tolerance so tight the search ceiling is exceeded")
+        void rejectsAToleranceSoTightTheSearchCeilingIsExceeded() {
+            assertThatThrownBy(() -> calculator.requiredSamples(0.90, 0.8999999, 0.95, 0.80))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("too tight");
+        }
+    }
+
+    @Nested
+    @DisplayName("Self-consistent power")
+    class SelfConsistentPower {
+
+        @Test
+        @DisplayName("increases with the sample size within the domain")
+        void increasesWithTheSampleSizeWithinTheDomain() {
+            double previous = 0.0;
+            for (int candidate : new int[] {50, 150, 405, 826, 1200, 5000}) {
+                double power = calculator.powerAt(candidate, 0.96, 0.93, 0.95);
+                assertThat(power)
+                        .as("power at n=%d exceeds power at the previous candidate", candidate)
+                        .isGreaterThan(previous);
+                previous = power;
+            }
+        }
+
+        @Test
+        @DisplayName("shows the fixed-threshold closed form understates the requirement")
+        void showsTheFixedThresholdClosedFormUnderstatesTheRequirement() {
+            // The fixed-threshold seed for the worked example lands at 826
+            // samples; against the moving floor that size falls short of the
+            // 80% detection target.
+            assertThat(calculator.powerAt(826, 0.87, 0.84, 0.95)).isLessThan(0.80);
+        }
+    }
+
+    @Nested
+    @DisplayName("Detectable rate")
+    class DetectableRate {
+
+        @Test
+        @DisplayName("round-trips: power at the detectable rate meets the target, a nudge above falls below")
+        void roundTripsPowerAtTheDetectableRateMeetsTheTargetANudgeAboveFallsBelow() {
+            double detectable = calculator.detectableRate(100, 0.87, 0.95, 0.80);
+            assertThat(calculator.powerAt(100, 0.87, detectable, 0.95))
+                    .isGreaterThanOrEqualTo(0.80);
+            assertThat(calculator.powerAt(100, 0.87, detectable + 1e-6, 0.95))
+                    .isLessThan(0.80);
+        }
+
+        @Test
+        @DisplayName("inverting at the required sample size recovers the declared tolerance")
+        void invertingAtTheRequiredSampleSizeRecoversTheDeclaredTolerance() {
+            int requiredSamples = calculator.requiredSamples(0.87, 0.84, 0.95, 0.80);
+            assertThat(calculator.detectableRate(requiredSamples, 0.87, 0.95, 0.80))
+                    .isCloseTo(0.84, within(1e-3));
+        }
+
+        @Test
+        @DisplayName("finds the collapse a small affordable sample can still detect")
+        void findsTheCollapseASmallAffordableSampleCanStillDetect() {
+            assertThat(calculator.detectableRate(100, 0.87, 0.95, 0.80))
+                    .isCloseTo(0.769353, within(1e-6));
+        }
+    }
+
+    @Nested
+    @DisplayName("Domain")
+    class Domain {
+
+        @Test
+        @DisplayName("rejects a tolerated minimum equal to the baseline rate")
+        void rejectsAToleratedMinimumEqualToTheBaselineRate() {
+            assertThatThrownBy(() -> calculator.powerAt(100, 0.90, 0.90, 0.95))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("below the measured baseline rate");
+        }
+
+        @Test
+        @DisplayName("rejects a tolerated minimum above the baseline rate")
+        void rejectsAToleratedMinimumAboveTheBaselineRate() {
+            assertThatThrownBy(() -> calculator.requiredSamples(0.90, 0.95, 0.95, 0.80))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("re-measure the baseline");
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive sample size")
+        void rejectsANonPositiveSampleSize() {
+            assertThatThrownBy(() -> calculator.powerAt(0, 0.90, 0.85, 0.95))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Sample size must be positive");
+        }
+
+        @Test
+        @DisplayName("rejects rates and probabilities outside the open unit interval")
+        void rejectsRatesAndProbabilitiesOutsideTheOpenUnitInterval() {
+            assertThatThrownBy(() -> calculator.powerAt(100, 1.0, 0.85, 0.95))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> calculator.requiredSamples(0.90, 0.85, 0.95, 1.0))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> calculator.detectableRate(100, 0.90, 0.0, 0.80))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
@@ -226,46 +226,68 @@ final class ConformanceCatalog {
         double tolerance = suite.get("tolerance").asDouble();
         List<CaseCheck> checks = new ArrayList<>();
         for (JsonNode c : suite.get("cases")) {
-            String approach = c.get("approach").asText();
-            checks.add(new CaseCheck("risk_driven_sizing", c.get("name").asText(), recorder -> {
-                var inputs = c.get("inputs");
-                double baselineRate = inputs.get("baseline_rate").asDouble();
-                double confidence = inputs.get("confidence").asDouble();
-
-                if ("required_n".equals(approach)) {
-                    double minimumAcceptableRate = inputs.get("minimum_acceptable_rate").asDouble();
-                    double targetPower = inputs.get("target_power").asDouble();
-                    int requiredSamples = RISK_DRIVEN_SIZING.requiredSamples(
-                            baselineRate, minimumAcceptableRate, confidence, targetPower);
-                    assertOracle(recorder, "risk_driven_sizing", c, "required_n",
-                            requiredSamples);
-                    assertOracle(recorder, "risk_driven_sizing", c, "floor",
-                            ESTIMATOR.lowerBoundFromRate(baselineRate, requiredSamples, confidence),
-                            tolerance);
-                    assertOracle(recorder, "risk_driven_sizing", c, "achieved_power",
-                            RISK_DRIVEN_SIZING.powerAt(requiredSamples, baselineRate,
-                                    minimumAcceptableRate, confidence),
-                            tolerance);
-                } else if ("power_at".equals(approach)) {
-                    double minimumAcceptableRate = inputs.get("minimum_acceptable_rate").asDouble();
-                    int testSamples = inputs.get("test_samples").asInt();
-                    assertOracle(recorder, "risk_driven_sizing", c, "floor",
-                            ESTIMATOR.lowerBoundFromRate(baselineRate, testSamples, confidence),
-                            tolerance);
-                    assertOracle(recorder, "risk_driven_sizing", c, "power",
-                            RISK_DRIVEN_SIZING.powerAt(testSamples, baselineRate,
-                                    minimumAcceptableRate, confidence),
-                            tolerance);
-                } else if ("detectable_rate".equals(approach)) {
-                    assertOracle(recorder, "risk_driven_sizing", c, "detectable_rate",
-                            RISK_DRIVEN_SIZING.detectableRate(
-                                    inputs.get("test_samples").asInt(), baselineRate,
-                                    confidence, inputs.get("target_power").asDouble()),
-                            tolerance);
-                }
-            }));
+            checks.add(new CaseCheck("risk_driven_sizing", c.get("name").asText(),
+                    recorder -> assertRiskDrivenSizingCase(recorder, c, tolerance)));
         }
         return checks;
+    }
+
+    private static void assertRiskDrivenSizingCase(
+            ConformanceRecorder recorder, JsonNode c, double tolerance) {
+        switch (c.get("approach").asText()) {
+            case "required_n" -> assertRequiredSampleSizeCase(recorder, c, tolerance);
+            case "power_at" -> assertPowerAtCandidateSizeCase(recorder, c, tolerance);
+            case "detectable_rate" -> assertDetectableRateInversionCase(recorder, c, tolerance);
+            default -> throw new IllegalStateException(
+                    "unknown sizing approach '%s' in case '%s'".formatted(
+                            c.get("approach").asText(), c.get("name").asText()));
+        }
+    }
+
+    private static void assertRequiredSampleSizeCase(
+            ConformanceRecorder recorder, JsonNode c, double tolerance) {
+        var inputs = c.get("inputs");
+        double baselineRate = inputs.get("baseline_rate").asDouble();
+        double confidence = inputs.get("confidence").asDouble();
+        double minimumAcceptableRate = inputs.get("minimum_acceptable_rate").asDouble();
+        int requiredSamples = RISK_DRIVEN_SIZING.requiredSamples(
+                baselineRate, minimumAcceptableRate, confidence,
+                inputs.get("target_power").asDouble());
+        assertOracle(recorder, "risk_driven_sizing", c, "required_n", requiredSamples);
+        assertOracle(recorder, "risk_driven_sizing", c, "floor",
+                ESTIMATOR.lowerBoundFromRate(baselineRate, requiredSamples, confidence),
+                tolerance);
+        assertOracle(recorder, "risk_driven_sizing", c, "achieved_power",
+                RISK_DRIVEN_SIZING.powerAt(requiredSamples, baselineRate,
+                        minimumAcceptableRate, confidence),
+                tolerance);
+    }
+
+    private static void assertPowerAtCandidateSizeCase(
+            ConformanceRecorder recorder, JsonNode c, double tolerance) {
+        var inputs = c.get("inputs");
+        double baselineRate = inputs.get("baseline_rate").asDouble();
+        double confidence = inputs.get("confidence").asDouble();
+        int testSamples = inputs.get("test_samples").asInt();
+        assertOracle(recorder, "risk_driven_sizing", c, "floor",
+                ESTIMATOR.lowerBoundFromRate(baselineRate, testSamples, confidence),
+                tolerance);
+        assertOracle(recorder, "risk_driven_sizing", c, "power",
+                RISK_DRIVEN_SIZING.powerAt(testSamples, baselineRate,
+                        inputs.get("minimum_acceptable_rate").asDouble(), confidence),
+                tolerance);
+    }
+
+    private static void assertDetectableRateInversionCase(
+            ConformanceRecorder recorder, JsonNode c, double tolerance) {
+        var inputs = c.get("inputs");
+        assertOracle(recorder, "risk_driven_sizing", c, "detectable_rate",
+                RISK_DRIVEN_SIZING.detectableRate(
+                        inputs.get("test_samples").asInt(),
+                        inputs.get("baseline_rate").asDouble(),
+                        inputs.get("confidence").asDouble(),
+                        inputs.get("target_power").asDouble()),
+                tolerance);
     }
 
     // ── feasibility ─────────────────────────────────────────────────

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
@@ -13,6 +13,7 @@ import org.mavai.punit.statistics.DerivedThreshold;
 import org.mavai.punit.statistics.LatencyStatistics;
 import org.mavai.punit.statistics.LatencyThresholdDeriver;
 import org.mavai.punit.statistics.OperationalApproach;
+import org.mavai.punit.statistics.RiskDrivenSizingCalculator;
 import org.mavai.punit.statistics.SampleSizeCalculator;
 import org.mavai.punit.statistics.SampleSizeRequirement;
 import org.mavai.punit.statistics.TestVerdictEvaluator;
@@ -61,6 +62,7 @@ final class ConformanceCatalog {
     private static final BinomialProportionEstimator ESTIMATOR = new BinomialProportionEstimator();
     private static final ThresholdDeriver THRESHOLD_DERIVER = new ThresholdDeriver();
     private static final SampleSizeCalculator SAMPLE_SIZE_CALCULATOR = new SampleSizeCalculator();
+    private static final RiskDrivenSizingCalculator RISK_DRIVEN_SIZING = new RiskDrivenSizingCalculator();
     private static final TestVerdictEvaluator VERDICT_EVALUATOR = new TestVerdictEvaluator();
 
     private ConformanceCatalog() { }
@@ -72,6 +74,7 @@ final class ConformanceCatalog {
         checks.addAll(wilsonLower());
         checks.addAll(thresholdDerivation());
         checks.addAll(powerAnalysis());
+        checks.addAll(riskDrivenSizing());
         checks.addAll(feasibility());
         checks.addAll(verdict());
         checks.addAll(latencyPercentileValues());
@@ -201,6 +204,65 @@ final class ConformanceCatalog {
                         result.requiredSamples(), baselineRate, minDetectableEffect, confidence);
                 assertOracle(recorder, "power_analysis", c, "achieved_power",
                         achievedPower, tolerance);
+            }));
+        }
+        return checks;
+    }
+
+    // ── risk_driven_sizing ──────────────────────────────────────────
+
+    /**
+     * Sizing against the moving acceptance floor. Three case groups,
+     * discriminated by the {@code approach} field: required-n cases bind
+     * the minimal sample size plus the floor and achieved power at that
+     * size; power-at cases bind the floor and self-consistent power at a
+     * fixed candidate size; detectable-rate cases bind the inversion.
+     * The floor is asserted through the same Wilson-from-rate machinery
+     * the calculator itself reuses, so the shared-z requirement is
+     * exercised on the production path.
+     */
+    static List<CaseCheck> riskDrivenSizing() {
+        JsonNode suite = ConformanceFixtures.load("risk_driven_sizing.json");
+        double tolerance = suite.get("tolerance").asDouble();
+        List<CaseCheck> checks = new ArrayList<>();
+        for (JsonNode c : suite.get("cases")) {
+            String approach = c.get("approach").asText();
+            checks.add(new CaseCheck("risk_driven_sizing", c.get("name").asText(), recorder -> {
+                var inputs = c.get("inputs");
+                double baselineRate = inputs.get("baseline_rate").asDouble();
+                double confidence = inputs.get("confidence").asDouble();
+
+                if ("required_n".equals(approach)) {
+                    double minimumAcceptableRate = inputs.get("minimum_acceptable_rate").asDouble();
+                    double targetPower = inputs.get("target_power").asDouble();
+                    int requiredSamples = RISK_DRIVEN_SIZING.requiredSamples(
+                            baselineRate, minimumAcceptableRate, confidence, targetPower);
+                    assertOracle(recorder, "risk_driven_sizing", c, "required_n",
+                            requiredSamples);
+                    assertOracle(recorder, "risk_driven_sizing", c, "floor",
+                            ESTIMATOR.lowerBoundFromRate(baselineRate, requiredSamples, confidence),
+                            tolerance);
+                    assertOracle(recorder, "risk_driven_sizing", c, "achieved_power",
+                            RISK_DRIVEN_SIZING.powerAt(requiredSamples, baselineRate,
+                                    minimumAcceptableRate, confidence),
+                            tolerance);
+                } else if ("power_at".equals(approach)) {
+                    double minimumAcceptableRate = inputs.get("minimum_acceptable_rate").asDouble();
+                    int testSamples = inputs.get("test_samples").asInt();
+                    assertOracle(recorder, "risk_driven_sizing", c, "floor",
+                            ESTIMATOR.lowerBoundFromRate(baselineRate, testSamples, confidence),
+                            tolerance);
+                    assertOracle(recorder, "risk_driven_sizing", c, "power",
+                            RISK_DRIVEN_SIZING.powerAt(testSamples, baselineRate,
+                                    minimumAcceptableRate, confidence),
+                            tolerance);
+                } else if ("detectable_rate".equals(approach)) {
+                    assertOracle(recorder, "risk_driven_sizing", c, "detectable_rate",
+                            RISK_DRIVEN_SIZING.detectableRate(
+                                    inputs.get("test_samples").asInt(), baselineRate,
+                                    confidence, inputs.get("target_power").asDouble()),
+                            tolerance);
+                }
             }));
         }
         return checks;

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ProportionConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ProportionConformanceTest.java
@@ -74,6 +74,17 @@ class ProportionConformanceTest {
     }
 
     @Nested
+    @DisplayName("risk_driven_sizing")
+    class RiskDrivenSizing {
+
+        @TestFactory
+        @DisplayName("Sizing against the moving acceptance floor")
+        Collection<DynamicTest> cases() {
+            return dynamicTests(ConformanceCatalog.riskDrivenSizing());
+        }
+    }
+
+    @Nested
     @DisplayName("feasibility")
     class Feasibility {
 

--- a/punit-core/src/test/resources/org/mavai/punit/statistics/conformance/conformance-scope.json
+++ b/punit-core/src/test/resources/org/mavai/punit/statistics/conformance/conformance-scope.json
@@ -4,6 +4,7 @@
     "feasibility",
     "power_analysis",
     "latency_percentile_minimums",
-    "latency_threshold_bootstrap"
+    "latency_threshold_bootstrap",
+    "risk_driven_sizing"
   ]
 }


### PR DESCRIPTION
## Summary

Statistics-layer adoption of risk-driven sizing (companion §5.4.1), oracle-locked to the mavai-R v0.8.5 `risk_driven_sizing` suite. Deliberately no authoring surface: how a `@ProbabilisticTest` author declares tolerance/confidence and receives a computed n is a separate, later directive — this PR proves the mathematics identical to R's first, so the API work builds on verified ground.

**`RiskDrivenSizingCalculator`** (statistics package, calculator-style beside `SampleSizeCalculator`):
- `powerAt(sampleSize, baselineRate, minimumAcceptableRate, confidence)` — the self-consistent power form: the acceptance floor is the baseline rate's Wilson lower bound evaluated at the test's own size, so the floor moves with n. The floor delegates to the existing `BinomialProportionEstimator.lowerBoundFromRate`; one z convention, no second normal-CDF path.
- `requiredSamples(...)` — smallest n meeting the target power; doubling + bisection over the monotone power curve.
- `detectableRate(...)` — the inversion; bisection to 1e-10.

Domain `minimumAcceptableRate < baselineRate` only; the over-reach regime is rejected with a misuse-signalling `IllegalArgumentException` (the tolerated minimum must sit below the measured baseline rate — re-measure rather than assert improvement through the tolerance).

**Conformance**: `risk_driven_sizing` added to the committed scope; all 13 cases' binding fields asserted through the production functions via the coverage catalog. Standing: `fixtures v0.8.5; mandatory 217/217 binding assertions over 7 suites; scope 98/98 over 5 suites` — the suite is no longer among the unaddressed. Fixtures arrive via the normal fetch (v0.8.5 is the latest release).

**Tests**: 13 unit tests (minimality — the target holds at the worked example's n and fails one below; monotonicity; the closed-form seed underpowering; detectable-rate pin and round-trips; domain rejections). Full `./gradlew build` green including the ArchUnit statistics-isolation and requirement-code guards. `PowerAnalysis` (the closed-form seed, still oracle-locked by `power_analysis.json`) is untouched.

Tracked by DIR-PU-SIZING-statistics-adoption in the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)