### PR TITLE
Artefact key discipline: shape-B failure distribution, bounded emission keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Artefact key discipline and the redesigned `failureDistribution`
+  (breaking for exploration and optimization outputs).** The
+  `statistics.failureDistribution` block of `mavai-explore-1` and
+  `mavai-optimize-1` documents is now a *sequence* of
+  `{condition, count}` entries instead of a mapping keyed by
+  free-text check identity: each failed trial is attributed to its
+  first failing condition, so entry counts sum to the enclosing
+  `failures` total, and no mapping key carries unbounded free text.
+  Every mapping key punit emits into these artefacts (postcondition
+  descriptions in `resultProjection`, criterion names, factor names)
+  is now bounded at 256 characters — comfortably under YAML's
+  1,024-character implicit-key limit — with over-long keys truncated
+  to a bounded prefix plus a short content hash so distinct keys
+  stay distinct. Per-input identity remains structural
+  (`inputIndex`); input text appears only in values. The vendored
+  interchange schemas are re-pinned to the mavai-R v0.9.0
+  publication, and the conformance suite now drives a run with a
+  >1,024-character input and over-long condition identities to prove
+  the emitted document parses and validates.
+
 - **Canonical interchange schemas for experiment artefacts (breaking
   for exploration and optimization outputs).** EXPLORE and OPTIMIZE
   runs now emit the mavai family's canonical interchange formats —

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/EmittedKeys.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/EmittedKeys.java
@@ -1,0 +1,75 @@
+package org.mavai.punit.internal.engine.emit;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Artefact key discipline for every YAML mapping key punit emits.
+ *
+ * <p>The mavai interchange formats bound every emitted mapping key at
+ * {@value #MAX_KEY_LENGTH} characters — comfortably under YAML's
+ * 1,024-character implicit-key limit — and forbid keys whose content
+ * or length depends on input or response content. Free-text identity
+ * strings that reach a mapping-key position (postcondition
+ * descriptions, criterion names, factor names) therefore pass through
+ * {@link #bound(String)} on their way into an emitted document.
+ *
+ * <p>An over-long key is truncated to a bounded prefix plus a short
+ * SHA-256 content hash, so two distinct keys stay distinct after
+ * truncation. Keys within the bound pass through unchanged.
+ */
+public final class EmittedKeys {
+
+    /** Maximum length of any emitted mapping key, in characters. */
+    public static final int MAX_KEY_LENGTH = 256;
+
+    /** Hex characters of content hash appended to a truncated key. */
+    private static final int HASH_LENGTH = 8;
+
+    /** Prefix retained when truncating: bound − hash − one separator. */
+    private static final int PREFIX_LENGTH = MAX_KEY_LENGTH - HASH_LENGTH - 1;
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private EmittedKeys() { }
+
+    /**
+     * Bound {@code key} to {@link #MAX_KEY_LENGTH} characters. Keys
+     * within the bound are returned unchanged; longer keys become
+     * {@code {prefix}-{hash}} where the prefix is the key's first
+     * {@value #PREFIX_LENGTH} characters and the hash is the first
+     * {@value #HASH_LENGTH} hex characters of the full key's SHA-256
+     * digest — distinct inputs stay distinct after truncation.
+     */
+    public static String bound(String key) {
+        if (key.length() <= MAX_KEY_LENGTH) {
+            return key;
+        }
+        return key.substring(0, PREFIX_LENGTH) + "-" + sha256HexPrefix(key, HASH_LENGTH);
+    }
+
+    /**
+     * First {@code hexChars} hex characters of {@code input}'s SHA-256
+     * digest. Shared by the key-truncation rule and the
+     * {@linkplain ResultProjections#anchorOf diff anchors}.
+     */
+    static String sha256HexPrefix(String input, int hexChars) {
+        byte[] digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 must be supported by every JRE", e);
+        }
+        StringBuilder hex = new StringBuilder(hexChars);
+        for (int i = 0; hex.length() < hexChars && i < digest.length; i++) {
+            int b = digest[i] & 0xff;
+            hex.append(HEX[b >>> 4]);
+            if (hex.length() < hexChars) {
+                hex.append(HEX[b & 0x0f]);
+            }
+        }
+        return hex.toString();
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/FailureDistributions.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/FailureDistributions.java
@@ -1,0 +1,57 @@
+package org.mavai.punit.internal.engine.emit;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.spec.Trial;
+
+/**
+ * Builds the {@code failureDistribution:} block of the canonical
+ * exploration and optimize interchange schemas — a <em>sequence</em>
+ * of {@code {condition, count}} entries, never a mapping keyed by
+ * free-text identity (the interchange area's key discipline).
+ *
+ * <p>Each failed trial is attributed to its first failing condition
+ * — the same precedence {@link org.mavai.punit.api.ServiceContractOutcome#value()}
+ * applies when deriving the sample outcome: an apply-level failure's
+ * declared failure name short-circuits, otherwise the first failed
+ * postcondition's description. Entry counts therefore sum exactly to
+ * the enclosing {@code failures} total.
+ *
+ * <p>The {@code condition} field carries the condition's declared
+ * identity, bounded per {@link EmittedKeys#bound(String)} — never
+ * input or response content. punit's condition identities are the
+ * contract-declared descriptions (per-input attribution travels
+ * structurally as {@code inputIndex} in the result projection), so
+ * entries aggregate by condition alone.
+ */
+public final class FailureDistributions {
+
+    private FailureDistributions() { }
+
+    /**
+     * Aggregate {@code trials} into the sequence-of-entries failure
+     * distribution. Entries appear in first-occurrence order; an
+     * all-passing run yields an empty list.
+     */
+    public static List<Map<String, Object>> fromTrials(List<? extends Trial<?, ?>> trials) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (Trial<?, ?> trial : trials) {
+            if (trial.outcome().value() instanceof Outcome.Fail<?> fail) {
+                String condition = EmittedKeys.bound(fail.failure().id().name());
+                counts.merge(condition, 1, Integer::sum);
+            }
+        }
+        List<Map<String, Object>> entries = new ArrayList<>(counts.size());
+        for (Map.Entry<String, Integer> e : counts.entrySet()) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("condition", e.getKey());
+            entry.put("count", e.getValue());
+            entries.add(entry);
+        }
+        return entries;
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/ResultProjections.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/ResultProjections.java
@@ -1,8 +1,5 @@
 package org.mavai.punit.internal.engine.emit;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -44,8 +41,6 @@ public final class ResultProjections {
 
     private ResultProjections() { }
 
-    private static final char[] HEX = "0123456789abcdef".toCharArray();
-
     /**
      * Render one trial as the per-sample projection map.
      *
@@ -67,7 +62,10 @@ public final class ResultProjections {
         entry.put("inputIndex", trial.inputIndex());
         Map<String, Object> postconds = new LinkedHashMap<>();
         for (PostconditionResult pr : trial.outcome().postconditionResults()) {
-            postconds.put(pr.description(), pr.passed() ? "passed" : "failed");
+            // Key discipline: descriptions reach a mapping-key
+            // position here, so they pass through the emitted-key
+            // bound (prefix-plus-hash truncation past 256 chars).
+            postconds.put(EmittedKeys.bound(pr.description()), pr.passed() ? "passed" : "failed");
         }
         entry.put("postconditions", postconds);
         entry.put("executionTimeMs", trial.duration().toMillis());
@@ -121,7 +119,7 @@ public final class ResultProjections {
     /** Anchor for one (sampleIndex, inputIndex) pair. */
     public static String anchorOf(int sampleIndex, int inputIndex) {
         String content = sampleIndex + ":" + inputIndex;
-        return sha256HexPrefix(content, 8);
+        return EmittedKeys.sha256HexPrefix(content, 8);
     }
 
     /**
@@ -159,22 +157,4 @@ public final class ResultProjections {
         return out.toString();
     }
 
-    private static String sha256HexPrefix(String input, int hexChars) {
-        byte[] digest;
-        try {
-            digest = MessageDigest.getInstance("SHA-256")
-                    .digest(input.getBytes(StandardCharsets.UTF_8));
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 must be supported by every JRE", e);
-        }
-        StringBuilder hex = new StringBuilder(hexChars);
-        for (int i = 0; hex.length() < hexChars && i < digest.length; i++) {
-            int b = digest[i] & 0xff;
-            hex.append(HEX[b >>> 4]);
-            if (hex.length() < hexChars) {
-                hex.append(HEX[b & 0x0f]);
-            }
-        }
-        return hex.toString();
-    }
 }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -10,9 +10,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.mavai.punit.api.FactorBundle;
-import org.mavai.punit.api.spec.FailureCount;
 import org.mavai.punit.api.spec.PerConfigSummary;
 import org.mavai.punit.api.spec.SampleSummary;
+import org.mavai.punit.internal.engine.emit.EmittedKeys;
+import org.mavai.punit.internal.engine.emit.FailureDistributions;
 import org.mavai.punit.internal.engine.emit.LatencySection;
 import org.mavai.punit.internal.engine.emit.ResultProjections;
 import org.yaml.snakeyaml.DumperOptions;
@@ -118,7 +119,7 @@ public final class ExploreOutputWriter {
     private static Map<String, Object> factorsBlock(FactorBundle bundle) {
         Map<String, Object> block = new LinkedHashMap<>();
         for (FactorBundle.Entry e : bundle.entries()) {
-            block.put(e.name(), e.value().yamlValue());
+            block.put(EmittedKeys.bound(e.name()), e.value().yamlValue());
         }
         return block;
     }
@@ -136,11 +137,11 @@ public final class ExploreOutputWriter {
         block.put("observed", summary.passRate());
         block.put("successes", summary.successes());
         block.put("failures", summary.failures());
-        Map<String, Object> failureDistribution = new LinkedHashMap<>();
-        for (Map.Entry<String, FailureCount> entry : summary.failuresByPostcondition().entrySet()) {
-            failureDistribution.put(entry.getKey(), entry.getValue().count());
-        }
-        block.put("failureDistribution", failureDistribution);
+        // Sequence of {condition, count} entries — first-failing-
+        // condition attribution over the trials, so entry counts sum
+        // to the failures total. Never a mapping keyed by free-text
+        // identity (artefact key discipline).
+        block.put("failureDistribution", FailureDistributions.fromTrials(summary.trials()));
         // Per-criterion decomposition — required by the interchange
         // schema, one entry per declared criterion (including the
         // single-criterion case; a contract cannot run without at
@@ -158,7 +159,7 @@ public final class ExploreOutputWriter {
             row.put("fail", counts.fail());
             row.put("conditionFail", counts.conditionFail());
             row.put("transformFail", counts.transformFail());
-            criteria.put(counts.criterionId(), row);
+            criteria.put(EmittedKeys.bound(counts.criterionId()), row);
         }
         block.put("criteria", criteria);
         return block;

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
@@ -12,9 +12,10 @@ import java.time.Duration;
 import org.mavai.punit.api.FactorBundle;
 import org.mavai.punit.api.spec.CriterionSampleCounts;
 import org.mavai.punit.api.spec.FactorsStepper.IterationResult;
-import org.mavai.punit.api.spec.FailureCount;
 import org.mavai.punit.api.spec.SampleSummary;
 import org.mavai.punit.api.spec.Trial;
+import org.mavai.punit.internal.engine.emit.EmittedKeys;
+import org.mavai.punit.internal.engine.emit.FailureDistributions;
 import org.mavai.punit.internal.engine.emit.LatencySection;
 import org.mavai.punit.internal.engine.emit.ResultProjections;
 import org.yaml.snakeyaml.DumperOptions;
@@ -156,14 +157,13 @@ public final class OptimizeOutputWriter {
         block.put("observed", observed);
         block.put("successes", ir.successes());
         block.put("failures", ir.failures());
-        Map<String, Object> failureDistribution = new LinkedHashMap<>();
-        if (iterSummary != null) {
-            for (Map.Entry<String, FailureCount> e
-                    : iterSummary.failuresByPostcondition().entrySet()) {
-                failureDistribution.put(e.getKey(), e.getValue().count());
-            }
-        }
-        block.put("failureDistribution", failureDistribution);
+        // Sequence of {condition, count} entries — first-failing-
+        // condition attribution over the iteration's trials, so entry
+        // counts sum to the failures total. Never a mapping keyed by
+        // free-text identity (artefact key discipline).
+        block.put("failureDistribution", iterSummary != null
+                ? FailureDistributions.fromTrials(iterSummary.trials())
+                : List.of());
         // Per-criterion decomposition — required by the interchange
         // schema, one entry per declared criterion (including the
         // single-criterion case). conditionFail / transformFail are
@@ -177,7 +177,7 @@ public final class OptimizeOutputWriter {
                 row.put("fail", c.fail());
                 row.put("conditionFail", c.conditionFail());
                 row.put("transformFail", c.transformFail());
-                criteria.put(c.criterionId(), row);
+                criteria.put(EmittedKeys.bound(c.criterionId()), row);
             }
             block.put("criteria", criteria);
         }
@@ -219,7 +219,7 @@ public final class OptimizeOutputWriter {
     private static Map<String, Object> factorsBlock(FactorBundle bundle) {
         Map<String, Object> block = new LinkedHashMap<>();
         for (FactorBundle.Entry e : bundle.entries()) {
-            block.put(e.name(), e.value().yamlValue());
+            block.put(EmittedKeys.bound(e.name()), e.value().yamlValue());
         }
         return block;
     }

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/emit/EmittedKeysTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/emit/EmittedKeysTest.java
@@ -1,0 +1,46 @@
+package org.mavai.punit.internal.engine.emit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Emitted-key bound — artefact key discipline")
+class EmittedKeysTest {
+
+    @Test
+    @DisplayName("keys within the bound pass through unchanged")
+    void withinBoundUnchanged() {
+        String key = "a".repeat(EmittedKeys.MAX_KEY_LENGTH);
+        assertThat(EmittedKeys.bound(key)).isSameAs(key);
+        assertThat(EmittedKeys.bound("plain-condition")).isEqualTo("plain-condition");
+    }
+
+    @Test
+    @DisplayName("over-long keys truncate to exactly the bound: prefix, separator, content hash")
+    void overLongKeysTruncateToBound() {
+        String key = "k".repeat(EmittedKeys.MAX_KEY_LENGTH + 1);
+        String bounded = EmittedKeys.bound(key);
+        assertThat(bounded).hasSize(EmittedKeys.MAX_KEY_LENGTH);
+        assertThat(bounded).startsWith("k".repeat(247));
+        assertThat(bounded.charAt(247)).isEqualTo('-');
+        assertThat(bounded.substring(248)).matches("[0-9a-f]{8}");
+    }
+
+    @Test
+    @DisplayName("distinct keys sharing the truncated prefix stay distinct after truncation")
+    void truncatedKeysStayDistinct() {
+        String shared = "s".repeat(300);
+        String boundedA = EmittedKeys.bound(shared + "-variant-a");
+        String boundedB = EmittedKeys.bound(shared + "-variant-b");
+        assertThat(boundedA).isNotEqualTo(boundedB);
+        assertThat(boundedA.substring(0, 247)).isEqualTo(boundedB.substring(0, 247));
+    }
+
+    @Test
+    @DisplayName("truncation is deterministic — same key, same bounded form")
+    void truncationIsDeterministic() {
+        String key = "d".repeat(400);
+        assertThat(EmittedKeys.bound(key)).isEqualTo(EmittedKeys.bound(key));
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
@@ -41,7 +41,8 @@ import org.yaml.snakeyaml.Yaml;
  * <p>Small real EXPLORE and OPTIMIZE experiments are driven through
  * the engine and their emitted YAML artefacts are validated against
  * the vendored, pinned copies of the published JSON Schemas
- * ({@code mavai-explore-1}, {@code mavai-optimize-1}). On top of the
+ * ({@code mavai-explore-1}, {@code mavai-optimize-1}, pinned at the
+ * mavai-R v0.9.0 publication). On top of the
  * structural validation, the tests assert the semantic obligations
  * the schemas cannot express: the sorted passing-latency vector is
  * ascending and sized to {@code contributingSamples}; each latency
@@ -126,11 +127,24 @@ class InterchangeConformanceTest {
 
             @SuppressWarnings("unchecked")
             Map<String, Object> statistics = (Map<String, Object>) doc.get("statistics");
-            assertThat(((Number) statistics.get("failures")).intValue()).isPositive();
+            int failures = ((Number) statistics.get("failures")).intValue();
+            assertThat(failures).isPositive();
+            // Sequence-of-entries shape: {condition, count} entries whose
+            // counts sum to the enclosing failures total, each condition
+            // a bounded identity — never a free-text-keyed mapping.
             @SuppressWarnings("unchecked")
-            Map<String, Object> failureDistribution =
-                    (Map<String, Object>) statistics.get("failureDistribution");
+            List<Map<String, Object>> failureDistribution =
+                    (List<Map<String, Object>>) statistics.get("failureDistribution");
             assertThat(failureDistribution).isNotEmpty();
+            int attributed = 0;
+            for (Map<String, Object> entry : failureDistribution) {
+                assertThat(entry).containsKeys("condition", "count");
+                assertThat((String) entry.get("condition")).hasSizeLessThanOrEqualTo(256);
+                attributed += ((Number) entry.get("count")).intValue();
+            }
+            assertThat(attributed)
+                    .as("each failed trial attributed to its first failing condition")
+                    .isEqualTo(failures);
 
             @SuppressWarnings("unchecked")
             Map<String, Object> latency = (Map<String, Object>) doc.get("latency");
@@ -232,6 +246,124 @@ class InterchangeConformanceTest {
             assertThat(convergence.get("bestFactors")).isEqualTo(best.get("factors"));
             assertThat(((Number) convergence.get("totalIterations")).intValue())
                     .isEqualTo(iterations.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("artefact key discipline")
+    class ArtefactKeyDiscipline {
+
+        /** Driving input comfortably past YAML's 1,024-char implicit-key limit. */
+        private static final String LONG_INPUT = "lorem ipsum dolor sit amet ".repeat(48);
+
+        /** Condition identities past the 256-char emitted-key bound, sharing a prefix. */
+        private static final String LONG_DESCRIPTION_A =
+                "the response upholds every clause of the long-winded acceptance narrative "
+                        + "x".repeat(300) + " variant-A";
+        private static final String LONG_DESCRIPTION_B =
+                "the response upholds every clause of the long-winded acceptance narrative "
+                        + "x".repeat(300) + " variant-B";
+
+        /**
+         * Echoes its over-long input and alternates failures between
+         * two conditions whose declared identities exceed the emitted-key
+         * bound — exercising both the free-text-key exposure and the
+         * prefix-plus-hash truncation's distinctness.
+         */
+        private final class LongIdentityContract implements ServiceContract<LlmFactors, String, String> {
+            private final AtomicInteger invocations = new AtomicInteger();
+            @Override public String id() { return "interchange-long-identity"; }
+            @Override public Outcome<String> invoke(String input, TokenTracker tracker) {
+                return Outcome.ok(input);
+            }
+            @Override public Criteria<String> criteria() {
+                return meeting().<String>zeroFailures()
+                        .name("long-identity")
+                        .satisfies(LONG_DESCRIPTION_A, v -> invocations.get() % 2 == 0
+                                ? Outcome.fail(LONG_DESCRIPTION_A, "even invocation")
+                                : Outcome.ok())
+                        .satisfies(LONG_DESCRIPTION_B, v -> invocations.getAndIncrement() % 2 == 0
+                                ? Outcome.ok()
+                                : Outcome.fail(LONG_DESCRIPTION_B, "odd invocation"));
+            }
+        }
+
+        @Test
+        @DisplayName("over-long input and condition identities emit a parseable, schema-valid artefact with bounded keys")
+        void longInputAndIdentitiesStayWithinKeyBounds() {
+            assertThat(LONG_INPUT.length()).isGreaterThan(1024);
+
+            Sampling<LlmFactors, String, String> sampling = Sampling
+                    .<LlmFactors, String, String>builder()
+                    .serviceContractFactory(f -> new LongIdentityContract())
+                    .inputs(LONG_INPUT)
+                    .samples(4)
+                    .build();
+            Experiment experiment = Experiment.exploring(sampling)
+                    .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
+                    .build();
+            new Engine().run(experiment);
+
+            Map<String, String> sink = new LinkedHashMap<>();
+            ExploreEmitter.emit(experiment, sink::put);
+            assertThat(sink).hasSize(1);
+            String rawYaml = sink.values().iterator().next();
+
+            // The whole document parses — no implicit key anywhere near
+            // the 1,024-char limit that broke unbounded-key emission.
+            Map<String, Object> doc = new Yaml().load(rawYaml);
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+
+            // Every mapping key on every surface is bounded and never
+            // derived from input content.
+            List<String> keys = new ArrayList<>();
+            collectKeys(doc, keys);
+            for (String key : keys) {
+                assertThat(key.length())
+                        .as("emitted key must stay within the 256-char bound: %s", key)
+                        .isLessThanOrEqualTo(256);
+                assertThat(key).doesNotContain(LONG_INPUT.substring(0, 64));
+            }
+
+            // Failure attribution: bounded conditions, distinct after
+            // truncation despite the shared prefix, counts summing to
+            // the failures total.
+            @SuppressWarnings("unchecked")
+            Map<String, Object> statistics = (Map<String, Object>) doc.get("statistics");
+            int failures = ((Number) statistics.get("failures")).intValue();
+            assertThat(failures).isEqualTo(4);
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> failureDistribution =
+                    (List<Map<String, Object>>) statistics.get("failureDistribution");
+            assertThat(failureDistribution).hasSize(2);
+            List<String> conditions = new ArrayList<>();
+            int attributed = 0;
+            for (Map<String, Object> entry : failureDistribution) {
+                String condition = (String) entry.get("condition");
+                assertThat(condition).hasSize(256);
+                conditions.add(condition);
+                attributed += ((Number) entry.get("count")).intValue();
+            }
+            assertThat(attributed).isEqualTo(failures);
+            assertThat(conditions.get(0)).isNotEqualTo(conditions.get(1));
+
+            // The long input is welcome in values — the per-sample
+            // content still carries it in full.
+            assertThat(rawYaml).contains("lorem ipsum dolor sit amet");
+        }
+
+        /** Recursively collect every mapping key in the document. */
+        private static void collectKeys(Object node, List<String> keys) {
+            if (node instanceof Map<?, ?> map) {
+                for (Map.Entry<?, ?> e : map.entrySet()) {
+                    keys.add(String.valueOf(e.getKey()));
+                    collectKeys(e.getValue(), keys);
+                }
+            } else if (node instanceof List<?> list) {
+                for (Object item : list) {
+                    collectKeys(item, keys);
+                }
+            }
         }
     }
 

--- a/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
+++ b/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
@@ -107,9 +107,39 @@
       }
     },
     "failureDistribution": {
-      "type": "object",
-      "description": "Failure counts keyed by violating check name.",
-      "additionalProperties": { "type": "integer", "minimum": 0 }
+      "type": "array",
+      "description": "A sequence of failure entries aggregated over the run (amendment 2026-07-17: the earlier check-name-keyed mapping is withdrawn — no mapping key may derive from input or response content, per the interchange area's key discipline). Each failed trial is attributed to its first failing condition; the entries' counts sum to the enclosing failures total.",
+      "items": {
+        "type": "object",
+        "required": [
+          "condition",
+          "count"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "condition": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The violating condition's bounded identity, as the contract declares it — never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex."
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Failed trials attributed to this entry."
+          },
+          "inputIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based index into the inputs list, present when the condition is per-input — the structural input reference; the input value itself is never serialised as identity."
+          },
+          "inputExcerpt": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Informational bounded excerpt of the driving input, for human orientation only — consumers correlate via inputIndex."
+          }
+        }
+      }
     },
     "cost": {
       "type": "object",

--- a/punit-core/src/test/resources/conformance/interchange/mavai-optimize-1.schema.json
+++ b/punit-core/src/test/resources/conformance/interchange/mavai-optimize-1.schema.json
@@ -129,8 +129,39 @@
       }
     },
     "failureDistribution": {
-      "type": "object",
-      "additionalProperties": { "type": "integer", "minimum": 0 }
+      "type": "array",
+      "description": "A sequence of failure entries aggregated over the run (amendment 2026-07-17: the earlier check-name-keyed mapping is withdrawn — no mapping key may derive from input or response content, per the interchange area's key discipline). Each failed trial is attributed to its first failing condition; the entries' counts sum to the enclosing failures total.",
+      "items": {
+        "type": "object",
+        "required": [
+          "condition",
+          "count"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "condition": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The violating condition's bounded identity, as the contract declares it — never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex."
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Failed trials attributed to this entry."
+          },
+          "inputIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based index into the inputs list, present when the condition is per-input — the structural input reference; the input value itself is never serialised as identity."
+          },
+          "inputExcerpt": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Informational bounded excerpt of the driving input, for human orientation only — consumers correlate via inputIndex."
+          }
+        }
+      }
     },
     "cost": {
       "type": "object",


### PR DESCRIPTION
## What

Adopts the family's interchange key-discipline amendment and the redesigned `failureDistribution` (mavai-R v0.9.0 pinned).

punit already emits the canonical `mavai-explore-1`/`mavai-optimize-1` formats and never embeds input values in check identity (per-input identity was already structural via `inputIndex`), so this is adoption of the amended format, not a defect fix:

- **Shape-B `failureDistribution`** from both writers: a sequence of `{condition, count}` entries, each failed trial attributed to its first failing condition (same precedence as the outcome's own evaluation), counts summing to `failures`. New `FailureDistributions` builder.
- **Bounded emission keys**: new `EmittedKeys` — keys ≤256 characters pass through; longer keys become a 247-character prefix plus an 8-hex SHA-256 suffix, exactly 256 and distinct after truncation. Applied to criterion names, factor names, and result-projection postcondition descriptions.
- **Schemas re-pinned** to the published mavai-R v0.9.0 revision.
- **Conformance**: the mixed-run test asserts the sequence shape and counts-sum-to-failures; a new "artefact key discipline" section drives a real run with a >1,024-character input and two 384-character condition identities sharing a 247-character prefix — the emitted documents must parse, validate against the pinned schemas, carry no over-bound or input-derived key, and keep truncated conditions distinct.

Deliberately untouched: `BaselineWriter` (author-declared criterion ids, governed by the separate baseline-interchange follow-up; truncation would break the writer↔reader round-trip); per-criterion `failureDistribution` mirror (punit tracks no per-condition detail per criterion — the degenerate duplicate adds nothing).

## Verification

Full `./gradlew build` green — 2041 tests, 0 failures (including the architecture guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)