### PR TITLE
Emit the family's canonical interchange schemas for experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Canonical interchange schemas for experiment artefacts (breaking
+  for exploration and optimization outputs).** EXPLORE and OPTIMIZE
+  runs now emit the mavai family's canonical interchange formats —
+  `mavai-explore-1` (one YAML per explored configuration) and
+  `mavai-optimize-1` (one YAML per optimize run) — in place of the
+  punit-private `punit-spec-1` shape those two artefacts carried
+  before. The service identity field is now `serviceContractId`
+  (was `useCaseId`), exploration documents carry the configuration's
+  display name in a new body field `configuration` (the same
+  human-readable stem used for the filename, so consumers never
+  parse filenames), and the per-criterion `statistics.criteria`
+  decomposition is always present. The HTML comparison report
+  readers follow the new field names and schema identities, so
+  reports over newly emitted artefacts work unchanged; documents in
+  the old shape are no longer read. Baseline specs (MEASURE) and
+  verdict XML are untouched — `punit-spec-1` baselines and the spec
+  registry are unaffected. Emitted artefacts are validated in the
+  test suite against the pinned published JSON Schemas
+  (mavai-R release v0.8.6), including the semantic obligations the
+  schemas cannot express (ascending passing-latency vector,
+  floor-gated percentile statement, convergence consistency).
+
 ### Added
 
 - **Normative judgement at experiment time.** A measure experiment over

