### PR TITLE
Skip maxims reviews on Dependabot-triggered runs

### DIFF
--- a/.github/workflows/maxims-review-release.yml
+++ b/.github/workflows/maxims-review-release.yml
@@ -59,10 +59,13 @@ jobs:
   panel:
     needs: gate
     # Skip on fork PRs (secrets, and thus the private source, are withheld).
+    # Likewise skip Dependabot-triggered runs, which see only the Dependabot
+    # secrets store and so cannot fetch the private source either.
     if: >-
       needs.gate.outputs.run == 'true' &&
       (github.event_name == 'workflow_dispatch' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        github.actor != 'dependabot[bot]'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/maxims-review.yml
+++ b/.github/workflows/maxims-review.yml
@@ -12,8 +12,13 @@ on:
 jobs:
   architect:
     # Skip on fork PRs: secrets (and thus the private maxims source) are withheld
-    # from forked pull_request runs. Same-repo branch PRs only.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # from forked pull_request runs. Same-repo branch PRs only. Likewise skip
+    # Dependabot-triggered runs: they see only the Dependabot secrets store, so
+    # the checkout token resolves empty — and a maxims review of a version-bump
+    # diff has no value anyway.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Dependabot-triggered workflow runs receive only the Dependabot secrets store, not the repository Actions secrets, so `MAXIMS_SOURCE_TOKEN` resolves empty and the private-source checkout fails with "Input required and not supplied: token" (seen on the maxims `architect` job of every recent Dependabot PR, e.g. #250, #251).

Guard the `architect` job (maxims-review) and the `panel` job (maxims-review-release) with `github.actor != 'dependabot[bot]'`, alongside the existing fork-PR guard. Manual `workflow_dispatch` of the release panel is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)