### PR TITLE
Add the declarative measure verb; the measure-then-test ratchet runs end to end

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -170,6 +170,25 @@ public final class PUnit {
          * FAIL — and always before any sample runs.
          */
         void assertPasses();
+
+        /**
+         * Runs the declared contract as a measure experiment: every
+         * criterion recorded, the standard baseline artefact always
+         * persisted, no verdict rendered — recording is the
+         * experiment's main act. A measurement's budget is an
+         * experimental-design decision: an explicit sample count is
+         * required (1,000 is baseline-grade; a smaller deliberate
+         * budget is legitimate — an empirical bar derived from a
+         * smaller baseline widens honestly).
+         */
+        void run();
+
+        /**
+         * The measure experiment with the developer's opt-in assertion:
+         * identical recording and persistence-before-assertion, then
+         * asserts each declared bar was met.
+         */
+        void assertMeets();
     }
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -175,13 +175,15 @@ public final class PUnit {
          * Runs the declared contract as a measure experiment: every
          * criterion recorded, the standard baseline artefact always
          * persisted, no verdict rendered — recording is the
-         * experiment's main act. A measurement's budget is an
-         * experimental-design decision: an explicit sample count is
-         * required (1,000 is baseline-grade; a smaller deliberate
-         * budget is legitimate — an empirical bar derived from a
-         * smaller baseline widens honestly).
+         * experiment's main act. The terminal carries the verb: the
+         * declarative opener and the contract file are both
+         * posture-free, so the posture lives here. A measurement's
+         * budget is an experimental-design decision: an explicit
+         * sample count is required (1,000 is baseline-grade; a smaller
+         * deliberate budget is legitimate — an empirical bar derived
+         * from a smaller baseline widens honestly).
          */
-        void run();
+        void measure();
 
         /**
          * The measure experiment with the developer's opt-in assertion:

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -80,13 +80,87 @@ public final class DeclaredRun implements Declared {
 
     @Override
     public void assertPasses() {
+        Instantiated instantiated = instantiate(true);
+        Sizing.Sized sized = Sizing.resolve(instantiated.declaration(), samples);
+        runPlan(instantiated.declaration(), sized);
+        PUnit.testing(instantiated.sampling(sized.samples()))
+                .intent(instantiated.declaration().intent() == DeclaredIntent.SMOKE
+                        ? TestIntent.SMOKE
+                        : TestIntent.VERIFICATION)
+                .assertPasses();
+    }
+
+    @Override
+    public void run() {
+        Instantiated instantiated = instantiate(false);
+        Sizing.Sized sized = measureBudget(instantiated.declaration());
+        runPlan(instantiated.declaration(), sized);
+        PUnit.measuring(instantiated.sampling(sized.samples())).run();
+    }
+
+    @Override
+    public void assertMeets() {
+        Instantiated instantiated = instantiate(false);
+        Sizing.Sized sized = measureBudget(instantiated.declaration());
+        runPlan(instantiated.declaration(), sized);
+        PUnit.measuring(instantiated.sampling(sized.samples())).assertMeets();
+    }
+
+    /**
+     * A measurement's budget is always typed: property, then the
+     * builder's {@code samples(N)} — never a default.
+     */
+    private Sizing.Sized measureBudget(ContractDeclaration declaration) {
+        if (power != null || tolerateBare != null || !tolerateNamed.isEmpty()) {
+            throw new ContractConfigurationException(
+                    "tolerate/power overrides target the test posture — a measure run records "
+                            + "every criterion and consults no claims");
+        }
+        String property = "punit.samples." + declaration.contract();
+        String propertyValue = System.getProperty(property);
+        if (propertyValue != null) {
+            return new Sizing.Sized(Integer.parseInt(propertyValue.trim()), "set via -D" + property);
+        }
+        if (samples != null) {
+            return new Sizing.Sized(samples, "set via .samples(" + samples + ")");
+        }
+        throw new ContractConfigurationException(
+                "a measurement's budget is an experimental-design decision — type it with "
+                        + ".samples(N) or -D" + property + "=N (1,000 is baseline-grade; a "
+                        + "smaller deliberate budget is legitimate — an empirical bar derived "
+                        + "from a smaller baseline widens honestly)");
+    }
+
+    private void runPlan(ContractDeclaration declaration, Sizing.Sized sized) {
+        System.out.println("[PUNIT] run plan: contract '" + declaration.contract() + "', "
+                + sized.samples() + " samples — " + sized.provenance());
+    }
+
+    private record Instantiated(
+            ContractDeclaration declaration,
+            ServiceContract<NoFactors, Object, String> contract,
+            List<Object> inputs) {
+
+        Sampling<NoFactors, Object, String> sampling(int samples) {
+            return Sampling.<NoFactors, Object, String>builder()
+                    .serviceContractFactory(factors -> contract)
+                    .inputs(inputs)
+                    .samples(samples)
+                    .build();
+        }
+    }
+
+    private Instantiated instantiate(boolean testPosture) {
         ContractLocator.Located located = ContractLocator.locate(caller, methodName, explicitName);
         ContractDeclaration declaration = located.declaration();
-        if (declaration.latency() != null) {
+        if (declaration.latency() != null && !declaration.latency().empirical().isEmpty()) {
             throw new ContractConfigurationException(
-                    "the `latency:` block arrives with a later phase of the declarative surface");
+                    "the empirical `latency:` shape arrives with a later phase of the "
+                            + "declarative surface — declare explicit ceilings meanwhile");
         }
-        RiskClaims claims = RiskClaims.resolve(declaration, samples, power, tolerateBare, tolerateNamed);
+        RiskClaims claims = testPosture
+                ? RiskClaims.resolve(declaration, samples, power, tolerateBare, tolerateNamed)
+                : RiskClaims.none();
         BindingsRegistry registry = BindingsRegistry.of(resolveBindingsClass());
         ServicesResolver services = ServicesResolver.resolve(caller, servicesFile, registry);
         org.mavai.punit.decl.spi.ConfiguredService defined = services.lookup(declaration.service());
@@ -130,8 +204,6 @@ public final class DeclaredRun implements Declared {
                 registry);
         compiler.validateEagerly();
         Criteria<String> criteria = compiler.compile();
-        Sizing.Sized sized = Sizing.resolve(declaration, samples);
-
         ServiceContract<NoFactors, Object, String> contract = new ServiceContract<>() {
             @Override
             public Criteria<String> criteria() {
@@ -164,25 +236,30 @@ public final class DeclaredRun implements Declared {
                 covariates.forEach((key, value) -> resolvers.put(key, () -> value));
                 return resolvers;
             }
+
+            @Override
+            public org.mavai.punit.api.criterion.LatencyCriterion latency() {
+                if (declaration.latency() == null || declaration.latency().ceilings().isEmpty()) {
+                    return ServiceContract.super.latency();
+                }
+                org.mavai.punit.api.criterion.LatencyCriterion criterion = null;
+                for (var ceiling : declaration.latency().ceilings()) {
+                    org.mavai.punit.api.PercentileKey key =
+                            org.mavai.punit.api.PercentileKey.valueOf(
+                                    ceiling.percentile().toUpperCase(java.util.Locale.ROOT));
+                    java.time.Duration bound = java.time.Duration.ofMillis(ceiling.millis());
+                    criterion = criterion == null
+                            ? Criteria.meeting().atMost(key, bound)
+                            : criterion.atMost(key, bound);
+                }
+                return criterion;
+            }
         };
 
         List<Object> inputs = declaration.inputs().stream()
                 .map(InputDeclaration::value)
                 .toList();
-        Sampling<NoFactors, Object, String> sampling = Sampling.<NoFactors, Object, String>builder()
-                .serviceContractFactory(factors -> contract)
-                .inputs(inputs)
-                .samples(sized.samples())
-                .build();
-
-        System.out.println("[PUNIT] run plan: contract '" + declaration.contract() + "', "
-                + sized.samples() + " samples — " + sized.provenance());
-
-        PUnit.testing(sampling)
-                .intent(declaration.intent() == DeclaredIntent.SMOKE
-                        ? TestIntent.SMOKE
-                        : TestIntent.VERIFICATION)
-                .assertPasses();
+        return new Instantiated(declaration, contract, inputs);
     }
 
     private Class<?> resolveBindingsClass() {

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -91,7 +91,7 @@ public final class DeclaredRun implements Declared {
     }
 
     @Override
-    public void run() {
+    public void measure() {
         Instantiated instantiated = instantiate(false);
         Sizing.Sized sized = measureBudget(instantiated.declaration());
         runPlan(instantiated.declaration(), sized);

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/RiskClaims.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/RiskClaims.java
@@ -41,6 +41,11 @@ final class RiskClaims {
         return power;
     }
 
+    /** The measure posture's empty claims — no overrides, no derivation. */
+    static RiskClaims none() {
+        return new RiskClaims(new LinkedHashMap<>(), null);
+    }
+
     static RiskClaims resolve(ContractDeclaration declaration, Integer explicitSamples,
             Double builderPower, Double builderBare, Map<String, Double> builderNamed) {
         String contract = declaration.contract();

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -109,7 +109,7 @@ class DeclaredRunTest {
         @DisplayName("a measurement's budget must be typed — never defaulted")
         void budgetRequired() {
             Declared run = PUnit.declared("greeting-service-is-polite");
-            assertThatThrownBy(run::run)
+            assertThatThrownBy(run::measure)
                     .isInstanceOf(ContractConfigurationException.class)
                     .hasMessageContaining("experimental-design decision")
                     .hasMessageContaining("1,000 is baseline-grade");
@@ -121,7 +121,7 @@ class DeclaredRunTest {
                 throws java.io.IOException {
             System.setProperty("punit.baseline.dir", directory.toString());
             try {
-                PUnit.declared("greeting-service-is-polite").samples(40).run();
+                PUnit.declared("greeting-service-is-polite").samples(40).measure();
                 try (var files = java.nio.file.Files.walk(directory)) {
                     assertThat(files.filter(java.nio.file.Files::isRegularFile).count())
                             .as("persisted baseline artefacts")
@@ -157,7 +157,7 @@ class DeclaredRunTest {
         void measureThenTest(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory) {
             System.setProperty("punit.baseline.dir", directory.toString());
             try {
-                PUnit.declared("mostly-polite-holds-its-measured-form").samples(100).run();
+                PUnit.declared("mostly-polite-holds-its-measured-form").samples(100).measure();
                 // With the baseline in place the empirical criterion is
                 // judged — no INCONCLUSIVE abort, and the always-polite
                 // greeter clears both its bars.
@@ -175,7 +175,7 @@ class DeclaredRunTest {
         void overridesRefusedOnMeasure() {
             Declared run = PUnit.declared("greeting-service-is-polite")
                     .samples(50).atPower(0.9);
-            assertThatThrownBy(run::run)
+            assertThatThrownBy(run::measure)
                     .isInstanceOf(ContractConfigurationException.class)
                     .hasMessageContaining("test posture");
         }

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -87,6 +87,98 @@ class DeclaredRunTest {
             assertThatCode(() -> PUnit.declared().assertPasses())
                     .doesNotThrowAnyException();
         }
+
+        @Test
+        @DisplayName("explicit latency ceilings are judged on the test run")
+        void latencyBlockNotYetSupported() {
+            // The contract name is historical: explicit ceilings now run.
+            // The percentile-existence gate needs 59 samples for p95 at
+            // the default confidence, so the budget is explicit; a fast
+            // local binding sits well under the 500ms ceiling.
+            assertThatCode(() ->
+                    PUnit.declared("latency-block-not-yet-supported").samples(60).assertPasses())
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("measure")
+    class MeasureVerb {
+
+        @Test
+        @DisplayName("a measurement's budget must be typed — never defaulted")
+        void budgetRequired() {
+            Declared run = PUnit.declared("greeting-service-is-polite");
+            assertThatThrownBy(run::run)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("experimental-design decision")
+                    .hasMessageContaining("1,000 is baseline-grade");
+        }
+
+        @Test
+        @DisplayName("a measure run records and always persists the baseline artefact")
+        void measurePersists(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            System.setProperty("punit.baseline.dir", directory.toString());
+            try {
+                PUnit.declared("greeting-service-is-polite").samples(40).run();
+                try (var files = java.nio.file.Files.walk(directory)) {
+                    assertThat(files.filter(java.nio.file.Files::isRegularFile).count())
+                            .as("persisted baseline artefacts")
+                            .isPositive();
+                }
+            } finally {
+                System.clearProperty("punit.baseline.dir");
+            }
+        }
+
+        @Test
+        @DisplayName("assertMeets records, persists, then asserts the declared bars")
+        void assertMeetsPersistsBeforeAsserting(
+                @org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            System.setProperty("punit.baseline.dir", directory.toString());
+            try {
+                Declared failing = PUnit.declared("rude-service-fails-its-bar").samples(20);
+                assertThatThrownBy(failing::assertMeets)
+                        .isInstanceOf(AssertionFailedError.class);
+                try (var files = java.nio.file.Files.walk(directory)) {
+                    assertThat(files.filter(java.nio.file.Files::isRegularFile).count())
+                            .as("the artefact is on disk whatever the outcome")
+                            .isPositive();
+                }
+            } finally {
+                System.clearProperty("punit.baseline.dir");
+            }
+        }
+
+        @Test
+        @DisplayName("measure then test: the empirical criterion is judged against the baseline")
+        void measureThenTest(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory) {
+            System.setProperty("punit.baseline.dir", directory.toString());
+            try {
+                PUnit.declared("mostly-polite-holds-its-measured-form").samples(100).run();
+                // With the baseline in place the empirical criterion is
+                // judged — no INCONCLUSIVE abort, and the always-polite
+                // greeter clears both its bars.
+                assertThatCode(() ->
+                        PUnit.declared("mostly-polite-holds-its-measured-form").samples(100)
+                                .assertPasses())
+                        .doesNotThrowAnyException();
+            } finally {
+                System.clearProperty("punit.baseline.dir");
+            }
+        }
+
+        @Test
+        @DisplayName("tolerate and power overrides target the test posture, not measure")
+        void overridesRefusedOnMeasure() {
+            Declared run = PUnit.declared("greeting-service-is-polite")
+                    .samples(50).atPower(0.9);
+            assertThatThrownBy(run::run)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("test posture");
+        }
     }
 
     @Nested
@@ -388,12 +480,12 @@ class DeclaredRunTest {
         }
 
         @Test
-        @DisplayName("the latency block is refused until its phase arrives")
-        void latencyBlock() {
-            Declared run = PUnit.declared("latency-block-not-yet-supported");
+        @DisplayName("the empirical latency shape is refused until its phase arrives")
+        void empiricalLatencyShape() {
+            Declared run = PUnit.declared("empirical-latency-not-yet-supported");
             assertThatThrownBy(run::assertPasses)
                     .isInstanceOf(ContractConfigurationException.class)
-                    .hasMessageContaining("latency");
+                    .hasMessageContaining("empirical `latency:`");
         }
 
         @Test

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
@@ -52,6 +52,17 @@ class MavaiBindings {
         return "<receipt><total>12.50</total></receipt>";
     }
 
+    @Binding("mostly-polite")
+    String mostlyPolite(String name) {
+        // Deterministically imperfect: every twentieth response is curt,
+        // so a measured baseline records a 0.95 rate — inside (0, 1),
+        // as the engine's risk-driven sizing requires.
+        int turn = MOSTLY_POLITE_TURN++;
+        return turn % 20 == 19 ? "hmpf, " + name : "hello " + name + "!";
+    }
+
+    private static int MOSTLY_POLITE_TURN;
+
     @Binding("dual-source")
     String dualSourceBinding(String input) {
         return "from-the-binding";

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/latency-empirical.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/latency-empirical.yaml
@@ -1,0 +1,8 @@
+format: mavai-contract/1
+contract: empirical-latency-not-yet-supported
+service: greeting-service
+latency:
+  empirical: [p95]
+criteria:
+  - { threshold: 0.5, contains: "hello" }
+inputs: ["Alice"]

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/roundtrip.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/roundtrip.yaml
@@ -1,0 +1,11 @@
+format: mavai-contract/1
+contract: mostly-polite-holds-its-measured-form
+service: mostly-polite
+criteria:
+  - name: clears-its-bar
+    threshold: 0.5
+    contains: "hello"
+  - name: no-worse-than-measured
+    tolerate: 0.7
+    contains: "hello"
+inputs: ["Alice"]


### PR DESCRIPTION
Phase 4a of the declarative authoring surface (directive: DIR-PU-DA-declarative-surface; builds on #245). The declarative surface gains its recording verb, and with it the family's measure-then-test ratchet closes.

## The measure verb

```java
@Experiment
void basketBuilderBaseline() {
    PUnit.declared().samples(1000).run();
}
```

- **`run()`** — the measure posture through punit's existing `PUnit.measuring(...)` path: every criterion recorded, the standard baseline artefact **always** persisted to the conventional baseline directory, no verdict rendered.
- **`assertMeets()`** — the developer's opt-in assertion with persistence-before-assertion: identical recording, artefact on disk whatever the outcome, then the declared bars asserted (verified on a failing bar).
- **The budget is always typed**: `.samples(N)` or the per-contract property — never defaulted. The refusal recommends 1,000 as baseline-grade and notes that a smaller deliberate budget is legitimate (an empirical bar derived from a smaller baseline widens honestly).
- Tolerate/power overrides on a measure run are refused — they target the test posture; a measure records and consults no claims.

## The ratchet — and a discovery

With baselines producible declaratively, a subsequent test's empirical criteria resolve their matching baseline and are judged against it — the same file, measured first, tested forever after. Testing this surfaced that **punit's engine already performs risk-driven sizing engine-side**: when an empirical `tolerate:` claim meets a resolved baseline, `SampleSizeResolver` prices the claim through the oracle-locked `RiskDrivenSizingCalculator`, including the degenerate-baseline guard (a perfect 1.0-rate baseline is refused — the round-trip fixture now measures a deterministic 0.95 rate instead). Risk-driven runs therefore work fully under an explicit budget today; only budget *auto-derivation* remains a constructive refusal, since it would need baseline reads punit-core keeps internal (a public sizing seam is logged as a candidate core amendment).

## Latency ceilings

The `latency:` block's explicit shape now compiles onto the contract's latency criterion (chained `atMost` bounds per percentile), judged on test runs with the engine's existing percentile-existence gate — which surfaced a follow-up note: derived-minimum sizing does not yet count latency support (a p95 assertion needs ≥59 samples at the default confidence), so latency-asserting contracts currently want an explicit budget. The empirical latency shape remains a named refusal for its phase.

Six new measure tests plus latency updates; full build green, all guards included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyYHPj1u28MZ4bEPHKUX2V