### PR TITLE
Admit the value-comparison and boolean postcondition forms

### DIFF
--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/NumericValue.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/NumericValue.java
@@ -1,0 +1,50 @@
+package org.mavai.punit.decl.internal.model;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.regex.Pattern;
+
+/**
+ * The numeric interpretation rule the value-comparison forms share, for
+ * operands and subjects alike: a number — never a boolean — or a
+ * numeric string (sign, decimal point, exponent) qualifies, and
+ * comparison is decimal, not binary floating point, so formatting
+ * differences ({@code 2637.80} vs {@code 2.6378e3}) and float
+ * artefacts never decide a verdict. Quoting an operand preserves the
+ * exact decimal.
+ */
+public final class NumericValue {
+
+    private static final Pattern NUMERIC_STRING =
+            Pattern.compile("^-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$");
+
+    private NumericValue() {}
+
+    /** The value as an exact decimal, or {@code null} when uninterpretable. */
+    public static BigDecimal of(Object value) {
+        if (value instanceof Boolean) {
+            return null;
+        }
+        if (value instanceof BigDecimal decimal) {
+            return decimal;
+        }
+        if (value instanceof BigInteger integer) {
+            return new BigDecimal(integer);
+        }
+        if (value instanceof Double || value instanceof Float) {
+            return new BigDecimal(String.valueOf(value));
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.longValue());
+        }
+        if (value instanceof String text && NUMERIC_STRING.matcher(text.strip()).matches()) {
+            return new BigDecimal(text.strip());
+        }
+        return null;
+    }
+
+    /** Whether the value qualifies as a numeric operand or subject. */
+    public static boolean interpretable(Object value) {
+        return of(value) != null;
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/PostconditionForm.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/PostconditionForm.java
@@ -4,23 +4,73 @@ package org.mavai.punit.decl.internal.model;
  * The postcondition form vocabulary of the contract format — a real
  * criterion declares a compatible subset, since all its forms must hold
  * together (a conjunction).
+ *
+ * <p>The vocabulary spans the string forms, {@code parses}/{@code
+ * satisfies}, and the value-comparison forms (value comparison and
+ * boolean amendments, 2026-07-27): the scalar forms — universal over a
+ * multi-valued selection like the string forms, judging the selected
+ * value itself, never a text projection — and the collective set forms,
+ * which judge the whole selection at once and therefore require a
+ * declared view and a {@code path:}.
  */
 public enum PostconditionForm {
-    EQUALS("equals"),
-    ONE_OF("one-of"),
-    CONTAINS("contains"),
-    MATCHES("matches"),
-    PARSES("parses"),
-    SATISFIES("satisfies");
+    EQUALS("equals", Category.STRING),
+    ONE_OF("one-of", Category.STRING),
+    CONTAINS("contains", Category.STRING),
+    MATCHES("matches", Category.STRING),
+    PARSES("parses", Category.STRUCTURAL),
+    SATISFIES("satisfies", Category.STRUCTURAL),
+    EQ("eq", Category.NUMERIC),
+    NE("ne", Category.NUMERIC),
+    LT("lt", Category.NUMERIC),
+    LE("le", Category.NUMERIC),
+    GT("gt", Category.NUMERIC),
+    GE("ge", Category.NUMERIC),
+    NOT_EQUALS("not-equals", Category.SCALAR_VALUE),
+    EQUALS_CI("equals-ci", Category.SCALAR_VALUE),
+    IS_NULL("is-null", Category.SCALAR_VALUE),
+    IS("is", Category.SCALAR_VALUE),
+    EQUALS_SET("equals-set", Category.COLLECTIVE),
+    CONTAINS_SET("contains-set", Category.COLLECTIVE),
+    COUNT_EQUALS("count-equals", Category.COLLECTIVE);
+
+    private enum Category { STRING, STRUCTURAL, NUMERIC, SCALAR_VALUE, COLLECTIVE }
 
     private final String key;
+    private final Category category;
 
-    PostconditionForm(String key) {
+    PostconditionForm(String key, Category category) {
         this.key = key;
+        this.category = category;
     }
 
     /** The form's key as written in the contract file. */
     public String key() {
         return key;
+    }
+
+    /** A string form: judges a text projection of its subject. */
+    public boolean stringForm() {
+        return category == Category.STRING;
+    }
+
+    /** A numeric comparison: subject and operand interpreted as exact decimals. */
+    public boolean numeric() {
+        return category == Category.NUMERIC;
+    }
+
+    /** A scalar value form: universal over a selection, judging each value itself. */
+    public boolean scalarValue() {
+        return category == Category.NUMERIC || category == Category.SCALAR_VALUE;
+    }
+
+    /** A set form: judges the whole selection collectively — requires a view and a path. */
+    public boolean collective() {
+        return category == Category.COLLECTIVE;
+    }
+
+    /** Whether the form may carry a {@code path:} under a declared view. */
+    public boolean pathCapable() {
+        return stringForm() || scalarValue() || collective();
     }
 }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/CriteriaParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/CriteriaParser.java
@@ -25,20 +25,23 @@ final class CriteriaParser {
     /** The bar-provenance categories — a closed set; an unknown origin is refused. */
     static final List<String> THRESHOLD_ORIGINS = List.of("sla", "slo", "policy");
 
-    private static final Set<String> CRITERION_KEYS = Set.of(
-            "name",
-            "threshold",
-            "threshold-origin",
-            "contract-ref",
-            "tolerate",
-            "confidence",
-            "postconditions",
-            "equals",
-            "one-of",
-            "contains",
-            "matches",
-            "parses",
-            "satisfies");
+    private static final Set<String> CRITERION_KEYS = criterionKeys();
+
+    private static Set<String> criterionKeys() {
+        Set<String> keys = new java.util.HashSet<>(Set.of(
+                "name",
+                "threshold",
+                "threshold-origin",
+                "contract-ref",
+                "tolerate",
+                "confidence",
+                "postconditions"));
+        // Every form has a single-form spelling directly on the entry.
+        for (PostconditionForm form : PostconditionForm.values()) {
+            keys.add(form.key());
+        }
+        return Set.copyOf(keys);
+    }
 
     private CriteriaParser() {}
 

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
@@ -8,19 +8,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.mavai.punit.decl.internal.model.FormDeclaration;
+import org.mavai.punit.decl.internal.model.NumericValue;
 import org.mavai.punit.decl.internal.model.PostconditionForm;
 
 /**
  * One postcondition form entry, parsed: the form vocabulary, the
  * {@code in:} view and {@code path:} qualifiers, and the legality
- * checks — only the string forms take a {@code path:}, and
- * {@code parses:} names its view as its argument, never via
- * {@code in:}.
+ * checks — {@code path:} belongs to the string and value-comparison
+ * forms, a set form judges a selection collectively so it requires a
+ * declared view and a {@code path:}, and {@code parses:} names its
+ * view as its argument, never via {@code in:}.
  */
 final class FormParser {
-
-    private static final Set<PostconditionForm> STRING_FORMS =
-            Set.of(PostconditionForm.EQUALS, PostconditionForm.ONE_OF, PostconditionForm.CONTAINS, PostconditionForm.MATCHES);
 
     private FormParser() {}
 
@@ -59,13 +58,18 @@ final class FormParser {
         Object argument = entry.get(formKey);
         checkArgument(form, argument, where);
         if (path != null) {
-            if (!STRING_FORMS.contains(form)) {
-                throw fail(where + ": `path:` qualifies the string forms only");
+            if (!form.pathCapable()) {
+                throw fail(where + ": `path:` qualifies the string and value-comparison forms only");
             }
             if (view.equals(FormDeclaration.RAW_VIEW)) {
                 throw fail(where + ": `path:` requires `in:` naming a declared view — "
                         + "the raw response is unstructured text");
             }
+        }
+        if (form.collective() && (path == null || view.equals(FormDeclaration.RAW_VIEW))) {
+            throw fail(where + ": `" + form.key() + ":` judges the values a path selects, "
+                    + "collectively — it requires `in:` naming a declared view and a `path:` "
+                    + "(there is no collection over the raw text or a scalar)");
         }
         if (form == PostconditionForm.PARSES) {
             if (!view.equals(FormDeclaration.RAW_VIEW)) {
@@ -90,6 +94,18 @@ final class FormParser {
             }
             case EQUALS, CONTAINS, MATCHES -> {
                 if (!(argument instanceof String)) {
+                    // The guiding refusals (boolean amendment, 2026-07-27):
+                    // the intuitive-but-refused spellings name the form that
+                    // expresses the intent, instead of stranding the author
+                    // at the type rule.
+                    if (form == PostconditionForm.EQUALS && argument instanceof Boolean) {
+                        throw fail(where + ": `equals:` takes a string — a boolean field is "
+                                + "judged with `is: true` / `is: false`");
+                    }
+                    if (form == PostconditionForm.EQUALS && argument == null) {
+                        throw fail(where + ": `equals:` takes a string — a null expectation "
+                                + "is `is-null: true`");
+                    }
                     throw fail(where + ": `" + form.key() + ":` takes a string");
                 }
             }
@@ -102,7 +118,56 @@ final class FormParser {
                 // Checked against the declared views below, where the
                 // refusal can name them.
             }
+            case EQ, NE, LT, LE, GT, GE -> {
+                if (!NumericValue.interpretable(argument)) {
+                    throw fail(where + ": `" + form.key() + ":` takes a number or a numeric "
+                            + "string (sign/decimal/exponent), got "
+                            + Yaml.display(argument));
+                }
+            }
+            case NOT_EQUALS, EQUALS_CI -> {
+                if (!(argument instanceof String)) {
+                    throw fail(where + ": `" + form.key() + ":` takes a string");
+                }
+            }
+            case IS -> {
+                if (!(argument instanceof Boolean)) {
+                    throw fail(where + ": `is:` takes a boolean — it judges JSON true/false "
+                            + "by identity, and the string projections belong to `equals:`; "
+                            + "got " + Yaml.display(argument));
+                }
+            }
+            case IS_NULL -> {
+                if (!Boolean.TRUE.equals(argument)) {
+                    throw fail(where + ": `is-null:` takes the literal `true` and nothing "
+                            + "else — the negation is not offered");
+                }
+            }
+            case EQUALS_SET, CONTAINS_SET -> {
+                if (!(argument instanceof List<?> values)
+                        || values.isEmpty()
+                        || !values.stream().allMatch(FormParser::scalarElement)) {
+                    throw fail(where + ": `" + form.key() + ":` takes a non-empty list of "
+                            + "scalar values (an empty-selection assertion is `count-equals: 0`)");
+                }
+            }
+            case COUNT_EQUALS -> {
+                boolean nonNegativeInteger = !(argument instanceof Boolean)
+                        && argument instanceof Number count
+                        && count.longValue() >= 0
+                        && !(argument instanceof Double || argument instanceof Float);
+                if (!nonNegativeInteger) {
+                    throw fail(where + ": `count-equals:` takes a non-negative integer");
+                }
+            }
         }
+    }
+
+    private static boolean scalarElement(Object element) {
+        return element == null
+                || element instanceof String
+                || element instanceof Number
+                || element instanceof Boolean;
     }
 
     private static PostconditionForm forKey(String key) {

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/Yaml.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/Yaml.java
@@ -59,6 +59,12 @@ final class Yaml {
         return value instanceof Integer integer && integer >= minimum;
     }
 
+    /** A bounded rendering of an author-supplied value for a refusal message. */
+    static String display(Object value) {
+        String text = value instanceof String ? "\"" + value + "\"" : String.valueOf(value);
+        return text.length() <= 60 ? text : text.substring(0, 57) + "...";
+    }
+
     static ContractConfigurationException fail(String message) {
         return new ContractConfigurationException(message);
     }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
@@ -1,11 +1,14 @@
 package org.mavai.punit.decl.internal.run;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.xml.xpath.XPathConstants;
@@ -24,6 +27,7 @@ import org.mavai.punit.decl.internal.model.ContractDeclaration;
 import org.mavai.punit.decl.internal.model.CriterionDeclaration;
 import org.mavai.punit.decl.internal.model.FormDeclaration;
 import org.mavai.punit.decl.internal.model.InputDeclaration;
+import org.mavai.punit.decl.internal.model.NumericValue;
 import org.mavai.punit.decl.internal.model.PostconditionForm;
 import org.w3c.dom.NodeList;
 
@@ -184,6 +188,12 @@ final class CriteriaCompiler {
                 return parsed instanceof Outcome.Fail<?> fail ? fail : Outcome.ok();
             });
         }
+        if (form.form().collective()) {
+            return compileSetForm(form, name);
+        }
+        if (form.form().scalarValue()) {
+            return compileScalarValueForm(form, name);
+        }
         StringMatch match = stringMatch(form);
         if (form.view().equals(FormDeclaration.RAW_VIEW)) {
             return new Check(name, response -> match.holds(response)
@@ -250,6 +260,243 @@ final class CriteriaCompiler {
             return "null";
         }
         return null;
+    }
+
+    // ── Value-comparison forms ────────────────────────────────────
+    //
+    // These judge typed values, not text: a number by decimal
+    // comparison, a selection by strict JSON-value equality. The scalar
+    // forms judge one subject (fanned across a multi-valued selection,
+    // like the string forms — but judging the selected value itself,
+    // never a text projection); the collective set forms judge the
+    // whole selection at once.
+
+    /** A scalar value judgement: {@code null} = holds, else the failure reason. */
+    private interface ValueJudge {
+        String failure(Object value);
+    }
+
+    /** A collective judgement over the whole selection. */
+    private interface CollectiveJudge {
+        String failure(List<Object> selected);
+    }
+
+    private Check compileScalarValueForm(FormDeclaration form, String name) {
+        ValueJudge judge = valueJudge(form);
+        if (form.view().equals(FormDeclaration.RAW_VIEW)) {
+            return new Check(name, response -> judged(name, judge.failure(response)));
+        }
+        if (form.path() == null) {
+            return new Check(name, response -> {
+                Outcome<Object> parsed = views.view(form.view(), response);
+                if (parsed instanceof Outcome.Fail<?> fail) {
+                    return fail;
+                }
+                return judged(name, judge.failure(((Outcome.Ok<Object>) parsed).value()));
+            });
+        }
+        Selection selection = compileSelection(views.transformation(form.view()), form.path());
+        // is-null is null-or-absent: a path that selects nothing holds.
+        boolean emptySelectionHolds = form.form() == PostconditionForm.IS_NULL;
+        return new Check(name, response -> {
+            Outcome<Object> parsed = views.view(form.view(), response);
+            if (parsed instanceof Outcome.Fail<?> fail) {
+                return fail;
+            }
+            List<Object> selected;
+            try {
+                selected = selection.select(((Outcome.Ok<Object>) parsed).value());
+            } catch (RuntimeException error) {
+                return Outcome.fail("postcondition", name + " — selection failed: " + error.getMessage());
+            }
+            if (selected.isEmpty()) {
+                return emptySelectionHolds
+                        ? Outcome.ok()
+                        : Outcome.fail("postcondition", name + " — path selected nothing");
+            }
+            for (Object candidate : selected) {
+                String failure = judge.failure(candidate);
+                if (failure != null) {
+                    return Outcome.fail("postcondition", name + " — " + failure);
+                }
+            }
+            return Outcome.ok();
+        });
+    }
+
+    private Check compileSetForm(FormDeclaration form, String name) {
+        // The parser guarantees a declared view and a path — a collection
+        // only exists as a selection. The empty selection is the empty
+        // collection: count-equals: 0 holds, a non-empty operand fails.
+        Selection selection = compileSelection(views.transformation(form.view()), form.path());
+        CollectiveJudge judge = collectiveJudge(form);
+        return new Check(name, response -> {
+            Outcome<Object> parsed = views.view(form.view(), response);
+            if (parsed instanceof Outcome.Fail<?> fail) {
+                return fail;
+            }
+            List<Object> selected;
+            try {
+                selected = selection.select(((Outcome.Ok<Object>) parsed).value());
+            } catch (RuntimeException error) {
+                return Outcome.fail("postcondition", name + " — selection failed: " + error.getMessage());
+            }
+            return judged(name, judge.failure(selected));
+        });
+    }
+
+    private static Outcome<?> judged(String name, String failure) {
+        return failure == null
+                ? Outcome.ok()
+                : Outcome.fail("postcondition", name + " — " + failure);
+    }
+
+    private ValueJudge valueJudge(FormDeclaration form) {
+        if (form.form().numeric()) {
+            return numericJudge(form);
+        }
+        return switch (form.form()) {
+            case NOT_EQUALS -> {
+                String excluded = (String) form.argument();
+                yield value -> {
+                    if (!(value instanceof String text)) {
+                        return textTypeFailure("not-equals", value);
+                    }
+                    return text.equals(excluded)
+                            ? "response equals the excluded \"" + excluded + "\""
+                            : null;
+                };
+            }
+            case EQUALS_CI -> {
+                String expected = (String) form.argument();
+                String foldedExpected = folded(expected);
+                yield value -> {
+                    if (!(value instanceof String text)) {
+                        return textTypeFailure("equals-ci", value);
+                    }
+                    return folded(text).equals(foldedExpected)
+                            ? null
+                            : "response does not equal \"" + expected
+                                    + "\" (case/whitespace-insensitively)";
+                };
+            }
+            case IS_NULL -> value -> value == null
+                    ? null
+                    : "value " + Display.of(value) + " is not null";
+            case IS -> {
+                boolean operand = (Boolean) form.argument();
+                yield value -> {
+                    if (value instanceof Boolean actual) {
+                        return actual == operand ? null : "value is " + actual + ", not " + operand;
+                    }
+                    return "subject " + Display.of(value) + " is not a boolean — the form "
+                            + "judges JSON true/false by identity";
+                };
+            }
+            default -> throw new IllegalStateException("not a scalar value form: " + form.form());
+        };
+    }
+
+    private ValueJudge numericJudge(FormDeclaration form) {
+        BigDecimal operand = NumericValue.of(form.argument());
+        IntPredicate holds = switch (form.form()) {
+            case EQ -> comparison -> comparison == 0;
+            case NE -> comparison -> comparison != 0;
+            case LT -> comparison -> comparison < 0;
+            case LE -> comparison -> comparison <= 0;
+            case GT -> comparison -> comparison > 0;
+            case GE -> comparison -> comparison >= 0;
+            default -> throw new IllegalStateException("not a numeric form: " + form.form());
+        };
+        String key = form.form().key();
+        String operandDisplay = Display.of(form.argument());
+        return value -> {
+            BigDecimal actual = NumericValue.of(value);
+            if (actual == null) {
+                return "subject " + Display.of(value) + " is not a number — a numeric form "
+                        + "judges a number or a numeric string";
+            }
+            return holds.test(actual.compareTo(operand))
+                    ? null
+                    : "value " + Display.of(value) + " is not " + key + " " + operandDisplay;
+        };
+    }
+
+    private static String textTypeFailure(String form, Object value) {
+        return form + ": subject " + Display.of(value) + " is not text — a string form judges text";
+    }
+
+    private static final Pattern WHITESPACE_RUN =
+            Pattern.compile("\\s+", Pattern.UNICODE_CHARACTER_CLASS);
+
+    /**
+     * The equals-ci normalisation, exactly: Unicode case-fold, trim, and
+     * internal-whitespace-run collapse to a single space — nothing more.
+     * Upper-then-lower is Java's realisation of the full case fold
+     * ({@code ß} → {@code ss}), held to the family semantics by test.
+     */
+    private static String folded(String text) {
+        String cased = text.toUpperCase(Locale.ROOT).toLowerCase(Locale.ROOT);
+        return WHITESPACE_RUN.matcher(cased.strip()).replaceAll(" ");
+    }
+
+    private CollectiveJudge collectiveJudge(FormDeclaration form) {
+        return switch (form.form()) {
+            case EQUALS_SET -> {
+                List<?> operand = (List<?>) form.argument();
+                Map<Object, Long> expected = multiset(operand);
+                yield selected -> multiset(selected).equals(expected)
+                        ? null
+                        : "selected values " + Display.of(selected) + " do not equal "
+                                + Display.of(operand) + " as a multiset";
+            }
+            case CONTAINS_SET -> {
+                List<?> operand = (List<?>) form.argument();
+                Map<Object, Long> expected = multiset(operand);
+                yield selected -> {
+                    Map<Object, Long> actual = multiset(selected);
+                    boolean missing = expected.entrySet().stream()
+                            .anyMatch(entry -> actual.getOrDefault(entry.getKey(), 0L) < entry.getValue());
+                    return missing
+                            ? "selected values " + Display.of(selected) + " do not contain "
+                                    + "all of " + Display.of(operand)
+                            : null;
+                };
+            }
+            case COUNT_EQUALS -> {
+                int expected = ((Number) form.argument()).intValue();
+                yield selected -> selected.size() == expected
+                        ? null
+                        : "path selected " + selected.size() + " value(s), not " + expected;
+            }
+            default -> throw new IllegalStateException("not a set form: " + form.form());
+        };
+    }
+
+    private static Map<Object, Long> multiset(List<?> values) {
+        Map<Object, Long> counts = new HashMap<>();
+        for (Object value : values) {
+            counts.merge(elementKey(value), 1L, Long::sum);
+        }
+        return counts;
+    }
+
+    /**
+     * Strict JSON-value equality as a type-tagged key: numbers compare
+     * numerically (decimal), strings exactly, booleans and null by
+     * identity — a number never equals its string spelling.
+     */
+    private static Object elementKey(Object value) {
+        if (value instanceof Boolean) {
+            return List.of("bool", value);
+        }
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Number) {
+            return List.of("num", NumericValue.of(value).stripTrailingZeros());
+        }
+        return List.of("str", String.valueOf(value));
     }
 
     // ── String forms ──────────────────────────────────────────────

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
@@ -446,7 +446,7 @@ class ContractParserTest {
         }
 
         @Test
-        @DisplayName("path on a non-string form is refused")
+        @DisplayName("path on a form outside the path-capable vocabulary is refused")
         void pathOnNonStringForm() {
             assertRefused("""
                     format: mavai-contract/1
@@ -461,7 +461,7 @@ class ContractParserTest {
                             path: "$.items"
                             satisfies: looks-right
                     inputs: ["Alice"]
-                    """, "string forms only");
+                    """, "string and value-comparison forms only");
         }
 
         @Test
@@ -526,6 +526,194 @@ class ContractParserTest {
         void unknownForm() {
             assertRefused(MINIMAL.replace("contains: \"hello\"", "postconditions: [{ resembles: \"x\" }]"),
                     "unknown postcondition form `resembles`");
+        }
+    }
+
+    @Nested
+    @DisplayName("value-comparison forms")
+    class ValueComparisonForms {
+
+        @Test
+        @DisplayName("the scalar value-comparison vocabulary parses, per input too")
+        void scalarForms() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: quote-service-extracts-exact-values
+                    service: quote-service
+                    transforms:
+                      quote: json
+                    criteria:
+                      - name: extracted-values-match-the-document
+                        threshold: 0.95
+                        not-equals: "ERROR"
+                        postconditions:
+                          - in: quote
+                            path: "$.premium"
+                            eq: 2637.80
+                          - in: quote
+                            path: "$.excess"
+                            eq: "500.00"
+                          - in: quote
+                            path: "$.instalment-fee"
+                            ne: 0
+                          - in: quote
+                            path: "$.items[*].price"
+                            ge: 0
+                          - in: quote
+                            path: "$.tax-rate"
+                            lt: "0.2"
+                          - in: quote
+                            path: "$.term-months"
+                            gt: 0
+                          - in: quote
+                            path: "$.instalments"
+                            le: 12
+                          - in: quote
+                            path: "$.holder"
+                            equals-ci: "Frau  Beispiel"
+                          - in: quote
+                            path: "$.status"
+                            not-equals: "declined"
+                          - in: quote
+                            path: "$.cancellation-date"
+                            is-null: true
+                    inputs:
+                      - "quote the sample policy"
+                      - input: "quote the premium-only policy"
+                        expected:
+                          - in: quote
+                            path: "$.premium"
+                            eq: "1049.10"
+                    """);
+            var forms = declaration.criteria().get(0).forms();
+            assertThat(forms).extracting(f -> f.form()).containsExactly(
+                    PostconditionForm.NOT_EQUALS,
+                    PostconditionForm.EQ, PostconditionForm.EQ, PostconditionForm.NE,
+                    PostconditionForm.GE, PostconditionForm.LT, PostconditionForm.GT,
+                    PostconditionForm.LE, PostconditionForm.EQUALS_CI,
+                    PostconditionForm.NOT_EQUALS, PostconditionForm.IS_NULL);
+            assertThat(forms.get(0).view()).isEqualTo("raw");
+            assertThat(declaration.inputs().get(1).expected().get(0).form())
+                    .isEqualTo(PostconditionForm.EQ);
+        }
+
+        @Test
+        @DisplayName("the set forms and the boolean form parse, per input too")
+        void setAndBooleanForms() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: annotator-returns-the-gold-set
+                    service: buildings-annotator
+                    transforms:
+                      doc: json
+                    criteria:
+                      - name: extracted-sets-match-the-document
+                        threshold: 0.9
+                        postconditions:
+                          - in: doc
+                            path: "$.buildings[*].name"
+                            equals-set: ["Hauptgebäude", "Nebengebäude", "Nebengebäude"]
+                          - in: doc
+                            path: "$.rents[*].amount"
+                            contains-set: [1200, 950.50]
+                          - in: doc
+                            path: "$.rents[*].amount"
+                            count-equals: 2
+                          - in: doc
+                            path: "$.buildings[0].isIncluded"
+                            is: true
+                    inputs:
+                      - "annotate the sample lease"
+                      - input: "annotate the two-tenant lease"
+                        expected:
+                          - in: doc
+                            path: "$.tenants[*].name"
+                            contains-set: ["Muster AG"]
+                    """);
+            var forms = declaration.criteria().get(0).forms();
+            assertThat(forms).extracting(f -> f.form()).containsExactly(
+                    PostconditionForm.EQUALS_SET, PostconditionForm.CONTAINS_SET,
+                    PostconditionForm.COUNT_EQUALS, PostconditionForm.IS);
+            assertThat(forms.get(3).argument()).isEqualTo(Boolean.TRUE);
+        }
+
+        @Test
+        @DisplayName("a malformed numeric operand is refused")
+        void valueOperandMalformed() {
+            assertRefused(withQuoteForm("eq: \"twelve\""),
+                    "`eq:` takes a number or a numeric string");
+        }
+
+        @Test
+        @DisplayName("is-null takes the literal true and nothing else")
+        void isNullOperand() {
+            assertRefused(withQuoteForm("is-null: false"), "the negation is not offered");
+        }
+
+        @Test
+        @DisplayName("is takes a boolean operand and nothing else")
+        void isOperandNotBoolean() {
+            assertRefused(withQuoteForm("is: \"true\""), "`is:` takes a boolean");
+        }
+
+        @Test
+        @DisplayName("a set form without a declared view and path is refused")
+        void setFormWithoutPath() {
+            assertRefused("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - in: doc
+                            equals-set: ["a", "b"]
+                    inputs: ["Alice"]
+                    """, "requires `in:` naming a declared view and a `path:`");
+        }
+
+        @Test
+        @DisplayName("a set form's operand lists at least one scalar element")
+        void setOperandEmpty() {
+            assertRefused(withQuoteForm("contains-set: []"),
+                    "non-empty list of scalar values");
+        }
+
+        @Test
+        @DisplayName("count-equals takes a non-negative integer")
+        void countEqualsOperand() {
+            assertRefused(withQuoteForm("count-equals: -1"),
+                    "`count-equals:` takes a non-negative integer");
+            assertRefused(withQuoteForm("count-equals: 2.5"),
+                    "`count-equals:` takes a non-negative integer");
+        }
+
+        @Test
+        @DisplayName("the intuitive-but-refused spellings name the intended form")
+        void guidingRefusals() {
+            assertRefused(MINIMAL.replace("contains: \"hello\"", "equals: true"),
+                    "`is: true` / `is: false`");
+            assertRefused(MINIMAL.replace("contains: \"hello\"", "equals: null"),
+                    "a null expectation is `is-null: true`");
+        }
+
+        private static String withQuoteForm(String form) {
+            return """
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - in: doc
+                            path: "$.value"
+                            %s
+                    inputs: ["Alice"]
+                    """.formatted(form);
         }
     }
 

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -102,6 +102,49 @@ class DeclaredRunTest {
     }
 
     @Nested
+    @DisplayName("value-comparison forms")
+    class ValueComparisonForms {
+
+        @Test
+        @DisplayName("the scalar forms judge decimals, folded text, and null — per input too")
+        void quoteServiceExtractsExactValues() {
+            // Decimal semantics across spellings (2637.80 vs 2637.8,
+            // "500.00" vs "500.00" string subject), equals-ci folding,
+            // is-null on a null value and on an absent path.
+            assertThatCode(() ->
+                    PUnit.declared("quote-service-extracts-exact-values").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("the set forms judge the selection collectively")
+        void annotatorReturnsTheGoldSet() {
+            // Multiset equality with duplicates, containment across
+            // decimal spellings (950.50 vs 950.5), cardinality, and
+            // count-equals: 0 over an empty selection.
+            assertThatCode(() ->
+                    PUnit.declared("annotator-returns-the-gold-set").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("the boolean form judges JSON true/false by identity")
+        void annotatorFlagsCoverage() {
+            assertThatCode(() ->
+                    PUnit.declared("annotator-flags-coverage").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("a type mismatch is a per-sample failure, never an abort")
+        void textUnderValueFormsFailsPerSample() {
+            Declared run = PUnit.declared("text-under-value-forms-fails-per-sample").samples(30);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(AssertionFailedError.class);
+        }
+    }
+
+    @Nested
     @DisplayName("measure")
     class MeasureVerb {
 

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/MavaiBindings.java
@@ -42,6 +42,30 @@ class MavaiBindings {
         return "this is not json {";
     }
 
+    @Binding("quote-service")
+    String quote(String instruction) {
+        double premium = instruction.contains("premium-only") ? 1049.1 : 2637.8;
+        return """
+                {"premium": %s, "excess": "500.00", "instalment-fee": 12.5,
+                 "items": [{"price": 0}, {"price": 12.5}],
+                 "tax-rate": 0.19, "term-months": 12, "instalments": 12,
+                 "holder": " FRAU   beispiel ", "status": "approved",
+                 "cancellation-date": null}
+                """.formatted(premium);
+    }
+
+    @Binding("buildings-annotator")
+    String annotate(String instruction) {
+        return """
+                {"buildings": [
+                   {"name": "Hauptgebäude", "isIncluded": true, "isInsured": true},
+                   {"name": "Nebengebäude", "isIncluded": false, "isInsured": true},
+                   {"name": "Nebengebäude", "isIncluded": true, "isInsured": true}],
+                 "rents": [{"amount": 1200}, {"amount": 950.5}],
+                 "tenants": [{"name": "Muster AG"}, {"name": "Beispiel GmbH"}]}
+                """;
+    }
+
     @Binding("repeater")
     String repeat(String item, int count) {
         return item + " x" + count;

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/flags.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/flags.yaml
@@ -1,0 +1,20 @@
+format: mavai-contract/1
+contract: annotator-flags-coverage
+service: buildings-annotator
+transforms:
+  doc: json
+criteria:
+  - name: coverage-flags-match-the-document
+    threshold: 0.9
+    postconditions:
+      - in: doc
+        path: "$.buildings[0].isIncluded"
+        is: true
+      - in: doc
+        path: "$.buildings[1].isIncluded"
+        is: false
+      - in: doc
+        path: "$.buildings[*].isInsured"
+        is: true
+inputs:
+  - "annotate the sample lease"

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/gold-set.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/gold-set.yaml
@@ -1,0 +1,28 @@
+format: mavai-contract/1
+contract: annotator-returns-the-gold-set
+service: buildings-annotator
+transforms:
+  doc: json
+criteria:
+  - name: extracted-sets-match-the-document
+    threshold: 0.9
+    postconditions:
+      - in: doc
+        path: "$.buildings[*].name"
+        equals-set: ["Hauptgebäude", "Nebengebäude", "Nebengebäude"]
+      - in: doc
+        path: "$.rents[*].amount"
+        contains-set: [1200, 950.50]
+      - in: doc
+        path: "$.rents[*].amount"
+        count-equals: 2
+      - in: doc
+        path: "$.vacancies[*]"
+        count-equals: 0
+inputs:
+  - "annotate the sample lease"
+  - input: "annotate the two-tenant lease"
+    expected:
+      - in: doc
+        path: "$.tenants[*].name"
+        contains-set: ["Muster AG"]

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/quote.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/quote.yaml
@@ -1,0 +1,51 @@
+format: mavai-contract/1
+contract: quote-service-extracts-exact-values
+service: quote-service
+transforms:
+  quote: json
+criteria:
+  - name: extracted-values-match-the-document
+    threshold: 0.9
+    not-equals: "ERROR"
+    postconditions:
+      - in: quote
+        path: "$.excess"
+        eq: "500.00"
+      - in: quote
+        path: "$['instalment-fee']"
+        ne: 0
+      - in: quote
+        path: "$.items[*].price"
+        ge: 0
+      - in: quote
+        path: "$['tax-rate']"
+        lt: "0.2"
+      - in: quote
+        path: "$['term-months']"
+        gt: 0
+      - in: quote
+        path: "$.instalments"
+        le: 12
+      - in: quote
+        path: "$.holder"
+        equals-ci: "Frau  Beispiel"
+      - in: quote
+        path: "$.status"
+        not-equals: "declined"
+      - in: quote
+        path: "$['cancellation-date']"
+        is-null: true
+      - in: quote
+        path: "$['no-such-key']"
+        is-null: true
+inputs:
+  - input: "quote the sample policy"
+    expected:
+      - in: quote
+        path: "$.premium"
+        eq: 2637.80
+  - input: "quote the premium-only policy"
+    expected:
+      - in: quote
+        path: "$.premium"
+        eq: "1049.10"

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/typefail.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/typefail.yaml
@@ -1,0 +1,14 @@
+format: mavai-contract/1
+contract: text-under-value-forms-fails-per-sample
+service: buildings-annotator
+transforms:
+  doc: json
+criteria:
+  - name: a-string-is-never-a-boolean
+    threshold: 0.9
+    postconditions:
+      - in: doc
+        path: "$.tenants[0].name"
+        is: true
+inputs:
+  - "annotate the sample lease"


### PR DESCRIPTION
Phase 4d of `DIR-PU-DA-declarative-surface` (owner fold-in, 2026-07-27): baseltest 0.10.0 form parity for punit-decl, per the family's value-comparison (mavai-R v0.9.4) and boolean (v0.9.5) amendments and the amended MAPPING-java.md rows.

**The full form vocabulary lands**: the scalar forms `eq`/`ne`/`lt`/`le`/`gt`/`ge` (decimal semantics via a shared `NumericValue` interpretation rule), `not-equals`, `equals-ci` (exact fold: case-fold + trim + whitespace-run collapse), `is-null` (null-or-absent), `is` (boolean identity), and the collective set forms `equals-set` (multiset), `contains-set` (all-of with multiplicity), `count-equals` — strict JSON-value element equality as type-tagged multiset keys. Scalar forms judge the selected value itself, never a text projection; type mismatches are per-sample failures with stated reasons.

**Refusal catalogue aligned to the corpus categories** (`value-operand-malformed`, `is-null-operand`, `is-operand-not-boolean`, `set-form-without-path`, `set-operand-empty`) plus the guiding refusals (`equals: true/false` → `is:`; `equals: null` → `is-null:`). Form categories live on the `PostconditionForm` enum — single source for parser legality and compiler dispatch; the criterion-entry key allowlist derives from it.

**Verification**: parser acceptance mirrors of the corpus valid cases, 8 refusal cases, 4 end-to-end runs (decimal spellings across formats, per-input value expectations, multiset/duplicates/containment/cardinality incl. `count-equals: 0` on an empty selection, boolean identity, type-mismatch-fails-per-sample). Full build green (136 punit-decl tests). Rebased onto current main.

Execution log: the directive's Phase 4d entry (incl. the RFC 9535 corpus-path finding this phase surfaced, corrected upstream in mavai-R 0.9.6→0.10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwCM