### PR TITLE
Disclose the run's sizing design in the HTML report

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/VerdictAdapter.java
@@ -156,6 +156,17 @@ public final class VerdictAdapter {
                     engine.baselineFilename().orElse(null));
         }
 
+        // The resolved baseline's size and rate, published on the empirical
+        // criterion's derivation detail — the sizing-transparency
+        // disclosures compare the run's size against them.
+        java.util.Optional<Double> baselineSamples =
+                scanDoubleDetail(result.criterionResults(), "baselineSampleCount");
+        java.util.Optional<Double> baselineRate =
+                scanDoubleDetail(result.criterionResults(), "baselineRate");
+        if (baselineSamples.isPresent() && baselineRate.isPresent()) {
+            b.sizingBaseline((int) Math.round(baselineSamples.get()), baselineRate.get());
+        }
+
         // Termination
         b.termination(
                 mapTerminationReason(engine.terminationReason()),

--- a/punit-core/src/main/java/org/mavai/punit/statistics/StatisticalDefaults.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/StatisticalDefaults.java
@@ -94,6 +94,16 @@ public final class StatisticalDefaults {
      */
     public static final double SOUNDNESS_FLOOR_CONFIDENCE = 0.80;
 
+    /**
+     * Default target power: 80%.
+     *
+     * <p>The probability of detecting a genuine degradation; 0.80 is the
+     * conventional choice. The report's sensitivity statements — what drop
+     * a smaller-than-baseline run would actually catch — are made at this
+     * power for runs whose sizing did not declare one.
+     */
+    public static final double DEFAULT_TARGET_POWER = 0.80;
+
     private StatisticalDefaults() {
         // utility class
     }

--- a/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -340,15 +340,31 @@ public class ProbabilisticTestVerdictBuilder {
         Termination termination = buildTermination();
         PUnitVerdict punitVerdict = derivePUnitVerdict(covariates);
         String verdictReason = deriveVerdictReason(punitVerdict, covariates);
+        Map<String, String> environment = environmentWithSizingDisclosure();
 
         return new ProbabilisticTestVerdict(
                 id, Instant.now(),
                 identity, execution, functional, latency, statistics,
                 covariates, cost, pacing, provenance, termination,
-                environmentMetadata, junitPassed, punitVerdict, verdictReason,
+                environment, junitPassed, punitVerdict, verdictReason,
                 postconditionFailures,
                 perCriterion
         );
+    }
+
+    /**
+     * The verdict's environment entries: the caller-supplied metadata plus
+     * the sizing-transparency facts the report's run-design block renders —
+     * computed here, formatted there. The facts ride the schema's free-form
+     * environment entries, so the verdict XML schema is unchanged.
+     */
+    private Map<String, String> environmentWithSizingDisclosure() {
+        Map<String, String> environment =
+                new java.util.LinkedHashMap<>(environmentMetadata);
+        environment.putAll(SizingDisclosure.entries(
+                thresholdOrigin, plannedSamples, samplesExecuted, minPassRate,
+                resolvedConfidence, baseline, elapsedMs, methodTokensConsumed));
+        return java.util.Collections.unmodifiableMap(environment);
     }
 
     private static String newCorrelationId() {

--- a/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -95,6 +95,8 @@ public class ProbabilisticTestVerdictBuilder {
 
     // ── Baseline ──────────────────────────────────────────────────────────
     private BaselineData baseline;
+    private Integer sizingBaselineSamples;
+    private Double sizingBaselineRate;
 
     // ── Termination ───────────────────────────────────────────────────────
     private TerminationReason terminationReason = TerminationReason.COMPLETED;
@@ -246,6 +248,19 @@ public class ProbabilisticTestVerdictBuilder {
         return this;
     }
 
+    /**
+     * The resolved baseline's sampling size and effective rate, for the
+     * sizing-transparency disclosures. Set by the adapter from the
+     * criterion's derivation detail on paths that carry no full
+     * {@link BaselineData}; when {@link #baseline(BaselineData)} is also
+     * set, the full baseline wins.
+     */
+    public ProbabilisticTestVerdictBuilder sizingBaseline(int baselineSamples, double baselineRate) {
+        this.sizingBaselineSamples = baselineSamples;
+        this.sizingBaselineRate = baselineRate;
+        return this;
+    }
+
     public ProbabilisticTestVerdictBuilder baseline(BaselineData baseline) {
         this.baseline = baseline;
         return this;
@@ -359,11 +374,18 @@ public class ProbabilisticTestVerdictBuilder {
      * environment entries, so the verdict XML schema is unchanged.
      */
     private Map<String, String> environmentWithSizingDisclosure() {
+        Integer baselineSamples = sizingBaselineSamples;
+        Double baselineRate = sizingBaselineRate;
+        if (baseline != null && baseline.hasEmpiricalData()) {
+            baselineSamples = baseline.baselineSamples();
+            baselineRate = baseline.baselineRate();
+        }
         Map<String, String> environment =
                 new java.util.LinkedHashMap<>(environmentMetadata);
         environment.putAll(SizingDisclosure.entries(
                 thresholdOrigin, plannedSamples, samplesExecuted, minPassRate,
-                resolvedConfidence, baseline, elapsedMs, methodTokensConsumed));
+                resolvedConfidence, baselineSamples, baselineRate,
+                elapsedMs, methodTokensConsumed));
         return java.util.Collections.unmodifiableMap(environment);
     }
 

--- a/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
@@ -1,0 +1,128 @@
+package org.mavai.punit.verdict;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.mavai.punit.api.ThresholdOrigin;
+import org.mavai.punit.statistics.RiskDrivenSizingCalculator;
+import org.mavai.punit.statistics.StatisticalDefaults;
+import org.mavai.punit.statistics.transparent.BaselineData;
+
+/**
+ * Sizing-transparency facts recorded with the verdict.
+ *
+ * <p>A report shows verdicts and statistics, but is silent about the deal
+ * the operator struck when sizing the run: which operational approach
+ * shaped the design, what a smaller-than-baseline sample count cost in
+ * sensitivity, and what it saved in time and tokens. This class computes
+ * those facts at verdict-build time — the sensitivity figure through the
+ * statistics package's sizing calculator — and records them as free-form
+ * environment entries, so the verdict XML schema is unchanged and every
+ * renderer formats already-computed values.
+ *
+ * <p>The approach entry (with the parameters the run declared) is present
+ * on every verdict. The downsizing pair — the detectable rate at the run's
+ * size and the estimated savings versus a baseline-sized run — is present
+ * iff the run was sized below the resolved baseline's own sampling size;
+ * the token half of the savings is present iff the run recorded token
+ * costs. The entry vocabulary is shared across the framework family, and
+ * deliberately leaves room for the confidence-first parameters (tolerated
+ * rate, target power, computed sample size) that a risk-driven authoring
+ * surface will declare: those entries extend this disclosure additively.
+ */
+// javai-ref: JVI-RX30FM8 — do not remove (resolves in javai-orchestrator)
+final class SizingDisclosure {
+
+    static final String APPROACH_KEY = "sizing-approach";
+    static final String DECLARED_SAMPLES_KEY = "sizing-declared-samples";
+    static final String DECLARED_CONFIDENCE_KEY = "sizing-declared-confidence";
+    static final String DECLARED_MIN_PASS_RATE_KEY = "sizing-declared-min-pass-rate";
+    static final String DETECTABLE_RATE_KEY = "sizing-detectable-rate";
+    static final String DETECTABLE_POWER_KEY = "sizing-detectable-power";
+    static final String SAVED_FRACTION_KEY = "sizing-saved-fraction";
+    static final String TIME_SAVED_MS_KEY = "sizing-time-saved-ms";
+    static final String TOKENS_SAVED_KEY = "sizing-tokens-saved";
+
+    private static final RiskDrivenSizingCalculator SIZING_CALCULATOR =
+            new RiskDrivenSizingCalculator();
+
+    private SizingDisclosure() {
+    }
+
+    /**
+     * Computes the sizing-transparency entries one verdict carries.
+     *
+     * <p>An empirical threshold origin marks the sample-size-first
+     * approach (the run declared its sample count and confidence; the
+     * acceptance bar was derived at that size); any other origin —
+     * including none — marks threshold-first (the run declared its bar
+     * outright). The confidence-first (risk-driven) arm is disclosed by
+     * the authoring surface that declares it, not inferred here.
+     *
+     * @param thresholdOrigin where the run's threshold came from; may be null
+     * @param plannedSamples the sample count the run was sized at
+     * @param samplesExecuted the sample count actually executed
+     * @param minPassRate the run's acceptance threshold
+     * @param resolvedConfidence the confidence the run resolved
+     * @param baseline the resolved baseline, or null when none resolved
+     * @param elapsedMs the run's recorded wall-clock time
+     * @param tokensConsumed the run's recorded token cost (0 = unrecorded)
+     * @return the entries, in stable insertion order
+     */
+    static Map<String, String> entries(
+            ThresholdOrigin thresholdOrigin,
+            int plannedSamples,
+            int samplesExecuted,
+            double minPassRate,
+            double resolvedConfidence,
+            BaselineData baseline,
+            long elapsedMs,
+            long tokensConsumed) {
+        Map<String, String> entries = new LinkedHashMap<>();
+
+        boolean sampleSizeFirst = thresholdOrigin == ThresholdOrigin.EMPIRICAL;
+        entries.put(APPROACH_KEY, sampleSizeFirst ? "sample-size-first" : "threshold-first");
+        entries.put(DECLARED_SAMPLES_KEY, Integer.toString(plannedSamples));
+        if (sampleSizeFirst) {
+            entries.put(DECLARED_CONFIDENCE_KEY, Double.toString(resolvedConfidence));
+        } else {
+            entries.put(DECLARED_MIN_PASS_RATE_KEY, Double.toString(minPassRate));
+        }
+
+        if (downsized(plannedSamples, baseline) && samplesExecuted > 0) {
+            double targetPower = StatisticalDefaults.DEFAULT_TARGET_POWER;
+            double detectableRate = SIZING_CALCULATOR.detectableRate(
+                    plannedSamples, baseline.baselineRate(), resolvedConfidence, targetPower);
+            entries.put(DETECTABLE_RATE_KEY, Double.toString(detectableRate));
+            entries.put(DETECTABLE_POWER_KEY, Double.toString(targetPower));
+
+            int savedSamples = baseline.baselineSamples() - plannedSamples;
+            double savedFraction = (double) savedSamples / baseline.baselineSamples();
+            entries.put(SAVED_FRACTION_KEY, Double.toString(savedFraction));
+            long timeSavedMs = Math.round(
+                    (double) elapsedMs / samplesExecuted * savedSamples);
+            entries.put(TIME_SAVED_MS_KEY, Long.toString(timeSavedMs));
+            if (tokensConsumed > 0) {
+                long tokensSaved = Math.round(
+                        (double) tokensConsumed / samplesExecuted * savedSamples);
+                entries.put(TOKENS_SAVED_KEY, Long.toString(tokensSaved));
+            }
+        }
+
+        return entries;
+    }
+
+    /**
+     * The downsizing trade exists iff the run was sized below the resolved
+     * baseline's own sampling size, and the baseline's rate leaves a
+     * degradation to detect (a perfect or empty baseline does not).
+     */
+    private static boolean downsized(int plannedSamples, BaselineData baseline) {
+        return baseline != null
+                && baseline.hasEmpiricalData()
+                && plannedSamples > 0
+                && plannedSamples < baseline.baselineSamples()
+                && baseline.baselineRate() > 0.0
+                && baseline.baselineRate() < 1.0;
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.mavai.punit.api.ThresholdOrigin;
 import org.mavai.punit.statistics.RiskDrivenSizingCalculator;
 import org.mavai.punit.statistics.StatisticalDefaults;
-import org.mavai.punit.statistics.transparent.BaselineData;
 
 /**
  * Sizing-transparency facts recorded with the verdict.
@@ -37,6 +36,7 @@ final class SizingDisclosure {
     static final String DECLARED_SAMPLES_KEY = "sizing-declared-samples";
     static final String DECLARED_CONFIDENCE_KEY = "sizing-declared-confidence";
     static final String DECLARED_MIN_PASS_RATE_KEY = "sizing-declared-min-pass-rate";
+    static final String BASELINE_SAMPLES_KEY = "sizing-baseline-samples";
     static final String DETECTABLE_RATE_KEY = "sizing-detectable-rate";
     static final String DETECTABLE_POWER_KEY = "sizing-detectable-power";
     static final String SAVED_FRACTION_KEY = "sizing-saved-fraction";
@@ -64,7 +64,10 @@ final class SizingDisclosure {
      * @param samplesExecuted the sample count actually executed
      * @param minPassRate the run's acceptance threshold
      * @param resolvedConfidence the confidence the run resolved
-     * @param baseline the resolved baseline, or null when none resolved
+     * @param baselineSamples the resolved baseline's sampling size, or null
+     *                        when no baseline resolved
+     * @param baselineRate the resolved baseline's effective rate, or null
+     *                     when no baseline resolved
      * @param elapsedMs the run's recorded wall-clock time
      * @param tokensConsumed the run's recorded token cost (0 = unrecorded)
      * @return the entries, in stable insertion order
@@ -75,7 +78,8 @@ final class SizingDisclosure {
             int samplesExecuted,
             double minPassRate,
             double resolvedConfidence,
-            BaselineData baseline,
+            Integer baselineSamples,
+            Double baselineRate,
             long elapsedMs,
             long tokensConsumed) {
         Map<String, String> entries = new LinkedHashMap<>();
@@ -89,15 +93,16 @@ final class SizingDisclosure {
             entries.put(DECLARED_MIN_PASS_RATE_KEY, Double.toString(minPassRate));
         }
 
-        if (downsized(plannedSamples, baseline) && samplesExecuted > 0) {
+        if (downsized(plannedSamples, baselineSamples, baselineRate) && samplesExecuted > 0) {
             double targetPower = StatisticalDefaults.DEFAULT_TARGET_POWER;
             double detectableRate = SIZING_CALCULATOR.detectableRate(
-                    plannedSamples, baseline.baselineRate(), resolvedConfidence, targetPower);
+                    plannedSamples, baselineRate, resolvedConfidence, targetPower);
+            entries.put(BASELINE_SAMPLES_KEY, Integer.toString(baselineSamples));
             entries.put(DETECTABLE_RATE_KEY, Double.toString(detectableRate));
             entries.put(DETECTABLE_POWER_KEY, Double.toString(targetPower));
 
-            int savedSamples = baseline.baselineSamples() - plannedSamples;
-            double savedFraction = (double) savedSamples / baseline.baselineSamples();
+            int savedSamples = baselineSamples - plannedSamples;
+            double savedFraction = (double) savedSamples / baselineSamples;
             entries.put(SAVED_FRACTION_KEY, Double.toString(savedFraction));
             long timeSavedMs = Math.round(
                     (double) elapsedMs / samplesExecuted * savedSamples);
@@ -117,12 +122,13 @@ final class SizingDisclosure {
      * baseline's own sampling size, and the baseline's rate leaves a
      * degradation to detect (a perfect or empty baseline does not).
      */
-    private static boolean downsized(int plannedSamples, BaselineData baseline) {
-        return baseline != null
-                && baseline.hasEmpiricalData()
+    private static boolean downsized(
+            int plannedSamples, Integer baselineSamples, Double baselineRate) {
+        return baselineSamples != null
+                && baselineRate != null
                 && plannedSamples > 0
-                && plannedSamples < baseline.baselineSamples()
-                && baseline.baselineRate() > 0.0
-                && baseline.baselineRate() < 1.0;
+                && plannedSamples < baselineSamples
+                && baselineRate > 0.0
+                && baselineRate < 1.0;
     }
 }

--- a/punit-core/src/test/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
@@ -629,6 +629,19 @@ class ProbabilisticTestVerdictBuilderTest {
         }
 
         @Test
+        void adapterSuppliedSizingBaselineFeedsTheDownsizingDisclosure() {
+            ProbabilisticTestVerdict verdict = minimalBuilder()
+                    .provenance(ThresholdOrigin.EMPIRICAL, null, "svc.yaml")
+                    .sizingBaseline(1000, 0.96)
+                    .build();
+
+            assertThat(verdict.environmentMetadata())
+                    .containsEntry("sizing-baseline-samples", "1000")
+                    .containsKey("sizing-detectable-rate")
+                    .containsEntry("sizing-saved-fraction", "0.9");
+        }
+
+        @Test
         void capturesEnvironmentMetadata() {
             ProbabilisticTestVerdict verdict = minimalBuilder()
                     .environmentMetadata(Map.of("host", "prod-01", "region", "eu-west-1"))

--- a/punit-core/src/test/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilderTest.java
@@ -594,10 +594,38 @@ class ProbabilisticTestVerdictBuilderTest {
         }
 
         @Test
-        void environmentMetadataIsEmptyByDefault() {
+        void everyVerdictCarriesTheSizingDisclosureEntries() {
             ProbabilisticTestVerdict verdict = minimalBuilder().build();
 
-            assertThat(verdict.environmentMetadata()).isEmpty();
+            assertThat(verdict.environmentMetadata())
+                    .containsEntry("sizing-approach", "threshold-first")
+                    .containsEntry("sizing-declared-samples", "100")
+                    .containsEntry("sizing-declared-min-pass-rate", "0.9");
+        }
+
+        @Test
+        void empiricalProvenanceDisclosesTheSampleSizeFirstApproach() {
+            ProbabilisticTestVerdict verdict = minimalBuilder()
+                    .provenance(ThresholdOrigin.EMPIRICAL, null, "svc.yaml")
+                    .build();
+
+            assertThat(verdict.environmentMetadata())
+                    .containsEntry("sizing-approach", "sample-size-first")
+                    .containsEntry("sizing-declared-confidence", "0.95");
+        }
+
+        @Test
+        void aDownsizedRunDisclosesTheTradeAgainstItsBaseline() {
+            ProbabilisticTestVerdict verdict = minimalBuilder()
+                    .provenance(ThresholdOrigin.EMPIRICAL, null, "svc.yaml")
+                    .baseline(new BaselineData("svc.yaml",
+                            Instant.parse("2026-07-01T00:00:00Z"), 1000, 960))
+                    .build();
+
+            assertThat(verdict.environmentMetadata())
+                    .containsKey("sizing-detectable-rate")
+                    .containsEntry("sizing-saved-fraction", "0.9")
+                    .containsKey("sizing-time-saved-ms");
         }
 
         @Test
@@ -608,7 +636,8 @@ class ProbabilisticTestVerdictBuilderTest {
 
             assertThat(verdict.environmentMetadata())
                     .containsEntry("host", "prod-01")
-                    .containsEntry("region", "eu-west-1");
+                    .containsEntry("region", "eu-west-1")
+                    .containsEntry("sizing-approach", "threshold-first");
         }
     }
 

--- a/punit-core/src/test/java/org/mavai/punit/verdict/SizingDisclosureTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/verdict/SizingDisclosureTest.java
@@ -1,12 +1,10 @@
 package org.mavai.punit.verdict;
 
-import java.time.Instant;
 import java.util.Map;
 
 import org.mavai.punit.api.ThresholdOrigin;
 import org.mavai.punit.statistics.RiskDrivenSizingCalculator;
 import org.mavai.punit.statistics.StatisticalDefaults;
-import org.mavai.punit.statistics.transparent.BaselineData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,16 +13,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SizingDisclosureTest {
 
-    private static final Instant GENERATED = Instant.parse("2026-07-01T00:00:00Z");
-
-    private BaselineData baseline(int samples, int successes) {
-        return new BaselineData("svc.yaml", GENERATED, samples, successes);
-    }
-
     private Map<String, String> entries(
-            ThresholdOrigin origin, int planned, BaselineData baseline, long tokens) {
+            ThresholdOrigin origin, int planned, Integer baselineSamples,
+            Double baselineRate, long tokens) {
         return SizingDisclosure.entries(
-                origin, planned, planned, 0.90, 0.95, baseline, 5000, tokens);
+                origin, planned, planned, 0.90, 0.95,
+                baselineSamples, baselineRate, 5000, tokens);
     }
 
     @Nested
@@ -34,7 +28,7 @@ class SizingDisclosureTest {
         @Test
         void empiricalOriginDisclosesSampleSizeFirstWithDeclaredParameters() {
             Map<String, String> entries =
-                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(100, 96), 0);
+                    entries(ThresholdOrigin.EMPIRICAL, 100, 100, 0.96, 0);
 
             assertThat(entries)
                     .containsEntry("sizing-approach", "sample-size-first")
@@ -45,7 +39,7 @@ class SizingDisclosureTest {
 
         @Test
         void declaredThresholdOriginDisclosesThresholdFirstWithTheDeclaredBar() {
-            Map<String, String> entries = entries(ThresholdOrigin.SLA, 100, null, 0);
+            Map<String, String> entries = entries(ThresholdOrigin.SLA, 100, null, null, 0);
 
             assertThat(entries)
                     .containsEntry("sizing-approach", "threshold-first")
@@ -56,7 +50,7 @@ class SizingDisclosureTest {
 
         @Test
         void absentOriginStillDisclosesTheThresholdFirstDesign() {
-            Map<String, String> entries = entries(null, 100, null, 0);
+            Map<String, String> entries = entries(null, 100, null, null, 0);
 
             assertThat(entries).containsEntry("sizing-approach", "threshold-first");
         }
@@ -69,26 +63,27 @@ class SizingDisclosureTest {
         @Test
         void appearIffTheRunWasSizedBelowTheBaselinesOwnMeasurement() {
             Map<String, String> downsized =
-                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 0);
+                    entries(ThresholdOrigin.EMPIRICAL, 100, 1000, 0.96, 0);
             assertThat(downsized)
                     .containsKey("sizing-detectable-rate")
+                    .containsEntry("sizing-baseline-samples", "1000")
                     .containsKey("sizing-saved-fraction");
 
             Map<String, String> fullSize =
-                    entries(ThresholdOrigin.EMPIRICAL, 1000, baseline(1000, 960), 0);
+                    entries(ThresholdOrigin.EMPIRICAL, 1000, 1000, 0.96, 0);
             assertThat(fullSize)
                     .doesNotContainKey("sizing-detectable-rate")
                     .doesNotContainKey("sizing-saved-fraction");
 
             Map<String, String> baselineLess =
-                    entries(ThresholdOrigin.EMPIRICAL, 100, null, 0);
+                    entries(ThresholdOrigin.EMPIRICAL, 100, null, null, 0);
             assertThat(baselineLess).doesNotContainKey("sizing-detectable-rate");
         }
 
         @Test
         void detectableRateComesFromTheSizingCalculator() {
             Map<String, String> entries =
-                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 0);
+                    entries(ThresholdOrigin.EMPIRICAL, 100, 1000, 0.96, 0);
 
             double disclosed = Double.parseDouble(entries.get("sizing-detectable-rate"));
             double expected = new RiskDrivenSizingCalculator().detectableRate(
@@ -102,7 +97,7 @@ class SizingDisclosureTest {
             // 100 samples over 5,000 ms and 120,000 tokens: 50 ms and 1,200
             // tokens per sample; 900 saved samples versus the baseline's 1,000.
             Map<String, String> entries =
-                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 120_000);
+                    entries(ThresholdOrigin.EMPIRICAL, 100, 1000, 0.96, 120_000);
 
             assertThat(entries)
                     .containsEntry("sizing-saved-fraction", "0.9")
@@ -113,7 +108,7 @@ class SizingDisclosureTest {
         @Test
         void tokenHalfDegradesAwayWhenNoTokensAreRecorded() {
             Map<String, String> entries =
-                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 0);
+                    entries(ThresholdOrigin.EMPIRICAL, 100, 1000, 0.96, 0);
 
             assertThat(entries)
                     .containsKey("sizing-time-saved-ms")
@@ -123,7 +118,7 @@ class SizingDisclosureTest {
         @Test
         void aPerfectBaselineRateSuppressesTheDownsizingPair() {
             Map<String, String> entries =
-                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 1000), 0);
+                    entries(ThresholdOrigin.EMPIRICAL, 100, 1000, 1.0, 0);
 
             assertThat(entries)
                     .containsEntry("sizing-approach", "sample-size-first")

--- a/punit-core/src/test/java/org/mavai/punit/verdict/SizingDisclosureTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/verdict/SizingDisclosureTest.java
@@ -1,0 +1,134 @@
+package org.mavai.punit.verdict;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.mavai.punit.api.ThresholdOrigin;
+import org.mavai.punit.statistics.RiskDrivenSizingCalculator;
+import org.mavai.punit.statistics.StatisticalDefaults;
+import org.mavai.punit.statistics.transparent.BaselineData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SizingDisclosureTest {
+
+    private static final Instant GENERATED = Instant.parse("2026-07-01T00:00:00Z");
+
+    private BaselineData baseline(int samples, int successes) {
+        return new BaselineData("svc.yaml", GENERATED, samples, successes);
+    }
+
+    private Map<String, String> entries(
+            ThresholdOrigin origin, int planned, BaselineData baseline, long tokens) {
+        return SizingDisclosure.entries(
+                origin, planned, planned, 0.90, 0.95, baseline, 5000, tokens);
+    }
+
+    @Nested
+    @DisplayName("Approach disclosure")
+    class ApproachDisclosure {
+
+        @Test
+        void empiricalOriginDisclosesSampleSizeFirstWithDeclaredParameters() {
+            Map<String, String> entries =
+                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(100, 96), 0);
+
+            assertThat(entries)
+                    .containsEntry("sizing-approach", "sample-size-first")
+                    .containsEntry("sizing-declared-samples", "100")
+                    .containsEntry("sizing-declared-confidence", "0.95")
+                    .doesNotContainKey("sizing-declared-min-pass-rate");
+        }
+
+        @Test
+        void declaredThresholdOriginDisclosesThresholdFirstWithTheDeclaredBar() {
+            Map<String, String> entries = entries(ThresholdOrigin.SLA, 100, null, 0);
+
+            assertThat(entries)
+                    .containsEntry("sizing-approach", "threshold-first")
+                    .containsEntry("sizing-declared-samples", "100")
+                    .containsEntry("sizing-declared-min-pass-rate", "0.9")
+                    .doesNotContainKey("sizing-declared-confidence");
+        }
+
+        @Test
+        void absentOriginStillDisclosesTheThresholdFirstDesign() {
+            Map<String, String> entries = entries(null, 100, null, 0);
+
+            assertThat(entries).containsEntry("sizing-approach", "threshold-first");
+        }
+    }
+
+    @Nested
+    @DisplayName("Downsizing and efficiency disclosures")
+    class DownsizingDisclosure {
+
+        @Test
+        void appearIffTheRunWasSizedBelowTheBaselinesOwnMeasurement() {
+            Map<String, String> downsized =
+                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 0);
+            assertThat(downsized)
+                    .containsKey("sizing-detectable-rate")
+                    .containsKey("sizing-saved-fraction");
+
+            Map<String, String> fullSize =
+                    entries(ThresholdOrigin.EMPIRICAL, 1000, baseline(1000, 960), 0);
+            assertThat(fullSize)
+                    .doesNotContainKey("sizing-detectable-rate")
+                    .doesNotContainKey("sizing-saved-fraction");
+
+            Map<String, String> baselineLess =
+                    entries(ThresholdOrigin.EMPIRICAL, 100, null, 0);
+            assertThat(baselineLess).doesNotContainKey("sizing-detectable-rate");
+        }
+
+        @Test
+        void detectableRateComesFromTheSizingCalculator() {
+            Map<String, String> entries =
+                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 0);
+
+            double disclosed = Double.parseDouble(entries.get("sizing-detectable-rate"));
+            double expected = new RiskDrivenSizingCalculator().detectableRate(
+                    100, 0.96, 0.95, StatisticalDefaults.DEFAULT_TARGET_POWER);
+            assertThat(disclosed).isEqualTo(expected);
+            assertThat(entries).containsEntry("sizing-detectable-power", "0.8");
+        }
+
+        @Test
+        void savingsDeriveFromTheRunsRecordedCosts() {
+            // 100 samples over 5,000 ms and 120,000 tokens: 50 ms and 1,200
+            // tokens per sample; 900 saved samples versus the baseline's 1,000.
+            Map<String, String> entries =
+                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 120_000);
+
+            assertThat(entries)
+                    .containsEntry("sizing-saved-fraction", "0.9")
+                    .containsEntry("sizing-time-saved-ms", "45000")
+                    .containsEntry("sizing-tokens-saved", "1080000");
+        }
+
+        @Test
+        void tokenHalfDegradesAwayWhenNoTokensAreRecorded() {
+            Map<String, String> entries =
+                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 960), 0);
+
+            assertThat(entries)
+                    .containsKey("sizing-time-saved-ms")
+                    .doesNotContainKey("sizing-tokens-saved");
+        }
+
+        @Test
+        void aPerfectBaselineRateSuppressesTheDownsizingPair() {
+            Map<String, String> entries =
+                    entries(ThresholdOrigin.EMPIRICAL, 100, baseline(1000, 1000), 0);
+
+            assertThat(entries)
+                    .containsEntry("sizing-approach", "sample-size-first")
+                    .doesNotContainKey("sizing-detectable-rate")
+                    .doesNotContainKey("sizing-saved-fraction");
+        }
+    }
+}

--- a/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
@@ -167,6 +167,9 @@ final class HtmlReportWriter {
             appendMisalignmentGuidance(html, verdict);
         }
 
+        // Run design: the sizing-transparency disclosures
+        appendRunDesign(html, verdict);
+
         // Level 3: full statistical analysis (nested details)
         html.append("<details>\n");
         html.append("<summary>Statistical Analysis</summary>\n");
@@ -361,6 +364,132 @@ final class HtmlReportWriter {
         }
         html.append("</div>\n");
         html.append("</details>\n");
+    }
+
+    /**
+     * The canonical operational-approach glosses, in the plain register.
+     * The confidence-first entries are rendered when a run's configuration
+     * declares that approach — the vocabulary is ready ahead of the
+     * authoring surface that will produce it.
+     */
+    private static final Map<String, String> APPROACH_GLOSSES = Map.of(
+            "sample-size-first",
+            "the sample size was chosen first; the acceptance bar was derived honestly at that size",
+            "threshold-first",
+            "the pass bar is externally stipulated; the run judges the evidence against it",
+            "confidence-first",
+            "the run size was computed from the declared confidence, detectable effect, and power",
+            "confidence-first (risk-driven)",
+            "the run size was computed from the declared tolerance and confidence, "
+                    + "priced against the acceptance bar this very size derives");
+
+    /**
+     * The declared-parameter rows of the run-design block, in display
+     * order: entry key, label, and whether the value renders as a
+     * percentage. Rows whose entry is absent are skipped, so the block
+     * extends additively as future approaches declare more parameters.
+     */
+    private static final String[][] RUN_DESIGN_FACTS = {
+            {"sizing-declared-samples", "Declared samples", "plain"},
+            {"sizing-tolerated-rate", "Tolerated rate", "percent"},
+            {"sizing-declared-min-pass-rate", "Minimum pass rate", "percent"},
+            {"sizing-declared-min-detectable-effect", "Minimum detectable effect", "plain"},
+            {"sizing-declared-confidence", "Confidence", "percent"},
+            {"sizing-declared-power", "Target power", "percent"},
+            {"sizing-computed-samples", "Computed sample size", "plain"},
+    };
+
+    /**
+     * Renders the run-design block: the operational approach that shaped
+     * the run's size and — for a run sized below its baseline's own
+     * measurement — the paired downsizing and efficiency disclosures.
+     * All values arrive computed on the verdict's environment entries;
+     * this renderer only formats. Omitted for records that carry no
+     * sizing facts (verdicts predating the disclosures).
+     */
+    private static void appendRunDesign(StringBuilder html, ProbabilisticTestVerdict verdict) {
+        Map<String, String> env = verdict.environmentMetadata();
+        String approach = env.get("sizing-approach");
+        if (approach == null) {
+            return;
+        }
+        html.append("<details>\n<summary>Run design</summary>\n");
+        html.append("<div class=\"per-criterion\">\n<div class=\"criterion-block\">\n");
+        html.append("<p><strong>Approach:</strong> ").append(escape(approach));
+        String gloss = APPROACH_GLOSSES.get(approach);
+        if (gloss != null) {
+            html.append(" &mdash; ").append(escape(gloss));
+        }
+        html.append("</p>\n<dl>\n");
+        for (String[] fact : RUN_DESIGN_FACTS) {
+            String value = env.get(fact[0]);
+            if (value == null) {
+                continue;
+            }
+            String rendered = "percent".equals(fact[2]) ? percent(value) : escape(value);
+            html.append("<dt>").append(fact[1]).append("</dt><dd>")
+                    .append(rendered).append("</dd>\n");
+        }
+        html.append("</dl>\n");
+        appendSizingTrade(html, verdict, env);
+        html.append("</div>\n</div>\n</details>\n");
+    }
+
+    /**
+     * The downsizing disclosure and its paired efficiency estimate — one
+     * trade, two sides, presented together. Present iff the verdict
+     * carries the computed detectable rate and its baseline summary.
+     */
+    private static void appendSizingTrade(
+            StringBuilder html, ProbabilisticTestVerdict verdict, Map<String, String> env) {
+        String detectableRate = env.get("sizing-detectable-rate");
+        var baseline = verdict.statistics().baseline();
+        if (detectableRate == null || baseline.isEmpty()) {
+            return;
+        }
+        int planned = verdict.execution().plannedSamples();
+        int baselineSamples = baseline.get().baselineSamples();
+        html.append("<p>This test was sized at ").append(planned)
+                .append(" samples against a baseline measured over ").append(baselineSamples)
+                .append(". With ").append(planned)
+                .append(" samples, this test would only catch a drop below ")
+                .append(percent(detectableRate)).append(' ')
+                .append(powerPhrase(env.get("sizing-detectable-power"))).append(".</p>\n");
+
+        String savedFraction = env.get("sizing-saved-fraction");
+        String timeSavedMs = env.get("sizing-time-saved-ms");
+        String tokensSaved = env.get("sizing-tokens-saved");
+        html.append("<p>Estimated saving versus a run at the baseline's ")
+                .append(baselineSamples).append(" samples: about ")
+                .append(percent(savedFraction));
+        if (tokensSaved != null) {
+            html.append(" less execution time and tokens (roughly ")
+                    .append(seconds(timeSavedMs)).append(" and ").append(escape(tokensSaved))
+                    .append(" tokens, from this run's own per-sample averages). Estimates only.");
+        } else {
+            html.append(" less execution time (roughly ").append(seconds(timeSavedMs))
+                    .append(", from this run's own per-sample average). Estimates only; ")
+                    .append("no token figures are recorded for this run.");
+        }
+        html.append("</p>\n");
+    }
+
+    /** Plain language for the disclosed power; the default reads as odds. */
+    private static String powerPhrase(String targetPower) {
+        double power = Double.parseDouble(targetPower);
+        if (Math.abs(power - 0.8) < 1e-9) {
+            return "four times out of five";
+        }
+        return "about " + percent(targetPower) + " of the time";
+    }
+
+    private static String percent(String fraction) {
+        return Math.round(Double.parseDouble(fraction) * 100) + "%";
+    }
+
+    private static String seconds(String milliseconds) {
+        return String.format(java.util.Locale.ROOT, "%.1f seconds",
+                Double.parseDouble(milliseconds) / 1000.0);
     }
 
     private static String escape(String text) {

--- a/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
@@ -438,19 +438,19 @@ final class HtmlReportWriter {
     /**
      * The downsizing disclosure and its paired efficiency estimate — one
      * trade, two sides, presented together. Present iff the verdict
-     * carries the computed detectable rate and its baseline summary.
+     * carries the computed detectable rate (the baseline's sampling size
+     * travels beside it).
      */
     private static void appendSizingTrade(
             StringBuilder html, ProbabilisticTestVerdict verdict, Map<String, String> env) {
         String detectableRate = env.get("sizing-detectable-rate");
-        var baseline = verdict.statistics().baseline();
-        if (detectableRate == null || baseline.isEmpty()) {
+        String baselineSamples = env.get("sizing-baseline-samples");
+        if (detectableRate == null || baselineSamples == null) {
             return;
         }
         int planned = verdict.execution().plannedSamples();
-        int baselineSamples = baseline.get().baselineSamples();
         html.append("<p>This test was sized at ").append(planned)
-                .append(" samples against a baseline measured over ").append(baselineSamples)
+                .append(" samples against a baseline measured over ").append(escape(baselineSamples))
                 .append(". With ").append(planned)
                 .append(" samples, this test would only catch a drop below ")
                 .append(percent(detectableRate)).append(' ')
@@ -460,7 +460,7 @@ final class HtmlReportWriter {
         String timeSavedMs = env.get("sizing-time-saved-ms");
         String tokensSaved = env.get("sizing-tokens-saved");
         html.append("<p>Estimated saving versus a run at the baseline's ")
-                .append(baselineSamples).append(" samples: about ")
+                .append(escape(baselineSamples)).append(" samples: about ")
                 .append(percent(savedFraction));
         if (tokensSaved != null) {
             html.append(" less execution time and tokens (roughly ")

--- a/punit-report/src/test/java/org/mavai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/HtmlReportWriterTest.java
@@ -601,7 +601,107 @@ class HtmlReportWriterTest {
         }
     }
 
+    @Nested
+    @DisplayName("Run design block")
+    class RunDesignBlock {
+
+        @Test
+        @DisplayName("discloses the approach and the paired sizing trade")
+        void disclosesApproachAndSizingTrade() {
+            Map<String, String> env = new LinkedHashMap<>();
+            env.put("sizing-approach", "sample-size-first");
+            env.put("sizing-declared-samples", "100");
+            env.put("sizing-declared-confidence", "0.95");
+            env.put("sizing-detectable-rate", "0.876");
+            env.put("sizing-detectable-power", "0.8");
+            env.put("sizing-saved-fraction", "0.9");
+            env.put("sizing-time-saved-ms", "45000");
+            env.put("sizing-tokens-saved", "1080000");
+
+            String html = HtmlReportWriter.generate(List.of(downsizedVerdict(env)));
+
+            assertThat(html).contains("<summary>Run design</summary>");
+            assertThat(html).contains("sample-size-first &mdash; the sample size was chosen first");
+            assertThat(html).contains("<dt>Declared samples</dt><dd>100</dd>");
+            assertThat(html).contains("<dt>Confidence</dt><dd>95%</dd>");
+            assertThat(html).contains(
+                    "This test was sized at 100 samples against a baseline measured over 1000.");
+            assertThat(html).contains(
+                    "would only catch a drop below 88% four times out of five.");
+            assertThat(html).contains("about 90% less execution time and tokens");
+            assertThat(html).contains("roughly 45.0 seconds and 1080000 tokens");
+            assertThat(html).contains("Estimates only.");
+        }
+
+        @Test
+        @DisplayName("degrades the efficiency disclosure to time-only without token costs")
+        void degradesToTimeOnlyWithoutTokenCosts() {
+            Map<String, String> env = new LinkedHashMap<>();
+            env.put("sizing-approach", "sample-size-first");
+            env.put("sizing-declared-samples", "100");
+            env.put("sizing-declared-confidence", "0.95");
+            env.put("sizing-detectable-rate", "0.876");
+            env.put("sizing-detectable-power", "0.8");
+            env.put("sizing-saved-fraction", "0.9");
+            env.put("sizing-time-saved-ms", "45000");
+
+            String html = HtmlReportWriter.generate(List.of(downsizedVerdict(env)));
+
+            assertThat(html).contains("about 90% less execution time (roughly 45.0 seconds");
+            assertThat(html).contains("no token figures are recorded for this run.");
+            assertThat(html).doesNotContain("less execution time and tokens");
+        }
+
+        @Test
+        @DisplayName("the approach stands alone on a full-size run")
+        void approachStandsAloneOnFullSizeRun() {
+            Map<String, String> env = new LinkedHashMap<>();
+            env.put("sizing-approach", "threshold-first");
+            env.put("sizing-declared-samples", "100");
+            env.put("sizing-declared-min-pass-rate", "0.9");
+
+            String html = HtmlReportWriter.generate(List.of(downsizedVerdict(env)));
+
+            assertThat(html).contains("<summary>Run design</summary>");
+            assertThat(html).contains("threshold-first &mdash; the pass bar is externally stipulated");
+            assertThat(html).contains("<dt>Minimum pass rate</dt><dd>90%</dd>");
+            assertThat(html).doesNotContain("would only catch a drop below");
+            assertThat(html).doesNotContain("Estimated saving");
+        }
+
+        @Test
+        @DisplayName("omits the block for verdicts carrying no sizing facts")
+        void omitsBlockWithoutSizingFacts() {
+            String html = HtmlReportWriter.generate(List.of(passingVerdict()));
+
+            assertThat(html).doesNotContain("Run design");
+        }
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    /**
+     * A verdict carrying the given environment entries and a resolved
+     * baseline measured over 1,000 samples — the shape a downsized
+     * spec-driven run records.
+     */
+    private ProbabilisticTestVerdict downsizedVerdict(Map<String, String> env) {
+        ProbabilisticTestVerdict base = passingVerdict();
+        StatisticalAnalysis stats = new StatisticalAnalysis(
+                0.95, 0.0218, 0.8948,
+                Optional.of(2.29), Optional.of(0.011),
+                Optional.of("Wilson"),
+                Optional.of(new ProbabilisticTestVerdict.BaselineSummary(
+                        "svc.yaml", Instant.parse("2026-07-01T00:00:00Z"),
+                        1000, 960, 0.96, 0.9)),
+                List.of());
+        return new ProbabilisticTestVerdict(
+                base.correlationId(), base.timestamp(), base.identity(), base.execution(),
+                base.functional(), base.latency(), stats, base.covariates(),
+                base.cost(), base.pacing(), base.provenance(), base.termination(),
+                env, base.junitPassed(), base.punitVerdict(),
+                base.verdictReason(), base.postconditionFailures(), base.perCriterion());
+    }
 
     private ProbabilisticTestVerdict verdictWithPerCriterion(PerCriterionStructure pc) {
         ProbabilisticTestVerdict base = passingVerdict();

--- a/punit-report/src/test/java/org/mavai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/HtmlReportWriterTest.java
@@ -612,6 +612,7 @@ class HtmlReportWriterTest {
             env.put("sizing-approach", "sample-size-first");
             env.put("sizing-declared-samples", "100");
             env.put("sizing-declared-confidence", "0.95");
+            env.put("sizing-baseline-samples", "1000");
             env.put("sizing-detectable-rate", "0.876");
             env.put("sizing-detectable-power", "0.8");
             env.put("sizing-saved-fraction", "0.9");
@@ -640,6 +641,7 @@ class HtmlReportWriterTest {
             env.put("sizing-approach", "sample-size-first");
             env.put("sizing-declared-samples", "100");
             env.put("sizing-declared-confidence", "0.95");
+            env.put("sizing-baseline-samples", "1000");
             env.put("sizing-detectable-rate", "0.876");
             env.put("sizing-detectable-power", "0.8");
             env.put("sizing-saved-fraction", "0.9");

--- a/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
@@ -76,6 +76,7 @@ class RunDesignDisclosurePipelineTest {
     /** An empirical pass-rate criterion that judges the invocation output. */
     private static Criteria<Boolean> judgedPassRate() {
         return Criteria.empirical().<Boolean>passRate()
+                .name("accuracy")
                 .satisfies("output is true", out ->
                         out ? Outcome.ok(out) : Outcome.fail("demo", "scripted failure"));
     }
@@ -119,7 +120,7 @@ class RunDesignDisclosurePipelineTest {
     @Order(3)
     @DisplayName("a declared-threshold run's verdict XML discloses the approach alone")
     void declaredThresholdRun() throws Exception {
-        PUnit.testing(sampling("demo-declared", 60, Integer.MAX_VALUE, Criteria.meeting().passRate(0.9)))
+        PUnit.testing(sampling("demo-declared", 60, Integer.MAX_VALUE, Criteria.meeting().<Boolean>passRate(0.9).name("stipulated accuracy")))
                 .assertPasses();
 
         String xml = java.nio.file.Files.readString(

--- a/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
@@ -1,0 +1,145 @@
+package org.mavai.punit.report;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.NoFactors;
+import org.mavai.punit.api.Sampling;
+import org.mavai.punit.api.ServiceContract;
+import org.mavai.punit.api.TokenTracker;
+import org.mavai.punit.api.criterion.Criteria;
+import org.mavai.punit.internal.engine.baseline.BaselineResolver;
+import org.mavai.punit.runtime.PUnit;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Hands-on demo of the report's run-design disclosures. Not part of the
+ * regression suite — a scratch driver to eyeball the rendered HTML.
+ *
+ * <p>Measures a baseline over 200 samples at a 96% rate, runs a downsized
+ * empirical test (50 samples, token costs recorded: the full sizing
+ * trade) and a declared-threshold test (approach disclosure alone), then
+ * renders the HTML report from the emitted verdict XML. Each run is its
+ * own test method so each verdict lands in its own XML file.
+ *
+ * <p>Run with
+ * {@code ./gradlew :punit-report:test --tests RunDesignReportDemo}
+ * and open {@code punit-report/build/run-design-demo/html/index.html}.
+ */
+@DisplayName("Run-design report demo (scratch, not a regression test)")
+@TestMethodOrder(OrderAnnotation.class)
+class RunDesignReportDemo {
+
+    private static final Path DEMO_DIR = Path.of("build/run-design-demo");
+
+    @BeforeAll
+    static void routeArtifactsToDemoDir() {
+        System.setProperty(BaselineResolver.BASELINE_DIR_PROPERTY,
+                DEMO_DIR.resolve("baselines").toString());
+        System.setProperty("punit.report.dir", DEMO_DIR.resolve("xml").toString());
+    }
+
+    @AfterAll
+    static void restoreProperties() {
+        System.clearProperty(BaselineResolver.BASELINE_DIR_PROPERTY);
+        System.clearProperty("punit.report.dir");
+    }
+
+    /** Passes exactly the first {@code passing} invocations, and records
+     *  a plausible token cost per sample. */
+    private static ServiceContract<NoFactors, Integer, Boolean> demoServiceContract(
+            String id, int passing, Criteria<Boolean> criteria) {
+        AtomicInteger invoked = new AtomicInteger();
+        return new ServiceContract<>() {
+            @Override public Criteria<Boolean> criteria() {
+                return criteria;
+            }
+            @Override public Outcome<Boolean> invoke(Integer input, TokenTracker tracker) {
+                tracker.recordTokens(1200);
+                // Failures are criterion-level (a judged output), not
+                // apply-level, so they count into the baseline's tally.
+                return Outcome.ok(invoked.getAndIncrement() < passing);
+            }
+            @Override public String id() { return id; }
+        };
+    }
+
+    /** An empirical pass-rate criterion that judges the invocation output. */
+    private static Criteria<Boolean> judgedPassRate() {
+        return Criteria.empirical().<Boolean>passRate()
+                .satisfies("output is true", out ->
+                        out ? Outcome.ok(out) : Outcome.fail("demo", "scripted failure"));
+    }
+
+    private static Sampling<NoFactors, Integer, Boolean> sampling(
+            String id, int samples, int passing, Criteria<Boolean> criteria) {
+        return Sampling.<NoFactors, Integer, Boolean>builder()
+                .serviceContractFactory(f -> demoServiceContract(id, passing, criteria))
+                .inputs(1, 2, 3)
+                .samples(samples)
+                .build();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("baseline: 200 samples at a 96% observed rate")
+    void measureBaseline() {
+        PUnit.measuring(sampling("demo-sized", 200, 192, judgedPassRate()))
+                .experimentId("demoBaseline")
+                .run();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("a downsized run's verdict XML carries the full sizing trade, both cost halves")
+    void downsizedRun() throws Exception {
+        PUnit.testing(sampling("demo-sized", 80, Integer.MAX_VALUE, judgedPassRate()))
+                .assertPasses();
+
+        String xml = java.nio.file.Files.readString(
+                DEMO_DIR.resolve("xml/demo-sized.demo-sized.xml"));
+        assertThat(xml)
+                .contains("key=\"sizing-approach\" value=\"sample-size-first\"")
+                .contains("key=\"sizing-baseline-samples\"")
+                .contains("key=\"sizing-detectable-rate\"")
+                .contains("key=\"sizing-time-saved-ms\"")
+                .contains("key=\"sizing-tokens-saved\"");
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("a declared-threshold run's verdict XML discloses the approach alone")
+    void declaredThresholdRun() throws Exception {
+        PUnit.testing(sampling("demo-declared", 60, Integer.MAX_VALUE, Criteria.meeting().passRate(0.9)))
+                .assertPasses();
+
+        String xml = java.nio.file.Files.readString(
+                DEMO_DIR.resolve("xml/demo-declared.demo-declared.xml"));
+        assertThat(xml)
+                .contains("key=\"sizing-approach\" value=\"threshold-first\"")
+                .doesNotContain("sizing-detectable-rate");
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("the HTML report renders the run-design block from the emitted XML")
+    void renderReport() throws Exception {
+        new ReportGenerator().generate(DEMO_DIR.resolve("xml"), DEMO_DIR.resolve("html"));
+        String html = java.nio.file.Files.readString(DEMO_DIR.resolve("html/index.html"));
+        assertThat(html)
+                .contains("Run design")
+                .contains("would only catch a drop below")
+                .contains("less execution time and tokens");
+        System.out.println("report written to "
+                + DEMO_DIR.resolve("html/index.html").toAbsolutePath());
+    }
+}

--- a/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
@@ -22,22 +22,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 /**
- * Hands-on demo of the report's run-design disclosures. Not part of the
- * regression suite — a scratch driver to eyeball the rendered HTML.
+ * The run-design disclosures through the full production pipeline:
+ * {@code PUnit.testing(...)} → verdict adapter → XML sink → report
+ * generator. Measures a baseline over 200 samples at a 96% criterion
+ * rate, runs a downsized empirical test (80 samples, token costs
+ * recorded: the full sizing trade) and a declared-threshold test
+ * (approach disclosure alone), then renders the HTML report from the
+ * emitted verdict XML. Each run is its own ordered test method so each
+ * verdict lands in its own XML file.
  *
- * <p>Measures a baseline over 200 samples at a 96% rate, runs a downsized
- * empirical test (50 samples, token costs recorded: the full sizing
- * trade) and a declared-threshold test (approach disclosure alone), then
- * renders the HTML report from the emitted verdict XML. Each run is its
- * own test method so each verdict lands in its own XML file.
- *
- * <p>Run with
- * {@code ./gradlew :punit-report:test --tests RunDesignReportDemo}
+ * <p>Doubles as a hands-on demo: run with
+ * {@code ./gradlew :punit-report:test --tests RunDesignDisclosurePipelineTest}
  * and open {@code punit-report/build/run-design-demo/html/index.html}.
  */
-@DisplayName("Run-design report demo (scratch, not a regression test)")
+@DisplayName("Run-design disclosures through the production pipeline")
 @TestMethodOrder(OrderAnnotation.class)
-class RunDesignReportDemo {
+class RunDesignDisclosurePipelineTest {
 
     private static final Path DEMO_DIR = Path.of("build/run-design-demo");
 

--- a/punit-sentinel/src/test/java/org/mavai/punit/sentinel/verdict/WebhookVerdictSinkTest.java
+++ b/punit-sentinel/src/test/java/org/mavai/punit/sentinel/verdict/WebhookVerdictSinkTest.java
@@ -134,8 +134,34 @@ class WebhookVerdictSinkTest {
         @Test
         @DisplayName("handles empty environment metadata")
         void handlesEmptyMetadata() {
-            var verdict = new ProbabilisticTestVerdictBuilder()
+            // Builder-produced verdicts always carry the sizing-disclosure
+            // entries, so the empty-map JSON shape is exercised on a record
+            // stripped back to no environment entries at all.
+            ProbabilisticTestVerdict built = new ProbabilisticTestVerdictBuilder()
                     .correlationId("v:empty1")
+                    .identity("TestClass", "test", "uc")
+                    .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
+                    .junitPassed(true)
+                    .criterionVerdict(Verdict.PASS)
+                    .build();
+            ProbabilisticTestVerdict verdict = new ProbabilisticTestVerdict(
+                    built.correlationId(), built.timestamp(), built.identity(),
+                    built.execution(), built.functional(), built.latency(),
+                    built.statistics(), built.covariates(), built.cost(),
+                    built.pacing(), built.provenance(), built.termination(),
+                    Map.of(), built.junitPassed(), built.punitVerdict(),
+                    built.verdictReason(), built.postconditionFailures(),
+                    built.perCriterion());
+            String json = WebhookVerdictSink.toJson(verdict);
+
+            assertThat(json).contains("\"environmentMetadata\":{}");
+        }
+
+        @Test
+        @DisplayName("serialises the builder's sizing-disclosure entries")
+        void serialisesSizingDisclosureEntries() {
+            var verdict = new ProbabilisticTestVerdictBuilder()
+                    .correlationId("v:sizing1")
                     .identity("TestClass", "test", "uc")
                     .execution(100, 100, 95, 5, 0.9, 0.95, 1000)
                     .junitPassed(true)
@@ -143,7 +169,7 @@ class WebhookVerdictSinkTest {
                     .build();
             String json = WebhookVerdictSink.toJson(verdict);
 
-            assertThat(json).contains("\"environmentMetadata\":{}");
+            assertThat(json).contains("\"sizing-approach\":\"threshold-first\"");
         }
     }
 }


### PR DESCRIPTION
## Summary

The HTML report showed verdicts and statistics but not the deal the operator struck when sizing the run: which operational approach shaped the design, what a smaller-than-baseline sample count cost in sensitivity, and what it saved in time and tokens. This PR makes the report state that deal.

**`SizingDisclosure`** (verdict package, computed at verdict-build time — renderers only format):
- Every verdict now carries the run's operational approach with the parameters it declared: an empirically derived threshold marks **sample-size-first** (declared samples + confidence; the acceptance bar was derived at that size), any stipulated bar marks **threshold-first** (declared samples + minimum pass rate, with the origin already on the provenance). The confidence-first (risk-driven) arm is deliberately not inferred here — it is disclosed by the authoring surface that declares it, which is a separate, later piece of work; the entry vocabulary and the renderer already reserve its keys (tolerated rate, target power, computed sample size), so that disclosure extends this one additively.
- A run sized below the resolved baseline's own sampling size additionally carries the **detectable rate** at the run's size — computed via the statistics package's `RiskDrivenSizingCalculator.detectableRate` at the resolved confidence and the new `StatisticalDefaults.DEFAULT_TARGET_POWER` (0.80) — paired with the estimated time and token savings versus a baseline-sized run, from the run's own recorded elapsed time and token consumption. Savings render as percentages, labelled estimates; the token half degrades away when no tokens were recorded. Nothing appears on baseline-less or full-size runs.
- The facts ride the verdict schema's free-form `environment` entries, merged with any caller-supplied metadata, so **the verdict XML schema is unchanged** (still 1.2) and the entries flow through the XML sink, the webhook sink, and post-hoc report generation without any reader change.

**Rendering**: `HtmlReportWriter` gains a "Run design" details block per verdict — approach name + plain-language gloss, the declared parameters, and the paired downsizing/efficiency sentences ("With 100 samples, this test would only catch a drop below 88% four times out of five."). The renderer parses and formats strings only; the abstraction-level rule (no statistics in renderers) holds.

**Tests**: unit tests on the disclosure computation (approach arms, the downsizing iff-condition, degradation, detectable-rate cross-checked against the sizing calculator); builder tests for the environment merge; HTML rendering tests for the full trade, the time-only degradation, the approach-only and absent cases; a webhook-sink test asserting the entries reach the JSON wire shape (and the empty-metadata JSON case reworked, since builder-produced verdicts now always carry the sizing entries). Full `./gradlew build` green, including the ArchUnit abstraction-level, statistics-isolation, and requirement-code guards.

Tracked by the sizing-transparency report-disclosures directive in the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
