### PR TITLE
Named scorers: state the scorer's identity in the optimize artefact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Named scorers, stated in the optimize artefact.** `Scorer` gains an
+  optional identity (`Scorer.name()`, default empty) and a built-in
+  named implementation, `Scorer.observedPassRate()`, which scores each
+  iteration by the observed pass rate the artefact's statistics block
+  states. When an optimize experiment's scorer carries a name, the
+  emitted `mavai-optimize-1` document states it in the additive
+  `scorer` field (e.g. `scorer: observed-pass-rate`), so downstream
+  consumers — the shared `mavai optimize` report — can label what the
+  score measures. Ad-hoc lambda scorers remain unnamed and the field
+  stays absent: the artefact never claims an identity the author did
+  not declare.
+
 ### Changed
 
 - **Canonical interchange schemas for experiment artefacts (breaking

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/Experiment.java
@@ -241,6 +241,21 @@ public final class Experiment implements Spec {
     }
 
     /**
+     * Diagnostic accessor populated for optimize experiments only.
+     * Returns the declared scorer's stable name, when the scorer
+     * carries one (see {@link Scorer#name()}). Empty for measure and
+     * explore, and for ad-hoc lambda scorers. Consumed by the
+     * OPTIMIZE artefact emitter for the additive {@code scorer}
+     * field.
+     */
+    public Optional<String> optimizeScorerName() {
+        if (internal instanceof OptimizeInternal<?, ?, ?> o) {
+            return o.scorer.name();
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Diagnostic accessor populated for optimize experiments only,
      * after the run has completed. Reports why the iteration loop
      * stopped: {@code MAX_ITERATIONS}, {@code NO_IMPROVEMENT}, or

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/Scorer.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/Scorer.java
@@ -1,5 +1,7 @@
 package org.mavai.punit.api.spec;
 
+import java.util.Optional;
+
 /**
  * Reduces a {@link SampleSummary} to a single comparable score for an
  * {@link Experiment} iteration.
@@ -7,4 +9,36 @@ package org.mavai.punit.api.spec;
 @FunctionalInterface
 public interface Scorer {
     double score(SampleSummary<?> summary);
+
+    /**
+     * The scorer's stable domain name, when it has one. A named scorer
+     * is stated in the optimize artefact's additive {@code scorer}
+     * field, so downstream consumers can label what the score
+     * measures. An ad-hoc lambda carries no name and the field stays
+     * absent — the artefact never claims an identity the author did
+     * not declare.
+     */
+    default Optional<String> name() {
+        return Optional.empty();
+    }
+
+    /**
+     * The built-in observed-pass-rate scorer: scores each iteration by
+     * its observed pass rate, exactly the rate the artefact's
+     * statistics block states. Named {@code observed-pass-rate} in the
+     * emitted artefact.
+     */
+    static Scorer observedPassRate() {
+        return new Scorer() {
+            @Override
+            public double score(SampleSummary<?> summary) {
+                return summary.passRate();
+            }
+
+            @Override
+            public Optional<String> name() {
+                return Optional.of("observed-pass-rate");
+            }
+        };
+    }
 }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
@@ -47,6 +47,11 @@ public final class OptimizeOutputWriter {
      * @param experimentId the experiment identifier (becomes the
      *                     filename stem)
      * @param objective {@code "MAXIMIZE"} or {@code "MINIMIZE"}
+     * @param scorerName the scorer's stable domain name (e.g.
+     *                   {@code observed-pass-rate}), or {@code null}
+     *                   for an unnamed ad-hoc scorer — stated in the
+     *                   additive {@code scorer} field only when the
+     *                   author declared one
      * @param history the full iteration history in execution order;
      *                each {@link IterationResult} carries its
      *                factors, score, raw counts, and per-clause
@@ -64,6 +69,7 @@ public final class OptimizeOutputWriter {
             String serviceContractId,
             String experimentId,
             String objective,
+            String scorerName,
             List<? extends IterationResult<?>> history,
             List<? extends SampleSummary<?>> iterationSummaries,
             IterationResult<?> bestIteration,
@@ -74,6 +80,9 @@ public final class OptimizeOutputWriter {
         root.put("serviceContractId", serviceContractId);
         root.put("experimentId", experimentId);
         root.put("objective", objective);
+        if (scorerName != null) {
+            root.put("scorer", scorerName);
+        }
         root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
         root.put("iterations", iterationsBlock(history, iterationSummaries));
         root.put("convergence", convergenceBlock(history, bestIteration, terminationReason));

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/OptimizeEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/OptimizeEmitter.java
@@ -102,6 +102,7 @@ public final class OptimizeEmitter {
         List<SampleSummary<?>> iterationSummaries = experiment.iterationSummaries();
         Optional<IterationResult<?>> best = experiment.bestOptimizeIteration();
         String objective = experiment.optimizeObjective().orElse("MAXIMIZE");
+        String scorerName = experiment.optimizeScorerName().orElse(null);
         String terminationReason = experiment.optimizeTerminationReason().orElse("UNKNOWN");
         String experimentId = experiment.experimentId();
 
@@ -111,6 +112,7 @@ public final class OptimizeEmitter {
                 serviceContractId,
                 experimentId,
                 objective,
+                scorerName,
                 history,
                 iterationSummaries,
                 best.orElse(null),

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
@@ -24,6 +24,7 @@ import org.mavai.punit.api.TokenTracker;
 import org.mavai.punit.api.criterion.Criteria;
 import org.mavai.punit.api.spec.Experiment;
 import org.mavai.punit.api.spec.NextFactor;
+import org.mavai.punit.api.spec.Scorer;
 import org.mavai.punit.internal.engine.Engine;
 import org.mavai.punit.internal.engine.emit.LatencySection;
 import org.mavai.punit.internal.runtime.ExploreEmitter;
@@ -184,7 +185,7 @@ class InterchangeConformanceTest {
                     .stepper((cur, hist) -> hist.size() < 2
                             ? NextFactor.next(new LlmFactors("gpt-4o", cur.temperature() + 0.3))
                             : NextFactor.stop())
-                    .maximize(s -> 1.0 * s.successes() / Math.max(1, s.total()))
+                    .maximize(Scorer.observedPassRate())
                     .maxIterations(5)
                     .experimentId("interchange-opt-run")
                     .build();
@@ -196,6 +197,10 @@ class InterchangeConformanceTest {
             Map<String, Object> doc = new Yaml().load(sink.values().iterator().next());
 
             assertThat(validate("mavai-optimize-1", doc)).isEmpty();
+
+            // The built-in scorer is named, so the additive scorer field
+            // states its identity — and the document still validates.
+            assertThat(doc).containsEntry("scorer", "observed-pass-rate");
 
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> iterations = (List<Map<String, Object>>) doc.get("iterations");

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriterTest.java
@@ -16,6 +16,7 @@ import org.mavai.punit.api.criterion.Criteria;
 import static org.mavai.punit.api.criterion.Criteria.meeting;
 import org.mavai.punit.api.spec.Experiment;
 import org.mavai.punit.api.spec.NextFactor;
+import org.mavai.punit.api.spec.Scorer;
 import org.mavai.punit.internal.engine.Engine;
 import org.mavai.punit.internal.runtime.OptimizeEmitter;
 import org.junit.jupiter.api.DisplayName;
@@ -80,6 +81,10 @@ class OptimizeOutputWriterTest {
         assertThat(parsed).containsEntry("experimentId", "opt-run-1");
         assertThat(parsed).containsEntry("objective", "MAXIMIZE");
         assertThat(parsed).containsKeys("iterations", "convergence", "generatedAt");
+        // An ad-hoc lambda scorer has no name, so the additive scorer
+        // field stays absent — the artefact never claims an identity
+        // the author did not declare.
+        assertThat(parsed).doesNotContainKey("scorer");
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> iterations = (List<Map<String, Object>>) parsed.get("iterations");
@@ -129,6 +134,41 @@ class OptimizeOutputWriterTest {
                 .filter(line -> line.contains("anchor:"))
                 .count();
         assertThat(anchorCount).isEqualTo((long) totalSamples);
+    }
+
+    @Test
+    @DisplayName("a named scorer is stated in the additive scorer field")
+    void namedScorerIsStated() {
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .serviceContractFactory(f -> new IdServiceContract("optimize-test"))
+                .inputs("a", "bb")
+                .samples(2)
+                .build();
+        Experiment experiment = Experiment.optimizing(sampling)
+                .initialFactors(new LlmFactors("gpt-4o", 0.0))
+                .stepper((cur, hist) -> NextFactor.stop())
+                .maximize(Scorer.observedPassRate())
+                .maxIterations(2)
+                .experimentId("opt-run-named")
+                .build();
+        new Engine().run(experiment);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        OptimizeEmitter.emit(experiment, sink::put);
+
+        Map<String, Object> parsed = new Yaml().load(sink.values().iterator().next());
+        assertThat(parsed).containsEntry("scorer", "observed-pass-rate");
+        // The built-in scores by the observed pass rate the statistics
+        // block states, so the two agree by construction.
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> iterations = (List<Map<String, Object>>) parsed.get("iterations");
+        for (Map<String, Object> iteration : iterations) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> statistics = (Map<String, Object>) iteration.get("statistics");
+            assertThat(((Number) iteration.get("score")).doubleValue())
+                    .isEqualTo(((Number) statistics.get("observed")).doubleValue());
+        }
     }
 
     @Test


### PR DESCRIPTION
Scorer gains an optional stable identity (`Scorer.name()`, default empty) and a built-in named implementation, `Scorer.observedPassRate()`, which scores each iteration by the observed pass rate the artefact's statistics block states. When an optimize experiment's scorer carries a name, the emitted `mavai-optimize-1` document states it in the additive `scorer` field (`scorer: observed-pass-rate`), so the shared `mavai optimize` report can label what the score measures. Ad-hoc lambda scorers remain unnamed and the field stays absent — the artefact never claims an identity the author did not declare.

Conformance and writer tests extended (named case asserted against the pinned schema; unnamed case asserts absence); the interchange conformance optimize run now uses the built-in scorer. The field name is registered in the orchestrator's interchange catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)