### PR TITLE
Add the declarative optimize verb over the definition's optimizations entries

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -210,6 +210,28 @@ public final class PUnit {
          * grid.
          */
         void explore();
+
+        /**
+         * The per-iteration sample count for an optimize run
+         * (default 5).
+         */
+        Declared samplesPerIteration(int samplesPerIteration);
+
+        /**
+         * Runs the service definition's sole {@code optimizations:}
+         * entry — the no-argument form for a definition declaring
+         * exactly one.
+         */
+        void optimize();
+
+        /**
+         * Runs the named {@code optimizations:} entry: the registered
+         * stepper proposes each next configuration, the scorer judges
+         * each iteration, and one optimization artefact records the
+         * iteration history and convergence. Descriptive posture —
+         * no thresholds, no verdict.
+         */
+        void optimize(String id);
     }
 
     /**

--- a/punit-decl/src/main/java/org/mavai/punit/decl/Scorer.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/Scorer.java
@@ -1,0 +1,21 @@
+package org.mavai.punit.decl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Registers a method of the bindings class as a named scorer — the
+ * judge an {@code optimizations:} entry's {@code scorer:} key resolves
+ * to. A no-argument method returning an
+ * {@link org.mavai.punit.api.spec.Scorer}. The default scorer,
+ * {@code pass-rate}, is built in and needs no registration.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Scorer {
+
+    /** The scorer's registry name — unique within the scorer registry. */
+    String value();
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/Stepper.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/Stepper.java
@@ -1,0 +1,24 @@
+package org.mavai.punit.decl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Registers a method of the bindings class as a named stepper — the
+ * algorithm an {@code optimizations:} entry's {@code stepper:} key
+ * resolves to. The method's parameter list <strong>is</strong> the
+ * entry's {@code stepper-config:} schema (kebab-case keys map to
+ * camelCase parameters, exactly as a {@link BindingFactory} factory's),
+ * and the method returns the constructed
+ * {@link org.mavai.punit.api.spec.FactorsStepper} — any state the
+ * algorithm keeps lives in the returned stepper's closure.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Stepper {
+
+    /** The stepper's registry name — unique within the stepper registry. */
+    String value();
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/BindingsRegistry.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/BindingsRegistry.java
@@ -14,6 +14,8 @@ import org.mavai.punit.decl.BindingFactory;
 import org.mavai.punit.decl.Check;
 import org.mavai.punit.decl.ContractConfigurationException;
 import org.mavai.punit.decl.Covariates;
+import org.mavai.punit.decl.Scorer;
+import org.mavai.punit.decl.Stepper;
 import org.mavai.punit.decl.Transform;
 import org.mavai.punit.decl.internal.model.FormDeclaration;
 