--- a/punit-core/build.gradle.kts
+++ b/punit-core/build.gradle.kts
@@ -76,6 +76,9 @@ dependencies {
     // Test
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.22.1")
+    // JSON Schema validation (draft 2020-12) for the interchange
+    // emitter conformance tests — test-only, never shipped.
+    testImplementation("com.networknt:json-schema-validator:1.5.6")
     testImplementation("org.apache.logging.log4j:log4j-core:2.26.1")
     testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:2.26.1")
     // punit-report provides the default VerdictSink (XML) via ServiceLoader;

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -19,28 +19,29 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * Serialises one EXPLORE configuration's outcome to the
- * explore-output YAML schema and resolves its readable-stem
- * filename.
+ * Serialises one EXPLORE configuration's outcome to the mavai
+ * family's canonical exploration interchange schema and resolves
+ * its readable-stem filename.
  *
  * <p>Both methods are pure — the writer performs no I/O. The
  * {@link org.mavai.punit.internal.runtime.ExploreEmitter EXPLORE emitter}
  * orchestrates persistence (writing to disk or to an in-memory
  * sink for tests).
  *
- * <p>Schema follows the canonical explore-output YAML shape:
- * {@code factors:} block in factor-record declaration order,
+ * <p>Emits the mavai family's canonical exploration interchange
+ * schema: {@code factors:} block in factor-record declaration order,
  * descriptive statistics only (no inferential statistics), small
- * sample counts accepted without warning. Per-sample result
- * projections are not emitted here yet — when the trial path threads
- * projection metadata through, a {@code resultProjection:} block can
- * be appended additively.
+ * sample counts accepted without warning. The {@code configuration:}
+ * field carries the configuration's display name — the same
+ * human-readable stem {@link #filenameFor(FactorBundle)} derives for
+ * the filename — so consumers identify configurations from the
+ * document body, never by parsing filenames.
  */
 // javai-ref: JVI-8CHB31R — do not remove (resolves in javai-orchestrator)
 public final class ExploreOutputWriter {
 
     /** Schema-version value carried in every emitted file. */
-    public static final String SCHEMA_VERSION = "punit-spec-1";
+    public static final String SCHEMA_VERSION = "mavai-explore-1";
 
     /** Maximum unsanitised canonical-value length before truncation kicks in. */
     private static final int MAX_RAW_LENGTH = 32;
@@ -56,16 +57,19 @@ public final class ExploreOutputWriter {
      * no I/O.
      *
      * @param serviceContractId the service contract identifier (becomes the
-     *                  {@code useCaseId:} field).
+     *                  {@code serviceContractId:} field).
      * @param factorBundle the configuration's factor bundle (becomes
-     *                     the {@code factors:} block).
+     *                     the {@code factors:} block and, via
+     *                     {@link #filenameFor(FactorBundle)}, the
+     *                     {@code configuration:} display name).
      * @param entry the per-config summary plus planned sample count.
-     * @return YAML matching the canonical explore-output schema.
+     * @return YAML matching the canonical exploration interchange schema.
      */
     public String writeYaml(String serviceContractId, FactorBundle factorBundle, PerConfigSummary<?, ?> entry) {
         Map<String, Object> root = new LinkedHashMap<>();
         root.put("schemaVersion", SCHEMA_VERSION);
-        root.put("useCaseId", serviceContractId);
+        root.put("serviceContractId", serviceContractId);
+        root.put("configuration", filenameFor(factorBundle));
         root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
         root.put("factors", factorsBlock(factorBundle));
         root.put("execution", executionBlock(entry));
@@ -137,26 +141,26 @@ public final class ExploreOutputWriter {
             failureDistribution.put(entry.getKey(), entry.getValue().count());
         }
         block.put("failureDistribution", failureDistribution);
-        // Per-criterion decomposition (only when the run produced
-        // methodology-level criterion counts — empty for contracts
-        // that declared no explicit criteria() value).
-        // Mirrors the per-criterion shape that MEASURE writes into
-        // baselines so a reader can compare explore vs measure
-        // emissions of the same contract criterion-by-criterion.
-        if (!summary.criterionSampleCounts().isEmpty()) {
-            Map<String, Object> criteria = new LinkedHashMap<>();
-            for (org.mavai.punit.api.spec.CriterionSampleCounts counts
-                    : summary.criterionSampleCounts()) {
-                Map<String, Object> row = new LinkedHashMap<>();
-                row.put("observedPassRate", counts.observedPassRate());
-                row.put("pass", counts.pass());
-                row.put("fail", counts.fail());
-                row.put("conditionFail", counts.conditionFail());
-                row.put("transformFail", counts.transformFail());
-                criteria.put(counts.criterionId(), row);
-            }
-            block.put("criteria", criteria);
+        // Per-criterion decomposition — required by the interchange
+        // schema, one entry per declared criterion (including the
+        // single-criterion case; a contract cannot run without at
+        // least one declared criterion). Mirrors the per-criterion
+        // shape that MEASURE writes into baselines so a reader can
+        // compare explore vs measure emissions of the same contract
+        // criterion-by-criterion. conditionFail / transformFail are
+        // permitted informational extras beyond the canonical fields.
+        Map<String, Object> criteria = new LinkedHashMap<>();
+        for (org.mavai.punit.api.spec.CriterionSampleCounts counts
+                : summary.criterionSampleCounts()) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("observedPassRate", counts.observedPassRate());
+            row.put("pass", counts.pass());
+            row.put("fail", counts.fail());
+            row.put("conditionFail", counts.conditionFail());
+            row.put("transformFail", counts.transformFail());
+            criteria.put(counts.criterionId(), row);
         }
+        block.put("criteria", criteria);
         return block;
     }
 

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
@@ -21,8 +21,9 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * Serialises a completed OPTIMIZE run's history to the
- * optimize-output YAML schema. Pure — performs no I/O. The
+ * Serialises a completed OPTIMIZE run's history to the mavai
+ * family's canonical optimize interchange schema. Pure — performs
+ * no I/O. The
  * {@link org.mavai.punit.internal.runtime.OptimizeEmitter OPTIMIZE emitter}
  * orchestrates persistence (writing to disk or to an in-memory sink
  * for tests).
@@ -36,7 +37,7 @@ import org.yaml.snakeyaml.Yaml;
 public final class OptimizeOutputWriter {
 
     /** Schema-version value carried in every emitted file. */
-    public static final String SCHEMA_VERSION = "punit-spec-1";
+    public static final String SCHEMA_VERSION = "mavai-optimize-1";
 
     /**
      * Build the optimize-output YAML for one optimize run. Pure —
@@ -57,7 +58,7 @@ public final class OptimizeOutputWriter {
      *                          {@code NO_IMPROVEMENT},
      *                          {@code STEPPER_STOP}, or another
      *                          framework-recognised value)
-     * @return YAML matching the canonical optimize-output schema
+     * @return YAML matching the canonical optimize interchange schema
      */
     public String writeYaml(
             String serviceContractId,
@@ -70,7 +71,7 @@ public final class OptimizeOutputWriter {
 
         Map<String, Object> root = new LinkedHashMap<>();
         root.put("schemaVersion", SCHEMA_VERSION);
-        root.put("useCaseId", serviceContractId);
+        root.put("serviceContractId", serviceContractId);
         root.put("experimentId", experimentId);
         root.put("objective", objective);
         root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
@@ -154,7 +155,11 @@ public final class OptimizeOutputWriter {
             }
         }
         block.put("failureDistribution", failureDistribution);
-        if (iterSummary != null && !iterSummary.criterionSampleCounts().isEmpty()) {
+        // Per-criterion decomposition — required by the interchange
+        // schema, one entry per declared criterion (including the
+        // single-criterion case). conditionFail / transformFail are
+        // permitted informational extras beyond the canonical fields.
+        if (iterSummary != null) {
             Map<String, Object> criteria = new LinkedHashMap<>();
             for (CriterionSampleCounts c : iterSummary.criterionSampleCounts()) {
                 Map<String, Object> row = new LinkedHashMap<>();

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriterTest.java
@@ -71,10 +71,12 @@ class ExploreOutputWriterTest {
 
         Map<String, Object> parsed = new Yaml().load(yaml);
         assertThat(parsed).containsKeys(
-                "schemaVersion", "useCaseId", "generatedAt",
+                "schemaVersion", "serviceContractId", "configuration", "generatedAt",
                 "factors", "execution", "statistics", "cost", "resultProjection");
-        assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");
-        assertThat(parsed).containsEntry("useCaseId", "LengthServiceContract");
+        assertThat(parsed).containsEntry("schemaVersion", "mavai-explore-1");
+        assertThat(parsed).containsEntry("serviceContractId", "LengthServiceContract");
+        // The body carries the same display name the filename stem uses.
+        assertThat(parsed).containsEntry("configuration", writer.filenameFor(bundle));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> factors = (Map<String, Object>) parsed.get("factors");
@@ -206,8 +208,8 @@ class ExploreOutputWriterTest {
         // Each captured value parses as YAML carrying the explore-output schema header.
         for (String yaml : sink.values()) {
             Map<String, Object> parsed = new Yaml().load(yaml);
-            assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");
-            assertThat(parsed).containsEntry("useCaseId", "explore-test");
+            assertThat(parsed).containsEntry("schemaVersion", "mavai-explore-1");
+            assertThat(parsed).containsEntry("serviceContractId", "explore-test");
         }
     }
 

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
@@ -1,0 +1,283 @@
+package org.mavai.punit.internal.engine.interchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mavai.punit.api.criterion.Criteria.meeting;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.Sampling;
+import org.mavai.punit.api.ServiceContract;
+import org.mavai.punit.api.TokenTracker;
+import org.mavai.punit.api.criterion.Criteria;
+import org.mavai.punit.api.spec.Experiment;
+import org.mavai.punit.api.spec.NextFactor;
+import org.mavai.punit.internal.engine.Engine;
+import org.mavai.punit.internal.engine.emit.LatencySection;
+import org.mavai.punit.internal.runtime.ExploreEmitter;
+import org.mavai.punit.internal.runtime.OptimizeEmitter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Emitter conformance against the mavai family's canonical
+ * interchange schemas.
+ *
+ * <p>Small real EXPLORE and OPTIMIZE experiments are driven through
+ * the engine and their emitted YAML artefacts are validated against
+ * the vendored, pinned copies of the published JSON Schemas
+ * ({@code mavai-explore-1}, {@code mavai-optimize-1}). On top of the
+ * structural validation, the tests assert the semantic obligations
+ * the schemas cannot express: the sorted passing-latency vector is
+ * ascending and sized to {@code contributingSamples}; each latency
+ * percentile is stated exactly when its minimum-sample floor is
+ * cleared; and the optimize convergence block is internally
+ * consistent with the iteration it names.
+ */
+@DisplayName("Canonical interchange emitters — schema and semantic conformance")
+class InterchangeConformanceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    record LlmFactors(String model, double temperature) {}
+
+    /** Always-passing contract with a single named criterion. */
+    private static final class PassingContract implements ServiceContract<LlmFactors, String, Integer> {
+        @Override public String id() { return "interchange-passing"; }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+        @Override public Criteria<Integer> criteria() {
+            return meeting().<Integer>zeroFailures();
+        }
+    }
+
+    /** Alternates pass / fail deterministically, independent of input choice. */
+    private static final class AlternatingContract implements ServiceContract<LlmFactors, String, Integer> {
+        private final AtomicInteger invocations = new AtomicInteger();
+        @Override public String id() { return "interchange-alternating"; }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+        @Override public Criteria<Integer> criteria() {
+            return meeting().<Integer>zeroFailures()
+                    .name("every-other")
+                    .satisfies("alternates", v -> invocations.getAndIncrement() % 2 == 0
+                            ? Outcome.ok()
+                            : Outcome.fail("alternating-check", "odd invocation"));
+        }
+    }
+
+    /** Never-passing contract — exercises the no-latency-block boundary. */
+    private static final class FailingContract implements ServiceContract<LlmFactors, String, Integer> {
+        @Override public String id() { return "interchange-failing"; }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+        @Override public Criteria<Integer> criteria() {
+            return meeting().<Integer>zeroFailures()
+                    .name("never-passes")
+                    .satisfies("always-fails", v -> Outcome.fail("always-fails", "by design"));
+        }
+    }
+
+    @Nested
+    @DisplayName("exploration artefacts")
+    class ExplorationArtefacts {
+
+        @Test
+        @DisplayName("all-passing run validates and states exactly the floor-cleared percentiles")
+        void allPassingRunConforms() {
+            Map<String, Object> doc = emitExplore(new PassingContract(), 6);
+
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+
+            // 6 passing samples: the latency block is required and its
+            // percentiles are gated by the minimum-sample floors.
+            @SuppressWarnings("unchecked")
+            Map<String, Object> latency = (Map<String, Object>) doc.get("latency");
+            assertThat(latency).as("latency block must be present when samples passed").isNotNull();
+            assertLatencySemantics(latency);
+            assertThat(latency).containsKey("p50Ms");
+            assertThat(latency).doesNotContainKeys("p95Ms", "p99Ms");
+        }
+
+        @Test
+        @DisplayName("mixed run carries the failure distribution the schema requires")
+        void mixedRunConforms() {
+            Map<String, Object> doc = emitExplore(new AlternatingContract(), 6);
+
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> statistics = (Map<String, Object>) doc.get("statistics");
+            assertThat(((Number) statistics.get("failures")).intValue()).isPositive();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> failureDistribution =
+                    (Map<String, Object>) statistics.get("failureDistribution");
+            assertThat(failureDistribution).isNotEmpty();
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> latency = (Map<String, Object>) doc.get("latency");
+            assertThat(latency).as("some samples passed, so latency is present").isNotNull();
+            assertLatencySemantics(latency);
+        }
+
+        @Test
+        @DisplayName("no-passing-samples run omits the latency block as a whole")
+        void noPassingSamplesRunConforms() {
+            Map<String, Object> doc = emitExplore(new FailingContract(), 4);
+
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+            assertThat(doc).doesNotContainKey("latency");
+        }
+
+        private Map<String, Object> emitExplore(
+                ServiceContract<LlmFactors, String, Integer> contract, int samples) {
+            Sampling<LlmFactors, String, Integer> sampling = Sampling
+                    .<LlmFactors, String, Integer>builder()
+                    .serviceContractFactory(f -> contract)
+                    .inputs("a", "bb")
+                    .samples(samples)
+                    .build();
+            Experiment experiment = Experiment.exploring(sampling)
+                    .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
+                    .build();
+            new Engine().run(experiment);
+
+            Map<String, String> sink = new LinkedHashMap<>();
+            ExploreEmitter.emit(experiment, sink::put);
+            assertThat(sink).hasSize(1);
+            return new Yaml().load(sink.values().iterator().next());
+        }
+    }
+
+    @Nested
+    @DisplayName("optimize artefacts")
+    class OptimizeArtefacts {
+
+        @Test
+        @DisplayName("run validates; iterations carry gated latency; convergence names a consistent optimum")
+        void optimizeRunConforms() {
+            Sampling<LlmFactors, String, Integer> sampling = Sampling
+                    .<LlmFactors, String, Integer>builder()
+                    .serviceContractFactory(f -> new PassingContract())
+                    .inputs("a", "bb")
+                    .samples(6)
+                    .build();
+            Experiment experiment = Experiment.optimizing(sampling)
+                    .initialFactors(new LlmFactors("gpt-4o", 0.0))
+                    .stepper((cur, hist) -> hist.size() < 2
+                            ? NextFactor.next(new LlmFactors("gpt-4o", cur.temperature() + 0.3))
+                            : NextFactor.stop())
+                    .maximize(s -> 1.0 * s.successes() / Math.max(1, s.total()))
+                    .maxIterations(5)
+                    .experimentId("interchange-opt-run")
+                    .build();
+            new Engine().run(experiment);
+
+            Map<String, String> sink = new LinkedHashMap<>();
+            OptimizeEmitter.emit(experiment, sink::put);
+            assertThat(sink).hasSize(1);
+            Map<String, Object> doc = new Yaml().load(sink.values().iterator().next());
+
+            assertThat(validate("mavai-optimize-1", doc)).isEmpty();
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> iterations = (List<Map<String, Object>>) doc.get("iterations");
+            assertThat(iterations).isNotEmpty();
+            for (Map<String, Object> iteration : iterations) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> statistics = (Map<String, Object>) iteration.get("statistics");
+                int successes = ((Number) statistics.get("successes")).intValue();
+                @SuppressWarnings("unchecked")
+                Map<String, Object> latency = (Map<String, Object>) iteration.get("latency");
+                if (successes > 0) {
+                    assertThat(latency)
+                            .as("iterations with passing samples must carry a latency block")
+                            .isNotNull();
+                    assertLatencySemantics(latency);
+                } else {
+                    assertThat(latency).isNull();
+                }
+            }
+
+            // Convergence must be internally consistent with the
+            // iteration it names as best.
+            @SuppressWarnings("unchecked")
+            Map<String, Object> convergence = (Map<String, Object>) doc.get("convergence");
+            int bestIndex = ((Number) convergence.get("bestIteration")).intValue();
+            Map<String, Object> best = iterations.get(bestIndex);
+            assertThat(((Number) convergence.get("bestScore")).doubleValue())
+                    .isEqualTo(((Number) best.get("score")).doubleValue());
+            assertThat(convergence.get("bestFactors")).isEqualTo(best.get("factors"));
+            assertThat(((Number) convergence.get("totalIterations")).intValue())
+                    .isEqualTo(iterations.size());
+        }
+    }
+
+    // ── Shared semantic assertions ───────────────────────────────────────────
+
+    /**
+     * The latency-block obligations the schema cannot express:
+     * ascending vector, vector length equal to contributingSamples
+     * and bounded by totalSamples, and each percentile stated exactly
+     * when its minimum-sample floor is cleared.
+     */
+    private static void assertLatencySemantics(Map<String, Object> latency) {
+        int contributing = ((Number) latency.get("contributingSamples")).intValue();
+        int total = ((Number) latency.get("totalSamples")).intValue();
+        @SuppressWarnings("unchecked")
+        List<Number> sorted = (List<Number>) latency.get("sortedPassingLatenciesMs");
+
+        assertThat(sorted).hasSize(contributing);
+        assertThat(contributing).isLessThanOrEqualTo(total);
+        List<Long> values = new ArrayList<>();
+        for (Number n : sorted) {
+            values.add(n.longValue());
+        }
+        assertThat(values).isSorted();
+
+        for (String label : List.of("p50", "p90", "p95", "p99")) {
+            boolean stated = latency.containsKey(label + "Ms");
+            boolean floorCleared = contributing >= LatencySection.minimumSamplesFor(label);
+            assertThat(stated)
+                    .as("%sMs stated iff its floor (%d) is cleared by %d contributing samples",
+                            label, LatencySection.minimumSamplesFor(label), contributing)
+                    .isEqualTo(floorCleared);
+        }
+    }
+
+    // ── Schema validation plumbing ───────────────────────────────────────────
+
+    /**
+     * Validates a parsed YAML document against a vendored interchange
+     * schema; returns the set of violations (empty means conformant).
+     */
+    private static Set<ValidationMessage> validate(String schemaName, Map<String, Object> document) {
+        JsonSchema schema = loadSchema(schemaName);
+        JsonNode node = MAPPER.valueToTree(document);
+        return schema.validate(node);
+    }
+
+    private static JsonSchema loadSchema(String schemaName) {
+        String resource = "/conformance/interchange/" + schemaName + ".schema.json";
+        InputStream in = InterchangeConformanceTest.class.getResourceAsStream(resource);
+        assertThat(in).as("vendored schema %s must be on the test classpath", resource).isNotNull();
+        return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(in);
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
@@ -75,8 +75,8 @@ class OptimizeOutputWriterTest {
 
         String yaml = sink.values().iterator().next();
         Map<String, Object> parsed = new Yaml().load(yaml);
-        assertThat(parsed).containsEntry("schemaVersion", "punit-spec-1");
-        assertThat(parsed).containsEntry("useCaseId", "optimize-test");
+        assertThat(parsed).containsEntry("schemaVersion", "mavai-optimize-1");
+        assertThat(parsed).containsEntry("serviceContractId", "optimize-test");
         assertThat(parsed).containsEntry("experimentId", "opt-run-1");
         assertThat(parsed).containsEntry("objective", "MAXIMIZE");
         assertThat(parsed).containsKeys("iterations", "convergence", "generatedAt");

--- a/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
+++ b/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mavai-org/mavai-R/schema/mavai-explore-1.schema.json",
+  "title": "mavai exploration interchange artefact",
+  "description": "One document per explored experiment configuration: the configuration's identity and the descriptive results its run observed. Framework-neutral: emitted by any mavai-family framework, consumed by shared tooling such as the report renderer. This schema is the machine-checkable structural projection of the canonical format specification; it validates the parsed data model of the YAML document. Statistics are stated by the emitter (percentiles value-or-absent under the emitter's own minimum-sample gate) — consumers never derive them. Additive evolution: emitters may add fields anywhere; consumers ignore what they do not know.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "serviceContractId",
+    "configuration",
+    "generatedAt",
+    "execution",
+    "statistics"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "schemaVersion": {
+      "const": "mavai-explore-1",
+      "description": "Schema identity. Consumers skip documents carrying any other value."
+    },
+    "serviceContractId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The explored service contract's stable identity. Groups configurations into one comparison."
+    },
+    "experimentId": {
+      "type": "string",
+      "description": "Informational: the experiment run this document belongs to."
+    },
+    "configuration": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The configuration's display name. Cross-document identity for consumers; filenames are never parsed."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of emission."
+    },
+    "factors": {
+      "type": "object",
+      "description": "The configuration's factor values, keyed by factor name. May be absent for a single-configuration exploration with no varied factors.",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      }
+    },
+    "execution": {
+      "type": "object",
+      "required": ["samplesPlanned", "samplesExecuted", "terminationReason"],
+      "additionalProperties": true,
+      "properties": {
+        "samplesPlanned": { "type": "integer", "minimum": 0 },
+        "samplesExecuted": { "type": "integer", "minimum": 0 },
+        "terminationReason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why the run ended. Consumers flag anything other than COMPLETED."
+        }
+      }
+    },
+    "statistics": { "$ref": "#/$defs/statistics" },
+    "cost": { "$ref": "#/$defs/cost" },
+    "latency": { "$ref": "#/$defs/latency" },
+    "resultProjection": {
+      "description": "Informational per-sample detail, emitter-formatted. Consumers must not require it."
+    }
+  },
+  "$defs": {
+    "statistics": {
+      "type": "object",
+      "required": ["observed", "successes", "failures", "criteria"],
+      "additionalProperties": true,
+      "properties": {
+        "observed": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Overall observed pass rate (successes / executed)."
+        },
+        "successes": { "type": "integer", "minimum": 0 },
+        "failures": { "type": "integer", "minimum": 0 },
+        "failureDistribution": { "$ref": "#/$defs/failureDistribution" },
+        "criteria": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "One entry per declared criterion, keyed by criterion name — including the single-criterion case.",
+          "additionalProperties": { "$ref": "#/$defs/criterion" }
+        }
+      },
+      "if": {
+        "properties": { "failures": { "exclusiveMinimum": 0 } },
+        "required": ["failures"]
+      },
+      "then": {
+        "required": ["failureDistribution"]
+      }
+    },
+    "criterion": {
+      "type": "object",
+      "required": ["observedPassRate", "pass", "fail"],
+      "additionalProperties": true,
+      "properties": {
+        "observedPassRate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "pass": { "type": "integer", "minimum": 0 },
+        "fail": { "type": "integer", "minimum": 0 },
+        "failureDistribution": { "$ref": "#/$defs/failureDistribution" }
+      }
+    },
+    "failureDistribution": {
+      "type": "object",
+      "description": "Failure counts keyed by violating check name.",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "cost": {
+      "type": "object",
+      "description": "Informational wall-clock and token totals/averages.",
+      "additionalProperties": true,
+      "properties": {
+        "totalTimeMs": { "type": "integer", "minimum": 0 },
+        "avgTimePerSampleMs": { "type": "integer", "minimum": 0 },
+        "totalTokens": { "type": "integer", "minimum": 0 },
+        "avgTokensPerSample": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "latency": {
+      "type": "object",
+      "description": "Absent as a whole when no sample passed. Percentiles are STATED value-or-absent: an absent key means 'not stateable at this sample count under the emitter's gate', never zero.",
+      "required": ["basis", "contributingSamples", "totalSamples", "sortedPassingLatenciesMs"],
+      "additionalProperties": true,
+      "properties": {
+        "basis": { "const": "passing-samples" },
+        "contributingSamples": { "type": "integer", "minimum": 1 },
+        "totalSamples": { "type": "integer", "minimum": 1 },
+        "p50Ms": { "type": "number", "minimum": 0 },
+        "p95Ms": { "type": "number", "minimum": 0 },
+        "p99Ms": { "type": "number", "minimum": 0 },
+        "sortedPassingLatenciesMs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "number", "minimum": 0 },
+          "description": "Recorded passing-trial durations, milliseconds, ascending. For shape-only consumption."
+        }
+      }
+    }
+  }
+}

--- a/punit-core/src/test/resources/conformance/interchange/mavai-optimize-1.schema.json
+++ b/punit-core/src/test/resources/conformance/interchange/mavai-optimize-1.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mavai-org/mavai-R/schema/mavai-optimize-1.schema.json",
+  "title": "mavai optimize interchange artefact",
+  "description": "One document per optimize run: the objective, the full iteration history (each iteration is one experiment configuration's descriptive result plus its score), and the convergence summary naming the selected optimum. Framework-neutral; the machine-checkable structural projection of the canonical format specification, validating the parsed data model of the YAML document. The statistics, cost, and latency blocks are shared with the exploration artefact and duplicated here so each schema is self-contained. Structural checks only: the cross-consistency of the convergence block with the iteration it names is a semantic obligation enforced by emitter conformance tests, not expressible here. Additive evolution: emitters may add fields anywhere; consumers ignore what they do not know.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "serviceContractId",
+    "objective",
+    "generatedAt",
+    "iterations",
+    "convergence"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "schemaVersion": {
+      "const": "mavai-optimize-1",
+      "description": "Schema identity. Consumers skip documents carrying any other value."
+    },
+    "serviceContractId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The optimized service contract's stable identity."
+    },
+    "experimentId": {
+      "type": "string",
+      "description": "Informational: the optimize run's name."
+    },
+    "objective": {
+      "enum": ["MAXIMIZE", "MINIMIZE"],
+      "description": "The direction the score is driven."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of emission."
+    },
+    "iterations": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The full history, in execution order. Never elided or truncated — the history is the artefact.",
+      "items": { "$ref": "#/$defs/iteration" }
+    },
+    "convergence": {
+      "type": "object",
+      "required": ["totalIterations", "bestIteration", "bestScore", "bestFactors"],
+      "additionalProperties": true,
+      "properties": {
+        "totalIterations": { "type": "integer", "minimum": 1 },
+        "bestIteration": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Index of the selected optimum in iterations. Must be internally consistent with that entry's score and factors (semantic obligation)."
+        },
+        "bestScore": { "type": "number" },
+        "bestFactors": { "$ref": "#/$defs/factors" }
+      }
+    }
+  },
+  "$defs": {
+    "iteration": {
+      "type": "object",
+      "required": ["iteration", "factors", "score", "execution", "statistics"],
+      "additionalProperties": true,
+      "properties": {
+        "iteration": { "type": "integer", "minimum": 0 },
+        "factors": { "$ref": "#/$defs/factors" },
+        "score": {
+          "type": "number",
+          "description": "The scoring function's value for this iteration, in objective units."
+        },
+        "execution": {
+          "type": "object",
+          "required": ["samplesExecuted", "terminationReason"],
+          "additionalProperties": true,
+          "properties": {
+            "samplesExecuted": { "type": "integer", "minimum": 0 },
+            "terminationReason": { "type": "string", "minLength": 1 }
+          }
+        },
+        "statistics": { "$ref": "#/$defs/statistics" },
+        "cost": { "$ref": "#/$defs/cost" },
+        "latency": { "$ref": "#/$defs/latency" },
+        "resultProjection": {
+          "description": "Informational per-sample detail, emitter-formatted. Consumers must not require it."
+        }
+      }
+    },
+    "factors": {
+      "type": "object",
+      "description": "Factor values keyed by factor name.",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      }
+    },
+    "statistics": {
+      "type": "object",
+      "required": ["observed", "successes", "failures", "criteria"],
+      "additionalProperties": true,
+      "properties": {
+        "observed": { "type": "number", "minimum": 0, "maximum": 1 },
+        "successes": { "type": "integer", "minimum": 0 },
+        "failures": { "type": "integer", "minimum": 0 },
+        "failureDistribution": { "$ref": "#/$defs/failureDistribution" },
+        "criteria": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "#/$defs/criterion" }
+        }
+      },
+      "if": {
+        "properties": { "failures": { "exclusiveMinimum": 0 } },
+        "required": ["failures"]
+      },
+      "then": {
+        "required": ["failureDistribution"]
+      }
+    },
+    "criterion": {
+      "type": "object",
+      "required": ["observedPassRate", "pass", "fail"],
+      "additionalProperties": true,
+      "properties": {
+        "observedPassRate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "pass": { "type": "integer", "minimum": 0 },
+        "fail": { "type": "integer", "minimum": 0 },
+        "failureDistribution": { "$ref": "#/$defs/failureDistribution" }
+      }
+    },
+    "failureDistribution": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "totalTimeMs": { "type": "integer", "minimum": 0 },
+        "avgTimePerSampleMs": { "type": "integer", "minimum": 0 },
+        "totalTokens": { "type": "integer", "minimum": 0 },
+        "avgTokensPerSample": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "latency": {
+      "type": "object",
+      "description": "Absent as a whole when no sample passed. Percentiles are STATED value-or-absent under the emitter's minimum-sample gate; at optimize's typically small per-iteration sample counts, most will be absent — that is the gate working.",
+      "required": ["basis", "contributingSamples", "totalSamples", "sortedPassingLatenciesMs"],
+      "additionalProperties": true,
+      "properties": {
+        "basis": { "const": "passing-samples" },
+        "contributingSamples": { "type": "integer", "minimum": 1 },
+        "totalSamples": { "type": "integer", "minimum": 1 },
+        "p50Ms": { "type": "number", "minimum": 0 },
+        "p95Ms": { "type": "number", "minimum": 0 },
+        "p99Ms": { "type": "number", "minimum": 0 },
+        "sortedPassingLatenciesMs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "number", "minimum": 0 }
+        }
+      }
+    }
+  }
+}

