### PR TITLE
Declare a risk appetite and let the framework size the run

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
@@ -215,10 +215,27 @@ public final class CriterionDecl<O> implements Decl<O> {
     /**
      * Declare the statistical power — probability of detecting a true
      * regression of size MDE. Composes only with {@code empirical()};
-     * must be paired with {@link #detectingMde(double)}.
+     * must be paired with {@link #detectingMde(double)} or
+     * {@link #tolerating(double)}.
      */
     public CriterionDecl<O> atPower(double power) {
         return new CriterionDecl<>(posture.withPower(power), postconditions, name);
+    }
+
+    /**
+     * Declare the worst true rate this criterion tolerates — an
+     * <em>absolute</em> bound, not a drop off the baseline. The
+     * framework computes the sample count that catches a genuine
+     * breach of the tolerance, priced self-consistently against the
+     * acceptance floor the run derives at its own size; the author's
+     * declared sample count remains a floor. Composes only with
+     * {@code empirical()}; mutually exclusive with
+     * {@link #detectingMde(double)}. Pair with
+     * {@link #atPower(double)} and {@link #atConfidence(double)} to
+     * override the framework defaults (0.80 and 0.95).
+     */
+    public CriterionDecl<O> tolerating(double rate) {
+        return new CriterionDecl<>(posture.withToleratedRate(rate), postconditions, name);
     }
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionPosture.java
@@ -97,6 +97,7 @@ public final class CriterionPosture {
     private final OptionalDouble confidenceFloor;
     private final OptionalDouble mde;
     private final OptionalDouble power;
+    private final OptionalDouble toleratedRate;
     private final Optional<String> contractRef;
     private final Optional<EnumSet<PercentileKey>> assertedPercentiles;
     private final Optional<LatencySpec> latencySpec;
@@ -111,12 +112,28 @@ public final class CriterionPosture {
             Optional<String> contractRef,
             Optional<EnumSet<PercentileKey>> assertedPercentiles,
             Optional<LatencySpec> latencySpec) {
+        this(kind, threshold, origin, confidenceFloor, mde, power,
+                OptionalDouble.empty(), contractRef, assertedPercentiles, latencySpec);
+    }
+
+    private CriterionPosture(
+            Kind kind,
+            OptionalDouble threshold,
+            Optional<ThresholdOrigin> origin,
+            OptionalDouble confidenceFloor,
+            OptionalDouble mde,
+            OptionalDouble power,
+            OptionalDouble toleratedRate,
+            Optional<String> contractRef,
+            Optional<EnumSet<PercentileKey>> assertedPercentiles,
+            Optional<LatencySpec> latencySpec) {
         this.kind = kind;
         this.threshold = threshold;
         this.origin = origin;
         this.confidenceFloor = confidenceFloor;
         this.mde = mde;
         this.power = power;
+        this.toleratedRate = toleratedRate;
         this.contractRef = contractRef;
         this.assertedPercentiles = assertedPercentiles;
         this.latencySpec = latencySpec;
@@ -257,8 +274,8 @@ public final class CriterionPosture {
                     ".atConfidence(c) requires c in (0, 1), got " + confidence);
         }
         return new CriterionPosture(kind, threshold, origin,
-                OptionalDouble.of(confidence), mde, power, contractRef,
-                assertedPercentiles, latencySpec);
+                OptionalDouble.of(confidence), mde, power, toleratedRate,
+                contractRef, assertedPercentiles, latencySpec);
     }
 
     /**
@@ -270,13 +287,20 @@ public final class CriterionPosture {
      */
     public CriterionPosture withMde(double mdeValue) {
         rejectRigourAdjunct("detectingMde");
+        if (toleratedRate.isPresent()) {
+            throw new IllegalStateException(
+                    ".detectingMde(m) cannot compose with .tolerating(rate) — a "
+                            + "criterion declares its sensitivity either relatively "
+                            + "(a detectable drop off the baseline) or absolutely "
+                            + "(a worst tolerable rate), never both");
+        }
         if (Double.isNaN(mdeValue) || mdeValue <= 0.0 || mdeValue >= 1.0) {
             throw new IllegalArgumentException(
                     ".detectingMde(m) requires m in (0, 1), got " + mdeValue);
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, OptionalDouble.of(mdeValue), power, contractRef,
-                assertedPercentiles, latencySpec);
+                confidenceFloor, OptionalDouble.of(mdeValue), power, toleratedRate,
+                contractRef, assertedPercentiles, latencySpec);
     }
 
     /**
@@ -292,8 +316,39 @@ public final class CriterionPosture {
                     ".atPower(p) requires p in (0, 1), got " + powerValue);
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, mde, OptionalDouble.of(powerValue), contractRef,
-                assertedPercentiles, latencySpec);
+                confidenceFloor, mde, OptionalDouble.of(powerValue), toleratedRate,
+                contractRef, assertedPercentiles, latencySpec);
+    }
+
+    /**
+     * Returns a copy of this posture with the given tolerated rate —
+     * the worst true rate the author tolerates, declared as an
+     * <em>absolute</em> bound (not a drop off the baseline). This is
+     * the confidence-first approach in its risk-driven form: the
+     * framework computes the sample count that catches a genuine
+     * breach of the tolerance at the declared power, priced
+     * self-consistently against the acceptance floor the run derives
+     * at its own size. Composes only with {@code .empirical()};
+     * mutually exclusive with {@link #withMde(double)} — a criterion
+     * declares its sensitivity either relatively or absolutely, never
+     * both. An unpaired power defaults to the framework's 0.80.
+     */
+    public CriterionPosture withToleratedRate(double rate) {
+        rejectRigourAdjunct("tolerating");
+        if (mde.isPresent()) {
+            throw new IllegalStateException(
+                    ".tolerating(rate) cannot compose with .detectingMde(m) — a "
+                            + "criterion declares its sensitivity either relatively "
+                            + "(a detectable drop off the baseline) or absolutely "
+                            + "(a worst tolerable rate), never both");
+        }
+        if (Double.isNaN(rate) || rate <= 0.0 || rate >= 1.0) {
+            throw new IllegalArgumentException(
+                    ".tolerating(rate) requires rate in (0, 1), got " + rate);
+        }
+        return new CriterionPosture(kind, threshold, origin,
+                confidenceFloor, mde, power, OptionalDouble.of(rate),
+                contractRef, assertedPercentiles, latencySpec);
     }
 
     /**
@@ -313,7 +368,7 @@ public final class CriterionPosture {
             throw new IllegalArgumentException(".contractRef requires a non-blank string");
         }
         return new CriterionPosture(kind, threshold, origin,
-                confidenceFloor, mde, power, Optional.of(ref),
+                confidenceFloor, mde, power, toleratedRate, Optional.of(ref),
                 assertedPercentiles, latencySpec);
     }
 
@@ -350,7 +405,7 @@ public final class CriterionPosture {
                             + "IS the source");
         }
         return new CriterionPosture(kind, threshold, Optional.of(newOrigin),
-                confidenceFloor, mde, power, Optional.of(ref),
+                confidenceFloor, mde, power, toleratedRate, Optional.of(ref),
                 assertedPercentiles, latencySpec);
     }
 
@@ -392,10 +447,11 @@ public final class CriterionPosture {
                     ".detectingMde(m) requires a paired .atPower(p) — "
                             + "half a sensitivity declaration is undefined");
         }
-        if (power.isPresent() && mde.isEmpty()) {
+        if (power.isPresent() && mde.isEmpty() && toleratedRate.isEmpty()) {
             throw new IllegalStateException(
-                    ".atPower(p) requires a paired .detectingMde(m) — "
-                            + "half a sensitivity declaration is undefined");
+                    ".atPower(p) requires a paired .detectingMde(m) or "
+                            + ".tolerating(rate) — half a sensitivity declaration "
+                            + "is undefined");
         }
     }
 
@@ -425,6 +481,11 @@ public final class CriterionPosture {
     /** Statistical power when declared via {@code .atPower(...)}, empty otherwise. */
     public OptionalDouble power() {
         return power;
+    }
+
+    /** Worst tolerated true rate when declared via {@code .tolerating(...)}, empty otherwise. */
+    public OptionalDouble toleratedRate() {
+        return toleratedRate;
     }
 
     /**
@@ -477,5 +538,16 @@ public final class CriterionPosture {
      */
     public boolean isConfidenceFirst() {
         return kind == Kind.STATISTICAL_EMPIRICAL && mde.isPresent() && power.isPresent();
+    }
+
+    /**
+     * Whether this posture is in the confidence-first approach's
+     * risk-driven form — empirical with an absolute tolerated rate
+     * declared. Used by the framework to identify criteria whose
+     * sample-count floor is priced self-consistently against the
+     * moving acceptance floor rather than by the closed form.
+     */
+    public boolean isRiskDriven() {
+        return kind == Kind.STATISTICAL_EMPIRICAL && toleratedRate.isPresent();
     }
 }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
