### PR TITLE
Complete the bindings artefact and declarative service definitions

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -129,6 +129,13 @@ public final class PUnit {
         Declared bindings(Class<?> bindingsClass);
 
         /**
+         * An explicit service-definition file, overriding discovery
+         * (the conventional {@code mavai-services.yaml} beside the
+         * contract files, then the project root).
+         */
+        Declared services(java.nio.file.Path servicesFile);
+
+        /**
          * The target power for a risk-driven run (default 0.80) — the
          * {@code --power} flag's equivalent; property channel
          * {@code -Dpunit.power.<contract-name>=P}. One sizing source per

--- a/punit-decl/src/main/java/module-info.java
+++ b/punit-decl/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module org.mavai.punit.decl {
     // is black-box enablement of the declarative approach, not an
     // API, and subject to change without notice.
     exports org.mavai.punit.decl;
+    exports org.mavai.punit.decl.spi;
 
     // ── Required modules ──────────────────────────────────────
     requires transitive org.mavai.punit.core;
@@ -29,6 +30,7 @@ module org.mavai.punit.decl {
     // Explicitly NO requires for JUnit.
 
     // ── Services ──────────────────────────────────────────────
+    uses org.mavai.punit.decl.spi.ServiceType;
     provides org.mavai.punit.runtime.PUnit.DeclarativeFrontEnd
             with org.mavai.punit.decl.internal.DeclFrontEnd;
 }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/BindingFactory.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/BindingFactory.java
@@ -1,0 +1,28 @@
+package org.mavai.punit.decl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Registers a method of the bindings class as a configurable service
+ * <em>type</em>: the named implementation a {@code mavai-services/1}
+ * definition's {@code type:} key resolves to. The method's parameter
+ * list <strong>is</strong> the configuration schema — kebab-case file
+ * keys map to camelCase parameters, scalar types are checked, and a
+ * definition that does not fit the signature is refused at load with
+ * the signature in the message. The factory runs at contract-load time
+ * (cheap, side-effect-light) and returns the per-sample callable, a
+ * {@link java.util.function.Function} from the input to the response.
+ *
+ * <p>Type names and service names are separate namespaces; registering
+ * a factory under a built-in type's name is refused at load.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BindingFactory {
+
+    /** The service-type name — unique within the type registry. */
+    String value();
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/Check.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/Check.java
@@ -1,0 +1,24 @@
+package org.mavai.punit.decl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Registers a method of the bindings class as a named check — the code
+ * a contract file's {@code satisfies:} form resolves to, and the
+ * gentlest graduation step: one predicate in code, everything else
+ * still declarative. The method receives the subject (the named view's
+ * value when the form carries {@code in:}, else the raw response text)
+ * and answers with a {@code boolean} or an
+ * {@link org.mavai.outcome.Outcome} (whose failure carries the reason
+ * into the run's failure accounting).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Check {
+
+    /** The check's registry name — unique within the check registry. */
+    String value();
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/Covariates.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/Covariates.java
@@ -1,0 +1,22 @@
+package org.mavai.punit.decl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Registers a method of the bindings class as a service's computed
+ * covariate feed: a no-argument method returning
+ * {@code Map<String, String>}, invoked once per run when the named
+ * service resolves, its entries joining the resolved configuration in
+ * run and baseline provenance — the drift-checked identity's second
+ * feed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Covariates {
+
+    /** The service name the feed belongs to. */
+    String value();
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/Transform.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/Transform.java
@@ -1,0 +1,24 @@
+package org.mavai.punit.decl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Registers a method of the bindings class as a named transformation —
+ * a view a contract file's {@code transforms:} block can name beside
+ * the stock {@code json}/{@code xml}/{@code yaml} ones. One response
+ * in, the view's value out ({@code String → T}, or
+ * {@code String → Outcome<T>} where an anticipated parse failure
+ * travels as a failed trial with the transform-failure reason). The
+ * view is computed at most once per response and shared by every
+ * consumer; {@code raw} is reserved.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Transform {
+
+    /** The transformation's registry name — unique, never {@code raw}. */
+    String value();
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/BindingsRegistry.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/BindingsRegistry.java
@@ -1,56 +1,47 @@
 package org.mavai.punit.decl.internal.run;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.mavai.outcome.Outcome;
 import org.mavai.punit.decl.Binding;
+import org.mavai.punit.decl.BindingFactory;
+import org.mavai.punit.decl.Check;
 import org.mavai.punit.decl.ContractConfigurationException;
+import org.mavai.punit.decl.Covariates;
+import org.mavai.punit.decl.Transform;
+import org.mavai.punit.decl.internal.model.FormDeclaration;
 
 /**
- * The bindings-class registry: {@link Binding @Binding}-annotated
- * methods, resolved by name at load time with fail-fast duplicate and
- * unresolvable semantics. Discovery is the conventional
- * {@code MavaiBindings} class in the test's package, or the
- * compile-checked {@code .bindings(Class)} override.
+ * The bindings artefact's registries: {@link Binding @Binding} service
+ * bindings, {@link BindingFactory @BindingFactory} configurable service
+ * types, {@link Transform @Transform} named transformations,
+ * {@link Check @Check} named checks, and
+ * {@link Covariates @Covariates} computed covariate feeds — each
+ * resolved by name at load time with fail-fast duplicate and
+ * unresolvable semantics.
  */
 final class BindingsRegistry {
 
     private final Class<?> bindingsClass;
     private final Object instance;
-    private final Map<String, Method> bindings;
+    private final Map<String, Method> bindings = new LinkedHashMap<>();
+    private final Map<String, Method> factories = new LinkedHashMap<>();
+    private final Map<String, Method> transforms = new LinkedHashMap<>();
+    private final Map<String, Method> checks = new LinkedHashMap<>();
+    private final Map<String, Method> covariateFeeds = new LinkedHashMap<>();
 
-    private BindingsRegistry(Class<?> bindingsClass, Object instance, Map<String, Method> bindings) {
+    private BindingsRegistry(Class<?> bindingsClass, Object instance) {
         this.bindingsClass = bindingsClass;
         this.instance = instance;
-        this.bindings = bindings;
     }
 
     static BindingsRegistry of(Class<?> bindingsClass) {
-        Map<String, Method> bindings = new LinkedHashMap<>();
-        for (Method method : bindingsClass.getDeclaredMethods()) {
-            Binding annotation = method.getAnnotation(Binding.class);
-            if (annotation == null) {
-                continue;
-            }
-            String name = annotation.value();
-            if (name.isEmpty()) {
-                throw new ContractConfigurationException(
-                        "@Binding on " + bindingsClass.getSimpleName() + "." + method.getName()
-                                + " needs a non-empty name");
-            }
-            Method previous = bindings.putIfAbsent(name, method);
-            if (previous != null) {
-                throw new ContractConfigurationException(
-                        "binding '" + name + "' is registered twice in "
-                                + bindingsClass.getSimpleName() + " (" + previous.getName()
-                                + " and " + method.getName() + ") — binding names are unique");
-            }
-            method.setAccessible(true);
-        }
         Object instance;
         try {
             var constructor = bindingsClass.getDeclaredConstructor();
@@ -61,11 +52,67 @@ final class BindingsRegistry {
                     "cannot instantiate bindings class " + bindingsClass.getName()
                             + " — it needs an accessible no-argument constructor", error);
         }
-        return new BindingsRegistry(bindingsClass, instance, bindings);
+        BindingsRegistry registry = new BindingsRegistry(bindingsClass, instance);
+        for (Method method : bindingsClass.getDeclaredMethods()) {
+            registry.register(method, Binding.class, Binding::value, registry.bindings, "binding");
+            registry.register(method, BindingFactory.class, BindingFactory::value,
+                    registry.factories, "service type");
+            registry.register(method, Transform.class, Transform::value,
+                    registry.transforms, "transformation");
+            registry.register(method, Check.class, Check::value, registry.checks, "check");
+            registry.register(method, Covariates.class, Covariates::value,
+                    registry.covariateFeeds, "covariate feed");
+        }
+        for (String view : registry.transforms.keySet()) {
+            if (view.equals(FormDeclaration.RAW_VIEW)) {
+                throw new ContractConfigurationException(
+                        "@Transform(\"raw\") in " + bindingsClass.getSimpleName() + " — `raw` is "
+                                + "the reserved name of the untransformed response");
+            }
+        }
+        return registry;
     }
 
-    /** The resolved invoker for a service name, or a refusal naming the known bindings. */
-    Invoker resolve(String serviceName) {
+    private <A extends Annotation> void register(Method method, Class<A> annotationType,
+            Function<A, String> nameOf, Map<String, Method> registry, String what) {
+        A annotation = method.getAnnotation(annotationType);
+        if (annotation == null) {
+            return;
+        }
+        String name = nameOf.apply(annotation);
+        if (name.isEmpty()) {
+            throw new ContractConfigurationException(
+                    "@" + annotationType.getSimpleName() + " on " + bindingsClass.getSimpleName()
+                            + "." + method.getName() + " needs a non-empty name");
+        }
+        Method previous = registry.putIfAbsent(name, method);
+        if (previous != null) {
+            throw new ContractConfigurationException(
+                    what + " '" + name + "' is registered twice in "
+                            + bindingsClass.getSimpleName() + " (" + previous.getName()
+                            + " and " + method.getName() + ") — names are unique per registry");
+        }
+        method.setAccessible(true);
+    }
+
+    Class<?> bindingsClass() {
+        return bindingsClass;
+    }
+
+    Map<String, Method> factories() {
+        return factories;
+    }
+
+    boolean hasBinding(String serviceName) {
+        return bindings.containsKey(serviceName);
+    }
+
+    boolean hasTransform(String name) {
+        return transforms.containsKey(name);
+    }
+
+    /** The resolved invoker for a bare binding, or a refusal naming the known ones. */
+    Invoker resolveBinding(String serviceName) {
         Method method = bindings.get(serviceName);
         if (method == null) {
             String known = bindings.isEmpty() ? "none registered" : String.join(", ", bindings.keySet());
@@ -74,40 +121,98 @@ final class BindingsRegistry {
                             + bindingsClass.getSimpleName() + ": " + known
                             + " (register with @Binding(\"" + serviceName + "\"))");
         }
-        return input -> invoke(method, input);
+        return input -> asResponse(method, invoke(method, arguments(method, input)));
+    }
+
+    /** The named transformation, applied: the view's value or a transform failure. */
+    Outcome<Object> applyTransform(String name, String response) {
+        Method method = transforms.get(name);
+        Object result = invoke(method, new Object[] {response});
+        if (result instanceof Outcome.Fail<?> fail) {
+            @SuppressWarnings("unchecked")
+            Outcome<Object> failure = (Outcome<Object>) fail;
+            return failure;
+        }
+        if (result instanceof Outcome.Ok<?> ok) {
+            return Outcome.ok(ok.value());
+        }
+        return Outcome.ok(result);
+    }
+
+    /** The named check, applied to its subject: ok, or the check's failure. */
+    Outcome<?> applyCheck(String name, Object subject) {
+        Method method = checks.get(name);
+        if (method == null) {
+            String known = checks.isEmpty() ? "none registered" : String.join(", ", checks.keySet());
+            throw new ContractConfigurationException(
+                    "`satisfies: " + name + "` names no registered check; known checks in "
+                            + bindingsClass.getSimpleName() + ": " + known
+                            + " (register with @Check(\"" + name + "\"))");
+        }
+        Object result = invoke(method, new Object[] {subject});
+        if (result instanceof Outcome<?> outcome) {
+            return outcome;
+        }
+        if (result instanceof Boolean holds) {
+            return holds ? Outcome.ok() : Outcome.fail("check", "check '" + name + "' did not hold");
+        }
+        throw new ContractConfigurationException(
+                "check '" + name + "' must answer with a boolean or an Outcome, got "
+                        + (result == null ? "null" : result.getClass().getSimpleName()));
+    }
+
+    boolean hasCheck(String name) {
+        return checks.containsKey(name);
+    }
+
+    /** The service's computed covariate feed, invoked once; empty when none registered. */
+    Map<String, String> covariateFeed(String serviceName) {
+        Method method = covariateFeeds.get(serviceName);
+        if (method == null) {
+            return Map.of();
+        }
+        Object result = invoke(method, new Object[0]);
+        if (!(result instanceof Map<?, ?> feed)) {
+            throw new ContractConfigurationException(
+                    "@Covariates(\"" + serviceName + "\") must return Map<String, String>, got "
+                            + (result == null ? "null" : result.getClass().getSimpleName()));
+        }
+        Map<String, String> covariates = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : feed.entrySet()) {
+            covariates.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+        }
+        return covariates;
     }
 
     interface Invoker {
         Outcome<String> invoke(Object input);
     }
 
-    @SuppressWarnings("unchecked")
-    private Outcome<String> invoke(Method method, Object input) {
-        Object[] arguments;
-        int parameterCount = method.getParameterCount();
-        if (input instanceof List<?> tuple && parameterCount == tuple.size() && parameterCount != 1) {
-            arguments = tuple.toArray();
-        } else if (parameterCount == 1) {
-            arguments = new Object[] {input};
-        } else {
+    /** Adapts a factory-produced per-sample callable to the invoker seam. */
+    Invoker adaptCallable(String serviceName, Object callable) {
+        if (!(callable instanceof Function<?, ?>)) {
             throw new ContractConfigurationException(
-                    "binding '" + method.getName() + "' takes " + parameterCount
-                            + " parameters but the input " + display(input) + " does not fit — "
-                            + "an argument-list input must match the binding's arity");
+                    "the factory for service '" + serviceName + "' must return a "
+                            + "java.util.function.Function (the per-sample callable), got "
+                            + (callable == null ? "null" : callable.getClass().getSimpleName()));
         }
-        Object result;
+        @SuppressWarnings("unchecked")
+        Function<Object, Object> function = (Function<Object, Object>) callable;
+        return input -> asResponse(null, function.apply(input));
+    }
+
+    Object invoke(Method method, Object[] arguments) {
         try {
-            result = method.invoke(Modifier.isStatic(method.getModifiers()) ? null : instance, arguments);
+            return method.invoke(Modifier.isStatic(method.getModifiers()) ? null : instance, arguments);
         } catch (IllegalAccessException error) {
-            throw new IllegalStateException("binding invocation failed: " + error, error);
+            throw new IllegalStateException("bindings invocation failed: " + error, error);
         } catch (IllegalArgumentException error) {
             throw new ContractConfigurationException(
-                    "binding '" + method.getName() + "' cannot accept the input "
-                            + display(input) + ": " + error.getMessage(), error);
+                    method.getName() + " cannot accept the given arguments: " + error.getMessage(),
+                    error);
         } catch (InvocationTargetException error) {
-            // A defect inside the binding aborts the run — the family's
-            // expected-failure-versus-defect discipline: anticipated bad
-            // responses return as responses; only bugs throw.
+            // A defect inside the bindings class aborts the run — the
+            // family's expected-failure-versus-defect discipline.
             Throwable cause = error.getCause();
             if (cause instanceof RuntimeException runtime) {
                 throw runtime;
@@ -115,11 +220,28 @@ final class BindingsRegistry {
             if (cause instanceof Error fatal) {
                 throw fatal;
             }
-            throw new IllegalStateException("binding defect: " + cause, cause);
+            throw new IllegalStateException("bindings defect: " + cause, cause);
         }
+    }
+
+    private Object[] arguments(Method method, Object input) {
+        int parameterCount = method.getParameterCount();
+        if (input instanceof List<?> tuple && parameterCount == tuple.size() && parameterCount != 1) {
+            return tuple.toArray();
+        }
+        if (parameterCount == 1) {
+            return new Object[] {input};
+        }
+        throw new ContractConfigurationException(
+                "binding '" + method.getName() + "' takes " + parameterCount
+                        + " parameters but the input " + display(input) + " does not fit — "
+                        + "an argument-list input must match the binding's arity");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Outcome<String> asResponse(Method method, Object result) {
+        String who = method == null ? "the per-sample callable" : "binding '" + method.getName() + "'";
         if (result instanceof Outcome.Fail<?> fail) {
-            // An anticipated failure travels as data, straight through
-            // to the engine's failed-sample accounting.
             return (Outcome<String>) fail;
         }
         if (result instanceof Outcome.Ok<?> ok) {
@@ -127,16 +249,14 @@ final class BindingsRegistry {
                 return (Outcome<String>) ok;
             }
             throw new ContractConfigurationException(
-                    "binding '" + method.getName() + "' must carry the service's response as a "
-                            + "String, got Outcome of "
+                    who + " must carry the service's response as a String, got Outcome of "
                             + (ok.value() == null ? "null" : ok.value().getClass().getSimpleName()));
         }
         if (result instanceof String response) {
             return Outcome.ok(response);
         }
         throw new ContractConfigurationException(
-                "binding '" + method.getName() + "' must return the service's response as a "
-                        + "String (or an Outcome), got "
+                who + " must return the service's response as a String (or an Outcome), got "
                         + (result == null ? "null" : result.getClass().getSimpleName()));
     }
 

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
@@ -25,7 +25,6 @@ import org.mavai.punit.decl.internal.model.CriterionDeclaration;
 import org.mavai.punit.decl.internal.model.FormDeclaration;
 import org.mavai.punit.decl.internal.model.InputDeclaration;
 import org.mavai.punit.decl.internal.model.PostconditionForm;
-import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
 /**
@@ -47,16 +46,18 @@ final class CriteriaCompiler {
     private final AtomicReference<Object> currentInput;
     private final Map<String, Double> tolerateOverrides;
     private final Double power;
+    private final BindingsRegistry registry;
     private final Map<Object, List<FormDeclaration>> expectations = new IdentityHashMap<>();
 
     CriteriaCompiler(ContractDeclaration declaration, StockViews views,
             AtomicReference<Object> currentInput,
-            Map<String, Double> tolerateOverrides, Double power) {
+            Map<String, Double> tolerateOverrides, Double power, BindingsRegistry registry) {
         this.declaration = declaration;
         this.views = views;
         this.currentInput = currentInput;
         this.tolerateOverrides = tolerateOverrides;
         this.power = power;
+        this.registry = registry;
         for (InputDeclaration input : declaration.inputs()) {
             if (input.hasExpectations()) {
                 expectations.put(input.value(), input.expected());
@@ -159,10 +160,22 @@ final class CriteriaCompiler {
 
     private Check compileForm(FormDeclaration form, String name) {
         if (form.form() == PostconditionForm.SATISFIES) {
-            throw new ContractConfigurationException(
-                    "`satisfies: " + form.argument() + "` names a check registered in code — "
-                            + "the named-check registry arrives with the bindings-artefact phase "
-                            + "of the declarative surface");
+            String checkName = (String) form.argument();
+            if (!registry.hasCheck(checkName)) {
+                // Force the registry's refusal, which names the known checks.
+                registry.applyCheck(checkName, "");
+            }
+            return new Check(name, response -> {
+                Object subject = response;
+                if (!form.view().equals(FormDeclaration.RAW_VIEW)) {
+                    Outcome<Object> parsed = views.view(form.view(), response);
+                    if (parsed instanceof Outcome.Fail<?> fail) {
+                        return fail;
+                    }
+                    subject = ((Outcome.Ok<Object>) parsed).value();
+                }
+                return registry.applyCheck(checkName, subject);
+            });
         }
         if (form.form() == PostconditionForm.PARSES) {
             String view = (String) form.argument();
@@ -282,7 +295,14 @@ final class CriteriaCompiler {
     }
 
     private Selection compileSelection(String transformation, String expression) {
-        if (transformation.equals("xml")) {
+        // Stock views pin the language by transformation; a registered
+        // view's expression selects its own language by syntax — a
+        // $-rooted expression is JSONPath (the RFC mandates the root),
+        // anything else XPath 1.0.
+        boolean stock = transformation.equals("json") || transformation.equals("yaml")
+                || transformation.equals("xml");
+        boolean jsonPath = stock ? !transformation.equals("xml") : expression.startsWith("$");
+        if (!jsonPath) {
             XPathExpression compiled;
             try {
                 compiled = XPathFactory.newInstance().newXPath().compile(expression);
@@ -291,7 +311,13 @@ final class CriteriaCompiler {
                         "`path: " + expression + "` is not a valid XPath 1.0 expression: "
                                 + error.getMessage());
             }
-            return viewValue -> selectXml(compiled, (Document) viewValue);
+            return viewValue -> {
+                if (!(viewValue instanceof org.w3c.dom.Node node)) {
+                    throw new IllegalArgumentException("the view's value is not a parsed XML "
+                            + "document — an XPath selection needs one");
+                }
+                return selectXml(compiled, node);
+            };
         }
         CompiledJsonPath compiled;
         try {
@@ -301,10 +327,16 @@ final class CriteriaCompiler {
                     "`path: " + expression + "` is not a valid JSONPath (RFC 9535) expression: "
                             + error.getMessage());
         }
-        return compiled::select;
+        return viewValue -> {
+            if (!(viewValue instanceof Map) && !(viewValue instanceof List)) {
+                throw new IllegalArgumentException("the view's value is not a JSON-model "
+                        + "structure — a JSONPath selection needs a mapping or sequence");
+            }
+            return compiled.select(viewValue);
+        };
     }
 
-    private static List<Object> selectXml(XPathExpression expression, Document document) {
+    private static List<Object> selectXml(XPathExpression expression, org.w3c.dom.Node document) {
         try {
             NodeList nodes = (NodeList) expression.evaluate(document, XPathConstants.NODESET);
             List<Object> values = new ArrayList<>(nodes.getLength());

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -1,6 +1,7 @@
 package org.mavai.punit.decl.internal.run;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.mavai.outcome.Outcome;
 import org.mavai.punit.api.NoFactors;
@@ -30,6 +31,7 @@ public final class DeclaredRun implements Declared {
 
     private Integer samples;
     private Class<?> bindingsClass;
+    private java.nio.file.Path servicesFile;
     private Double power;
     private Double tolerateBare;
     private final java.util.Map<String, Double> tolerateNamed = new java.util.LinkedHashMap<>();
@@ -49,6 +51,12 @@ public final class DeclaredRun implements Declared {
     @Override
     public Declared bindings(Class<?> bindingsClass) {
         this.bindingsClass = bindingsClass;
+        return this;
+    }
+
+    @Override
+    public Declared services(java.nio.file.Path servicesFile) {
+        this.servicesFile = servicesFile;
         return this;
     }
 
@@ -80,11 +88,46 @@ public final class DeclaredRun implements Declared {
         }
         RiskClaims claims = RiskClaims.resolve(declaration, samples, power, tolerateBare, tolerateNamed);
         BindingsRegistry registry = BindingsRegistry.of(resolveBindingsClass());
-        BindingsRegistry.Invoker invoker = registry.resolve(declaration.service());
-        StockViews views = new StockViews(declaration);
+        ServicesResolver services = ServicesResolver.resolve(caller, servicesFile, registry);
+        org.mavai.punit.decl.spi.ConfiguredService defined = services.lookup(declaration.service());
+        final BindingsRegistry.Invoker invoker;
+        Map<String, String> configurationCovariates;
+        if (defined != null) {
+            // A definition wins service: resolution over a same-named binding.
+            invoker = defined::invoke;
+            configurationCovariates = defined.configurationCovariates();
+        } else if (registry.hasBinding(declaration.service())) {
+            invoker = registry.resolveBinding(declaration.service());
+            configurationCovariates = Map.of();
+        } else {
+            // Neither population resolves the name — the binding
+            // registry's refusal names the known bindings; extend it
+            // with the definition population.
+            try {
+                registry.resolveBinding(declaration.service());
+                throw new IllegalStateException("unreachable");
+            } catch (ContractConfigurationException refusal) {
+                throw new ContractConfigurationException(refusal.getMessage()
+                        + "; no mavai-services.yaml definition names it either "
+                        + "(registered types: " + services.registeredTypeNames() + ")");
+            }
+        }
+        Map<String, String> covariateFeed = registry.covariateFeed(declaration.service());
+        for (String key : covariateFeed.keySet()) {
+            if (configurationCovariates.containsKey(key)) {
+                throw new ContractConfigurationException(
+                        "covariate '" + key + "' arrives from both the resolved configuration "
+                                + "and the @Covariates feed for service '" + declaration.service()
+                                + "' — one identity, two feeds, no overlapping keys");
+            }
+        }
+        Map<String, String> covariates = new java.util.LinkedHashMap<>(configurationCovariates);
+        covariates.putAll(covariateFeed);
+        StockViews views = new StockViews(declaration, registry);
         AtomicReference<Object> currentInput = new AtomicReference<>();
         CriteriaCompiler compiler = new CriteriaCompiler(
-                declaration, views, currentInput, claims.tolerateByCriterion(), claims.power());
+                declaration, views, currentInput, claims.tolerateByCriterion(), claims.power(),
+                registry);
         compiler.validateEagerly();
         Criteria<String> criteria = compiler.compile();
         Sizing.Sized sized = Sizing.resolve(declaration, samples);
@@ -104,6 +147,22 @@ public final class DeclaredRun implements Declared {
             @Override
             public String id() {
                 return declaration.contract();
+            }
+
+            @Override
+            public List<org.mavai.punit.api.covariate.Covariate> covariates() {
+                return covariates.keySet().stream()
+                        .map(key -> org.mavai.punit.api.covariate.Covariate.custom(key,
+                                org.mavai.punit.api.covariate.CovariateCategory.CONFIGURATION))
+                        .toList();
+            }
+
+            @Override
+            public Map<String, java.util.function.Supplier<String>> customCovariateResolvers() {
+                Map<String, java.util.function.Supplier<String>> resolvers =
+                        new java.util.LinkedHashMap<>();
+                covariates.forEach((key, value) -> resolvers.put(key, () -> value));
+                return resolvers;
             }
         };
 

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/FactoryType.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/FactoryType.java
@@ -1,0 +1,134 @@
+package org.mavai.punit.decl.internal.run;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.mavai.punit.decl.ContractConfigurationException;
+import org.mavai.punit.decl.spi.ConfiguredService;
+import org.mavai.punit.decl.spi.ServiceType;
+
+/**
+ * A user-registered configurable service type: the
+ * {@code @BindingFactory} method whose parameter list <em>is</em> the
+ * configuration schema. Kebab-case file keys map to camelCase
+ * parameters deterministically; scalar types are checked; a misfit is a
+ * load-time refusal carrying the rendered signature. The factory runs
+ * at contract-load time and yields the per-sample callable.
+ */
+final class FactoryType implements ServiceType {
+
+    private final String name;
+    private final Method factory;
+    private final BindingsRegistry registry;
+
+    FactoryType(String name, Method factory, BindingsRegistry registry) {
+        this.name = name;
+        this.factory = factory;
+        this.registry = registry;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public ConfiguredService configure(String serviceName, Map<String, Object> configuration) {
+        Parameter[] parameters = factory.getParameters();
+        Map<String, Parameter> byKey = new LinkedHashMap<>();
+        for (Parameter parameter : parameters) {
+            byKey.put(kebabCase(parameter.getName()), parameter);
+        }
+        for (String key : configuration.keySet()) {
+            if (!byKey.containsKey(key)) {
+                throw misfit(serviceName, "unknown configuration key `" + key + ":`");
+            }
+        }
+        Object[] arguments = new Object[parameters.length];
+        int index = 0;
+        for (Map.Entry<String, Parameter> slot : byKey.entrySet()) {
+            if (!configuration.containsKey(slot.getKey())) {
+                throw misfit(serviceName, "missing configuration key `" + slot.getKey() + ":`");
+            }
+            Object value = configuration.get(slot.getKey());
+            Object converted = convert(value, slot.getValue().getType());
+            if (converted == null) {
+                throw misfit(serviceName, "`" + slot.getKey() + ":` must be a "
+                        + slot.getValue().getType().getSimpleName() + ", got "
+                        + (value == null ? "null" : value.getClass().getSimpleName()));
+            }
+            arguments[index++] = converted;
+        }
+        Object callable = registry.invoke(factory, arguments);
+        BindingsRegistry.Invoker invoker = registry.adaptCallable(serviceName, callable);
+        Map<String, String> covariates = new LinkedHashMap<>();
+        covariates.put("serviceType", name);
+        for (Map.Entry<String, Object> entry : configuration.entrySet()) {
+            covariates.put(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+        return new ConfiguredService() {
+            @Override
+            public org.mavai.outcome.Outcome<String> invoke(Object input) {
+                return invoker.invoke(input);
+            }
+
+            @Override
+            public Map<String, String> configurationCovariates() {
+                return covariates;
+            }
+        };
+    }
+
+    private ContractConfigurationException misfit(String serviceName, String problem) {
+        String signature = name + "(" + java.util.Arrays.stream(factory.getParameters())
+                .map(parameter -> kebabCase(parameter.getName()) + ": "
+                        + parameter.getType().getSimpleName())
+                .collect(Collectors.joining(", ")) + ")";
+        return new ContractConfigurationException(
+                "service '" + serviceName + "': " + problem + " — the type's configuration "
+                        + "schema is its factory's signature: " + signature);
+    }
+
+    /** camelCase parameter names as kebab-case file keys: {@code topP} → {@code top-p}. */
+    static String kebabCase(String parameterName) {
+        StringBuilder kebab = new StringBuilder(parameterName.length() + 4);
+        for (int i = 0; i < parameterName.length(); i++) {
+            char c = parameterName.charAt(i);
+            if (Character.isUpperCase(c)) {
+                kebab.append('-').append(Character.toLowerCase(c));
+            } else {
+                kebab.append(c);
+            }
+        }
+        return kebab.toString();
+    }
+
+    /** The value as the parameter's scalar type, or {@code null} on a misfit. */
+    private static Object convert(Object value, Class<?> type) {
+        if (type == String.class) {
+            return value instanceof String ? value : null;
+        }
+        if (type == int.class || type == Integer.class) {
+            return value instanceof Integer ? value : null;
+        }
+        if (type == long.class || type == Long.class) {
+            if (value instanceof Long) {
+                return value;
+            }
+            return value instanceof Integer whole ? whole.longValue() : null;
+        }
+        if (type == double.class || type == Double.class) {
+            if (value instanceof Double) {
+                return value;
+            }
+            return value instanceof Number number && !(value instanceof Boolean)
+                    ? number.doubleValue() : null;
+        }
+        if (type == boolean.class || type == Boolean.class) {
+            return value instanceof Boolean ? value : null;
+        }
+        return null;
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
@@ -1,0 +1,142 @@
+package org.mavai.punit.decl.internal.run;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.TreeMap;
+import org.mavai.punit.decl.ContractConfigurationException;
+import org.mavai.punit.decl.internal.model.ServiceEntry;
+import org.mavai.punit.decl.internal.model.ServicesDeclaration;
+import org.mavai.punit.decl.internal.parser.ServicesParser;
+import org.mavai.punit.decl.spi.ConfiguredService;
+import org.mavai.punit.decl.spi.ServiceType;
+
+/**
+ * Service definitions at run time: discovery of the conventional
+ * {@code mavai-services.yaml} (beside the contract files in the test
+ * class's resource package, then the project root; an explicit path
+ * overrides), the service-type registry (built-ins via
+ * {@link ServiceLoader}, user types from the bindings class — separate
+ * namespaces, built-in names unshadowable), configuration validation
+ * through each type, and the exploration grid's duplicate-point
+ * refusal over resolved covariate values.
+ */
+final class ServicesResolver {
+
+    private final Map<String, ServiceType> types = new LinkedHashMap<>();
+    private final Map<String, ConfiguredService> configured = new LinkedHashMap<>();
+
+    private ServicesResolver() {}
+
+    static ServicesResolver resolve(Class<?> caller, Path explicitFile, BindingsRegistry registry) {
+        ServicesResolver resolver = new ServicesResolver();
+        for (ServiceType builtIn : ServiceLoader.load(ServiceType.class)) {
+            resolver.types.put(builtIn.name(), builtIn);
+        }
+        for (Map.Entry<String, java.lang.reflect.Method> factory : registry.factories().entrySet()) {
+            if (resolver.types.containsKey(factory.getKey())) {
+                throw new ContractConfigurationException(
+                        "@BindingFactory(\"" + factory.getKey() + "\") in "
+                                + registry.bindingsClass().getSimpleName() + " shadows the "
+                                + "built-in type of that name — built-in type names cannot be "
+                                + "re-registered");
+            }
+            resolver.types.put(factory.getKey(),
+                    new FactoryType(factory.getKey(), factory.getValue(), registry));
+        }
+        ServicesDeclaration declaration = discover(caller, explicitFile);
+        if (declaration != null) {
+            for (ServiceEntry entry : declaration.services().values()) {
+                resolver.configure(entry);
+            }
+        }
+        return resolver;
+    }
+
+    /** The configured service a {@code service:} key resolves to, or {@code null}. */
+    ConfiguredService lookup(String serviceName) {
+        return configured.get(serviceName);
+    }
+
+    String registeredTypeNames() {
+        return types.isEmpty() ? "none registered" : String.join(", ", new TreeMap<>(types).keySet());
+    }
+
+    private void configure(ServiceEntry entry) {
+        ServiceType type = types.get(entry.type());
+        if (type == null) {
+            throw new ContractConfigurationException(
+                    "service '" + entry.name() + "': unknown `type: " + entry.type() + "` — "
+                            + "registered types: " + registeredTypeNames() + " (built-in types "
+                            + "ship via their module; user types are registered in the bindings "
+                            + "class with @BindingFactory(\"" + entry.type() + "\"))");
+        }
+        configured.put(entry.name(), type.configure(entry.name(), entry.configuration()));
+        validateExplorations(entry, type);
+    }
+
+    /**
+     * The grid's duplicate-point refusal: each exploration entry is the
+     * baseline with its keys replaced, and two entries resolving to the
+     * same covariate point (or restating the baseline) are refused —
+     * one population, one grid point.
+     */
+    private void validateExplorations(ServiceEntry entry, ServiceType type) {
+        if (entry.explorations().isEmpty()) {
+            return;
+        }
+        Map<Map<String, String>, String> seen = new LinkedHashMap<>();
+        seen.put(type.configure(entry.name(), entry.configuration()).configurationCovariates(),
+                "the baseline `configuration:`");
+        int index = 0;
+        for (Map<String, Object> deltas : entry.explorations()) {
+            index++;
+            Map<String, Object> merged = new LinkedHashMap<>(entry.configuration());
+            merged.putAll(deltas);
+            Map<String, String> point =
+                    type.configure(entry.name(), merged).configurationCovariates();
+            String previous = seen.putIfAbsent(point, "exploration entry " + index);
+            if (previous != null) {
+                throw new ContractConfigurationException(
+                        "service '" + entry.name() + "': exploration entry " + index
+                                + " resolves to the same configuration as " + previous
+                                + " — two grid entries for one population; each entry must "
+                                + "resolve to a distinct covariate point");
+            }
+        }
+    }
+
+    // ── Discovery ─────────────────────────────────────────────────
+
+    private static ServicesDeclaration discover(Class<?> caller, Path explicitFile) {
+        if (explicitFile != null) {
+            if (!Files.isRegularFile(explicitFile)) {
+                throw new ContractConfigurationException(
+                        "the services file named via .services(...) does not exist: " + explicitFile);
+            }
+            return ServicesParser.load(explicitFile);
+        }
+        String resource = caller.getPackageName().replace('.', '/') + "/"
+                + ServicesDeclaration.CONVENTIONAL_FILENAME;
+        URL packaged = caller.getClassLoader().getResource(resource);
+        if (packaged != null) {
+            try (InputStream in = packaged.openStream()) {
+                return ServicesParser.parse(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException error) {
+                throw new ContractConfigurationException(
+                        "cannot read services file " + packaged + ": " + error.getMessage(), error);
+            }
+        }
+        Path projectRoot = Path.of(ServicesDeclaration.CONVENTIONAL_FILENAME);
+        if (Files.isRegularFile(projectRoot)) {
+            return ServicesParser.load(projectRoot);
+        }
+        return null;
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/StockViews.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/StockViews.java
@@ -31,30 +31,37 @@ import org.xml.sax.InputSource;
 final class StockViews {
 
     private static final ObjectMapper JSON = new ObjectMapper();
+    private static final java.util.Set<String> STOCK = java.util.Set.of("json", "xml", "yaml");
 
     private final Map<String, String> transforms;
+    private final BindingsRegistry registry;
 
     private Object currentResponse;
     private Map<String, Outcome<Object>> cache = new HashMap<>();
 
-    StockViews(ContractDeclaration declaration) {
+    StockViews(ContractDeclaration declaration, BindingsRegistry registry) {
         this.transforms = declaration.transforms();
+        this.registry = registry;
         for (Map.Entry<String, String> view : transforms.entrySet()) {
             String transformation = view.getValue();
-            if (!transformation.equals("json") && !transformation.equals("xml")
-                    && !transformation.equals("yaml")) {
+            if (!STOCK.contains(transformation) && !registry.hasTransform(transformation)) {
                 throw new ContractConfigurationException(
                         "view '" + view.getKey() + "' names transformation '" + transformation
-                                + "', which is not a stock one (json, xml, yaml) — registered "
-                                + "transformations arrive with the bindings-artefact phase of "
-                                + "the declarative surface");
+                                + "', which is neither a stock one (json, xml, yaml) nor "
+                                + "registered in " + registry.bindingsClass().getSimpleName()
+                                + " (register with @Transform(\"" + transformation + "\"))");
             }
         }
     }
 
-    /** The transformation a view applies (stock names only in this phase). */
+    /** The transformation a view applies. */
     String transformation(String view) {
         return transforms.get(view);
+    }
+
+    /** Whether the view's transformation is one of the stock three. */
+    boolean isStock(String view) {
+        return STOCK.contains(transforms.get(view));
     }
 
     /** The view's value for this response — computed once, shared, memoised. */
@@ -68,6 +75,14 @@ final class StockViews {
 
     private Outcome<Object> compute(String name, String response) {
         String transformation = transforms.get(name);
+        if (!STOCK.contains(transformation)) {
+            Outcome<Object> value = registry.applyTransform(transformation, response);
+            return value instanceof Outcome.Fail<?>
+                    ? Outcome.fail("transform-failure",
+                            "view '" + name + "' (" + transformation + "): "
+                                    + ((Outcome.Fail<Object>) value).failure().message())
+                    : value;
+        }
         try {
             return switch (transformation) {
                 case "json" -> Outcome.ok(JSON.readValue(response, Object.class));

--- a/punit-decl/src/main/java/org/mavai/punit/decl/spi/ConfiguredService.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/spi/ConfiguredService.java
@@ -1,0 +1,29 @@
+package org.mavai.punit.decl.spi;
+
+import java.util.Map;
+import org.mavai.outcome.Outcome;
+
+/**
+ * A service definition resolved to a runnable configuration: the
+ * per-sample invocation plus the resolved configuration's provenance
+ * projection. One invocation, one request — the family's
+ * sampling-independence rule binds implementations: no retries, no
+ * caching, no request sophistication.
+ */
+public interface ConfiguredService {
+
+    /**
+     * Invokes the service once. An anticipated bad response travels
+     * back as the response (or an {@link Outcome} failure) for the
+     * criteria to judge; only genuine defects throw.
+     */
+    Outcome<String> invoke(Object input);
+
+    /**
+     * The resolved configuration as covariate values — every parameter
+     * as actually used, joining run and baseline provenance.
+     */
+    default Map<String, String> configurationCovariates() {
+        return Map.of();
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/spi/ServiceType.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/spi/ServiceType.java
@@ -1,0 +1,32 @@
+package org.mavai.punit.decl.spi;
+
+import java.util.Map;
+
+/**
+ * A built-in service type: the deliberate extension seam through which
+ * a module registers what a {@code mavai-services/1} definition's
+ * {@code type:} key can name — discovered via
+ * {@link java.util.ServiceLoader} (punit-lm provides
+ * {@code language-model}). User types register through the bindings
+ * class instead; a built-in's name cannot be shadowed.
+ *
+ * <p>This SPI and {@link ConfiguredService} are the whole of the
+ * extension surface: everything else in punit-decl is internal
+ * enablement, not API.
+ */
+public interface ServiceType {
+
+    /** The type name a definition's {@code type:} key resolves to. */
+    String name();
+
+    /**
+     * Validates a definition's complete {@code configuration:} record
+     * against this type's schema and returns the configured, invocable
+     * service. Runs at contract-load time — a misfit throws (an
+     * {@link IllegalStateException} subtype) before any sample.
+     *
+     * @param serviceName the definition's name (for refusal messages)
+     * @param configuration the resolved configuration record
+     */
+    ConfiguredService configure(String serviceName, Map<String, Object> configuration);
+}

--- a/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
@@ -46,6 +46,10 @@ class DeclArchitectureTest {
                 .that().resideInAPackage("org.mavai.punit.decl")
                 .and().areTopLevelClasses()
                 .should().haveSimpleNameEndingWith("Binding")
+                .orShould().haveSimpleName("BindingFactory")
+                .orShould().haveSimpleName("Transform")
+                .orShould().haveSimpleName("Check")
+                .orShould().haveSimpleName("Covariates")
                 .orShould().haveSimpleName("ContractConfigurationException")
                 .because("everything beyond the author surface is internal enablement — "
                         + "new public types belong under internal.* unless they are "
@@ -71,7 +75,7 @@ class DeclArchitectureTest {
                 .collect(java.util.stream.Collectors.toSet());
         org.assertj.core.api.Assertions.assertThat(exported)
                 .as("packages exported by org.mavai.punit.decl")
-                .containsExactly("org.mavai.punit.decl");
+                .containsExactlyInAnyOrder("org.mavai.punit.decl", "org.mavai.punit.decl.spi");
     }
 
     @Test

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -128,6 +128,154 @@ class DeclaredRunTest {
     }
 
     @Nested
+    @DisplayName("bindings artefact and service definitions")
+    class BindingsAndServices {
+
+        @Test
+        @DisplayName("a services-file definition configures a user type through its factory signature")
+        void triageAssistantRoutesRequests() {
+            assertThatCode(() -> PUnit.declared().assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("a registered check answers the satisfies form")
+        void satisfiesResolvesRegisteredCheck() {
+            assertThatCode(() ->
+                    PUnit.declared("triage-assistant-routes-requests").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("a registered transformation is a view, with a dollar-rooted JSONPath")
+        void judgedViewTakesAJsonpath() {
+            assertThatCode(() -> PUnit.declared().assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("a registered view holding a document takes XPath by expression syntax")
+        void registeredViewTakesAnXpath() {
+            assertThatCode(() ->
+                    PUnit.declared("registered-view-takes-an-xpath").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("a definition wins service resolution over a same-named binding")
+        void definitionWinsServiceResolution() {
+            assertThatCode(() -> PUnit.declared().assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("a built-in type resolves via ServiceLoader")
+        void builtInTypeResolvesViaServiceLoader() {
+            assertThatCode(() -> PUnit.declared().assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("an unknown type is refused naming the registered types")
+        void unknownType(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            java.nio.file.Path services = directory.resolve("mavai-services.yaml");
+            java.nio.file.Files.writeString(services, """
+                    format: mavai-services/1
+                    services:
+                      impossible:
+                        type: warp-drive
+                        configuration:
+                          dilithium: high
+                    """);
+            Declared run = PUnit.declared("greeting-service-is-polite").services(services);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("unknown `type: warp-drive`")
+                    .hasMessageContaining("triage");
+        }
+
+        @Test
+        @DisplayName("a configuration misfit is refused with the factory's rendered signature")
+        void configurationMisfit(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            java.nio.file.Path services = directory.resolve("mavai-services.yaml");
+            java.nio.file.Files.writeString(services, """
+                    format: mavai-services/1
+                    services:
+                      triage-assistant:
+                        type: triage
+                        configuration:
+                          tone: matter-of-fact
+                          certainty: "very"
+                    """);
+            Declared run = PUnit.declared("triage-assistant-routes-requests").services(services);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("`certainty:` must be a double")
+                    .hasMessageContaining("triage(tone: String, certainty: double)");
+        }
+
+        @Test
+        @DisplayName("a missing configuration key is refused with the signature")
+        void missingConfigurationKey(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            java.nio.file.Path services = directory.resolve("mavai-services.yaml");
+            java.nio.file.Files.writeString(services, """
+                    format: mavai-services/1
+                    services:
+                      triage-assistant:
+                        type: triage
+                        configuration:
+                          tone: matter-of-fact
+                    """);
+            Declared run = PUnit.declared("triage-assistant-routes-requests").services(services);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("missing configuration key `certainty:`");
+        }
+
+        @Test
+        @DisplayName("duplicate resolved grid points are refused naming the colliding entries")
+        void duplicateGridPoint(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            java.nio.file.Path services = directory.resolve("mavai-services.yaml");
+            java.nio.file.Files.writeString(services, """
+                    format: mavai-services/1
+                    services:
+                      triage-assistant:
+                        type: triage
+                        configuration:
+                          tone: matter-of-fact
+                          certainty: 0.9
+                        explorations:
+                          - certainty: 0.9
+                    """);
+            Declared run = PUnit.declared("triage-assistant-routes-requests").services(services);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("same configuration as the baseline");
+        }
+
+        @Test
+        @DisplayName("shadowing a built-in type name is refused")
+        void shadowingBuiltInType() {
+            Declared run = PUnit.declared("greeting-service-is-polite")
+                    .bindings(ShadowingBindings.class);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("shadows the built-in type");
+        }
+    }
+
+    static class ShadowingBindings {
+        @org.mavai.punit.decl.BindingFactory("echo-model")
+        java.util.function.Function<String, String> echo(String prefix) {
+            return input -> prefix + input;
+        }
+    }
+
+    @Nested
     @DisplayName("risk claims")
     class RiskClaimRules {
 
@@ -217,14 +365,26 @@ class DeclaredRunTest {
         }
 
         @Test
-        @DisplayName("an unresolvable service names the known bindings")
-        void unresolvableService() {
+        @DisplayName("an unresolvable service names both populations")
+        void unresolvableService(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            java.nio.file.Path services = directory.resolve("mavai-services.yaml");
+            java.nio.file.Files.writeString(services, """
+                    format: mavai-services/1
+                    services:
+                      echo-service:
+                        type: echo-model
+                        configuration:
+                          prefix: "echo:"
+                    """);
             Declared run = PUnit.declared("greeting-service-is-polite")
-                    .bindings(EmptyBindings.class);
+                    .bindings(EmptyBindings.class)
+                    .services(services);
             assertThatThrownBy(run::assertPasses)
                     .isInstanceOf(ContractConfigurationException.class)
                     .hasMessageContaining("greeting-service")
-                    .hasMessageContaining("@Binding");
+                    .hasMessageContaining("@Binding")
+                    .hasMessageContaining("no mavai-services.yaml definition names it");
         }
 
         @Test

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/EchoServiceType.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/EchoServiceType.java
@@ -1,0 +1,40 @@
+package org.mavai.punit.decl.internal.run;
+
+import java.util.Map;
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.decl.ContractConfigurationException;
+import org.mavai.punit.decl.spi.ConfiguredService;
+import org.mavai.punit.decl.spi.ServiceType;
+
+/**
+ * A test-scope built-in service type, registered via the test
+ * classpath's {@code META-INF/services} — exercises the ServiceLoader
+ * discovery route punit-lm will use, and the built-in-name shadowing
+ * refusal.
+ */
+public class EchoServiceType implements ServiceType {
+
+    @Override
+    public String name() {
+        return "echo-model";
+    }
+
+    @Override
+    public ConfiguredService configure(String serviceName, Map<String, Object> configuration) {
+        if (!(configuration.get("prefix") instanceof String prefix)) {
+            throw new ContractConfigurationException(
+                    "service '" + serviceName + "': `prefix:` is required and must be a string");
+        }
+        return new ConfiguredService() {
+            @Override
+            public Outcome<String> invoke(Object input) {
+                return Outcome.ok(prefix + " " + input);
+            }
+
+            @Override
+            public Map<String, String> configurationCovariates() {
+                return Map.of("serviceType", "echo-model", "prefix", prefix);
+            }
+        };
+    }
+}

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
@@ -1,6 +1,12 @@
 package org.mavai.punit.decl.internal.run;
 
+import java.util.Map;
+import java.util.function.Function;
 import org.mavai.punit.decl.Binding;
+import org.mavai.punit.decl.BindingFactory;
+import org.mavai.punit.decl.Check;
+import org.mavai.punit.decl.Covariates;
+import org.mavai.punit.decl.Transform;
 
 /**
  * The conventional bindings class for this package's declarative-run
@@ -44,5 +50,38 @@ class MavaiBindings {
     @Binding("receipt-service")
     String receipt(String order) {
         return "<receipt><total>12.50</total></receipt>";
+    }
+
+    @Binding("dual-source")
+    String dualSourceBinding(String input) {
+        return "from-the-binding";
+    }
+
+    @BindingFactory("triage")
+    Function<String, String> triage(String tone, double certainty) {
+        return request -> "category: billing (" + tone + " at " + certainty + ")";
+    }
+
+    @Transform("basket-judge")
+    Map<String, Object> judge(String response) {
+        return Map.of("namesUnique", "true");
+    }
+
+    @Transform("receipt-dom")
+    org.w3c.dom.Document receiptDom(String response) throws Exception {
+        var factory = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        return factory.newDocumentBuilder()
+                .parse(new org.xml.sax.InputSource(new java.io.StringReader(response)));
+    }
+
+    @Check("mentions-category")
+    boolean mentionsCategory(String subject) {
+        return subject.contains("category");
+    }
+
+    @Covariates("triage-assistant")
+    Map<String, String> triageCovariates() {
+        return Map.of("rules-hash", "abc123");
     }
 }

--- a/punit-decl/src/test/resources/META-INF/services/org.mavai.punit.decl.spi.ServiceType
+++ b/punit-decl/src/test/resources/META-INF/services/org.mavai.punit.decl.spi.ServiceType
@@ -1,0 +1,1 @@
+org.mavai.punit.decl.internal.run.EchoServiceType

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/domview.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/domview.yaml
@@ -1,0 +1,13 @@
+format: mavai-contract/1
+contract: registered-view-takes-an-xpath
+service: receipt-service
+transforms:
+  dom: receipt-dom
+criteria:
+  - name: total-is-decimal
+    threshold: 0.5
+    postconditions:
+      - in: dom
+        path: "/receipt/total"
+        matches: '^\d+\.\d{2}$'
+inputs: ["order-1"]

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/dual.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/dual.yaml
@@ -1,0 +1,6 @@
+format: mavai-contract/1
+contract: definition-wins-service-resolution
+service: dual-source
+criteria:
+  - { threshold: 0.5, contains: "from-the-definition" }
+inputs: ["anything"]

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/echo.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/echo.yaml
@@ -1,0 +1,6 @@
+format: mavai-contract/1
+contract: built-in-type-resolves-via-service-loader
+service: echo-service
+criteria:
+  - { threshold: 0.5, contains: "echo:" }
+inputs: ["ping"]

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/judged.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/judged.yaml
@@ -1,0 +1,14 @@
+format: mavai-contract/1
+contract: judged-view-takes-a-jsonpath
+service: basket-builder
+transforms:
+  judged: basket-judge
+criteria:
+  - name: names-are-unique
+    threshold: 0.5
+    postconditions:
+      - in: judged
+        path: "$.namesUnique"
+        equals: "true"
+inputs:
+  - "a dozen eggs, please"

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/mavai-services.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/mavai-services.yaml
@@ -1,0 +1,19 @@
+format: mavai-services/1
+services:
+  triage-assistant:
+    type: triage
+    configuration:
+      tone: matter-of-fact
+      certainty: 0.9
+    explorations:
+      - certainty: 0.7
+      - tone: reassuring
+  echo-service:
+    type: echo-model
+    configuration:
+      prefix: "echo:"
+  dual-source:
+    type: triage
+    configuration:
+      tone: from-the-definition
+      certainty: 0.5

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/triage.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/triage.yaml
@@ -1,0 +1,11 @@
+format: mavai-contract/1
+contract: triage-assistant-routes-requests
+service: triage-assistant
+criteria:
+  - name: request-is-routed
+    threshold: 0.7
+    postconditions:
+      - contains: "category"
+      - satisfies: mentions-category
+inputs:
+  - "I was charged twice for one invoice"


### PR DESCRIPTION
Phase 3 of the declarative authoring surface (directive: DIR-PU-DA-declarative-surface; builds on #244). The bindings artefact grows to its full contract, and `mavai-services.yaml` definitions become a live second population of the service registry.

## The bindings artefact

Beside `@Binding` (from #244), the bindings class now carries:

- **`@BindingFactory("type")`** — a configurable service *type* whose method parameter list **is** the configuration schema: kebab-case file keys map to camelCase parameters, scalar types are checked, and a definition that does not fit is refused at load with the rendered signature in the message (`triage(tone: String, certainty: double)`). The factory runs at contract-load time and returns the per-sample callable. (v1: all parameters are required keys — Java has no parameter defaults; an optionality mechanism is a later, demanded addition.)
- **`@Transform("view")`** — a registered transformation usable in `transforms:` beside the stock three. An `Outcome` failure travels as a per-sample transform failure; a thrown exception remains a defect and aborts — the family's defect≠FAIL taxonomy.
- **`@Check("name")`** — what `satisfies:` resolves to; answers with a `boolean` or an `Outcome`.
- **`@Covariates("service")`** — the computed covariate feed, joining the resolved configuration in run/baseline provenance; a key arriving from both feeds is refused.

Each registry keeps fail-fast duplicate and unresolvable semantics, with refusals naming the known names.

## Service definitions and the type registry

- Discovery: `mavai-services.yaml` beside the contract files in the test class's resource package, then the project root; `PUnit.declared().services(path)` overrides.
- Every definition's configuration validates through its type at load; the exploration grid's duplicate-point refusal runs over **resolved covariate values** (two entries for one population, or an entry restating the baseline, refuse naming the colliding entries).
- The type registry's two populations: **built-ins via ServiceLoader** through the new `org.mavai.punit.decl.spi` extension seam (`ServiceType` / `ConfiguredService` — the deliberate API punit-lm will implement; exported, and added to both sealing guards), and **user types** from the bindings class. Built-in names cannot be shadowed; a definition wins `service:` resolution over a same-named binding.
- Resolved configuration and the covariate feed land on the contract as custom covariates through punit-core's existing covariate machinery.

## Deferrals lifted

`satisfies:` and registered transformations from #244's log both work now — including `path:` over a registered view, where the expression's own syntax selects the language (`$`-rooted → JSONPath via the module's RFC 9535 engine, anything else → XPath 1.0) with per-trial subject-type checks.

11 new end-to-end tests (user type via factory signature, built-in via ServiceLoader, definition-wins, shadowing/misfit/unknown-type/duplicate-point refusals, registered-view JSONPath and XPath, satisfies, covariates). Full build green, all guards included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyYHPj1u28MZ4bEPHKUX2V