### PR TITLE
Add the declarative explore verb over the services file's configuration grid

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/api/FactorBundle.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/FactorBundle.java
@@ -15,7 +15,7 @@ import java.util.TreeMap;
  * canonical form consumed by the baseline spec YAML and by the
  * {@code factorBundleHash} segment of the baseline filename.
  *
- * <p>The bundle is produced from one of two shapes:
+ * <p>The bundle is produced from one of three shapes:
  *
  * <ul>
  *   <li>A Java {@code record} — the multi-component shape. The record's
@@ -29,6 +29,11 @@ import java.util.TreeMap;
  *       sugar for service contracts parameterised over a single named, finite
  *       set of choices, where defining a one-component wrapper record
  *       would add ceremony without information.</li>
+ *   <li>A string-keyed {@code Map} — the named-entries shape, for
+ *       callers whose factor components exist only at run time (the
+ *       declarative reader's resolved configurations). Entries are
+ *       taken in the map's iteration order and each value is lifted
+ *       via {@link FactorValue#of(Object)}.</li>
  * </ul>
  *
  * <p>{@link #canonicalJson()} serialises the bundle with keys sorted
@@ -87,15 +92,46 @@ public final class FactorBundle {
      */
     public static <FT> FactorBundle of(FT factors) {
         Objects.requireNonNull(factors, "factors");
+        if (factors instanceof java.util.Map<?, ?> named) {
+            return fromMap(named);
+        }
         if (!(factors instanceof Enum<?>) && !factors.getClass().isRecord()) {
             throw new IllegalArgumentException(
-                    "factor type must be a record or enum, got "
+                    "factor type must be a record, enum, or string-keyed map, got "
                             + factors.getClass().getName());
         }
         if (factors instanceof Enum<?> e) {
             return fromEnum(e);
         }
         return fromRecord(factors);
+    }
+
+    /**
+     * The named-entries shape: a string-keyed map of admissible scalar
+     * values, in the map's iteration order — the form a declaratively
+     * resolved configuration takes, where no record type exists to
+     * carry the components. Canonicalisation and hashing are identical
+     * to the record shape's.
+     */
+    private static FactorBundle fromMap(java.util.Map<?, ?> named) {
+        if (named.isEmpty()) {
+            return EMPTY;
+        }
+        List<Entry> out = new ArrayList<>(named.size());
+        for (java.util.Map.Entry<?, ?> entry : named.entrySet()) {
+            if (!(entry.getKey() instanceof String name)) {
+                throw new IllegalArgumentException(
+                        "factor map keys must be strings, got "
+                                + (entry.getKey() == null ? "null" : entry.getKey().getClass().getName()));
+            }
+            try {
+                out.add(new Entry(name, FactorValue.of(entry.getValue())));
+            } catch (RuntimeException e) {
+                throw new IllegalArgumentException(
+                        "factor map has inadmissible value for '" + name + "': " + e.getMessage(), e);
+            }
+        }
+        return new FactorBundle(out);
     }
 
     private static FactorBundle fromEnum(Enum<?> e) {

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -191,6 +191,25 @@ public final class PUnit {
          * asserts each declared bar was met.
          */
         void assertMeets();
+
+        /**
+         * The per-configuration sample count for an explore run
+         * (default 5 — descriptive, ungated: feasibility protects a
+         * verdict, and explore renders none).
+         */
+        Declared samplesPerConfig(int samplesPerConfig);
+
+        /**
+         * Runs the declared contract as an explore experiment: one
+         * measure-shaped, descriptive run per configuration of the
+         * referenced service definition's grid — the baseline
+         * {@code configuration:} plus each {@code explorations:} delta
+         * entry — one exploration artefact per configuration, no
+         * thresholds consulted, no verdict. Requires a service
+         * definition: a bare code binding carries no configuration
+         * grid.
+         */
+        void explore();
     }
 
     /**

--- a/punit-core/src/test/java/org/mavai/punit/api/FactorBundleTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/api/FactorBundleTest.java
@@ -82,7 +82,7 @@ class FactorBundleTest {
     void rejectsNonRecordNonEnum() {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> FactorBundle.of("not a record"))
-                .withMessageContaining("must be a record or enum");
+                .withMessageContaining("must be a record, enum, or string-keyed map");
     }
 
     @Test
@@ -125,5 +125,34 @@ class FactorBundleTest {
                         + "\"streaming\":true,\"temperature\":0.3}");
         // Hash must be stable — equal across JVMs and across runs.
         assertThat(b.bundleHash()).matches("[0-9a-f]{4}");
+    }
+
+    @org.junit.jupiter.api.Test
+    @org.junit.jupiter.api.DisplayName("lifts a string-keyed map in iteration order — the named-entries shape")
+    void liftsStringKeyedMap() {
+        java.util.Map<String, Object> named = new java.util.LinkedHashMap<>();
+        named.put("temperature", 0.2);
+        named.put("model", "small-model");
+        named.put("cached", true);
+        FactorBundle bundle = FactorBundle.of(named);
+        org.assertj.core.api.Assertions.assertThat(bundle.entries()).hasSize(3);
+        org.assertj.core.api.Assertions.assertThat(bundle.entries().get(0).name())
+                .isEqualTo("temperature");
+        org.assertj.core.api.Assertions.assertThat(bundle.canonicalJson())
+                .isEqualTo("{\"cached\":true,\"model\":\"small-model\",\"temperature\":0.2}");
+    }
+
+    @org.junit.jupiter.api.Test
+    @org.junit.jupiter.api.DisplayName("rejects a map with a non-string key or inadmissible value")
+    void rejectsBadMapShapes() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                () -> FactorBundle.of(java.util.Map.of(42, "x")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("keys must be strings");
+        java.util.Map<String, Object> withNull = new java.util.LinkedHashMap<>();
+        withNull.put("absent", null);
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> FactorBundle.of(withNull))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inadmissible value for 'absent'");
     }
 }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -30,6 +30,7 @@ public final class DeclaredRun implements Declared {
     private final String explicitName;
 
     private Integer samples;
+    private Integer samplesPerConfig;
     private Class<?> bindingsClass;
     private java.nio.file.Path servicesFile;
     private Double power;
@@ -51,6 +52,12 @@ public final class DeclaredRun implements Declared {
     @Override
     public Declared bindings(Class<?> bindingsClass) {
         this.bindingsClass = bindingsClass;
+        return this;
+    }
+
+    @Override
+    public Declared samplesPerConfig(int samplesPerConfig) {
+        this.samplesPerConfig = samplesPerConfig;
         return this;
     }
 
@@ -104,6 +111,133 @@ public final class DeclaredRun implements Declared {
         Sizing.Sized sized = measureBudget(instantiated.declaration());
         runPlan(instantiated.declaration(), sized);
         PUnit.measuring(instantiated.sampling(sized.samples())).assertMeets();
+    }
+
+    @Override
+    public void explore() {
+        ContractLocator.Located located = ContractLocator.locate(caller, methodName, explicitName);
+        ContractDeclaration declaration = located.declaration();
+        if (declaration.latency() != null && !declaration.latency().empirical().isEmpty()) {
+            throw new ContractConfigurationException(
+                    "the empirical `latency:` shape arrives with a later phase of the "
+                            + "declarative surface — declare explicit ceilings meanwhile");
+        }
+        if (samples != null) {
+            throw new ContractConfigurationException(
+                    ".samples(N) sizes a test or measure run — an exploration is sized per "
+                            + "configuration: use .samplesPerConfig(N) (default 5)");
+        }
+        if (power != null || tolerateBare != null || !tolerateNamed.isEmpty()) {
+            throw new ContractConfigurationException(
+                    "tolerate/power overrides target the test posture — an explore run is "
+                            + "descriptive and consults no claims");
+        }
+        BindingsRegistry registry = BindingsRegistry.of(resolveBindingsClass());
+        ServicesResolver services = ServicesResolver.resolve(caller, servicesFile, registry);
+        if (!services.isDefined(declaration.service())) {
+            if (registry.hasBinding(declaration.service())) {
+                throw new ContractConfigurationException(
+                        "service '" + declaration.service() + "' resolves to a bare code "
+                                + "binding, which carries no configuration grid — explore "
+                                + "needs a mavai-services.yaml definition (a configurable "
+                                + "@BindingFactory type with a configuration: block)");
+            }
+            throw new ContractConfigurationException(
+                    "service '" + declaration.service() + "' has no mavai-services.yaml "
+                            + "definition to explore (registered types: "
+                            + services.registeredTypeNames() + ")");
+        }
+        Map<String, String> covariateFeed = registry.covariateFeed(declaration.service());
+        StockViews views = new StockViews(declaration, registry);
+        AtomicReference<Object> currentInput = new AtomicReference<>();
+        CriteriaCompiler compiler = new CriteriaCompiler(
+                declaration, views, currentInput, Map.of(), null, registry);
+        compiler.validateEagerly();
+        Criteria<String> criteria = compiler.compile();
+
+        List<Map<String, Object>> grid = services.explorationGrid(declaration.service());
+        int perConfig = exploreBudget(declaration);
+        List<Object> inputs = declaration.inputs().stream()
+                .map(InputDeclaration::value)
+                .toList();
+
+        Sampling<Map<String, Object>, Object, String> sampling =
+                Sampling.<Map<String, Object>, Object, String>builder()
+                        .serviceContractFactory(configuration -> exploreContract(
+                                declaration, criteria, currentInput,
+                                services, covariateFeed, configuration))
+                        .inputs(inputs)
+                        .samples(perConfig)
+                        .build();
+
+        System.out.println("[PUNIT] run plan: contract '" + declaration.contract() + "', "
+                + grid.size() + " configurations x " + perConfig + " samples — explore");
+
+        PUnit.exploring(sampling).grid(grid).run();
+    }
+
+    private ServiceContract<Map<String, Object>, Object, String> exploreContract(
+            ContractDeclaration declaration,
+            Criteria<String> criteria,
+            AtomicReference<Object> currentInput,
+            ServicesResolver services,
+            Map<String, String> covariateFeed,
+            Map<String, Object> configuration) {
+        org.mavai.punit.decl.spi.ConfiguredService point =
+                services.configurePoint(declaration.service(), configuration);
+        Map<String, String> covariates =
+                new java.util.LinkedHashMap<>(point.configurationCovariates());
+        covariates.putAll(covariateFeed);
+        return new ServiceContract<>() {
+            @Override
+            public Criteria<String> criteria() {
+                return criteria;
+            }
+
+            @Override
+            public Outcome<String> invoke(Object input, TokenTracker tracker) {
+                currentInput.set(input);
+                return point.invoke(input);
+            }
+
+            @Override
+            public String id() {
+                return declaration.contract();
+            }
+
+            @Override
+            public List<org.mavai.punit.api.covariate.Covariate> covariates() {
+                return covariates.keySet().stream()
+                        .map(key -> org.mavai.punit.api.covariate.Covariate.custom(key,
+                                org.mavai.punit.api.covariate.CovariateCategory.CONFIGURATION))
+                        .toList();
+            }
+
+            @Override
+            public Map<String, java.util.function.Supplier<String>> customCovariateResolvers() {
+                Map<String, java.util.function.Supplier<String>> resolvers =
+                        new java.util.LinkedHashMap<>();
+                covariates.forEach((key, value) -> resolvers.put(key, () -> value));
+                return resolvers;
+            }
+        };
+    }
+
+    /** Explore is sized per configuration: property, builder, then the descriptive default 5. */
+    private int exploreBudget(ContractDeclaration declaration) {
+        String property = "punit.samplesPerConfig." + declaration.contract();
+        String propertyValue = System.getProperty(property);
+        if (propertyValue != null) {
+            return Integer.parseInt(propertyValue.trim());
+        }
+        if (samplesPerConfig != null) {
+            if (samplesPerConfig < 1) {
+                throw new ContractConfigurationException(
+                        ".samplesPerConfig(" + samplesPerConfig + ") must be positive");
+            }
+            return samplesPerConfig;
+        }
+        return 5;
     }
 
     /**

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
@@ -31,6 +31,7 @@ final class ServicesResolver {
 
     private final Map<String, ServiceType> types = new LinkedHashMap<>();
     private final Map<String, ConfiguredService> configured = new LinkedHashMap<>();
+    private final Map<String, ServiceEntry> entries = new LinkedHashMap<>();
 
     private ServicesResolver() {}
 
@@ -64,6 +65,34 @@ final class ServicesResolver {
         return configured.get(serviceName);
     }
 
+    /** Whether a definition exists for the service name. */
+    boolean isDefined(String serviceName) {
+        return entries.containsKey(serviceName);
+    }
+
+    /**
+     * The definition's exploration grid as resolved configuration
+     * records: the baseline first, then each delta entry merged over
+     * it — {baseline} ∪ explorations, one point per population.
+     */
+    java.util.List<Map<String, Object>> explorationGrid(String serviceName) {
+        ServiceEntry entry = entries.get(serviceName);
+        java.util.List<Map<String, Object>> grid = new java.util.ArrayList<>();
+        grid.add(new LinkedHashMap<>(entry.configuration()));
+        for (Map<String, Object> deltas : entry.explorations()) {
+            Map<String, Object> merged = new LinkedHashMap<>(entry.configuration());
+            merged.putAll(deltas);
+            grid.add(merged);
+        }
+        return grid;
+    }
+
+    /** Configures the named service at one resolved grid point. */
+    ConfiguredService configurePoint(String serviceName, Map<String, Object> configuration) {
+        ServiceEntry entry = entries.get(serviceName);
+        return types.get(entry.type()).configure(serviceName, configuration);
+    }
+
     String registeredTypeNames() {
         return types.isEmpty() ? "none registered" : String.join(", ", new TreeMap<>(types).keySet());
     }
@@ -78,6 +107,7 @@ final class ServicesResolver {
                             + "class with @BindingFactory(\"" + entry.type() + "\"))");
         }
         configured.put(entry.name(), type.configure(entry.name(), entry.configuration()));
+        entries.put(entry.name(), entry);
         validateExplorations(entry, type);
     }
 

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -368,6 +368,48 @@ class DeclaredRunTest {
     }
 
     @Nested
+    @DisplayName("explore")
+    class ExploreVerb {
+
+        @Test
+        @DisplayName("an explore run emits one descriptive artefact per grid configuration")
+        void exploreEmitsPerConfiguration(
+                @org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            System.setProperty("punit.explorations.outputDir", directory.toString());
+            try {
+                PUnit.declared("triage-assistant-routes-requests").samplesPerConfig(3).explore();
+                try (var files = java.nio.file.Files.walk(directory)) {
+                    assertThat(files.filter(java.nio.file.Files::isRegularFile).count())
+                            .as("one artefact per grid point: baseline + two explorations")
+                            .isEqualTo(3);
+                }
+            } finally {
+                System.clearProperty("punit.explorations.outputDir");
+            }
+        }
+
+        @Test
+        @DisplayName("a bare code binding cannot be explored — it carries no grid")
+        void bareBindingRefused() {
+            Declared run = PUnit.declared("greeting-service-is-polite");
+            assertThatThrownBy(run::explore)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("no configuration grid")
+                    .hasMessageContaining("@BindingFactory");
+        }
+
+        @Test
+        @DisplayName("an exploration is sized per configuration, not per run")
+        void samplesRefusedOnExplore() {
+            Declared run = PUnit.declared("triage-assistant-routes-requests").samples(50);
+            assertThatThrownBy(run::explore)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining(".samplesPerConfig(");
+        }
+    }
+
+    @Nested
     @DisplayName("risk claims")
     class RiskClaimRules {
 


### PR DESCRIPTION
Phase 4b of the declarative authoring surface (directive: DIR-PU-DA-declarative-surface; builds on #246). The explore verb, on the terminal-carries-the-verb scheme:

```java
@Experiment
void basketBuilderConfigurations() {
    PUnit.declared().samplesPerConfig(5).explore();
}
```

## The explore verb

- One measure-shaped, **descriptive** run per configuration of the referenced service definition's grid — the baseline `configuration:` record plus each `explorations:` delta entry — driven through punit's existing `PUnit.exploring(...)` path, one exploration artefact per configuration under the conventional explorations directory. Thresholds are never consulted; no verdict is rendered.
- `samplesPerConfig(N)` defaults to 5 and is deliberately **ungated**: feasibility and power analysis protect a verdict, and explore renders none.
- **A definition is required**: a bare code binding carries no configuration grid and refuses with the configurable-registration pointer (`@BindingFactory` + a `configuration:` block).
- Sizing keys stay disjoint: `.samples(N)` on an explore run refuses naming `.samplesPerConfig(N)`; tolerate/power overrides refuse (they target the test posture).
- Each grid point's resolved configuration joins provenance as that point's covariates — populations identified by their covariate values, per the family model.

## The one core seam this strictly requires

`FactorBundle` accepted only records and enums — but a declaratively resolved configuration has no record type to carry its components. It gains a third, **named-entries** shape: a string-keyed map, entries in iteration order, canonicalisation and hashing identical to the record shape's, lifting matching the record path exactly (anything stringifiable lifts via `FactorValue`; null is inadmissible). Unit-tested in core alongside the existing shapes; the pre-existing rejection-message test updated for the widened wording.

Verification: explore end-to-end over a three-point grid (baseline + two deltas → exactly three artefacts), the bare-binding and sizing-key refusals, and the core unit tests. Full build green, all guards included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyYHPj1u28MZ4bEPHKUX2V