### PR TITLE
Resolve the default subject view for bare path checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **The default subject view (declarative contracts).** A `path:`-bearing
+  check may now omit `in:`: its subject resolves to the view named by the
+  owning criterion's single `parses:` form, else the contract's sole
+  declared transform, else a load refusal naming the check and both fixes
+  — retiring the near-universal `in: <view>` boilerplate line. A path-less
+  bare check still judges the raw response, an explicit `in:` always wins,
+  and a `path:` can never target `raw`. Resolution happens at parse time,
+  so the compiled criterion is indistinguishable from one with `in:`
+  spelled. Per the family's 2026-07-27 subject-rule amendment
+  (conformance corpus mavai-R ≥ v0.10.0).
+
 - **Named scorers, stated in the optimize artefact.** `Scorer` gains an
   optional identity (`Scorer.name()`, default empty) and a built-in
   named implementation, `Scorer.observedPassRate()`, which scores each

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/FormDeclaration.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/FormDeclaration.java
@@ -10,7 +10,12 @@ package org.mavai.punit.decl.internal.model;
  * @param argument the form's argument — a string, or a list of strings
  *     for {@code one-of}
  * @param view the subject view; {@link #RAW_VIEW} when the form judges
- *     the untransformed response
+ *     the untransformed response; {@code null} only transiently inside
+ *     the parser — a {@code path:}-bearing form that omitted {@code in:}
+ *     awaits the path-conditional default resolution against its owning
+ *     criterion (single {@code parses:} view, else the sole declared
+ *     transform, else a load refusal). The parser resolves every subject
+ *     before a declaration leaves it; nothing downstream sees {@code null}.
  * @param path the selection expression, or {@code null} when the form
  *     judges its subject whole
  */
@@ -18,4 +23,9 @@ public record FormDeclaration(PostconditionForm form, Object argument, String vi
 
     /** The reserved name of the untransformed response. */
     public static final String RAW_VIEW = "raw";
+
+    /** This form with its defaulted subject resolved to the given view. */
+    public FormDeclaration withView(String resolved) {
+        return new FormDeclaration(form, argument, resolved, path);
+    }
 }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.mavai.punit.decl.ContractConfigurationException;
 import org.mavai.punit.decl.internal.model.ContractDeclaration;
 import org.mavai.punit.decl.internal.model.CriterionDeclaration;
@@ -22,6 +23,7 @@ import org.mavai.punit.decl.internal.model.DeclaredIntent;
 import org.mavai.punit.decl.internal.model.FormDeclaration;
 import org.mavai.punit.decl.internal.model.InputDeclaration;
 import org.mavai.punit.decl.internal.model.LatencyDeclaration;
+import org.mavai.punit.decl.internal.model.PostconditionForm;
 import org.mavai.punit.statistics.StatisticalDefaults;
 
 /**
@@ -100,6 +102,8 @@ public final class ContractParser {
                         + "`expected:` entries supplement a criterion's forms, never replace them");
             }
         }
+        criteria = resolveDefaultSubjects(criteria, views);
+        inputs = resolveExpectedSubjects(inputs, criteria, views);
 
         boolean confidenceDeclared = data.containsKey("confidence");
         double confidence = StatisticalDefaults.DEFAULT_CONFIDENCE;
@@ -124,6 +128,84 @@ public final class ContractParser {
                 confidenceDeclared,
                 latency,
                 sourcePath);
+    }
+
+    /**
+     * The path-conditional default subject (subject rule, 2026-07-27):
+     * a {@code path:}-bearing check that omitted {@code in:} resolves to
+     * its criterion's anchor — the view named by the criterion's
+     * <em>single</em> {@code parses:} form (an explicit statement of
+     * the canonical view; several resolve no anchor and fall through),
+     * else the contract's <em>sole</em> declared transform — or refuses
+     * naming the check and both fixes. Resolution happens here, at
+     * parse time, so the compiled criterion is indistinguishable from
+     * one with {@code in:} spelled.
+     */
+    private static List<CriterionDeclaration> resolveDefaultSubjects(
+            List<CriterionDeclaration> criteria, Map<String, String> views) {
+        List<CriterionDeclaration> resolved = new ArrayList<>();
+        for (CriterionDeclaration criterion : criteria) {
+            List<FormDeclaration> forms = new ArrayList<>();
+            for (FormDeclaration form : criterion.forms()) {
+                forms.add(resolveSubject(form, criterion, views));
+            }
+            resolved.add(new CriterionDeclaration(
+                    criterion.name(), forms, criterion.threshold(), criterion.thresholdOrigin(),
+                    criterion.contractRef(), criterion.tolerate(), criterion.confidence()));
+        }
+        return resolved;
+    }
+
+    /**
+     * Per-input {@code expected:} entries resolve identically — the
+     * single-criterion ownership rule (validated above) guarantees the
+     * anchor is that lone criterion's.
+     */
+    private static List<InputDeclaration> resolveExpectedSubjects(
+            List<InputDeclaration> inputs, List<CriterionDeclaration> criteria,
+            Map<String, String> views) {
+        CriterionDeclaration owner = criteria.get(0);
+        List<InputDeclaration> resolved = new ArrayList<>();
+        for (InputDeclaration input : inputs) {
+            List<FormDeclaration> expected = new ArrayList<>();
+            for (FormDeclaration form : input.expected()) {
+                expected.add(resolveSubject(form, owner, views));
+            }
+            resolved.add(new InputDeclaration(input.value(), expected));
+        }
+        return resolved;
+    }
+
+    private static FormDeclaration resolveSubject(
+            FormDeclaration form, CriterionDeclaration criterion, Map<String, String> views) {
+        if (form.view() != null) {
+            return form;
+        }
+        String anchor = subjectAnchor(criterion, views);
+        if (anchor == null) {
+            throw fail("criterion '" + criterion.name() + "': a `path:` check omitting `in:` "
+                    + "has no resolvable default view — declare a single `parses: <view>` on "
+                    + "the criterion, or add `in:` naming the view ("
+                    + (views.isEmpty() ? "no transforms declared"
+                            : "declared transforms: " + views.keySet().stream().sorted()
+                                    .collect(Collectors.joining(", ")))
+                    + ")");
+        }
+        return form.withView(anchor);
+    }
+
+    private static String subjectAnchor(CriterionDeclaration criterion, Map<String, String> views) {
+        List<String> parsed = criterion.forms().stream()
+                .filter(form -> form.form() == PostconditionForm.PARSES)
+                .map(form -> String.valueOf(form.argument()))
+                .toList();
+        if (parsed.size() == 1) {
+            return parsed.get(0);
+        }
+        if (views.size() == 1) {
+            return views.keySet().iterator().next();
+        }
+        return null;
     }
 
     /** Reads and parses a contract file from disk. */

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
@@ -57,18 +57,28 @@ final class FormParser {
         }
         Object argument = entry.get(formKey);
         checkArgument(form, argument, where);
+        boolean explicitIn = entry.containsKey("in");
         if (path != null) {
             if (!form.pathCapable()) {
                 throw fail(where + ": `path:` qualifies the string and value-comparison forms only");
             }
-            if (view.equals(FormDeclaration.RAW_VIEW)) {
-                throw fail(where + ": `path:` requires `in:` naming a declared view — "
-                        + "the raw response is unstructured text");
+            if (explicitIn && view.equals(FormDeclaration.RAW_VIEW)) {
+                throw fail(where + ": `path:` cannot target `raw` — the raw response is "
+                        + "unstructured text; name a declared view with `in:`");
+            }
+            if (!explicitIn) {
+                // The path-conditional default (subject rule, 2026-07-27):
+                // a path-bearing check omitting `in:` cannot mean the raw
+                // text — a path needs structure — so its subject resolves
+                // against the owning criterion (its single `parses:` view,
+                // else the contract's sole transform) once all the
+                // criterion's forms are known. Unresolved here, by design.
+                view = null;
             }
         }
-        if (form.collective() && (path == null || view.equals(FormDeclaration.RAW_VIEW))) {
+        if (form.collective() && path == null) {
             throw fail(where + ": `" + form.key() + ":` judges the values a path selects, "
-                    + "collectively — it requires `in:` naming a declared view and a `path:` "
+                    + "collectively — it requires a `path:` under a declared view "
                     + "(there is no collection over the raw text or a scalar)");
         }
         if (form == PostconditionForm.PARSES) {

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
@@ -430,8 +430,11 @@ class ContractParserTest {
         }
 
         @Test
-        @DisplayName("path without a subject view is refused")
-        void pathWithoutIn() {
+        @DisplayName("a bare path check with no views to resolve against is refused naming both fixes")
+        void defaultViewNoViews() {
+            // The default-view amendment (2026-07-27): the shape is
+            // structurally admitted; with no transforms declared there is
+            // no default to resolve to, and the refusal names both fixes.
             assertRefused("""
                     format: mavai-contract/1
                     contract: c
@@ -442,7 +445,153 @@ class ContractParserTest {
                           - path: "$.items[*].name"
                             matches: '\\w'
                     inputs: ["Alice"]
-                    """, "`path:` requires `in:`");
+                    """, "no resolvable default view");
+        }
+
+        @Test
+        @DisplayName("a bare path check under several transforms with no parses anchor is refused")
+        void defaultViewUnresolvable() {
+            assertRefused("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                      markup: xml
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - path: "$.items[*].name"
+                            matches: '\\w'
+                    inputs: ["Alice"]
+                    """, "declare a single `parses: <view>`");
+        }
+
+        @Test
+        @DisplayName("a bare path check resolves to the criterion's single parses view")
+        void defaultViewParsesAnchor() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                      markup: xml
+                    criteria:
+                      - threshold: 0.9
+                        parses: doc
+                        postconditions:
+                          - path: "$.items[*].name"
+                            matches: '\\w'
+                    inputs: ["Alice"]
+                    """);
+            assertThat(declaration.criteria().get(0).forms())
+                    .filteredOn(form -> form.path() != null)
+                    .allSatisfy(form -> assertThat(form.view()).isEqualTo("doc"));
+        }
+
+        @Test
+        @DisplayName("a bare path check resolves to the sole declared transform")
+        void defaultViewSoleTransform() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - path: "$.items[*].name"
+                            matches: '\\w'
+                    inputs: ["Alice"]
+                    """);
+            assertThat(declaration.criteria().get(0).forms().get(0).view()).isEqualTo("doc");
+        }
+
+        @Test
+        @DisplayName("several parses forms resolve no anchor and fall through to the sole transform")
+        void defaultViewMultiParsesFallsThrough() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - parses: doc
+                          - parses: doc
+                          - path: "$.items[*].name"
+                            matches: '\\w'
+                    inputs: ["Alice"]
+                    """);
+            assertThat(declaration.criteria().get(0).forms().get(2).view()).isEqualTo("doc");
+        }
+
+        @Test
+        @DisplayName("an explicit in: always wins over the resolvable default")
+        void defaultViewExplicitInWins() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                      markup: xml
+                    criteria:
+                      - threshold: 0.9
+                        parses: doc
+                        postconditions:
+                          - in: markup
+                            path: "//name"
+                            matches: '\\w'
+                    inputs: ["Alice"]
+                    """);
+            assertThat(declaration.criteria().get(0).forms())
+                    .filteredOn(form -> form.path() != null)
+                    .allSatisfy(form -> assertThat(form.view()).isEqualTo("markup"));
+        }
+
+        @Test
+        @DisplayName("a path can never target raw — explicitly or by default")
+        void pathCannotTargetRaw() {
+            assertRefused("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - in: raw
+                            path: "$.items[*].name"
+                            matches: '\\w'
+                    inputs: ["Alice"]
+                    """, "`path:` cannot target `raw`");
+        }
+
+        @Test
+        @DisplayName("per-input expected entries resolve through the same default")
+        void defaultViewInExpected() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        parses: doc
+                    inputs:
+                      - input: "Alice"
+                        expected:
+                          - path: "$.name"
+                            equals: "Alice"
+                    """);
+            assertThat(declaration.inputs().get(0).expected().get(0).view()).isEqualTo("doc");
         }
 
         @Test
