### PR TITLE
Assert embedded verdict schemas are synced snapshots of the published set

### DIFF
--- a/punit-report/build.gradle.kts
+++ b/punit-report/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.net.HttpURLConnection
+import java.net.URI
+
 plugins {
     id("signing")
     id("com.vanniktech.maven.publish") version "0.37.0"
@@ -17,6 +20,93 @@ dependencies {
     testImplementation("org.xmlunit:xmlunit-core:2.12.0")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.22.1")
 }
+
+// --- published verdict interchange schemas ---------------------------------------
+// The verdict XSDs embedded in this module's resources are vendored snapshots
+// of the published family schemas (mavai-R's `schema/verdict-*.xsd`, shipped
+// in the `interchange-<tag>.zip` release asset), synced per release. This task
+// fetches the latest published set (same latest-release resolution and cache
+// as punit-core's conformance-data fetch) onto the test classpath so the
+// snapshot-sync test can assert the embedded copies are byte-identical to the
+// published ones — a drifted snapshot fails the build instead of shipping.
+
+val publishedInterchangeDir = layout.buildDirectory.dir("generated/interchange")
+
+val fetchPublishedInterchangeSchemas by tasks.registering {
+    description = "Fetches the latest published mavai-R interchange schemas"
+    group = "verification"
+
+    outputs.dir(publishedInterchangeDir)
+    outputs.upToDateWhen { false }
+
+    // Local-directory override: -PinterchangeSchemaDir=/path/to/mavai-R/schema
+    // sources the published schemas from a local checkout instead of the
+    // latest GitHub release (for working against merged-but-untagged content).
+    val interchangeSchemaDirOverride = providers.gradleProperty("interchangeSchemaDir")
+
+    doLast {
+        val destDir = publishedInterchangeDir.get().asFile.resolve("published-interchange")
+        val overrideDir = interchangeSchemaDirOverride.orNull
+        if (overrideDir != null) {
+            val srcDir = file(overrideDir)
+            require(srcDir.isDirectory) {
+                "interchangeSchemaDir does not resolve to a directory: $srcDir"
+            }
+            if (destDir.exists()) destDir.deleteRecursively()
+            destDir.mkdirs()
+            copy {
+                from(srcDir) { include("verdict-*.xsd") }
+                into(destDir)
+            }
+            logger.lifecycle("Using local published interchange schemas: $srcDir")
+            return@doLast
+        }
+        val latestUrl = URI("https://github.com/mavai-org/mavai-R/releases/latest").toURL()
+        val conn = latestUrl.openConnection() as HttpURLConnection
+        conn.instanceFollowRedirects = false
+        conn.requestMethod = "HEAD"
+        val status = conn.responseCode
+        val location = conn.getHeaderField("Location")
+        conn.disconnect()
+        require(status in 301..308 && location != null) {
+            "Expected redirect from $latestUrl, got $status (location=$location)"
+        }
+        val tag = location.substringAfterLast("/tag/")
+        require(tag.matches(Regex("^v\\d+\\.\\d+\\.\\d+$"))) {
+            "Unexpected tag format '$tag' in $location"
+        }
+
+        val cacheZip = layout.buildDirectory
+            .file("interchange-cache/interchange-$tag.zip").get().asFile
+        if (!cacheZip.exists()) {
+            cacheZip.parentFile.mkdirs()
+            val assetUrl = URI(
+                "https://github.com/mavai-org/mavai-R/releases/download/$tag/interchange-$tag.zip"
+            ).toURL()
+            assetUrl.openStream().use { input ->
+                cacheZip.outputStream().use { output -> input.copyTo(output) }
+            }
+        }
+
+        if (destDir.exists()) destDir.deleteRecursively()
+        destDir.mkdirs()
+        copy {
+            from(zipTree(cacheZip)) { include("verdict-*.xsd") }
+            into(destDir)
+        }
+        logger.lifecycle("Fetched published interchange schemas: $tag")
+    }
+}
+
+sourceSets.test {
+    resources.srcDir(publishedInterchangeDir)
+}
+
+tasks.named<ProcessResources>("processTestResources") {
+    dependsOn(fetchPublishedInterchangeSchemas)
+}
+
+// ---------------------------------------------------------------------------------
 
 tasks.jar {
     manifest {

--- a/punit-report/src/test/java/org/mavai/punit/report/VerdictSchemaSnapshotSyncTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/VerdictSchemaSnapshotSyncTest.java
@@ -1,0 +1,64 @@
+package org.mavai.punit.report;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The verdict XML schemas embedded in this module are vendored snapshots of
+ * the published family schemas (mavai-R's {@code schema/verdict-*.xsd},
+ * shipped in the {@code interchange-<tag>.zip} release asset), synced per
+ * release. This test asserts each embedded copy is byte-identical to the
+ * published one the build fetched — so a schema change authored anywhere
+ * but the family's canonical channel, or a missed sync after a release,
+ * fails the build instead of shipping a silently divergent schema.
+ */
+class VerdictSchemaSnapshotSyncTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"verdict-1.0.xsd", "verdict-1.1.xsd", "verdict-1.2.xsd"})
+    @DisplayName("embedded verdict schema is byte-identical to the published family schema")
+    void embeddedSchemaMatchesPublished(String schemaFile) throws IOException {
+        assertArrayEquals(
+                published(schemaFile),
+                embedded(schemaFile),
+                schemaFile
+                        + " differs from the published family schema — the embedded copy is a"
+                        + " vendored snapshot; sync it from the mavai-R release rather than"
+                        + " editing it in place");
+    }
+
+    @Test
+    @DisplayName("the published schema set covers every embedded snapshot")
+    void publishedSetIsPresent() throws IOException {
+        // The fetch task puts the published set on the test classpath; if the
+        // release asset ever stops carrying the XSDs, this fails loudly
+        // rather than the parameterized test silently comparing nothing.
+        for (String schemaFile : new String[] {"verdict-1.0.xsd", "verdict-1.1.xsd", "verdict-1.2.xsd"}) {
+            assertNotNull(
+                    getClass().getResource("/published-interchange/" + schemaFile),
+                    "published copy of " + schemaFile + " missing from the fetched release asset");
+        }
+    }
+
+    private byte[] embedded(String schemaFile) throws IOException {
+        return bytes("/org/mavai/punit/report/" + schemaFile);
+    }
+
+    private byte[] published(String schemaFile) throws IOException {
+        return bytes("/published-interchange/" + schemaFile);
+    }
+
+    private byte[] bytes(String resource) throws IOException {
+        try (InputStream in = getClass().getResourceAsStream(resource)) {
+            assertNotNull(in, "missing resource: " + resource);
+            return in.readAllBytes();
+        }
+    }
+}


### PR DESCRIPTION
The verdict XSDs embedded in punit-report's resources are vendored snapshots of the published family schemas (mavai-R's `schema/verdict-*.xsd`, shipped in the `interchange-<tag>.zip` release asset), synced per release. Until now nothing enforced that: a schema edited in place, or a missed sync after a release, would ship silently divergent.

- `fetchPublishedInterchangeSchemas` (punit-report build): fetches the latest published schema set onto the test classpath — same latest-release resolution, caching, and local-directory override idiom as punit-core's conformance-data fetch (`-PinterchangeSchemaDir=/path/to/mavai-R/schema` for merged-but-untagged content).
- `VerdictSchemaSnapshotSyncTest`: asserts each embedded XSD (1.0/1.1/1.2) is byte-identical to the published one, plus a guard that the published set is present in the fetched asset at all.

Verified against the live release channel: the fetch resolves v0.9.2 and the suite is green. The family amendment path this enforces (schema changes are authored in the canonical channel and land in framework snapshots via a release, never framework-side) is recorded in the family catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyYHPj1u28MZ4bEPHKUX2V