### PR TITLE
Adopt json-schema-validator 3.x in the interchange conformance test

### DIFF
--- a/punit-core/build.gradle.kts
+++ b/punit-core/build.gradle.kts
@@ -78,7 +78,11 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.22.1")
     // JSON Schema validation (draft 2020-12) for the interchange
     // emitter conformance tests — test-only, never shipped.
-    testImplementation("com.networknt:json-schema-validator:1.5.6")
+    testImplementation("com.networknt:json-schema-validator:3.0.6")
+    // networknt 3.x validates against Jackson 3 (the tools.jackson line),
+    // distinct from the com.fasterxml Jackson 2 the statistics conformance
+    // tests use above; both are test-only and coexist on the test classpath.
+    testImplementation("tools.jackson.core:jackson-databind:3.1.4")
     testImplementation("org.apache.logging.log4j:log4j-core:2.26.1")
     testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:2.26.1")
     // punit-report provides the default VerdictSink (XML) via ServiceLoader;

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
@@ -8,15 +8,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
 import org.mavai.outcome.Outcome;
 import org.mavai.punit.api.Sampling;
 import org.mavai.punit.api.ServiceContract;
@@ -33,6 +30,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Emitter conformance against the mavai family's canonical
@@ -403,18 +402,18 @@ class InterchangeConformanceTest {
 
     /**
      * Validates a parsed YAML document against a vendored interchange
-     * schema; returns the set of violations (empty means conformant).
+     * schema; returns the list of violations (empty means conformant).
      */
-    private static Set<ValidationMessage> validate(String schemaName, Map<String, Object> document) {
-        JsonSchema schema = loadSchema(schemaName);
+    private static List<Error> validate(String schemaName, Map<String, Object> document) {
+        Schema schema = loadSchema(schemaName);
         JsonNode node = MAPPER.valueToTree(document);
         return schema.validate(node);
     }
 
-    private static JsonSchema loadSchema(String schemaName) {
+    private static Schema loadSchema(String schemaName) {
         String resource = "/conformance/interchange/" + schemaName + ".schema.json";
         InputStream in = InterchangeConformanceTest.class.getResourceAsStream(resource);
         assertThat(in).as("vendored schema %s must be on the test classpath", resource).isNotNull();
-        return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(in);
+        return SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12).getSchema(in);
     }
 }


### PR DESCRIPTION
Supersedes the dependabot bump **#237** (`com.networknt:json-schema-validator` 1.5.6 → 3.0.6) by carrying both the version bump and the code migration 3.x requires. Once this merges, #237 is redundant and can be closed.

## Why it's more than a version bump

networknt 3.x is a major API redesign that validates against **Jackson 3** (`tools.jackson`), not the Jackson 2 (`com.fasterxml`) the test used:

| 1.x | 3.x |
|---|---|
| `JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)` | `SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12)` |
| `JsonSchema` | `Schema` |
| `validate()` → `Set<ValidationMessage>` | `validate()` → `List<Error>` |
| `com.fasterxml.jackson` `ObjectMapper`/`JsonNode` | `tools.jackson` `ObjectMapper`/`JsonNode` |

Callers only assert `.isEmpty()`, so they're unchanged.

## Scope / blast radius

- **Test-only.** `json-schema-validator` is a `testImplementation`; no production code, `module-info`, or emitted-artefact bytes change.
- **Jackson 2 stays.** Production and the *statistics* conformance tests still use `com.fasterxml` Jackson 2. Jackson 3 is added as an explicit test dep pinned to networknt's own version (3.1.4). The two majors coexist only on the test classpath.
- networknt 3.x also pulls graaljs/truffle transitively (its ECMA regex option) — test classpath only.

## Verification

`./gradlew build` is green — full suite across all three modules plus the ArchUnit module-dependency, statistics-isolation, and requirement-code-isolation guards. The `InterchangeConformanceTest` schema validations pass against the vendored draft-2020-12 schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)