@@ -109,7 +109,7 @@ public final class Engine {
                             cfg.samples());
             if (resolution.wasUplifted()) {
                 System.out.println(String.format(
-                        "[PUNIT-UPLIFT] criterion '%s' demands %d samples (PowerAnalysis); "
+                        "[PUNIT-UPLIFT] criterion '%s' demands %d samples; "
                                 + "uplifting declared count of %d.",
                         resolution.drivenBy().get(),
                         resolution.effective(),

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/SampleSizeResolver.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/SampleSizeResolver.java
@@ -13,17 +13,21 @@ import org.mavai.punit.api.spec.BaselineProvider;
 import org.mavai.punit.api.spec.PassRateStatistics;
 import org.mavai.punit.api.spec.PerCriterionPassRateStatistics;
 import org.mavai.punit.internal.engine.covariate.CovariateResolver;
+import org.mavai.punit.statistics.RiskDrivenSizingCalculator;
 import org.mavai.punit.statistics.SampleSizeCalculator;
+import org.mavai.punit.statistics.StatisticalDefaults;
 
 /**
  * Resolves the *effective* sample count for a run by composing the
- * author-declared sample count with any confidence-first criterion's
- * power-analysis floor. The directive's silent-uplift rule:
+ * author-declared sample count with the confidence-first criteria's
+ * computed floors — the closed-form power analysis for a declared
+ * detectable effect, or the self-consistent risk-driven pricing for a
+ * declared absolute tolerance. The silent-uplift rule:
  *
  * <pre>
  * N_effective = max(
  *     declared,
- *     max over confidence-first criteria of PowerAnalysis(baseline, mde, power)
+ *     max over sizing criteria of their computed requirement
  * )
  * </pre>
  *
@@ -35,6 +39,8 @@ public final class SampleSizeResolver {
 
     private static final double DEFAULT_CONFIDENCE = 0.95;
     private static final SampleSizeCalculator CALCULATOR = new SampleSizeCalculator();
+    private static final RiskDrivenSizingCalculator RISK_CALCULATOR =
+            new RiskDrivenSizingCalculator();
 
     private SampleSizeResolver() { }
 
@@ -74,10 +80,10 @@ public final class SampleSizeResolver {
             int declaredSamples) {
 
         List<? extends Criterion<OT>> criteria = contract.effectiveCriteria();
-        List<? extends Criterion<OT>> confidenceFirst = criteria.stream()
-                .filter(c -> c.posture().isConfidenceFirst())
+        List<? extends Criterion<OT>> sizing = criteria.stream()
+                .filter(c -> c.posture().isConfidenceFirst() || c.posture().isRiskDriven())
                 .toList();
-        if (confidenceFirst.isEmpty()) {
+        if (sizing.isEmpty()) {
             return new Resolution(declaredSamples, declaredSamples, Optional.empty());
         }
 
@@ -103,10 +109,8 @@ public final class SampleSizeResolver {
 
         int maxRequired = declaredSamples;
         String drivenBy = null;
-        for (Criterion<OT> c : confidenceFirst) {
+        for (Criterion<OT> c : sizing) {
             CriterionPosture posture = c.posture();
-            double mde = posture.mde().getAsDouble();
-            double power = posture.power().getAsDouble();
             double confidence = posture.confidenceFloor().orElse(DEFAULT_CONFIDENCE);
             PassRateStatistics stats = baseline.get().byCriterion().get(c.id());
             if (stats == null && baseline.get().byCriterion().size() == 1) {
@@ -119,14 +123,21 @@ public final class SampleSizeResolver {
                 continue;
             }
             double baselineRate = stats.observedPassRate();
-            if (baselineRate - mde <= 0.0) {
-                // Defer to the verdict path's own diagnostic on
-                // alternative-hypothesis-rate ≤ 0.
-                continue;
+            int required;
+            if (posture.isRiskDriven()) {
+                required = riskDrivenRequirement(c.id(), posture, baselineRate, confidence, stats);
+            } else {
+                double mde = posture.mde().getAsDouble();
+                double power = posture.power().getAsDouble();
+                if (baselineRate - mde <= 0.0) {
+                    // Defer to the verdict path's own diagnostic on
+                    // alternative-hypothesis-rate ≤ 0.
+                    continue;
+                }
+                required = CALCULATOR
+                        .calculateForPower(baselineRate, mde, confidence, power)
+                        .requiredSamples();
             }
-            int required = CALCULATOR
-                    .calculateForPower(baselineRate, mde, confidence, power)
-                    .requiredSamples();
             if (required > maxRequired) {
                 maxRequired = required;
                 drivenBy = c.id();
@@ -136,5 +147,44 @@ public final class SampleSizeResolver {
             return new Resolution(declaredSamples, declaredSamples, Optional.empty());
         }
         return new Resolution(declaredSamples, maxRequired, Optional.of(drivenBy));
+    }
+
+    /**
+     * The self-consistently priced sample count for a risk-driven
+     * criterion, with the two pre-flight refusals stated in sizing
+     * terms rather than left to generic diagnostics downstream:
+     * over-reach (the tolerance does not sit strictly below the
+     * criterion's baseline rate) and a requirement the baseline's own
+     * measurement cannot ground.
+     */
+    private static int riskDrivenRequirement(
+            String criterionId,
+            CriterionPosture posture,
+            double baselineRate,
+            double confidence,
+            PassRateStatistics stats) {
+        double tolerated = posture.toleratedRate().getAsDouble();
+        double power = posture.power().orElse(StatisticalDefaults.DEFAULT_TARGET_POWER);
+        if (tolerated >= baselineRate) {
+            throw new IllegalStateException(String.format(
+                    "risk-driven sizing is undefined for criterion '%s': the tolerated "
+                            + "rate (%s) must sit strictly below the criterion's baseline "
+                            + "rate (%s). The tolerance declares how far below the measured "
+                            + "baseline a true rate may drop; to demand more than the "
+                            + "baseline delivered, re-measure the baseline rather than "
+                            + "raising the tolerance.",
+                    criterionId, tolerated, baselineRate));
+        }
+        int required = RISK_CALCULATOR.requiredSamples(
+                baselineRate, tolerated, confidence, power);
+        if (required > stats.sampleCount()) {
+            throw new IllegalStateException(String.format(
+                    "risk-driven sizing for criterion '%s' requires %d samples, but the "
+                            + "baseline was measured over only %d — a baseline must be at "
+                            + "least as rigorous as the test it grounds. Re-measure the "
+                            + "baseline with at least %d samples, or relax the tolerance.",
+                    criterionId, required, stats.sampleCount(), required));
+        }
+        return required;
     }
 }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
@@ -614,6 +614,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
             CriterionPosture onlyPosture = ctx.criterionPostures().getOrDefault(
                     only.criterionId(), CriterionPosture.implicit());
             onlyPosture.contractRef().ifPresent(ref -> detail.put("contractRef", ref));
+            publishSizingDeclaration(detail, onlyPosture);
         } else {
             detail.put("origin", resolvedOrigin.name());
             detail.put("total", total);
@@ -624,6 +625,17 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
             }
             detail.put("thresholdsByCriterion", Map.copyOf(thresholdsByCriterion));
             detail.put("observedByCriterion", Map.copyOf(observedByCriterion));
+            // The run-level sizing declaration: the first criterion that
+            // declared one. Per-criterion claim disclosure is the family's
+            // later refinement; one declaring criterion is today's shape.
+            for (CriterionSampleCounts counts : methodologyCriteria) {
+                CriterionPosture p = ctx.criterionPostures().getOrDefault(
+                        counts.criterionId(), CriterionPosture.implicit());
+                if (p.isRiskDriven() || p.isConfidenceFirst()) {
+                    publishSizingDeclaration(detail, p);
+                    break;
+                }
+            }
             if (!wilsonLowerByCriterion.isEmpty()) {
                 detail.put("wilsonLowerByCriterion", Map.copyOf(wilsonLowerByCriterion));
             }
@@ -665,4 +677,18 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
     private CriterionResult inconclusive(String reason, Map<String, Object> detail) {
         return new CriterionResult(NAME, Verdict.INCONCLUSIVE, reason, detail);
     }
+    /**
+     * Publishes the criterion's declared sizing facts — the absolute
+     * tolerated rate, or the relative detectable effect, with the
+     * declared power — so the verdict path can name the run's
+     * operational approach from its configuration rather than
+     * inferring it from the threshold origin.
+     */
+    private static void publishSizingDeclaration(
+            Map<String, Object> detail, CriterionPosture posture) {
+        posture.toleratedRate().ifPresent(rate -> detail.put("toleratedRate", rate));
+        posture.mde().ifPresent(m -> detail.put("declaredMde", m));
+        posture.power().ifPresent(pw -> detail.put("declaredPower", pw));
+    }
+
 }

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/VerdictAdapter.java
@@ -167,6 +167,14 @@ public final class VerdictAdapter {
             b.sizingBaseline((int) Math.round(baselineSamples.get()), baselineRate.get());
         }
 
