### PR TITLE
Rename cross-reference anchor token javai-ref: → mavai-ref:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ punit-sentinel/punit/
 
 ### Orchestrator-managed
 # Requirements / design / planning material for punit lives in
-# javai-orchestrator from 0.7.0 onwards, not in this repository.
+# mavai-orchestrator from 0.7.0 onwards, not in this repository.
 # The block below prevents accidental re-introduction.
 /plan/
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1658,7 +1658,7 @@ is required for the defaults.
 ### Verdict XML (RP07)
 
 Every probabilistic test verdict serialises to an XML file conforming
-to the **RP07 javai verdict interchange standard**:
+to the **RP07 mavai verdict interchange standard**:
 
 - Namespace: `http://mavai.org/verdict/1.0`
 - Root: `<verdict-record>`

--- a/punit-core/src/main/java/org/mavai/punit/api/BudgetExhaustedBehavior.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/BudgetExhaustedBehavior.java
@@ -4,7 +4,7 @@ package org.mavai.punit.api;
  * Defines the behavior when a budget (time or token) is exhausted
  * before all samples have been executed.
  */
-// javai-ref: JVI-KJS8SB7 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-KJS8SB7 — do not remove (resolves in mavai-orchestrator)
 public enum BudgetExhaustedBehavior {
     
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/Contract.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/Contract.java
@@ -45,7 +45,7 @@ import org.mavai.punit.api.criterion.LatencyCriterion;
  * @param <I> the per-sample input type
  * @param <O> the per-sample output value type
  */
-// javai-ref: JVI-GQXC6W9 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-GQXC6W9 — do not remove (resolves in mavai-orchestrator)
 public interface Contract<I, O> {
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/ControlFactor.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/ControlFactor.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-// javai-ref: JVI-0CRN8G6 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-0CRN8G6 — do not remove (resolves in mavai-orchestrator)
 public @interface ControlFactor {
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/ExceptionHandling.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/ExceptionHandling.java
@@ -4,8 +4,8 @@ package org.mavai.punit.api;
  * Defines how non-{@link AssertionError} exceptions thrown by the test method
  * should be handled.
  */
-// javai-ref: JVI-A076E41 — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-EGG7M2* — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-A076E41 — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-EGG7M2* — do not remove (resolves in mavai-orchestrator)
 public enum ExceptionHandling {
     
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/InputSource.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/InputSource.java
@@ -69,7 +69,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-// javai-ref: JVI-QBEZ3W9 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-QBEZ3W9 — do not remove (resolves in mavai-orchestrator)
 public @interface InputSource {
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/InputSupplier.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/InputSupplier.java
@@ -73,7 +73,7 @@ import java.util.function.Supplier;
  *
  * @param <IT> the per-sample input type
  */
-// javai-ref: JVI-WXK2ZQP — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-WXK2ZQP — do not remove (resolves in mavai-orchestrator)
 public interface InputSupplier<IT> {
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/LatencySpec.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/LatencySpec.java
@@ -22,7 +22,7 @@ import java.util.OptionalLong;
  * @param p95Millis optional 95th-percentile ceiling, in millis
  * @param p99Millis optional 99th-percentile ceiling, in millis
  */
-// javai-ref: JVI-NBPN769 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-NBPN769 — do not remove (resolves in mavai-orchestrator)
 public record LatencySpec(
         OptionalLong p50Millis,
         OptionalLong p90Millis,

--- a/punit-core/src/main/java/org/mavai/punit/api/Pacing.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/Pacing.java
@@ -41,10 +41,10 @@ import java.util.OptionalLong;
  *                           in milliseconds
  * @param maxConcurrent optional cap on the number of in-flight samples
  */
-// javai-ref: JVI-PC8GT83 — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-P1GG550 — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-M1TXHHQ — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-FNJKJT5 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-PC8GT83 — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-P1GG550 — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-M1TXHHQ — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-FNJKJT5 — do not remove (resolves in mavai-orchestrator)
 public record Pacing(
         OptionalDouble maxRequestsPerSecond,
         OptionalDouble maxRequestsPerMinute,

--- a/punit-core/src/main/java/org/mavai/punit/api/Postcondition.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/Postcondition.java
@@ -61,7 +61,7 @@ import org.mavai.punit.api.criterion.ValueMatcher;
  *
  * @param <T> the type the postcondition evaluates
  */
-// javai-ref: JVI-K90P6S1 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-K90P6S1 — do not remove (resolves in mavai-orchestrator)
 public sealed interface Postcondition<T> permits Postcondition.Leaf, Postcondition.Matching {
 
     /** Human-readable description; non-blank. */

--- a/punit-core/src/main/java/org/mavai/punit/api/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/ProbabilisticTest.java
@@ -49,6 +49,6 @@ import org.junit.jupiter.api.Test;
 @Tag("punit")
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-// javai-ref: JVI-DKY6R8R — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-DKY6R8R — do not remove (resolves in mavai-orchestrator)
 public @interface ProbabilisticTest {
 }

--- a/punit-core/src/main/java/org/mavai/punit/api/Sampling.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/Sampling.java
@@ -94,8 +94,8 @@ import org.mavai.punit.api.spec.ExceptionPolicy;
  *       failure-retention. The 20% case.</li>
  * </ul>
  */
-// javai-ref: JVI-QRV7SYX — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-WXK2ZQP — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-QRV7SYX — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-WXK2ZQP — do not remove (resolves in mavai-orchestrator)
 public final class Sampling<FT, IT, OT> {
 
     private final Function<FT, ServiceContract<FT, IT, OT>> serviceContractFactory;

--- a/punit-core/src/main/java/org/mavai/punit/api/ServiceContract.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/ServiceContract.java
@@ -43,7 +43,7 @@ import org.mavai.punit.api.covariate.Covariate;
  * @param <IT> the per-sample input type
  * @param <OT> the per-sample output value type
  */
-// javai-ref: JVI-SMQ2S1R — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-SMQ2S1R — do not remove (resolves in mavai-orchestrator)
 public interface ServiceContract<FT, IT, OT> extends Contract<IT, OT> {
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/ServiceContractAttributes.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/ServiceContractAttributes.java
@@ -11,7 +11,7 @@ package org.mavai.punit.api;
  * @param warmup number of warmup invocations to discard before counting (0 = no warmup)
  * @param maxConcurrent maximum concurrent sample executions (0 = framework default)
  */
-// javai-ref: JVI-FX47WDW — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-FX47WDW — do not remove (resolves in mavai-orchestrator)
 public record ServiceContractAttributes(int warmup, int maxConcurrent) {
 
     /** Default attributes (no warmup, no concurrency override). */

--- a/punit-core/src/main/java/org/mavai/punit/api/TestIntent.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/TestIntent.java
@@ -36,8 +36,8 @@ package org.mavai.punit.api;
  *
  * @see ProbabilisticTest#intent()
  */
-// javai-ref: JVI-Q3H5YYY — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-WKHRGXJ — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-Q3H5YYY — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-WKHRGXJ — do not remove (resolves in mavai-orchestrator)
 public enum TestIntent {
     /**
      * Evidential intent. Use this when the test is expected to support a confidence-backed

--- a/punit-core/src/main/java/org/mavai/punit/api/ThresholdOrigin.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/ThresholdOrigin.java
@@ -40,7 +40,7 @@ package org.mavai.punit.api;
  * @see ProbabilisticTest#thresholdOrigin()
  * @see ProbabilisticTest#contractRef()
  */
-// javai-ref: JVI-J8G7TKM — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-J8G7TKM — do not remove (resolves in mavai-orchestrator)
 public enum ThresholdOrigin {
 
 	SLA(true, "Externally agreed normative target (contract/SLA)."),

--- a/punit-core/src/main/java/org/mavai/punit/api/TokenChargeRecorder.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/TokenChargeRecorder.java
@@ -34,7 +34,7 @@ package org.mavai.punit.api;
  * @see ProbabilisticTest#tokenBudget()
  * @see ProbabilisticTest#tokenCharge()
  */
-// javai-ref: JVI-76VA511 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-76VA511 — do not remove (resolves in mavai-orchestrator)
 public interface TokenChargeRecorder {
     
     /**

--- a/punit-core/src/main/java/org/mavai/punit/api/covariate/Covariate.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/covariate/Covariate.java
@@ -50,7 +50,7 @@ import java.util.Set;
  * exhaustiveness at compile time. Adding a sixth variant requires
  * extending the framework — user code cannot.
  */
-// javai-ref: JVI-44AD1Q8 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-44AD1Q8 — do not remove (resolves in mavai-orchestrator)
 public sealed interface Covariate
         permits DayOfWeekCovariate,
                 TimeOfDayCovariate,

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
@@ -58,7 +58,7 @@ import org.mavai.punit.api.PostconditionCheck;
  *
  * @param <O> the contract's per-sample output value type
  */
-// javai-ref: JVI-JGG2K8= — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-JGG2K8= — do not remove (resolves in mavai-orchestrator)
 public final class CriterionDecl<O> implements Decl<O> {
 
     private final CriterionPosture posture;

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionPosture.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionPosture.java
@@ -46,11 +46,11 @@ import org.mavai.punit.api.ThresholdOrigin;
  * <p>An instance is immutable; the static factory methods produce
  * the four kinds.
  */
-// javai-ref: JVI-0NGDRGR — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-0FVFYBM — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-5YJVXGF — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-6789AKT — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-THPVKXD — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-0NGDRGR — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-0FVFYBM — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-5YJVXGF — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-6789AKT — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-THPVKXD — do not remove (resolves in mavai-orchestrator)
 public final class CriterionPosture {
 
     /** Posture kinds. */

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/LatencyCriterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/LatencyCriterion.java
@@ -43,8 +43,8 @@ import org.mavai.punit.api.ThresholdOrigin;
  * authored at the call site. Authors who want a project-specific
  * label put it in {@link #contractRef(ThresholdOrigin, String)}.
  */
-// javai-ref: JVI-MPAYH0Q — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-QVNG2SX — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-MPAYH0Q — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-QVNG2SX — do not remove (resolves in mavai-orchestrator)
 public final class LatencyCriterion {
 
     /** The fixed id under which a present latency criterion appears in {@code effectiveCriteria()}. */

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/MatchingDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/MatchingDecl.java
@@ -31,7 +31,7 @@ import org.mavai.punit.api.Postcondition;
  *
  * @param <O> the contract's per-sample output value type
  */
-// javai-ref: JVI-3P2SEQ4 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-3P2SEQ4 — do not remove (resolves in mavai-orchestrator)
 public final class MatchingDecl<O> implements Decl<O> {
 
     private final CriterionPosture posture;

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/NamedPostcondition.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/NamedPostcondition.java
@@ -16,7 +16,7 @@ import org.mavai.punit.api.PostconditionCheck;
  *
  * @param <O> the value type the check evaluates against
  */
-// javai-ref: JVI-BD4F1AB — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-BD4F1AB — do not remove (resolves in mavai-orchestrator)
 public record NamedPostcondition<O>(
         String name,
         PostconditionCheck<O> check

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingDecl.java
@@ -33,7 +33,7 @@ import org.mavai.punit.api.PostconditionCheck;
  * @param <T> the transformed value type the postconditions evaluate
  *            against
  */
-// javai-ref: JVI-Q8BDYMS — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-Q8BDYMS — do not remove (resolves in mavai-orchestrator)
 public final class TransformingDecl<O, T> implements Decl<O> {
 
     private final CriterionPosture posture;

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/Experiment.java
@@ -341,7 +341,7 @@ public final class Experiment implements Spec {
         }
     }
 
-    // javai-ref: JVI-315MNJX — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-315MNJX — do not remove (resolves in mavai-orchestrator)
     public static final class MeasureBuilder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -460,7 +460,7 @@ public final class Experiment implements Spec {
         }
     }
 
-    // javai-ref: JVI-HGF78G* — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-HGF78G* — do not remove (resolves in mavai-orchestrator)
     public static final class ExploreBuilder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -642,7 +642,7 @@ public final class Experiment implements Spec {
         }
     }
 
-    // javai-ref: JVI-PS5XC2C — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-PS5XC2C — do not remove (resolves in mavai-orchestrator)
     public static final class OptimizeBuilder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -797,7 +797,7 @@ public final class Experiment implements Spec {
         }
     }
 
-    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-SVDWG0G — do not remove (resolves in mavai-orchestrator)
     public static final class InlineMeasureBuilder<FT, IT, OT> {
 
         private final InlineSamplingState<FT, IT, OT> sampling;
@@ -891,7 +891,7 @@ public final class Experiment implements Spec {
         }
     }
 
-    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-SVDWG0G — do not remove (resolves in mavai-orchestrator)
     public static final class InlineExploreBuilder<FT, IT, OT> {
 
         private final InlineSamplingState<FT, IT, OT> sampling;
@@ -986,7 +986,7 @@ public final class Experiment implements Spec {
         }
     }
 
-    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-SVDWG0G — do not remove (resolves in mavai-orchestrator)
     public static final class InlineOptimizeBuilder<FT, IT, OT> {
 
         private final InlineSamplingState<FT, IT, OT> sampling;

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/PerCriterionVerdicts.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/PerCriterionVerdicts.java
@@ -42,7 +42,7 @@ import java.util.Optional;
  *       per-criterion verdicts.</li>
  * </ul>
  */
-// javai-ref: JVI-ZCSHQ5K — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-ZCSHQ5K — do not remove (resolves in mavai-orchestrator)
 public final class PerCriterionVerdicts {
 
     private PerCriterionVerdicts() {}

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTest.java
@@ -464,7 +464,7 @@ public final class ProbabilisticTest implements Spec {
 
     // ── Builder ──────────────────────────────────────────────────────
 
-    // javai-ref: JVI-QRV7SYX — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-QRV7SYX — do not remove (resolves in mavai-orchestrator)
     public static final class Builder<FT, IT, OT> {
 
         private final Sampling<FT, IT, OT> sampling;
@@ -582,7 +582,7 @@ public final class ProbabilisticTest implements Spec {
      * {@link #build()} time. Rejects empirical criteria at build time
      * with a diagnostic teaching the helper-extraction pattern.
      */
-    // javai-ref: JVI-QRV7SYX — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-QRV7SYX — do not remove (resolves in mavai-orchestrator)
     public static final class InlineBuilder<FT, IT, OT> {
 
         private final Function<FT, ServiceContract<FT, IT, OT>> serviceContractFactory;

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/ResourceControls.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/ResourceControls.java
@@ -35,10 +35,10 @@ import java.util.OptionalLong;
  *                       {@code ServiceContract.apply}; default ABORT_TEST
  * @param maxExampleFailures cap on retained failure detail; default 10
  */
-// javai-ref: JVI-9M5SBQZ — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-N0WK25H — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-W6A4WRA — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-T60D7VU — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-9M5SBQZ — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-N0WK25H — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-W6A4WRA — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-T60D7VU — do not remove (resolves in mavai-orchestrator)
 public record ResourceControls(
         Optional<Duration> timeBudget,
         OptionalLong tokenBudget,

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
@@ -328,8 +328,8 @@ public final class Engine {
          * same sample — it takes precedence over a (necessarily
          * stale) success-guaranteed reading.
          */
-        // javai-ref: JVI-BQTS77W — do not remove (resolves in javai-orchestrator)
-        // javai-ref: JVI-GZFMZXV — do not remove (resolves in javai-orchestrator)
+        // mavai-ref: JVI-BQTS77W — do not remove (resolves in mavai-orchestrator)
+        // mavai-ref: JVI-GZFMZXV — do not remove (resolves in mavai-orchestrator)
         private void checkStatisticalEarlyTermination() {
             if (earlyTermination.isEmpty()) {
                 return;

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineIntegrity.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineIntegrity.java
@@ -41,7 +41,7 @@ import org.mavai.punit.internal.util.HashUtils;
  * to (but excluding) the matched line — which is what the writer
  * hashes when it builds the file.
  */
-// javai-ref: JVI-CNDHE1$ — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-CNDHE1$ — do not remove (resolves in mavai-orchestrator)
 final class BaselineIntegrity {
 
     private BaselineIntegrity() { }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineSelector.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineSelector.java
@@ -55,7 +55,7 @@ import org.mavai.punit.api.covariate.CovariateProfile;
  * declared covariates; the candidate file alone (which only carries
  * key/value pairs in the {@code covariates:} block) is not enough.
  */
-// javai-ref: JVI-YN3BJ6U — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-YN3BJ6U — do not remove (resolves in mavai-orchestrator)
 final class BaselineSelector {
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/CovariateHashing.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/CovariateHashing.java
@@ -41,7 +41,7 @@ import org.mavai.punit.internal.util.HashUtils;
  * preserves that order through resolution and round-trip, so the
  * implementation here just iterates the profile's value map.
  */
-// javai-ref: JVI-07HPCY* — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-07HPCY* — do not remove (resolves in mavai-orchestrator)
 final class CovariateHashing {
 
     static final int HASH_LENGTH = 4;

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/budget/DefaultTokenChargeRecorder.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/budget/DefaultTokenChargeRecorder.java
@@ -15,7 +15,7 @@ import org.mavai.punit.api.TokenChargeRecorder;
  * 
  * <p>Not thread-safe - intended for use within a single test execution thread.
  */
-// javai-ref: JVI-76VA511 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-76VA511 — do not remove (resolves in mavai-orchestrator)
 public class DefaultTokenChargeRecorder implements TokenChargeRecorder {
 
     private final long tokenBudget;

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/covariate/CovariateResolver.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/covariate/CovariateResolver.java
@@ -64,7 +64,7 @@ import org.mavai.punit.api.covariate.TimezoneCovariate;
  * mid-run (the clock advances, the system property could mutate),
  * defeating the purpose of recording a snapshot.
  */
-// javai-ref: JVI-GYHECWN — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-GYHECWN — do not remove (resolves in mavai-orchestrator)
 public final class CovariateResolver {
 
     static final String REGION_PROPERTY = "punit.region";

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/Feasibility.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/Feasibility.java
@@ -65,7 +65,7 @@ import org.mavai.punit.statistics.VerificationFeasibilityEvaluator.FeasibilityRe
  * orchestrates. Diagnostic prose comes from
  * {@link InfeasibilityMessageRenderer}.
  */
-// javai-ref: JVI-RDWGWVV — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-RDWGWVV — do not remove (resolves in mavai-orchestrator)
 public final class Feasibility {
 
     private Feasibility() { }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
@@ -66,7 +66,7 @@ import org.mavai.punit.statistics.ThresholdDeriver;
  * dependencies. The {@link Criterion} interface itself stays in
  * {@code api package}; only this implementation moved.
  */
-// javai-ref: JVI-C5P3EQE — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-C5P3EQE — do not remove (resolves in mavai-orchestrator)
 public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateStatistics> {
 
     private static final String NAME = "bernoulli-pass-rate";
@@ -260,8 +260,8 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
     }
 
     @Override
-    // javai-ref: JVI-BQTS77W — do not remove (resolves in javai-orchestrator)
-    // javai-ref: JVI-GZFMZXV — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-BQTS77W — do not remove (resolves in mavai-orchestrator)
+    // mavai-ref: JVI-GZFMZXV — do not remove (resolves in mavai-orchestrator)
     public OptionalDouble earlyTerminationPassRate() {
         return contractualTarget();
     }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/ResultProjections.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/ResultProjections.java
@@ -36,7 +36,7 @@ import org.mavai.punit.api.spec.Trial;
  * so the anchor line matches across the two files and acts as a
  * synchronisation point for the diff tool.
  */
-// javai-ref: JVI-G0R8DT$ — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-G0R8DT$ — do not remove (resolves in mavai-orchestrator)
 public final class ResultProjections {
 
     private ResultProjections() { }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -38,7 +38,7 @@ import org.yaml.snakeyaml.Yaml;
  * the filename — so consumers identify configurations from the
  * document body, never by parsing filenames.
  */
-// javai-ref: JVI-8CHB31R — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-8CHB31R — do not remove (resolves in mavai-orchestrator)
 public final class ExploreOutputWriter {
 
     /** Schema-version value carried in every emitted file. */

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
@@ -34,7 +34,7 @@ import org.yaml.snakeyaml.Yaml;
  * {@code {serviceContractId}/{experimentId}.yaml} — assembled by the
  * emitter, not the writer.
  */
-// javai-ref: JVI-FJK9SN9 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-FJK9SN9 — do not remove (resolves in mavai-orchestrator)
 public final class OptimizeOutputWriter {
 
     /** Schema-version value carried in every emitted file. */

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/spec/expiration/ExpirationEvaluator.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/spec/expiration/ExpirationEvaluator.java
@@ -11,7 +11,7 @@ import org.mavai.punit.internal.engine.spec.model.ExecutionSpecification;
  * <p>Provides convenient methods to evaluate expiration at the current time
  * or at a specified instant.
  */
-// javai-ref: JVI-09GQGN$ — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-09GQGN$ — do not remove (resolves in mavai-orchestrator)
 public final class ExpirationEvaluator {
 
     private ExpirationEvaluator() {

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/ConsoleVerdictSink.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/ConsoleVerdictSink.java
@@ -19,7 +19,7 @@ import org.mavai.punit.verdict.VerdictSink;
  * <p>Output uses the standard PUnit framing (header/footer dividers) and
  * label-value alignment provided by {@link PUnitReporter}.
  */
-// javai-ref: JVI-ZVX9J8V — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-ZVX9J8V — do not remove (resolves in mavai-orchestrator)
 public final class ConsoleVerdictSink implements VerdictSink {
 
     private final PrintStream out;

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/TransparentStatsRenderer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/TransparentStatsRenderer.java
@@ -61,7 +61,7 @@ import org.mavai.punit.api.spec.Verdict;
  * <p>Output is plain text — readable in IDE test consoles,
  * surefire reports, and CI logs without further processing.
  */
-// javai-ref: JVI-G3NPRSS — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-G3NPRSS — do not remove (resolves in mavai-orchestrator)
 public final class TransparentStatsRenderer {
 
     private static final String LABEL_INDENT = "      ";

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/VerdictTextRenderer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/VerdictTextRenderer.java
@@ -40,7 +40,7 @@ import org.mavai.punit.verdict.ProbabilisticTestVerdict.Termination;
  *   <li>{@link #renderForReporter} — verbose box-drawn output for transparent stats console</li>
  * </ul>
  */
-// javai-ref: JVI-ZVX9J8V — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-ZVX9J8V — do not remove (resolves in mavai-orchestrator)
 public final class VerdictTextRenderer {
 
     private static final int LINE_WIDTH = 78;

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
@@ -72,7 +72,7 @@ import org.mavai.punit.statistics.StatisticalDefaults;
  *   <li>{@code generatedAt} — {@code Instant.now()}</li>
  * </ul>
  */
-// javai-ref: JVI-EC8CPT3 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-EC8CPT3 — do not remove (resolves in mavai-orchestrator)
 public final class BaselineEmitter {
 
     private BaselineEmitter() { }

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/ExploreEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/ExploreEmitter.java
@@ -38,7 +38,7 @@ import org.mavai.punit.internal.engine.explore.ExploreOutputWriter;
  * overload; both share the same per-configuration logic so tests
  * exercise the same path production code drives.
  */
-// javai-ref: JVI-8CHB31R — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-8CHB31R — do not remove (resolves in mavai-orchestrator)
 public final class ExploreEmitter {
 
     private ExploreEmitter() { }

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/OptimizeEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/OptimizeEmitter.java
@@ -43,7 +43,7 @@ import org.mavai.punit.internal.engine.optimize.OptimizeOutputWriter;
  * <p>The Path overload is a thin wrapper around the BiConsumer
  * overload; both share the same artefact-assembly logic.
  */
-// javai-ref: JVI-FJK9SN9 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-FJK9SN9 — do not remove (resolves in mavai-orchestrator)
 public final class OptimizeEmitter {
 
     private OptimizeEmitter() { }

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -104,7 +104,7 @@ public final class PUnit {
     // ── Sampling-bound factories ────────────────────────────────────
 
     /** Compose a contractual probabilistic test against a shared sampling. */
-    // javai-ref: JVI-SVDWG0G — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-SVDWG0G — do not remove (resolves in mavai-orchestrator)
     public static <FT, IT, OT> TestBuilder<FT, IT, OT> testing(
             Sampling<FT, IT, OT> sampling, FT factors) {
         return new TestBuilder<>(
@@ -459,7 +459,7 @@ public final class PUnit {
     // ── Wrapper builders ────────────────────────────────────────────
 
     /** Wrapper around {@link Experiment.MeasureBuilder} adding {@link #run}. */
-    // javai-ref: JVI-315MNJX — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-315MNJX — do not remove (resolves in mavai-orchestrator)
     public static final class MeasureBuilder<FT, IT, OT> {
         private final Experiment.MeasureBuilder<FT, IT, OT> delegate;
 
@@ -648,7 +648,7 @@ public final class PUnit {
     }
 
     /** Wrapper around {@link Experiment.ExploreBuilder} adding {@link #run}. */
-    // javai-ref: JVI-HGF78G* — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-HGF78G* — do not remove (resolves in mavai-orchestrator)
     public static final class ExploreBuilder<FT, IT, OT> {
         private final Experiment.ExploreBuilder<FT, IT, OT> delegate;
 
@@ -682,7 +682,7 @@ public final class PUnit {
     }
 
     /** Wrapper around {@link Experiment.OptimizeBuilder} adding {@link #run}. */
-    // javai-ref: JVI-PS5XC2C — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-PS5XC2C — do not remove (resolves in mavai-orchestrator)
     public static final class OptimizeBuilder<FT, IT, OT> {
         private final Experiment.OptimizeBuilder<FT, IT, OT> delegate;
 

--- a/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
@@ -77,7 +77,7 @@ public class BinomialProportionEstimator {
      * @param confidenceLevel Confidence level (1-α), e.g., 0.95 for 95% CI
      * @return Proportion estimate with Wilson score confidence interval
      */
-    // javai-ref: JVI-58DBYP~ — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-58DBYP~ — do not remove (resolves in mavai-orchestrator)
     public ProportionEstimate estimate(int successes, int trials, double confidenceLevel) {
         validateInputs(successes, trials);
         validateConfidenceLevel(confidenceLevel);
@@ -116,8 +116,8 @@ public class BinomialProportionEstimator {
      * @param confidenceLevel Confidence level (1-α), e.g., 0.95 for 95% lower bound
      * @return One-sided lower confidence bound for p
      */
-    // javai-ref: JVI-MNVWS4U — do not remove (resolves in javai-orchestrator)
-    // javai-ref: JVI-TX478RT — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-MNVWS4U — do not remove (resolves in mavai-orchestrator)
+    // mavai-ref: JVI-TX478RT — do not remove (resolves in mavai-orchestrator)
     public double lowerBound(int successes, int trials, double confidenceLevel) {
         validateInputs(successes, trials);
         double pHat = (double) successes / trials;

--- a/punit-core/src/main/java/org/mavai/punit/statistics/LatencyStatistics.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/LatencyStatistics.java
@@ -35,7 +35,7 @@ public final class LatencyStatistics {
      * @param p the percentile level in (0, 1]
      * @return the percentile value
      */
-    // javai-ref: JVI-CHSD1WP — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-CHSD1WP — do not remove (resolves in mavai-orchestrator)
     public static double nearestRankPercentile(double[] latencies, double p) {
         Objects.requireNonNull(latencies, "latencies must not be null");
         if (latencies.length == 0) {

--- a/punit-core/src/main/java/org/mavai/punit/statistics/LatencyThresholdDeriver.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/LatencyThresholdDeriver.java
@@ -35,7 +35,7 @@ import org.apache.commons.statistics.distribution.BinomialDistribution;
  * <p>This construction is non-parametric, distribution-free, and exact for any
  * continuous underlying latency distribution.
  */
-// javai-ref: JVI-QVNG2SX — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-QVNG2SX — do not remove (resolves in mavai-orchestrator)
 public final class LatencyThresholdDeriver {
 
     private LatencyThresholdDeriver() {}

--- a/punit-core/src/main/java/org/mavai/punit/statistics/NormativeJudgementEvaluator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/NormativeJudgementEvaluator.java
@@ -36,7 +36,7 @@ package org.mavai.punit.statistics;
  * word it as a relation to the stipulation, never as a claim about
  * the service's validity.
  */
-// javai-ref: JVI-305FCX1 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-305FCX1 — do not remove (resolves in mavai-orchestrator)
 public final class NormativeJudgementEvaluator {
 
     private static final BinomialProportionEstimator ESTIMATOR =

--- a/punit-core/src/main/java/org/mavai/punit/statistics/SampleSizeCalculator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/SampleSizeCalculator.java
@@ -72,8 +72,8 @@ public class SampleSizeCalculator {
      * @param power The desired statistical power (1-β)
      * @return Sample size requirement with full context
      */
-    // javai-ref: JVI-2FYNHXX — do not remove (resolves in javai-orchestrator)
-    // javai-ref: JVI-EGMJ0MU — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-2FYNHXX — do not remove (resolves in mavai-orchestrator)
+    // mavai-ref: JVI-EGMJ0MU — do not remove (resolves in mavai-orchestrator)
     public SampleSizeRequirement calculateForPower(
             double baselineRate,
             double minDetectableEffect,

--- a/punit-core/src/main/java/org/mavai/punit/statistics/TestVerdictEvaluator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/TestVerdictEvaluator.java
@@ -45,7 +45,7 @@ public class TestVerdictEvaluator {
      * @param threshold The derived threshold against which to compare
      * @return Verdict with full statistical context
      */
-    // javai-ref: JVI-T08PKZ6 — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-T08PKZ6 — do not remove (resolves in mavai-orchestrator)
     public VerdictWithConfidence evaluate(int testSuccesses, int testSamples, DerivedThreshold threshold) {
         validateInputs(testSuccesses, testSamples, threshold);
 

--- a/punit-core/src/main/java/org/mavai/punit/statistics/ThresholdDeriver.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/ThresholdDeriver.java
@@ -70,7 +70,7 @@ public class ThresholdDeriver {
      * @param thresholdConfidence Desired confidence level (1-α)
      * @return Derived threshold with full context
      */
-    // javai-ref: JVI-9HJ92BC — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-9HJ92BC — do not remove (resolves in mavai-orchestrator)
     public DerivedThreshold deriveSampleSizeFirst(
             int baselineSamples,
             int baselineSuccesses,
@@ -145,7 +145,7 @@ public class ThresholdDeriver {
      * @param explicitThreshold The explicitly specified threshold
      * @return Derived threshold with implied confidence and soundness flag
      */
-    // javai-ref: JVI-HHV7KT0 — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-HHV7KT0 — do not remove (resolves in mavai-orchestrator)
     public DerivedThreshold deriveThresholdFirst(
             int baselineSamples,
             int baselineSuccesses,

--- a/punit-core/src/main/java/org/mavai/punit/statistics/VerificationFeasibilityEvaluator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/VerificationFeasibilityEvaluator.java
@@ -77,7 +77,7 @@ public final class VerificationFeasibilityEvaluator {
      * @return the feasibility result including minimum required samples
      * @throws IllegalArgumentException if any parameter is out of range
      */
-    // javai-ref: JVI-M5YQ6RB — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-M5YQ6RB — do not remove (resolves in mavai-orchestrator)
     public static FeasibilityResult evaluate(int samples, double target, double confidence) {
         if (samples <= 0) {
             throw new IllegalArgumentException("samples must be > 0, got: " + samples);

--- a/punit-core/src/main/java/org/mavai/punit/verdict/CriterionRow.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/CriterionRow.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  *                      no threshold was resolved (e.g. the run gated
  *                      INCONCLUSIVE before threshold derivation)
  */
-// javai-ref: JVI-8E4WNW5 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-8E4WNW5 — do not remove (resolves in mavai-orchestrator)
 public record CriterionRow(
         String criterionId,
         org.mavai.punit.api.spec.Verdict verdict,

--- a/punit-core/src/main/java/org/mavai/punit/verdict/ExpirationPolicy.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/ExpirationPolicy.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  *
  * @see ExpirationStatus
  */
-// javai-ref: JVI-09GQGN$ — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-09GQGN$ — do not remove (resolves in mavai-orchestrator)
 public record ExpirationPolicy(
     int expiresInDays,
     Instant baselineEndTime

--- a/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdict.java
@@ -24,8 +24,8 @@ import org.mavai.punit.api.ServiceContractAttributes;
  * <p>All rendering paths (text logs, XML report, HTML report) consume this model.
  * No rendering target has access to information that another lacks.
  */
-// javai-ref: JVI-60WEAWK — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-NSB1JPC — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-60WEAWK — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-NSB1JPC — do not remove (resolves in mavai-orchestrator)
 public record ProbabilisticTestVerdict(
         String correlationId,
         Instant timestamp,

--- a/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/SizingDisclosure.java
@@ -29,7 +29,7 @@ import org.mavai.punit.statistics.StatisticalDefaults;
  * rate, target power, computed sample size) that a risk-driven authoring
  * surface will declare: those entries extend this disclosure additively.
  */
-// javai-ref: JVI-RX30FM8 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-RX30FM8 — do not remove (resolves in mavai-orchestrator)
 final class SizingDisclosure {
 
     static final String APPROACH_KEY = "sizing-approach";

--- a/punit-core/src/main/java/org/mavai/punit/verdict/VerdictSink.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/VerdictSink.java
@@ -10,7 +10,7 @@ package org.mavai.punit.verdict;
  * <p>Implementations must be thread-safe if used from concurrent test execution.
  */
 @FunctionalInterface
-// javai-ref: JVI-C8AT3DD — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-C8AT3DD — do not remove (resolves in mavai-orchestrator)
 public interface VerdictSink {
 
     /**

--- a/punit-core/src/test/java/org/mavai/punit/api/FactorValueTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/api/FactorValueTest.java
@@ -91,9 +91,9 @@ class FactorValueTest {
     @Test
     @DisplayName("lifts URI to canonical string form")
     void lifts_uris() {
-        FactorValue v = FactorValue.of(URI.create("https://javai.org/x"));
+        FactorValue v = FactorValue.of(URI.create("https://mavai.org/x"));
         assertThat(v).isInstanceOf(UriValue.class);
-        assertThat(v.canonical()).isEqualTo("\"https://javai.org/x\"");
+        assertThat(v.canonical()).isEqualTo("\"https://mavai.org/x\"");
     }
 
     @Test

--- a/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/HtmlReportWriter.java
@@ -28,7 +28,7 @@ import org.mavai.punit.internal.reporting.VerdictTextRenderer;
  * Test results are grouped by use-case-id (or class name when absent) and presented
  * in an expandable table using HTML5 {@code <details>}/{@code <summary>} elements.
  */
-// javai-ref: JVI-PNR8C3F — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-PNR8C3F — do not remove (resolves in mavai-orchestrator)
 final class HtmlReportWriter {
 
     private static final DateTimeFormatter TIMESTAMP_FORMAT =

--- a/punit-report/src/main/java/org/mavai/punit/report/ReportGenerator.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/ReportGenerator.java
@@ -17,7 +17,7 @@ import org.mavai.punit.verdict.ProbabilisticTestVerdict;
  * {@link ProbabilisticTestVerdict} instances, and writes a standalone
  * HTML report.
  */
-// javai-ref: JVI-PNR8C3F — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-PNR8C3F — do not remove (resolves in mavai-orchestrator)
 public final class ReportGenerator {
 
     private final VerdictXmlReader reader = new VerdictXmlReader();

--- a/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlReader.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlReader.java
@@ -32,7 +32,7 @@ import org.w3c.dom.NodeList;
  *
  * <p>Uses DOM parsing since individual verdict files are small.
  */
-// javai-ref: JVI-DQWKY4Z — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-DQWKY4Z — do not remove (resolves in mavai-orchestrator)
 public final class VerdictXmlReader {
 
     private static final DocumentBuilderFactory FACTORY = DocumentBuilderFactory.newInstance();

--- a/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlWriter.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlWriter.java
@@ -26,8 +26,8 @@ import org.mavai.punit.verdict.ProbabilisticTestVerdict.*;
  * remains unchanged — this class maps from the punit record to the
  * cross-project XML format.
  */
-// javai-ref: JVI-6506GYF — do not remove (resolves in javai-orchestrator)
-// javai-ref: JVI-DQWKY4Z — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-6506GYF — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-DQWKY4Z — do not remove (resolves in mavai-orchestrator)
 public final class VerdictXmlWriter {
 
     /**

--- a/punit-report/src/main/java/org/mavai/punit/report/explore/ReportGenerator.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/explore/ReportGenerator.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * already in the YAML; it computes no statistics the exploration producer
  * did not.
  */
-// javai-ref: JVI-ZFQ8WNQ — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-ZFQ8WNQ — do not remove (resolves in mavai-orchestrator)
 public final class ReportGenerator {
 
     private final YamlReader reader = new YamlReader();

--- a/punit-report/src/main/java/org/mavai/punit/report/optimize/ReportGenerator.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/optimize/ReportGenerator.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
  * already in the YAML; it computes no statistics the optimize producer did
  * not.
  */
-// javai-ref: JVI-5PPSMV$ — do not remove (resolves in mavai-orchestrator)
+// mavai-ref: JVI-5PPSMV$ — do not remove (resolves in mavai-orchestrator)
 public final class ReportGenerator {
 
     private final YamlReader reader = new YamlReader();

--- a/punit-sentinel/src/main/java/org/mavai/punit/sentinel/EnvironmentMetadata.java
+++ b/punit-sentinel/src/main/java/org/mavai/punit/sentinel/EnvironmentMetadata.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * @param environmentId identifies the environment, e.g., "prod", "staging", "us-east-1"
  * @param instanceId identifies the instance, e.g., hostname or pod name
  */
-// javai-ref: JVI-R7NTQ6~ — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-R7NTQ6~ — do not remove (resolves in mavai-orchestrator)
 public record EnvironmentMetadata(
         String environmentId,
         String instanceId

--- a/punit-sentinel/src/main/java/org/mavai/punit/sentinel/SentinelExecutor.java
+++ b/punit-sentinel/src/main/java/org/mavai/punit/sentinel/SentinelExecutor.java
@@ -42,7 +42,7 @@ import org.opentest4j.TestAbortedException;
  * across calls; orchestration over a registry of classes lives in
  * {@link SentinelOrchestrator}.
  */
-// javai-ref: JVI-C4CJAN~ — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-C4CJAN~ — do not remove (resolves in mavai-orchestrator)
 public class SentinelExecutor {
 
     /**

--- a/punit-sentinel/src/main/java/org/mavai/punit/sentinel/SentinelMain.java
+++ b/punit-sentinel/src/main/java/org/mavai/punit/sentinel/SentinelMain.java
@@ -66,9 +66,9 @@ public class SentinelMain {
         this.system = system;
     }
 
-    // javai-ref: JVI-PYF4FP9 — do not remove (resolves in javai-orchestrator)
-    // javai-ref: JVI-P37E1Y2 — do not remove (resolves in javai-orchestrator)
-    // javai-ref: JVI-D0BEKXM — do not remove (resolves in javai-orchestrator)
+    // mavai-ref: JVI-PYF4FP9 — do not remove (resolves in mavai-orchestrator)
+    // mavai-ref: JVI-P37E1Y2 — do not remove (resolves in mavai-orchestrator)
+    // mavai-ref: JVI-D0BEKXM — do not remove (resolves in mavai-orchestrator)
     public static void main(String[] args) {
         new SentinelMain(args, new RealSystemBridge()).run();
     }

--- a/punit-sentinel/src/main/java/org/mavai/punit/sentinel/SentinelOrchestrator.java
+++ b/punit-sentinel/src/main/java/org/mavai/punit/sentinel/SentinelOrchestrator.java
@@ -29,7 +29,7 @@ import org.mavai.punit.api.ProbabilisticTest;
  * aren't run twice when a subclass is also registered. If inheritance
  * becomes a real authoring pattern, this is the place to extend.
  */
-// javai-ref: JVI-0PYEB09 — do not remove (resolves in javai-orchestrator)
+// mavai-ref: JVI-0PYEB09 — do not remove (resolves in mavai-orchestrator)
 public final class SentinelOrchestrator {
 
     private final SentinelExecutor executor;


### PR DESCRIPTION
Part of the family-wide **`DIR-FAM-XREF-anchor-token-rename`**.

Renames the opaque cross-reference anchor token `javai-ref:` → `mavai-ref:` at every embedded site in this repo, plus a few stale live javai references — a .gitignore comment, a user-guide phrase, two test-fixture URIs. This is the last live `javai` string in engineering source — the family rename (`DIR-JAVAI-MAVAI-MIGRATION-family`) deliberately deferred the anchor token because the anchor is opaque and meant to survive renames.

**Behaviour-preserving:** the token lives only in comments (and one test string), so nothing compiled or emitted changes.

**Lockstep:** the orchestrator's `anchors.py` `TOKEN` constant moves in the same set of changes. The token and its embeddings must land together or the registry integrity check (`anchors.py check`) goes red on a committed state — it currently reports the same 211 sites / 109 anchors / 0 errors after the rename. **Merge alongside the sibling rename PRs and the orchestrator change.**

The `JVI-` id prefix is unchanged (opaque, does not contain `javai`); `CHANGELOG.md` history is untouched (accurate record of past `org.javai` releases).

Refs `DIR-FAM-XREF-anchor-token-rename`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)