@@ -35,6 +37,8 @@ final class BindingsRegistry {
     private final Map<String, Method> transforms = new LinkedHashMap<>();
     private final Map<String, Method> checks = new LinkedHashMap<>();
     private final Map<String, Method> covariateFeeds = new LinkedHashMap<>();
+    private final Map<String, Method> steppers = new LinkedHashMap<>();
+    private final Map<String, Method> scorers = new LinkedHashMap<>();
 
     private BindingsRegistry(Class<?> bindingsClass, Object instance) {
         this.bindingsClass = bindingsClass;
@@ -62,6 +66,8 @@ final class BindingsRegistry {
             registry.register(method, Check.class, Check::value, registry.checks, "check");
             registry.register(method, Covariates.class, Covariates::value,
                     registry.covariateFeeds, "covariate feed");
+            registry.register(method, Stepper.class, Stepper::value, registry.steppers, "stepper");
+            registry.register(method, Scorer.class, Scorer::value, registry.scorers, "scorer");
         }
         for (String view : registry.transforms.keySet()) {
             if (view.equals(FormDeclaration.RAW_VIEW)) {
@@ -182,6 +188,41 @@ final class BindingsRegistry {
             covariates.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
         }
         return covariates;
+    }
+
+    /** The named stepper's factory method, or a refusal naming the registered ones. */
+    Method stepperFactory(String name) {
+        Method method = steppers.get(name);
+        if (method == null) {
+            String known = steppers.isEmpty() ? "none registered" : String.join(", ", steppers.keySet());
+            throw new ContractConfigurationException(
+                    "`stepper: " + name + "` names no registered stepper; known steppers in "
+                            + bindingsClass.getSimpleName() + ": " + known
+                            + " (register with @Stepper(\"" + name + "\"))");
+        }
+        return method;
+    }
+
+    /** The named scorer, resolved — {@code pass-rate} is built in. */
+    org.mavai.punit.api.spec.Scorer resolveScorer(String name) {
+        if (name.equals("pass-rate")) {
+            return org.mavai.punit.api.spec.Scorer.observedPassRate();
+        }
+        Method method = scorers.get(name);
+        if (method == null) {
+            String known = scorers.isEmpty() ? "pass-rate (built in)"
+                    : "pass-rate (built in), " + String.join(", ", scorers.keySet());
+            throw new ContractConfigurationException(
+                    "`scorer: " + name + "` names no registered scorer; known scorers: " + known
+                            + " (register with @Scorer(\"" + name + "\"))");
+        }
+        Object result = invoke(method, new Object[0]);
+        if (!(result instanceof org.mavai.punit.api.spec.Scorer scorer)) {
+            throw new ContractConfigurationException(
+                    "@Scorer(\"" + name + "\") must return an org.mavai.punit.api.spec.Scorer, got "
+                            + (result == null ? "null" : result.getClass().getSimpleName()));
+        }
+        return scorer;
     }
 
     interface Invoker {

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ConfigBinding.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ConfigBinding.java
@@ -1,0 +1,107 @@
+package org.mavai.punit.decl.internal.run;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.mavai.punit.decl.ContractConfigurationException;
+
+/**
+ * The factory-signature-is-the-schema rule, shared by every registry
+ * that binds a kebab-case configuration mapping onto a method's
+ * camelCase parameter list — service-type factories and stepper
+ * factories alike. A misfit is a load-time refusal carrying the
+ * rendered signature.
+ */
+final class ConfigBinding {
+
+    private ConfigBinding() {}
+
+    /** Binds the configuration onto the method's parameters, in slot order. */
+    static Object[] bind(String context, String name, Method method, Map<String, Object> configuration) {
+        Parameter[] parameters = method.getParameters();
+        Map<String, Parameter> byKey = new LinkedHashMap<>();
+        for (Parameter parameter : parameters) {
+            byKey.put(kebabCase(parameter.getName()), parameter);
+        }
+        for (String key : configuration.keySet()) {
+            if (!byKey.containsKey(key)) {
+                throw misfit(context, name, method, "unknown configuration key `" + key + ":`");
+            }
+        }
+        Object[] arguments = new Object[parameters.length];
+        int index = 0;
+        for (Map.Entry<String, Parameter> slot : byKey.entrySet()) {
+            if (!configuration.containsKey(slot.getKey())) {
+                throw misfit(context, name, method, "missing configuration key `" + slot.getKey() + ":`");
+            }
+            Object value = configuration.get(slot.getKey());
+            Object converted = convert(value, slot.getValue().getType());
+            if (converted == null) {
+                throw misfit(context, name, method, "`" + slot.getKey() + ":` must be a "
+                        + slot.getValue().getType().getSimpleName() + ", got "
+                        + (value == null ? "null" : value.getClass().getSimpleName()));
+            }
+            arguments[index++] = converted;
+        }
+        return arguments;
+    }
+
+    private static ContractConfigurationException misfit(
+            String context, String name, Method method, String problem) {
+        return new ContractConfigurationException(
+                context + ": " + problem + " — the configuration schema is the factory's "
+                        + "signature: " + renderedSignature(name, method));
+    }
+
+    /** The signature as authors read it: {@code name(kebab-key: Type, ...)}. */
+    static String renderedSignature(String name, Method method) {
+        return name + "(" + Arrays.stream(method.getParameters())
+                .map(parameter -> kebabCase(parameter.getName()) + ": "
+                        + parameter.getType().getSimpleName())
+                .collect(Collectors.joining(", ")) + ")";
+    }
+
+    /** camelCase parameter names as kebab-case file keys: {@code topP} → {@code top-p}. */
+    static String kebabCase(String parameterName) {
+        StringBuilder kebab = new StringBuilder(parameterName.length() + 4);
+        for (int i = 0; i < parameterName.length(); i++) {
+            char c = parameterName.charAt(i);
+            if (Character.isUpperCase(c)) {
+                kebab.append('-').append(Character.toLowerCase(c));
+            } else {
+                kebab.append(c);
+            }
+        }
+        return kebab.toString();
+    }
+
+    /** The value as the parameter's scalar type, or {@code null} on a misfit. */
+    static Object convert(Object value, Class<?> type) {
+        if (type == String.class) {
+            return value instanceof String ? value : null;
+        }
+        if (type == int.class || type == Integer.class) {
+            return value instanceof Integer ? value : null;
+        }
+        if (type == long.class || type == Long.class) {
+            if (value instanceof Long) {
+                return value;
+            }
+            return value instanceof Integer whole ? whole.longValue() : null;
+        }
+        if (type == double.class || type == Double.class) {
+            if (value instanceof Double) {
+                return value;
+            }
+            return value instanceof Number number && !(value instanceof Boolean)
+                    ? number.doubleValue() : null;
+        }
+        if (type == boolean.class || type == Boolean.class) {
+            return value instanceof Boolean ? value : null;
+        }
+        return null;
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -31,6 +31,7 @@ public final class DeclaredRun implements Declared {
 
     private Integer samples;
     private Integer samplesPerConfig;
+    private Integer samplesPerIteration;
     private Class<?> bindingsClass;
     private java.nio.file.Path servicesFile;
     private Double power;
@@ -58,6 +59,12 @@ public final class DeclaredRun implements Declared {
     @Override
     public Declared samplesPerConfig(int samplesPerConfig) {
         this.samplesPerConfig = samplesPerConfig;
+        return this;
+    }
+
+    @Override
+    public Declared samplesPerIteration(int samplesPerIteration) {
+        this.samplesPerIteration = samplesPerIteration;
         return this;
     }
 
@@ -174,6 +181,139 @@ public final class DeclaredRun implements Declared {
                 + grid.size() + " configurations x " + perConfig + " samples — explore");
 
         PUnit.exploring(sampling).grid(grid).run();
+    }
+
+    @Override
+    public void optimize() {
+        optimize(null);
+    }
+
+    @Override
+    public void optimize(String id) {
+        ContractLocator.Located located = ContractLocator.locate(caller, methodName, explicitName);
+        ContractDeclaration declaration = located.declaration();
+        if (samples != null) {
+            throw new ContractConfigurationException(
+                    ".samples(N) sizes a test or measure run — an optimization is sized per "
+                            + "iteration: use .samplesPerIteration(N) (default 5)");
+        }
+        if (power != null || tolerateBare != null || !tolerateNamed.isEmpty()) {
+            throw new ContractConfigurationException(
+                    "tolerate/power overrides target the test posture — an optimize run is "
+                            + "descriptive and consults no claims");
+        }
+        BindingsRegistry registry = BindingsRegistry.of(resolveBindingsClass());
+        ServicesResolver services = ServicesResolver.resolve(caller, servicesFile, registry);
+        if (!services.isDefined(declaration.service())) {
+            throw new ContractConfigurationException(
+                    "service '" + declaration.service() + "' has no mavai-services.yaml "
+                            + "definition — an optimize run consumes the definition's "
+                            + "`optimizations:` entries");
+        }
+        List<org.mavai.punit.decl.internal.model.OptimizationDeclaration> entries =
+                services.optimizations(declaration.service());
+        if (entries.isEmpty()) {
+            throw new ContractConfigurationException(
+                    "service '" + declaration.service() + "' declares no `optimizations:` "
+                            + "entries — add one to its mavai-services.yaml definition");
+        }
+        org.mavai.punit.decl.internal.model.OptimizationDeclaration entry;
+        if (id == null) {
+            if (entries.size() > 1) {
+                throw new ContractConfigurationException(
+                        "service '" + declaration.service() + "' declares "
+                                + entries.size() + " optimizations — name one: "
+                                + entries.stream()
+                                        .map(org.mavai.punit.decl.internal.model.OptimizationDeclaration::id)
+                                        .reduce((a, b) -> a + ", " + b).orElse(""));
+            }
+            entry = entries.get(0);
+        } else {
+            entry = entries.stream().filter(e -> e.id().equals(id)).findFirst()
+                    .orElseThrow(() -> new ContractConfigurationException(
+                            "no optimization '" + id + "' on service '" + declaration.service()
+                                    + "' — declared: " + entries.stream()
+                                            .map(org.mavai.punit.decl.internal.model.OptimizationDeclaration::id)
+                                            .reduce((a, b) -> a + ", " + b).orElse("none")));
+        }
+
+        java.lang.reflect.Method stepperFactory = registry.stepperFactory(entry.stepper());
+        Object[] stepperArguments = ConfigBinding.bind(
+                "optimization '" + entry.id() + "'", entry.stepper(), stepperFactory,
+                entry.stepperConfig());
+        Object stepper = registry.invoke(stepperFactory, stepperArguments);
+        if (!(stepper instanceof org.mavai.punit.api.spec.FactorsStepper)) {
+            throw new ContractConfigurationException(
+                    "@Stepper(\"" + entry.stepper() + "\") must return an "
+                            + "org.mavai.punit.api.spec.FactorsStepper, got "
+                            + (stepper == null ? "null" : stepper.getClass().getSimpleName()));
+        }
+        @SuppressWarnings("unchecked")
+        org.mavai.punit.api.spec.FactorsStepper<Map<String, Object>> typedStepper =
+                (org.mavai.punit.api.spec.FactorsStepper<Map<String, Object>>) stepper;
+        org.mavai.punit.api.spec.Scorer scorer = registry.resolveScorer(entry.scorer());
+
+        Map<String, String> covariateFeed = registry.covariateFeed(declaration.service());
+        StockViews views = new StockViews(declaration, registry);
+        AtomicReference<Object> currentInput = new AtomicReference<>();
+        CriteriaCompiler compiler = new CriteriaCompiler(
+                declaration, views, currentInput, Map.of(), null, registry);
+        compiler.validateEagerly();
+        Criteria<String> criteria = compiler.compile();
+
+        Map<String, Object> initial = new java.util.LinkedHashMap<>(
+                services.baselineConfiguration(declaration.service()));
+        initial.putAll(entry.initial());
+        // Validate iteration 0's configuration at load.
+        services.configurePoint(declaration.service(), initial);
+
+        int perIteration = optimizeBudget(declaration);
+        List<Object> inputs = declaration.inputs().stream()
+                .map(InputDeclaration::value)
+                .toList();
+        Sampling<Map<String, Object>, Object, String> sampling =
+                Sampling.<Map<String, Object>, Object, String>builder()
+                        .serviceContractFactory(configuration -> exploreContract(
+                                declaration, criteria, currentInput,
+                                services, covariateFeed, configuration))
+                        .inputs(inputs)
+                        .samples(perIteration)
+                        .build();
+
+        System.out.println("[PUNIT] run plan: contract '" + declaration.contract()
+                + "', optimization '" + entry.id() + "', up to " + entry.maxIterations()
+                + " iterations x " + perIteration + " samples — optimize");
+
+        var builder = PUnit.optimizing(sampling)
+                .initialFactors(initial)
+                .stepper(typedStepper)
+                .maxIterations(entry.maxIterations())
+                .experimentId(entry.id());
+        builder = entry.objective()
+                        == org.mavai.punit.decl.internal.model.OptimizationDeclaration.Objective.MINIMIZE
+                ? builder.minimize(scorer)
+                : builder.maximize(scorer);
+        builder = entry.noImprovementWindow() != null
+                ? builder.noImprovementWindow(entry.noImprovementWindow())
+                : builder.disableEarlyTermination();
+        builder.run();
+    }
+
+    /** Optimize is sized per iteration: property, builder, then the default 5. */
+    private int optimizeBudget(ContractDeclaration declaration) {
+        String property = "punit.samplesPerIteration." + declaration.contract();
+        String propertyValue = System.getProperty(property);
+        if (propertyValue != null) {
+            return Integer.parseInt(propertyValue.trim());
+        }
+        if (samplesPerIteration != null) {
+            if (samplesPerIteration < 1) {
+                throw new ContractConfigurationException(
+                        ".samplesPerIteration(" + samplesPerIteration + ") must be positive");
+            }
+            return samplesPerIteration;
+        }
+        return 5;
     }
 
     private ServiceContract<Map<String, Object>, Object, String> exploreContract(

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/FactoryType.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/FactoryType.java
@@ -1,11 +1,8 @@
 package org.mavai.punit.decl.internal.run;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-import org.mavai.punit.decl.ContractConfigurationException;
 import org.mavai.punit.decl.spi.ConfiguredService;
 import org.mavai.punit.decl.spi.ServiceType;
 
@@ -36,31 +33,8 @@ final class FactoryType implements ServiceType {
 
     @Override
     public ConfiguredService configure(String serviceName, Map<String, Object> configuration) {
-        Parameter[] parameters = factory.getParameters();
-        Map<String, Parameter> byKey = new LinkedHashMap<>();
-        for (Parameter parameter : parameters) {
-            byKey.put(kebabCase(parameter.getName()), parameter);
-        }
-        for (String key : configuration.keySet()) {
-            if (!byKey.containsKey(key)) {
-                throw misfit(serviceName, "unknown configuration key `" + key + ":`");
-            }
-        }
-        Object[] arguments = new Object[parameters.length];
-        int index = 0;
-        for (Map.Entry<String, Parameter> slot : byKey.entrySet()) {
-            if (!configuration.containsKey(slot.getKey())) {
-                throw misfit(serviceName, "missing configuration key `" + slot.getKey() + ":`");
-            }
-            Object value = configuration.get(slot.getKey());
-            Object converted = convert(value, slot.getValue().getType());
-            if (converted == null) {
-                throw misfit(serviceName, "`" + slot.getKey() + ":` must be a "
-                        + slot.getValue().getType().getSimpleName() + ", got "
-                        + (value == null ? "null" : value.getClass().getSimpleName()));
-            }
-            arguments[index++] = converted;
-        }
+        Object[] arguments = ConfigBinding.bind(
+                "service '" + serviceName + "'", name, factory, configuration);
         Object callable = registry.invoke(factory, arguments);
         BindingsRegistry.Invoker invoker = registry.adaptCallable(serviceName, callable);
         Map<String, String> covariates = new LinkedHashMap<>();
@@ -81,54 +55,4 @@ final class FactoryType implements ServiceType {
         };
     }
 
-    private ContractConfigurationException misfit(String serviceName, String problem) {
-        String signature = name + "(" + java.util.Arrays.stream(factory.getParameters())
-                .map(parameter -> kebabCase(parameter.getName()) + ": "
-                        + parameter.getType().getSimpleName())
-                .collect(Collectors.joining(", ")) + ")";
-        return new ContractConfigurationException(
-                "service '" + serviceName + "': " + problem + " — the type's configuration "
-                        + "schema is its factory's signature: " + signature);
-    }
-
-    /** camelCase parameter names as kebab-case file keys: {@code topP} → {@code top-p}. */
-    static String kebabCase(String parameterName) {
-        StringBuilder kebab = new StringBuilder(parameterName.length() + 4);
-        for (int i = 0; i < parameterName.length(); i++) {
-            char c = parameterName.charAt(i);
-            if (Character.isUpperCase(c)) {
-                kebab.append('-').append(Character.toLowerCase(c));
-            } else {
-                kebab.append(c);
-            }
-        }
-        return kebab.toString();
-    }
-
-    /** The value as the parameter's scalar type, or {@code null} on a misfit. */
-    private static Object convert(Object value, Class<?> type) {
-        if (type == String.class) {
-            return value instanceof String ? value : null;
-        }
-        if (type == int.class || type == Integer.class) {
-            return value instanceof Integer ? value : null;
-        }
-        if (type == long.class || type == Long.class) {
-            if (value instanceof Long) {
-                return value;
-            }
-            return value instanceof Integer whole ? whole.longValue() : null;
-        }
-        if (type == double.class || type == Double.class) {
-            if (value instanceof Double) {
-                return value;
-            }
-            return value instanceof Number number && !(value instanceof Boolean)
-                    ? number.doubleValue() : null;
-        }
-        if (type == boolean.class || type == Boolean.class) {
-            return value instanceof Boolean ? value : null;
-        }
-        return null;
-    }
 }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
@@ -87,6 +87,17 @@ final class ServicesResolver {
         return grid;
     }
 
+    /** The definition's baseline configuration record. */
+    Map<String, Object> baselineConfiguration(String serviceName) {
+        return new LinkedHashMap<>(entries.get(serviceName).configuration());
+    }
+
+    /** The definition's declared optimizations. */
+    java.util.List<org.mavai.punit.decl.internal.model.OptimizationDeclaration> optimizations(
+            String serviceName) {
+        return entries.get(serviceName).optimizations();
+    }
+
     /** Configures the named service at one resolved grid point. */
     ConfiguredService configurePoint(String serviceName, Map<String, Object> configuration) {
         ServiceEntry entry = entries.get(serviceName);

--- a/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
@@ -50,6 +50,8 @@ class DeclArchitectureTest {
                 .orShould().haveSimpleName("Transform")
                 .orShould().haveSimpleName("Check")
                 .orShould().haveSimpleName("Covariates")
+                .orShould().haveSimpleName("Stepper")
+                .orShould().haveSimpleName("Scorer")
                 .orShould().haveSimpleName("ContractConfigurationException")
                 .because("everything beyond the author surface is internal enablement — "
                         + "new public types belong under internal.* unless they are "

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -410,6 +410,92 @@ class DeclaredRunTest {
     }
 
     @Nested
+    @DisplayName("optimize")
+    class OptimizeVerb {
+
+        @Test
+        @DisplayName("a named optimization runs its stepper and records the iteration history")
+        void optimizeRunsAndRecords(
+                @org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            System.setProperty("punit.optimizations.outputDir", directory.toString());
+            try {
+                PUnit.declared("triage-assistant-routes-requests")
+                        .samplesPerIteration(3)
+                        .optimize("certainty-sweep");
+                try (var files = java.nio.file.Files.walk(directory)) {
+                    assertThat(files.filter(java.nio.file.Files::isRegularFile).count())
+                            .as("the optimization artefact")
+                            .isPositive();
+                }
+            } finally {
+                System.clearProperty("punit.optimizations.outputDir");
+            }
+        }
+
+        @Test
+        @DisplayName("with several optimizations declared, the run must name one")
+        void severalEntriesNeedAName() {
+            Declared run = PUnit.declared("triage-assistant-routes-requests");
+            assertThatThrownBy(run::optimize)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("certainty-sweep, tone-flip");
+        }
+
+        @Test
+        @DisplayName("an unknown optimization id is refused naming the declared ones")
+        void unknownId() {
+            Declared run = PUnit.declared("triage-assistant-routes-requests");
+            assertThatThrownBy(() -> run.optimize("no-such-run"))
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("no optimization 'no-such-run'")
+                    .hasMessageContaining("certainty-sweep");
+        }
+
+        @Test
+        @DisplayName("a definition without optimizations is refused constructively")
+        void noOptimizations() {
+            Declared run = PUnit.declared("built-in-type-resolves-via-service-loader");
+            assertThatThrownBy(run::optimize)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("no `optimizations:` entries");
+        }
+
+        @Test
+        @DisplayName("an optimization is sized per iteration, not per run")
+        void samplesRefusedOnOptimize() {
+            Declared run = PUnit.declared("triage-assistant-routes-requests").samples(50);
+            assertThatThrownBy(() -> run.optimize("certainty-sweep"))
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining(".samplesPerIteration(");
+        }
+
+        @Test
+        @DisplayName("a stepper-config misfit is refused with the stepper factory's signature")
+        void stepperConfigMisfit(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
+                throws java.io.IOException {
+            java.nio.file.Path services = directory.resolve("mavai-services.yaml");
+            java.nio.file.Files.writeString(services, """
+                    format: mavai-services/1
+                    services:
+                      triage-assistant:
+                        type: triage
+                        configuration:
+                          tone: matter-of-fact
+                          certainty: 0.9
+                        optimizations:
+                          - stepper: certainty-stepper
+                            stepper-config: { step: "wide" }
+                            max-iterations: 3
+                    """);
+            Declared run = PUnit.declared("triage-assistant-routes-requests").services(services);
+            assertThatThrownBy(run::optimize)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("certainty-stepper(step: double, stop: double)");
+        }
+    }
+
+    @Nested
     @DisplayName("risk claims")
     class RiskClaimRules {
 

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
@@ -95,4 +95,18 @@ class MavaiBindings {
     Map<String, String> triageCovariates() {
         return Map.of("rules-hash", "abc123");
     }
+
+    @org.mavai.punit.decl.Stepper("certainty-stepper")
+    org.mavai.punit.api.spec.FactorsStepper<Map<String, Object>> certaintyStepper(
+            double step, double stop) {
+        return (current, history) -> {
+            double certainty = ((Number) current.get("certainty")).doubleValue() + step;
+            if (certainty > stop) {
+                return org.mavai.punit.api.spec.NextFactor.stop();
+            }
+            Map<String, Object> next = new java.util.LinkedHashMap<>(current);
+            next.put("certainty", certainty);
+            return org.mavai.punit.api.spec.NextFactor.next(next);
+        };
+    }
 }

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/mavai-services.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/mavai-services.yaml
@@ -8,6 +8,18 @@ services:
     explorations:
       - certainty: 0.7
       - tone: reassuring
+    optimizations:
+      - id: certainty-sweep
+        stepper: certainty-stepper
+        stepper-config: { step: 0.05, stop: 1.0 }
+        max-iterations: 4
+        no-improvement-window: 2
+      - id: tone-flip
+        stepper: certainty-stepper
+        stepper-config: { step: 0.1, stop: 1.0 }
+        scorer: pass-rate
+        objective: maximize
+        max-iterations: 2
   echo-service:
     type: echo-model
     configuration:


### PR DESCRIPTION
Phase 4c of the declarative authoring surface (directive: DIR-PU-DA-declarative-surface; builds on #247). The last of the four verbs — with this, the declarative surface covers test, measure, explore, and optimize.

```java
@Experiment
void basketBuilderPromptTuning() {
    PUnit.declared().samplesPerIteration(30).optimize("prompt-tuning");
}
```

## The optimize verb

- `optimize("id")` — and the no-argument form for a definition declaring exactly one entry — maps the services file's `optimizations:` entry onto punit's existing `PUnit.optimizing(...)` path: the registered stepper proposes each next configuration, the scorer judges each iteration, iteration 0 is the baseline with the entry's `initial:` overlay applied (validated at load), the objective direction and termination controls travel through (`no-improvement-window` absent → early termination disabled), and the optimization artefact records the iteration history under the conventional directory.
- `samplesPerIteration(N)` defaults to 5, with the per-contract property channel; `.samples(N)` and tolerate/power overrides refuse with pointers to the right keys.

## The bindings artefact completes: @Stepper and @Scorer

- **`@Stepper("name")`** — the factory whose parameter list **is** the entry's `stepper-config:` schema, under the same factory-signature-is-the-schema rule as `@BindingFactory` (now extracted into a shared `ConfigBinding` helper used by both registries; misfits carry the rendered signature, e.g. `certainty-stepper(step: double, stop: double)`). The method returns the constructed `FactorsStepper` — algorithm state lives in its closure.
- **`@Scorer("name")`** — a no-argument method returning a punit `Scorer`. The default, **`pass-rate`, is punit-core's own `Scorer.observedPassRate()`** — built in, no registration.
- **No built-in steppers in this phase, deliberately**: the family conformance corpus's `requires:` mechanism provisions named steppers per case, so conformance does not need them; baseltest-parity built-ins (`linear-sweep`, `refining-grid`) are a later, demanded addition, and `prompt-engineer` belongs to punit-lm.

## Refusal surface

Several declared optimizations require naming one (the refusal lists them); an unknown id names the declared ids; a definition without an `optimizations:` section refuses constructively; sizing-key and claim-override misuse refuse with the correct keys. The module's public-surface guard fired on the two new annotations exactly as designed — the allowlist grew by precisely those two, as a reviewed decision.

Optimize end-to-end (stepper sweep → artefact recorded) plus five refusal cases; full build green, all guards included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyYHPj1u28MZ4bEPHKUX2V