+        // The run's declared sizing, published on the criterion detail —
+        // the disclosure names the operational approach from the
+        // configuration, never inferred from the threshold origin alone.
+        b.sizingDeclaration(
+                scanDoubleDetail(result.criterionResults(), "toleratedRate").orElse(null),
+                scanDoubleDetail(result.criterionResults(), "declaredMde").orElse(null),
+                scanDoubleDetail(result.criterionResults(), "declaredPower").orElse(null));
+
         // Termination
         b.termination(
                 mapTerminationReason(engine.terminationReason()),

--- a/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -97,6 +97,9 @@ public class ProbabilisticTestVerdictBuilder {
     private BaselineData baseline;
     private Integer sizingBaselineSamples;
     private Double sizingBaselineRate;
+    private Double declaredToleratedRate;
+    private Double declaredMde;
+    private Double declaredPower;
 
     // ── Termination ───────────────────────────────────────────────────────
     private TerminationReason terminationReason = TerminationReason.COMPLETED;
@@ -261,6 +264,21 @@ public class ProbabilisticTestVerdictBuilder {
         return this;
     }
 
+    /**
+     * The run's declared sizing, when the configuration carried one: the
+     * absolute tolerated rate (the confidence-first approach's risk-driven
+     * form) or the relative minimum detectable effect (its closed form),
+     * with the declared power. Any argument may be null. The sizing
+     * disclosure names the operational approach from these facts.
+     */
+    public ProbabilisticTestVerdictBuilder sizingDeclaration(
+            Double toleratedRate, Double mde, Double power) {
+        this.declaredToleratedRate = toleratedRate;
+        this.declaredMde = mde;
+        this.declaredPower = power;
+        return this;
+    }
+
     public ProbabilisticTestVerdictBuilder baseline(BaselineData baseline) {
         this.baseline = baseline;
         return this;
@@ -383,7 +401,8 @@ public class ProbabilisticTestVerdictBuilder {
         Map<String, String> environment =
                 new java.util.LinkedHashMap<>(environmentMetadata);
         environment.putAll(SizingDisclosure.entries(
-                thresholdOrigin, plannedSamples, samplesExecuted, minPassRate,
+                thresholdOrigin, declaredToleratedRate, declaredMde, declaredPower,
+                plannedSamples, samplesExecuted, minPassRate,
                 resolvedConfidence, baselineSamples, baselineRate,
                 elapsedMs, methodTokensConsumed));
         return java.util.Collections.unmodifiableMap(environment);

--- a/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
@@ -36,6 +36,11 @@ final class SizingDisclosure {
     static final String DECLARED_SAMPLES_KEY = "sizing-declared-samples";
     static final String DECLARED_CONFIDENCE_KEY = "sizing-declared-confidence";
     static final String DECLARED_MIN_PASS_RATE_KEY = "sizing-declared-min-pass-rate";
+    static final String TOLERATED_RATE_KEY = "sizing-tolerated-rate";
+    static final String DECLARED_EFFECT_KEY = "sizing-declared-min-detectable-effect";
+    static final String DECLARED_POWER_KEY = "sizing-declared-power";
+    static final String COMPUTED_SAMPLES_KEY = "sizing-computed-samples";
+    static final String SIZED_SAMPLES_KEY = "sizing-sized-samples";
     static final String BASELINE_SAMPLES_KEY = "sizing-baseline-samples";
     static final String DETECTABLE_RATE_KEY = "sizing-detectable-rate";
     static final String DETECTABLE_POWER_KEY = "sizing-detectable-power";
@@ -52,14 +57,21 @@ final class SizingDisclosure {
     /**
      * Computes the sizing-transparency entries one verdict carries.
      *
-     * <p>An empirical threshold origin marks the sample-size-first
-     * approach (the run declared its sample count and confidence; the
-     * acceptance bar was derived at that size); any other origin —
-     * including none — marks threshold-first (the run declared its bar
-     * outright). The confidence-first (risk-driven) arm is disclosed by
-     * the authoring surface that declares it, not inferred here.
+     * <p>The operational approach is named from the run's configuration:
+     * a declared absolute tolerance marks the confidence-first approach's
+     * risk-driven form; a declared minimum detectable effect marks its
+     * closed form. With neither declared, an empirical threshold origin
+     * marks sample-size-first (the run declared its sample count and
+     * confidence; the acceptance bar was derived at that size) and any
+     * other origin — including none — marks threshold-first (the run
+     * declared its bar outright). The downsizing sensitivity statement
+     * is made at the declared power when the run carried one, else at
+     * the framework default.
      *
      * @param thresholdOrigin where the run's threshold came from; may be null
+     * @param toleratedRate the declared worst tolerable rate, or null
+     * @param declaredMde the declared minimum detectable effect, or null
+     * @param declaredPower the declared target power, or null
      * @param plannedSamples the sample count the run was sized at
      * @param samplesExecuted the sample count actually executed
      * @param minPassRate the run's acceptance threshold
@@ -74,6 +86,9 @@ final class SizingDisclosure {
      */
     static Map<String, String> entries(
             ThresholdOrigin thresholdOrigin,
+            Double toleratedRate,
+            Double declaredMde,
+            Double declaredPower,
             int plannedSamples,
             int samplesExecuted,
             double minPassRate,
@@ -84,24 +99,46 @@ final class SizingDisclosure {
             long tokensConsumed) {
         Map<String, String> entries = new LinkedHashMap<>();
 
-        boolean sampleSizeFirst = thresholdOrigin == ThresholdOrigin.EMPIRICAL;
-        entries.put(APPROACH_KEY, sampleSizeFirst ? "sample-size-first" : "threshold-first");
-        entries.put(DECLARED_SAMPLES_KEY, Integer.toString(plannedSamples));
-        if (sampleSizeFirst) {
+        // The count the run was *sized* at. The record's planned count is
+        // the author's declared floor; a computed requirement (the silent
+        // uplift) surfaces only as an executed count above it, so the
+        // sized count is the larger of the two.
+        int sizedSamples = Math.max(plannedSamples, samplesExecuted);
+        double power = declaredPower != null
+                ? declaredPower
+                : StatisticalDefaults.DEFAULT_TARGET_POWER;
+        if (toleratedRate != null) {
+            entries.put(APPROACH_KEY, "confidence-first (risk-driven)");
+            entries.put(TOLERATED_RATE_KEY, Double.toString(toleratedRate));
+            entries.put(DECLARED_CONFIDENCE_KEY, Double.toString(resolvedConfidence));
+            entries.put(DECLARED_POWER_KEY, Double.toString(power));
+            entries.put(COMPUTED_SAMPLES_KEY, Integer.toString(sizedSamples));
+        } else if (declaredMde != null) {
+            entries.put(APPROACH_KEY, "confidence-first");
+            entries.put(DECLARED_EFFECT_KEY, Double.toString(declaredMde));
+            entries.put(DECLARED_CONFIDENCE_KEY, Double.toString(resolvedConfidence));
+            entries.put(DECLARED_POWER_KEY, Double.toString(power));
+            entries.put(COMPUTED_SAMPLES_KEY, Integer.toString(sizedSamples));
+        } else if (thresholdOrigin == ThresholdOrigin.EMPIRICAL) {
+            entries.put(APPROACH_KEY, "sample-size-first");
+            entries.put(DECLARED_SAMPLES_KEY, Integer.toString(plannedSamples));
             entries.put(DECLARED_CONFIDENCE_KEY, Double.toString(resolvedConfidence));
         } else {
+            entries.put(APPROACH_KEY, "threshold-first");
+            entries.put(DECLARED_SAMPLES_KEY, Integer.toString(plannedSamples));
             entries.put(DECLARED_MIN_PASS_RATE_KEY, Double.toString(minPassRate));
         }
 
-        if (downsized(plannedSamples, baselineSamples, baselineRate) && samplesExecuted > 0) {
-            double targetPower = StatisticalDefaults.DEFAULT_TARGET_POWER;
+        if (downsized(sizedSamples, baselineSamples, baselineRate) && samplesExecuted > 0) {
+            double targetPower = power;
             double detectableRate = SIZING_CALCULATOR.detectableRate(
-                    plannedSamples, baselineRate, resolvedConfidence, targetPower);
+                    sizedSamples, baselineRate, resolvedConfidence, targetPower);
+            entries.put(SIZED_SAMPLES_KEY, Integer.toString(sizedSamples));
             entries.put(BASELINE_SAMPLES_KEY, Integer.toString(baselineSamples));
             entries.put(DETECTABLE_RATE_KEY, Double.toString(detectableRate));
             entries.put(DETECTABLE_POWER_KEY, Double.toString(targetPower));
 
-            int savedSamples = baselineSamples - plannedSamples;
+            int savedSamples = baselineSamples - sizedSamples;
             double savedFraction = (double) savedSamples / baselineSamples;
             entries.put(SAVED_FRACTION_KEY, Double.toString(savedFraction));
             long timeSavedMs = Math.round(

--- a/punit-core/src/test/java/org/mavai/punit/api/criterion/CriteriaFactoryTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/api/criterion/CriteriaFactoryTest.java
@@ -4,6 +4,7 @@ import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mavai.punit.api.PercentileKey.P50;
 import static org.mavai.punit.api.PercentileKey.P95;
 import static org.mavai.punit.api.PercentileKey.P99;
@@ -110,6 +111,74 @@ class CriteriaFactoryTest {
             assertThat(decl.posture().confidenceFloor()).isPresent();
             assertThat(decl.posture().mde()).isPresent();
             assertThat(decl.posture().power()).isPresent();
+        }
+
+        @Test
+        @DisplayName(".tolerating(rate) declares the risk-driven form of confidence-first")
+        void toleratingDeclaresRiskDriven() {
+            CriterionDecl<String> decl = empirical().<String>passRate()
+                    .tolerating(0.93)
+                    .atConfidence(0.95)
+                    .atPower(0.80);
+
+            assertThat(decl.posture().toleratedRate()).hasValue(0.93);
+            assertThat(decl.posture().isRiskDriven()).isTrue();
+            assertThat(decl.posture().isConfidenceFirst()).isFalse();
+        }
+
+        @Test
+        @DisplayName(".tolerating alone is a complete declaration — power defaults downstream")
+        void toleratingAloneIsComplete() {
+            CriterionDecl<String> decl = empirical().<String>passRate()
+                    .tolerating(0.93);
+
+            decl.posture().validate();
+            assertThat(decl.posture().isRiskDriven()).isTrue();
+        }
+
+        @Test
+        @DisplayName(".atPower pairs with .tolerating — no MDE demanded")
+        void atPowerPairsWithTolerating() {
+            CriterionDecl<String> decl = empirical().<String>passRate()
+                    .tolerating(0.93)
+                    .atPower(0.90);
+
+            decl.posture().validate();
+            assertThat(decl.posture().power()).hasValue(0.90);
+        }
+
+        @Test
+        @DisplayName(".tolerating and .detectingMde are mutually exclusive, both ways")
+        void toleratingAndMdeAreMutuallyExclusive() {
+            assertThatThrownBy(() -> empirical().<String>passRate()
+                    .detectingMde(0.05)
+                    .tolerating(0.93))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("either relatively")
+                    .hasMessageContaining("or absolutely");
+            assertThatThrownBy(() -> empirical().<String>passRate()
+                    .tolerating(0.93)
+                    .detectingMde(0.05))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("never both");
+        }
+
+        @Test
+        @DisplayName(".tolerating rejects composition with a declared threshold")
+        void toleratingRejectsContractualPosture() {
+            assertThatThrownBy(() -> meeting().<String>passRate(0.9)
+                    .tolerating(0.93))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("cannot compose with .meeting");
+        }
+
+        @Test
+        @DisplayName(".tolerating rejects rates outside (0, 1)")
+        void toleratingRejectsOutOfRangeRates() {
+            assertThatThrownBy(() -> empirical().<String>passRate().tolerating(0.0))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> empirical().<String>passRate().tolerating(1.0))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/baseline/SampleSizeResolverTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/baseline/SampleSizeResolverTest.java
@@ -1,6 +1,7 @@
 package org.mavai.punit.internal.engine.baseline;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -141,6 +142,93 @@ class SampleSizeResolverTest {
         assertThat(resolution.declared()).isEqualTo(100);
         assertThat(resolution.effective()).isEqualTo(100);
         assertThat(resolution.drivenBy()).isEmpty();
+    }
+
+    private static ServiceContract<Factors, String, String> contractWithTolerance(
+            double tolerated) {
+        return new ServiceContract<>() {
+            @Override public String id() { return CONTRACT_ID; }
+            @Override public Outcome<String> invoke(String input, TokenTracker t) {
+                return Outcome.ok(input);
+            }
+            @Override public Criteria<String> criteria() {
+                return empirical().<String>passRate()
+                        .name("the-criterion")
+                        .tolerating(tolerated)
+                        .satisfies("always", v -> Outcome.ok());
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("risk-driven: a declared tolerance prices the count self-consistently and uplifts")
+    void riskDrivenTolerancePricesTheCount(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, 0.96, 1000);
+        var provider = new org.mavai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        var resolution = SampleSizeResolver.resolve(
+                contractWithTolerance(0.93),
+                FactorBundle.of(FACTORS),
+                provider,
+                100);
+
+        // The oracle-locked pricing for (0.96, 0.93, 0.95, 0.80).
+        int expected = new org.mavai.punit.statistics.RiskDrivenSizingCalculator()
+                .requiredSamples(0.96, 0.93, 0.95, 0.80);
+        assertThat(resolution.effective()).isEqualTo(expected);
+        assertThat(resolution.drivenBy()).contains("the-criterion");
+        assertThat(resolution.wasUplifted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("risk-driven: over-reach is refused naming the criterion and the re-measure remedy")
+    void riskDrivenOverReachIsRefused(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, 0.96, 1000);
+        var provider = new org.mavai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        assertThatThrownBy(() -> SampleSizeResolver.resolve(
+                contractWithTolerance(0.97),
+                FactorBundle.of(FACTORS),
+                provider,
+                100))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("criterion 'the-criterion'")
+                .hasMessageContaining("re-measure the baseline");
+    }
+
+    @Test
+    @DisplayName("risk-driven: a requirement the baseline cannot ground is refused in sizing terms")
+    void riskDrivenRequirementBeyondBaselineIsRefused(@TempDir Path dir) throws IOException {
+        // (0.96, 0.93) prices to ~hundreds of samples; a 200-sample
+        // baseline cannot ground that test.
+        writeBaseline(dir, 0.96, 200);
+        var provider = new org.mavai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        assertThatThrownBy(() -> SampleSizeResolver.resolve(
+                contractWithTolerance(0.93),
+                FactorBundle.of(FACTORS),
+                provider,
+                100))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("requires")
+                .hasMessageContaining("measured over only 200")
+                .hasMessageContaining("Re-measure the baseline with at least");
+    }
+
+    @Test
+    @DisplayName("risk-driven: the declared count stays a floor when it exceeds the requirement")
+    void riskDrivenDeclaredCountRemainsAFloor(@TempDir Path dir) throws IOException {
+        writeBaseline(dir, 0.96, 1000);
+        var provider = new org.mavai.punit.internal.engine.baseline.YamlBaselineProvider(dir);
+
+        var resolution = SampleSizeResolver.resolve(
+                contractWithTolerance(0.85),
+                FactorBundle.of(FACTORS),
+                provider,
+                900);
+
+        assertThat(resolution.effective()).isEqualTo(900);
+        assertThat(resolution.wasUplifted()).isFalse();
     }
 
     @Test

--- a/punit-core/src/test/java/org/mavai/punit/verdict/SizingDisclosureTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/verdict/SizingDisclosureTest.java
@@ -16,8 +16,15 @@ class SizingDisclosureTest {
     private Map<String, String> entries(
             ThresholdOrigin origin, int planned, Integer baselineSamples,
             Double baselineRate, long tokens) {
+        return declaredEntries(origin, null, null, null, planned,
+                baselineSamples, baselineRate, tokens);
+    }
+
+    private Map<String, String> declaredEntries(
+            ThresholdOrigin origin, Double tolerated, Double mde, Double power,
+            int planned, Integer baselineSamples, Double baselineRate, long tokens) {
         return SizingDisclosure.entries(
-                origin, planned, planned, 0.90, 0.95,
+                origin, tolerated, mde, power, planned, planned, 0.90, 0.95,
                 baselineSamples, baselineRate, 5000, tokens);
     }
 
@@ -53,6 +60,41 @@ class SizingDisclosureTest {
             Map<String, String> entries = entries(null, 100, null, null, 0);
 
             assertThat(entries).containsEntry("sizing-approach", "threshold-first");
+        }
+
+        @Test
+        void aDeclaredToleranceNamesTheRiskDrivenFormWithItsParameters() {
+            Map<String, String> entries = declaredEntries(
+                    ThresholdOrigin.EMPIRICAL, 0.93, null, 0.8, 405, 1000, 0.96, 0);
+
+            assertThat(entries)
+                    .containsEntry("sizing-approach", "confidence-first (risk-driven)")
+                    .containsEntry("sizing-tolerated-rate", "0.93")
+                    .containsEntry("sizing-declared-confidence", "0.95")
+                    .containsEntry("sizing-declared-power", "0.8")
+                    .containsEntry("sizing-computed-samples", "405")
+                    .doesNotContainKey("sizing-declared-samples");
+        }
+
+        @Test
+        void aDeclaredEffectNamesTheConfidenceFirstClosedForm() {
+            Map<String, String> entries = declaredEntries(
+                    ThresholdOrigin.EMPIRICAL, null, 0.05, 0.9, 470, 1000, 0.96, 0);
+
+            assertThat(entries)
+                    .containsEntry("sizing-approach", "confidence-first")
+                    .containsEntry("sizing-declared-min-detectable-effect", "0.05")
+                    .containsEntry("sizing-declared-power", "0.9")
+                    .containsEntry("sizing-computed-samples", "470")
+                    .doesNotContainKey("sizing-tolerated-rate");
+        }
+
+        @Test
+        void anUndeclaredPowerDisclosesTheFrameworkDefault() {
+            Map<String, String> entries = declaredEntries(
+                    ThresholdOrigin.EMPIRICAL, 0.93, null, null, 405, 1000, 0.96, 0);
+
+            assertThat(entries).containsEntry("sizing-declared-power", "0.8");
         }
     }
 
@@ -113,6 +155,18 @@ class SizingDisclosureTest {
             assertThat(entries)
                     .containsKey("sizing-time-saved-ms")
                     .doesNotContainKey("sizing-tokens-saved");
+        }
+
+        @Test
+        void theSensitivityStatementUsesTheDeclaredPowerWhenPresent() {
+            Map<String, String> entries = declaredEntries(
+                    ThresholdOrigin.EMPIRICAL, 0.85, null, 0.9, 100, 1000, 0.96, 0);
+
+            double disclosed = Double.parseDouble(entries.get("sizing-detectable-rate"));
+            double expected = new RiskDrivenSizingCalculator().detectableRate(
+                    100, 0.96, 0.95, 0.9);
+            assertThat(disclosed).isEqualTo(expected);
+            assertThat(entries).containsEntry("sizing-detectable-power", "0.9");
         }
 
         @Test

--- a/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
@@ -445,13 +445,13 @@ final class HtmlReportWriter {
             StringBuilder html, ProbabilisticTestVerdict verdict, Map<String, String> env) {
         String detectableRate = env.get("sizing-detectable-rate");
         String baselineSamples = env.get("sizing-baseline-samples");
-        if (detectableRate == null || baselineSamples == null) {
+        String sizedSamples = env.get("sizing-sized-samples");
+        if (detectableRate == null || baselineSamples == null || sizedSamples == null) {
             return;
         }
-        int planned = verdict.execution().plannedSamples();
-        html.append("<p>This test was sized at ").append(planned)
+        html.append("<p>This test was sized at ").append(escape(sizedSamples))
                 .append(" samples against a baseline measured over ").append(escape(baselineSamples))
-                .append(". With ").append(planned)
+                .append(". With ").append(escape(sizedSamples))
                 .append(" samples, this test would only catch a drop below ")
                 .append(percent(detectableRate)).append(' ')
                 .append(powerPhrase(env.get("sizing-detectable-power"))).append(".</p>\n");

--- a/punit-report/src/test/java/org/mavai/punit/report/HtmlReportWriterTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/HtmlReportWriterTest.java
@@ -612,6 +612,7 @@ class HtmlReportWriterTest {
             env.put("sizing-approach", "sample-size-first");
             env.put("sizing-declared-samples", "100");
             env.put("sizing-declared-confidence", "0.95");
+            env.put("sizing-sized-samples", "100");
             env.put("sizing-baseline-samples", "1000");
             env.put("sizing-detectable-rate", "0.876");
             env.put("sizing-detectable-power", "0.8");
@@ -641,6 +642,7 @@ class HtmlReportWriterTest {
             env.put("sizing-approach", "sample-size-first");
             env.put("sizing-declared-samples", "100");
             env.put("sizing-declared-confidence", "0.95");
+            env.put("sizing-sized-samples", "100");
             env.put("sizing-baseline-samples", "1000");
             env.put("sizing-detectable-rate", "0.876");
             env.put("sizing-detectable-power", "0.8");

--- a/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/RunDesignDisclosurePipelineTest.java
@@ -26,10 +26,11 @@ import org.junit.jupiter.api.TestMethodOrder;
  * {@code PUnit.testing(...)} → verdict adapter → XML sink → report
  * generator. Measures a baseline over 200 samples at a 96% criterion
  * rate, runs a downsized empirical test (80 samples, token costs
- * recorded: the full sizing trade) and a declared-threshold test
- * (approach disclosure alone), then renders the HTML report from the
- * emitted verdict XML. Each run is its own ordered test method so each
- * verdict lands in its own XML file.
+ * recorded: the full sizing trade), a declared-threshold test
+ * (approach disclosure alone), and a risk-driven test (a declared
+ * absolute tolerance priced to a computed count), then renders the
+ * HTML report from the emitted verdict XML. Each run is its own
+ * ordered test method so each verdict lands in its own XML file.
  *
  * <p>Doubles as a hands-on demo: run with
  * {@code ./gradlew :punit-report:test --tests RunDesignDisclosurePipelineTest}
@@ -132,12 +133,47 @@ class RunDesignDisclosurePipelineTest {
 
     @Test
     @Order(4)
+    @DisplayName("a risk-driven run prices its count from the tolerance and discloses the form")
+    void riskDrivenRun() throws Exception {
+        // A deeper baseline: the risk-driven pricing for a 0.93 tolerance
+        // demands several hundred samples, which a 200-sample baseline
+        // cannot ground.
+        PUnit.measuring(sampling("demo-risk", 1000, 960, judgedPassRate()))
+                .experimentId("riskBaseline")
+                .run();
+        // The declared count is a floor (and must itself clear the
+        // pre-flight feasibility gate); the tolerance prices the run
+        // far above it.
+        PUnit.testing(sampling("demo-risk", 100, Integer.MAX_VALUE,
+                Criteria.empirical().<Boolean>passRate()
+                        .name("accuracy")
+                        .tolerating(0.93)
+                        .satisfies("output is true", out ->
+                                out ? Outcome.ok(out) : Outcome.fail("demo", "scripted failure"))))
+                .assertPasses();
+
+        String xml = java.nio.file.Files.readString(
+                DEMO_DIR.resolve("xml/demo-risk.demo-risk.xml"));
+        int expected = new org.mavai.punit.statistics.RiskDrivenSizingCalculator()
+                .requiredSamples(0.96, 0.93, 0.95, 0.80);
+        assertThat(xml)
+                .contains("key=\"sizing-approach\" value=\"confidence-first (risk-driven)\"")
+                .contains("key=\"sizing-tolerated-rate\" value=\"0.93\"")
+                .contains("key=\"sizing-declared-power\" value=\"0.8\"")
+                .contains("key=\"sizing-computed-samples\" value=\"" + expected + "\"")
+                .contains("key=\"sizing-detectable-rate\"");
+    }
+
+    @Test
+    @Order(5)
     @DisplayName("the HTML report renders the run-design block from the emitted XML")
     void renderReport() throws Exception {
         new ReportGenerator().generate(DEMO_DIR.resolve("xml"), DEMO_DIR.resolve("html"));
         String html = java.nio.file.Files.readString(DEMO_DIR.resolve("html/index.html"));
         assertThat(html)
                 .contains("Run design")
+                .contains("confidence-first (risk-driven)")
+                .contains("Tolerated rate")
                 .contains("would only catch a drop below")
                 .contains("less execution time and tokens");
         System.out.println("report written to "


### PR DESCRIPTION
## Summary

An author can now shape a test by declaring a risk appetite — "the true rate may drop to 0.93 and no further" — and let the framework compute how many samples that promise costs, priced honestly for baseline-derived thresholds.

**Authoring surface** (the criterion posture chain, beside the existing rigour adjuncts):
- **`.tolerating(rate)`** declares the worst true rate the criterion tolerates, as an **absolute** bound. It composes with `.atConfidence(c)` and `.atPower(p)` (defaults 0.95 and 0.80), only on `.empirical()` criteria, and is **mutually exclusive with `.detectingMde`** — a criterion declares its sensitivity either relatively (a detectable drop off the baseline, the closed form) or absolutely (a tolerated rate, priced self-consistently), never both, enforced in both chaining orders.
- A tolerance alone is a complete declaration; `.atPower` now pairs with either sensitivity form.

**Pricing** (the existing silent-uplift resolution, extended):
- A tolerance-declaring criterion's requirement comes from `RiskDrivenSizingCalculator.requiredSamples` — the self-consistent form, whose acceptance floor moves with the test's own size — against that criterion's own resolved baseline rate, with the same per-criterion resolution and aggregate fallback the closed-form path uses. The governing count is the max across sizing criteria, attributed via the existing `drivenBy` mechanism; the author's declared count remains a floor. The closed-form `PowerAnalysis` path is untouched.
- Two refusals fire pre-flight, in sizing terms: an **over-reaching tolerance** (at or above the criterion's baseline rate) names the criterion and the remedy — re-measure the baseline rather than raising the tolerance; and a **requirement the baseline cannot ground** (computed count above the baseline's own sampling size) names the computed requirement and the size to re-measure at, instead of surfacing the generic rigour-constraint message mid-run.

**Disclosure** (the report's run-design block):
- The operational approach is now named from the run's **configuration**, not inferred from the threshold origin: tolerance-declared runs disclose `confidence-first (risk-driven)` with the tolerance, confidence, power, and computed count; detectable-effect runs disclose `confidence-first` with theirs — previously both read as `sample-size-first`. The sensitivity statement is made at the declared power when the run carried one.
- Because the verdict record's planned count is the author's floor and a computed requirement surfaces as the executed count, the disclosures are based on the **sized count** (the larger of the two), carried as its own environment entry so the renderer keeps formatting only. The renderer needed no vocabulary change — the risk-driven keys were reserved when the disclosures shipped.
- The pricing's self-consistency is visible in the live report: a run sized for a 0.93 tolerance discloses "would only catch a drop below 93%" — the disclosure recovers the declared tolerance.

**Tests**: posture composition and mutual-exclusion rules; resolver pricing pinned to the oracle-locked calculator, declared-floor semantics, and both refusal messages; disclosure arms including declared-power flow; and a new stage in the run-design pipeline test driving measure → risk-driven test → XML → HTML end to end. Full `./gradlew build` green, including the ArchUnit and requirement-code guards.

Tracked by the risk-driven authoring directive in the orchestrator; the named successor of the sizing statistics adoption (#230).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