--- a/punit-report/src/main/java/org/mavai/punit/report/explore/ServiceComparison.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/explore/ServiceComparison.java
@@ -6,7 +6,7 @@ import java.util.List;
  * All Explore-experiment variants gathered for one service contract — the
  * unit the comparison report renders as a single section.
  *
- * @param service  the service contract identifier ({@code useCaseId})
+ * @param service  the service contract identifier ({@code serviceContractId})
  * @param variants the variants compared, in file-discovery order
  *                 (the renderer applies its own ranking)
  */

--- a/punit-report/src/main/java/org/mavai/punit/report/explore/YamlReader.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/explore/YamlReader.java
@@ -30,8 +30,8 @@ import org.yaml.snakeyaml.Yaml;
  */
 final class YamlReader {
 
-    /** The exploration-output schema version this reader accepts. */
-    private static final String EXPLORATION_SCHEMA = "punit-spec-1";
+    /** The canonical exploration interchange schema version this reader accepts. */
+    private static final String EXPLORATION_SCHEMA = "mavai-explore-1";
 
     /**
      * Parses a single exploration YAML document.
@@ -51,7 +51,7 @@ final class YamlReader {
             return Optional.empty();
         }
 
-        String service = asString(root.get("useCaseId"));
+        String service = asString(root.get("serviceContractId"));
         Map<String, Object> factors = mapOf(root.get("factors"));
         Map<String, Object> execution = mapOf(root.get("execution"));
         Map<String, Object> statistics = mapOf(root.get("statistics"));

--- a/punit-report/src/main/java/org/mavai/punit/report/optimize/OptimizationRun.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/optimize/OptimizationRun.java
@@ -6,7 +6,7 @@ import java.util.List;
  * One OPTIMIZE experiment — the unit the comparison report renders as a
  * single section. Each optimization YAML file is one run.
  *
- * @param service      the service contract identifier ({@code useCaseId})
+ * @param service      the service contract identifier ({@code serviceContractId})
  * @param experimentId the experiment identifier
  * @param objective    {@code MAXIMIZE} or {@code MINIMIZE} — the sense in
  *                     which a higher/lower score is "better"

--- a/punit-report/src/main/java/org/mavai/punit/report/optimize/YamlReader.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/optimize/YamlReader.java
@@ -26,8 +26,8 @@ import org.yaml.snakeyaml.Yaml;
  */
 final class YamlReader {
 
-    /** The optimization-output schema version this reader accepts. */
-    private static final String OPTIMIZATION_SCHEMA = "punit-spec-1";
+    /** The canonical optimize interchange schema version this reader accepts. */
+    private static final String OPTIMIZATION_SCHEMA = "mavai-optimize-1";
 
     /**
      * Parses a single optimization YAML document.
@@ -50,7 +50,7 @@ final class YamlReader {
             return Optional.empty();
         }
 
-        String service = asString(root.get("useCaseId"));
+        String service = asString(root.get("serviceContractId"));
         String experimentId = asString(root.get("experimentId"));
         String objective = asString(root.get("objective"));
 

--- a/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.2.xsd
+++ b/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.2.xsd
@@ -55,8 +55,7 @@
          Producers emitting 1.2-shaped content do not write the
          element; permissive readers may continue to ignore it when
          encountered in 1.1-shaped content from older emitters in
-         service. See plan/directives/DIR-LEGACY-AGGREGATE-VERDICT-REMOVAL-punit.md
-         for the deprecation close-out. -->
+         service. -->
     <xs:attribute name="version"        type="xs:string"   use="required"/>
     <xs:attribute name="timestamp"      type="xs:dateTime"  use="required"/>
     <xs:attribute name="generator"      type="xs:string"    use="required"/>

--- a/punit-report/src/test/java/org/mavai/punit/report/explore/ReportGeneratorTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/explore/ReportGeneratorTest.java
@@ -318,8 +318,9 @@ class ReportGeneratorTest {
             double observed, int successes, int failures, String termination,
             long[] latencies, long avgMs) {
         Map<String, Object> root = new LinkedHashMap<>();
-        root.put("schemaVersion", "punit-spec-1");
-        root.put("useCaseId", service);
+        root.put("schemaVersion", "mavai-explore-1");
+        root.put("serviceContractId", service);
+        root.put("configuration", configurationNameFor(factors));
         root.put("factors", factors);
 
         Map<String, Object> execution = new LinkedHashMap<>();
@@ -352,6 +353,17 @@ class ReportGeneratorTest {
             root.put("latency", latency);
         }
         return root;
+    }
+
+    private static String configurationNameFor(Map<String, Object> factors) {
+        StringBuilder name = new StringBuilder();
+        for (Map.Entry<String, Object> e : factors.entrySet()) {
+            if (name.length() > 0) {
+                name.append('_');
+            }
+            name.append(e.getKey()).append('-').append(e.getValue());
+        }
+        return name.length() == 0 ? "no-factors" : name.toString();
     }
 
     private static Map<String, Object> factors(String model) {

--- a/punit-report/src/test/java/org/mavai/punit/report/optimize/ReportGeneratorTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/optimize/ReportGeneratorTest.java
@@ -299,8 +299,8 @@ class ReportGeneratorTest {
     private static Map<String, Object> run(String service, String experimentId, String objective,
             List<Map<String, Object>> iterations, Map<String, Object> convergence) {
         Map<String, Object> root = new LinkedHashMap<>();
-        root.put("schemaVersion", "punit-spec-1");
-        root.put("useCaseId", service);
+        root.put("schemaVersion", "mavai-optimize-1");
+        root.put("serviceContractId", service);
         root.put("experimentId", experimentId);
         root.put("objective", objective);
         root.put("iterations", iterations);


### PR DESCRIPTION
punit's exploration and optimization artefacts move to the mavai family's canonical interchange schemas (published at https://r.mavai.org/schema/ and as mavai-R release assets, pinned here at v0.8.6), so the family's shared tooling can consume punit's experiment results without punit-specific knowledge.

**Format changes (breaking for these two artefact types only):**

- Exploration output: `schemaVersion: mavai-explore-1`; `useCaseId` → `serviceContractId`; a new binding `configuration:` field carries the configuration's display name in the body (the same human-readable stem already used for filenames), so consumers never parse filenames. `statistics.criteria` is emitted unconditionally. Existing punit extras (`conditionFail`, `transformFail`, `p90Ms`) remain as permitted informational fields.
- Optimization output: `schemaVersion: mavai-optimize-1`; `useCaseId` → `serviceContractId`; per-iteration `criteria` emitted whenever the iteration summary exists. The convergence block is unchanged.
- Baseline specs and verdict XML are untouched.

The report readers follow the renamed fields, so the exploration and optimization HTML comparison reports keep working unchanged.

**Conformance:** pinned copies of the published JSON Schemas are vendored under test resources, and a new conformance test drives real explore and optimize runs through the engine, validates every emitted document against the schemas (new test-only dependency: com.networknt:json-schema-validator), and asserts the obligations the schemas cannot express — latency-vector sortedness, contributing-count consistency, percentile statedness following the minimum-sample floors (referenced through the existing latency section, not hardcoded), and the convergence block's internal consistency with the iteration it names.

**Also:** the embedded `verdict-1.2.xsd` drops a stray internal-planning reference from a comment, making it byte-identical to the published family copy — framework-embedded schema copies are vendored snapshots of the published text, synced per release.

Verified end-to-end: the family's shared renderer produces a correct comparison report directly from punit-emitted artefacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)