@@ -671,7 +820,7 @@ class ContractParserTest {
                           - in: doc
                             equals-set: ["a", "b"]
                     inputs: ["Alice"]
-                    """, "requires `in:` naming a declared view and a `path:`");
+                    """, "requires a `path:` under a declared view");
         }
 
         @Test

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -51,6 +51,17 @@ class DeclaredRunTest {
         }
 
         @Test
+        @DisplayName("a contract spelt with the default subject view runs identically")
+        void defaultedViewRunsEndToEnd() {
+            // The basket contract with every path check's `in: basket`
+            // omitted — the criterion's `parses: basket` anchors the
+            // default, per-input expectations included.
+            assertThatCode(() ->
+                    PUnit.declared("defaulted-view-runs-end-to-end").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
         @DisplayName("a wrong per-input expectation fails only its own input's samples — and the bar")
         void wrongExpectation() {
             Declared run = PUnit.declared("basket-builder-disappoints-one-input").samples(30);

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/defaulted.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/defaulted.yaml
@@ -1,0 +1,22 @@
+format: mavai-contract/1
+contract: defaulted-view-runs-end-to-end
+service: basket-builder
+transforms:
+  basket: json
+criteria:
+  - name: response-is-a-valid-basket
+    threshold: 0.8
+    postconditions:
+      - parses: basket
+      - path: "$.items[*].name"
+        matches: '\w'
+      - path: "$.items[*].quantity"
+        matches: '^[1-9][0-9]*$'
+inputs:
+  - input: "a dozen eggs, please"
+    expected:
+      - path: "$.items[*].name"
+        equals: "egg"
+      - path: "$.items[?@.name == 'egg'].quantity"
+        equals: "12"
+  - "two bottles of milk"


### PR DESCRIPTION
Item 1 of `DIR-PU-DA-baseltest-parity`, executing `DIR-PU-FORMS-default-view` (family subject-rule amendment, 2026-07-27; baseltest reference: baseltest#75).

**The rule.** A `path:`-bearing check omitting `in:` resolves path-conditionally: the owning criterion's **single** `parses:` view → else the contract's **sole** declared transform → else a load refusal naming the check and both fixes (add `in:`, or declare a single `parses:`). A path-less bare check still judges `raw`; an explicit `in:` always wins; several `parses:` forms resolve no anchor and fall through to the sole-transform tier; a `path:` can never target `raw` (explicitly or by default). Backward compatible by construction — the bare form was previously refused outright, so no existing contract carries it.

**Where.** `FormParser` marks the unresolved subject; `ContractParser` resolves every form (criterion forms and per-input `expected:` entries, through the single owning criterion) before the declaration leaves the parser — so the compiler, the once-per-response view sharing, and future materialisation see the resolved name with no changes of their own. Two refusal messages recategorise per the v0.10.0 corpus: the structural `path-without-in` refusal retires in favour of the semantic unresolvable-default refusal, and the set-form addressing message drops its `in:` clause.

**Tests.** One-for-one mirrors of the four v0.10.0 corpus cases (both valid resolution tiers, unresolvable-with-transforms, no-views), plus multi-`parses:` fall-through, explicit-`in:`-wins, path-cannot-target-raw, per-input `expected:` resolution, and an end-to-end run of the basket contract respelt with every `in: basket` omitted. Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwCM