### PR TITLE
Partial credit for optional postconditions, with postcondition standings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Partial credit for optional postconditions.** A criterion check may
+  be declared `optional` (programmatic `.optional()`, declarative
+  `optional: true`), and the criterion may grant an `optional-slack`
+  budget — an absolute count or an `"N%"` floor over the applicable
+  optional checks. A trial still resolves to a single Bernoulli
+  outcome: it fails when any required check fails, or when the number
+  of failed optional checks exceeds the slack budget. Both marks are a
+  double opt-in — an `optional` check without a slack budget binds
+  exactly as before, and a slack budget with no optional checks is
+  inert. Recorded per-check outcomes stay true; only the acceptance
+  predicate changes. Per the family partial-credit ruling (2026-07).
+
+- **Postcondition standings.** Every run now states a descriptive
+  per-`(input, check)` tally — passed, failed, skipped, and the
+  observed fraction — beside the verdict, with the declared
+  optional-slack budget verbatim. Descriptive vocabulary only: no
+  intervals, no thresholds, no per-check verdicts; the criterion stays
+  the only judged unit. The standings surface everywhere a run
+  reports: the console verdict, the verdict XML record (schema version
+  1.4, first-class `<postcondition-standings>` element), the MEASURE
+  baseline YAML, and the per-criterion statistics of the explore and
+  optimize artefacts.
+
 - **The default subject view (declarative contracts).** A `path:`-bearing
   check may now omit `in:`: its subject resolves to the view named by the
   owning criterion's single `parses:` form, else the contract's sole

--- a/punit-core/src/main/java/org/mavai/punit/api/Postcondition.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/Postcondition.java
@@ -68,6 +68,15 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf, Postconditi
     String description();
 
     /**
+     * Whether this postcondition is non-negotiable (the default). An
+     * optional check's failure counts against its criterion's
+     * optional-slack budget instead of failing the trial outright —
+     * partial credit is a double opt-in: an optional mark weakens
+     * nothing until the criterion also declares a budget.
+     */
+    boolean required();
+
+    /**
      * Evaluate this postcondition and return one summary result.
      *
      * <p>This signature is well-defined for the {@link Leaf} variant,
@@ -104,7 +113,7 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf, Postconditi
     // ── Variant ─────────────────────────────────────────────────────
 
     /** A direct postcondition: one description, one check. */
-    record Leaf<T>(String description, PostconditionCheck<T> check)
+    record Leaf<T>(String description, PostconditionCheck<T> check, boolean required)
             implements Postcondition<T> {
 
         public Leaf {
@@ -113,6 +122,11 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf, Postconditi
             if (description.isBlank()) {
                 throw new IllegalArgumentException("description must not be blank");
             }
+        }
+
+        /** A required leaf — the default. */
+        public Leaf(String description, PostconditionCheck<T> check) {
+            this(description, check, true);
         }
 
         @Override
@@ -124,11 +138,11 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf, Postconditi
                 String reason = e.getMessage() != null
                         ? e.getMessage()
                         : e.getClass().getSimpleName();
-                return PostconditionResult.failed(description, reason);
+                return PostconditionResult.failed(description, reason, required);
             }
             return switch (result) {
-                case Outcome.Ok<?> ignored -> PostconditionResult.passed(description);
-                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f);
+                case Outcome.Ok<?> ignored -> PostconditionResult.passed(description, required);
+                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f, required);
             };
         }
 
@@ -154,7 +168,7 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf, Postconditi
      * {@link #match(Object, Object)} directly. The interface-method
      * implementation throws to surface engine-side misuse.
      */
-    record Matching<T>(String description, ValueMatcher<T> matcher)
+    record Matching<T>(String description, ValueMatcher<T> matcher, boolean required)
             implements Postcondition<T> {
 
         public Matching {
@@ -163,6 +177,11 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf, Postconditi
             if (description.isBlank()) {
                 throw new IllegalArgumentException("description must not be blank");
             }
+        }
+
+        /** A required matching postcondition — the default. */
+        public Matching(String description, ValueMatcher<T> matcher) {
+            this(description, matcher, true);
         }
 
         /**
@@ -185,11 +204,11 @@ public sealed interface Postcondition<T> permits Postcondition.Leaf, Postconditi
                 String reason = e.getMessage() != null
                         ? e.getMessage()
                         : e.getClass().getSimpleName();
-                return PostconditionResult.failed(description, reason);
+                return PostconditionResult.failed(description, reason, required);
             }
             return switch (result) {
-                case Outcome.Ok<?> ignored -> PostconditionResult.passed(description);
-                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f);
+                case Outcome.Ok<?> ignored -> PostconditionResult.passed(description, required);
+                case Outcome.Fail<?> f -> PostconditionResult.failed(description, f, required);
             };
         }
 

--- a/punit-core/src/main/java/org/mavai/punit/api/PostconditionResult.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/PostconditionResult.java
@@ -14,11 +14,16 @@ import org.mavai.outcome.Outcome;
  *                postcondition held, {@link Outcome.Fail} otherwise
  *                (the failure carries the reason)
  */
-public record PostconditionResult(String description, Outcome<?> outcome) {
+public record PostconditionResult(String description, Outcome<?> outcome, boolean required) {
 
     public PostconditionResult {
         Objects.requireNonNull(description, "description");
         Objects.requireNonNull(outcome, "outcome");
+    }
+
+    /** A required check's result — the default. */
+    public PostconditionResult(String description, Outcome<?> outcome) {
+        this(description, outcome, true);
     }
 
     public boolean passed() {
@@ -75,6 +80,11 @@ public record PostconditionResult(String description, Outcome<?> outcome) {
         return new PostconditionResult(description, Outcome.ok());
     }
 
+    /** A passing result carrying the check's required/optional standing. */
+    public static PostconditionResult passed(String description, boolean required) {
+        return new PostconditionResult(description, Outcome.ok(), required);
+    }
+
     /**
      * Construct a failed result with a synthetic failure (name is the
      * description). Used for results that don't originate from an
@@ -87,6 +97,12 @@ public record PostconditionResult(String description, Outcome<?> outcome) {
         return new PostconditionResult(description, Outcome.fail(description, reason));
     }
 
+    /** A failed result carrying the check's required/optional standing. */
+    public static PostconditionResult failed(String description, String reason, boolean required) {
+        Objects.requireNonNull(reason, "reason");
+        return new PostconditionResult(description, Outcome.fail(description, reason), required);
+    }
+
     /**
      * Construct a failed result that preserves an author-supplied
      * {@link Outcome.Fail}. Both the failure's name and its message
@@ -96,5 +112,12 @@ public record PostconditionResult(String description, Outcome<?> outcome) {
     public static PostconditionResult failed(String description, Outcome.Fail<?> failure) {
         Objects.requireNonNull(failure, "failure");
         return new PostconditionResult(description, failure);
+    }
+
+    /** A failed result preserving the author's failure and the check's standing. */
+    public static PostconditionResult failed(
+            String description, Outcome.Fail<?> failure, boolean required) {
+        Objects.requireNonNull(failure, "failure");
+        return new PostconditionResult(description, failure, required);
     }
 }

--- a/punit-core/src/main/java/org/mavai/punit/api/ServiceContractOutcome.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/ServiceContractOutcome.java
@@ -108,6 +108,30 @@ public record ServiceContractOutcome<I, O>(
         if (result instanceof Outcome.Fail<O> f) {
             return f;
         }
+        // When per-criterion sample detail is present, the criteria's own
+        // acceptance predicates decide the trial — a criterion may accept
+        // a sample whose optional checks failed within its declared
+        // optional-slack budget (partial credit), so a flat any-failed
+        // walk would overrule the criterion's judgement. The flat walk
+        // remains the fallback for outcomes constructed without
+        // per-criterion detail (the back-compat constructor).
+        if (!criterionSampleResults.isEmpty()) {
+            for (org.mavai.punit.api.criterion.CriterionSampleResult c : criterionSampleResults) {
+                if (c.outcome() == org.mavai.punit.api.criterion.CriterionSampleOutcome.FAIL) {
+                    if (c.reason().isPresent()) {
+                        return Outcome.fail(c.reason().get().failure());
+                    }
+                    for (PostconditionResult r : c.postconditionResults()) {
+                        if (r.failed()) {
+                            return Outcome.fail(r.description(),
+                                    r.failureReason().orElse("postcondition failed"));
+                        }
+                    }
+                    return Outcome.fail(c.criterionId(), "criterion failed the sample");
+                }
+            }
+            return result;
+        }
         for (PostconditionResult r : postconditionResults) {
             if (r.failed()) {
                 return Outcome.fail(r.description(),

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/Criterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/Criterion.java
@@ -73,6 +73,15 @@ public interface Criterion<O> {
     CriterionSampleResult evaluate(O value);
 
     /**
+     * The criterion's declared optional-check failure budget, when one
+     * is declared — stated (never resolved) into the standings every
+     * run surfaces, verbatim as the author spelled it.
+     */
+    default java.util.Optional<OptionalSlack> optionalSlack() {
+        return java.util.Optional.empty();
+    }
+
+    /**
      * Evaluate this criterion against one sample's produced value
      * with an optional known-expected value of the same type
      * supplied alongside.

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
@@ -173,6 +173,12 @@ public final class CriterionDecl<O> implements Decl<O> {
                 Optional.of(OptionalSlack.percent(percentage)));
     }
 
+    /** Declare the optional-check failure budget from a constructed value. */
+    public CriterionDecl<O> optionalSlack(OptionalSlack slack) {
+        Objects.requireNonNull(slack, "slack");
+        return new CriterionDecl<>(posture, postconditions, name, Optional.of(slack));
+    }
+
     /**
      * Add a named postcondition. The predicate returns {@code true}
      * for pass; the framework synthesises the failure message when

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/CriterionDecl.java
@@ -64,6 +64,7 @@ public final class CriterionDecl<O> implements Decl<O> {
     private final CriterionPosture posture;
     private final List<NamedPostcondition<O>> postconditions;
     private final Optional<String> name;
+    private final Optional<OptionalSlack> optionalSlack;
 
     CriterionDecl(CriterionPosture posture, List<NamedPostcondition<O>> postconditions) {
         this(posture, postconditions, Optional.empty());
@@ -71,9 +72,15 @@ public final class CriterionDecl<O> implements Decl<O> {
 
     CriterionDecl(CriterionPosture posture, List<NamedPostcondition<O>> postconditions,
             Optional<String> name) {
+        this(posture, postconditions, name, Optional.empty());
+    }
+
+    CriterionDecl(CriterionPosture posture, List<NamedPostcondition<O>> postconditions,
+            Optional<String> name, Optional<OptionalSlack> optionalSlack) {
         this.posture = Objects.requireNonNull(posture, "posture");
         this.postconditions = List.copyOf(postconditions);
         this.name = Objects.requireNonNull(name, "name");
+        this.optionalSlack = Objects.requireNonNull(optionalSlack, "optionalSlack");
     }
 
     @Override
@@ -102,7 +109,7 @@ public final class CriterionDecl<O> implements Decl<O> {
                     ".name(...) already supplied as '" + this.name.get()
                             + "'; cannot reassign to '" + name + "'");
         }
-        return new CriterionDecl<>(posture, postconditions, Optional.of(name));
+        return new CriterionDecl<>(posture, postconditions, Optional.of(name), optionalSlack);
     }
 
     /** The criterion's posture — the verdict-producing commitment. */
@@ -113,6 +120,57 @@ public final class CriterionDecl<O> implements Decl<O> {
     /** Named postconditions in declaration order. May be empty. */
     public List<NamedPostcondition<O>> postconditions() {
         return postconditions;
+    }
+
+    /** The declared optional-check failure budget, when one is declared. */
+    public Optional<OptionalSlack> optionalSlack() {
+        return optionalSlack;
+    }
+
+    /**
+     * Mark the most recently declared postcondition optional:
+     * relaxable within this criterion's {@link #optionalSlack(int)
+     * optional-slack} budget. Partial credit is a double opt-in — the
+     * mark weakens nothing until the criterion also declares a budget
+     * (absent budget = zero, the check must still pass). The recorded
+     * per-check outcome stays true either way: standings see reality,
+     * not the softened verdict.
+     *
+     * @throws IllegalStateException when no postcondition has been
+     *     declared yet — the mark follows the check it relaxes
+     */
+    public CriterionDecl<O> optional() {
+        if (postconditions.isEmpty()) {
+            throw new IllegalStateException(
+                    ".optional() marks the postcondition declared before it — declare a "
+                            + ".where(...) / .satisfies(...) check first");
+        }
+        List<NamedPostcondition<O>> next = new ArrayList<>(postconditions);
+        next.set(next.size() - 1, next.get(next.size() - 1).asOptional());
+        return new CriterionDecl<>(posture, next, name, optionalSlack);
+    }
+
+    /**
+     * Declare the optional-check failure budget: at most {@code count}
+     * of this criterion's optional checks may fail per trial. A budget
+     * exceeding the applicable optional count is legal and means "all
+     * may fail"; a budget with no optional checks is legal and inert.
+     */
+    public CriterionDecl<O> optionalSlack(int count) {
+        return new CriterionDecl<>(posture, postconditions, name,
+                Optional.of(OptionalSlack.count(count)));
+    }
+
+    /**
+     * Declare the optional-check failure budget as an explicit
+     * percentage of the trial's applicable optional checks
+     * ({@code "20%"}), resolved by floor — the conservative reading.
+     * The {@code %} suffix is the disambiguator; a bare fraction is
+     * refused, never guessed at.
+     */
+    public CriterionDecl<O> optionalSlack(String percentage) {
+        return new CriterionDecl<>(posture, postconditions, name,
+                Optional.of(OptionalSlack.percent(percentage)));
     }
 
     /**
@@ -167,7 +225,7 @@ public final class CriterionDecl<O> implements Decl<O> {
      * alongside the verdict.
      */
     public CriterionDecl<O> contractRef(String ref) {
-        return new CriterionDecl<>(posture.withContractRef(ref), postconditions, name);
+        return new CriterionDecl<>(posture.withContractRef(ref), postconditions, name, optionalSlack);
     }
 
     /**
@@ -189,7 +247,7 @@ public final class CriterionDecl<O> implements Decl<O> {
     public CriterionDecl<O> contractRef(
             org.mavai.punit.api.ThresholdOrigin origin, String ref) {
         return new CriterionDecl<>(
-                posture.withContractRef(origin, ref), postconditions, name);
+                posture.withContractRef(origin, ref), postconditions, name, optionalSlack);
     }
 
     /**
@@ -199,7 +257,8 @@ public final class CriterionDecl<O> implements Decl<O> {
      * zero-failures commitment.
      */
     public CriterionDecl<O> atConfidence(double confidence) {
-        return new CriterionDecl<>(posture.withConfidenceFloor(confidence), postconditions, name);
+        return new CriterionDecl<>(
+                posture.withConfidenceFloor(confidence), postconditions, name, optionalSlack);
     }
 
     /**
@@ -209,7 +268,7 @@ public final class CriterionDecl<O> implements Decl<O> {
      * must be paired with {@link #atPower(double)}.
      */
     public CriterionDecl<O> detectingMde(double mde) {
-        return new CriterionDecl<>(posture.withMde(mde), postconditions, name);
+        return new CriterionDecl<>(posture.withMde(mde), postconditions, name, optionalSlack);
     }
 
     /**
@@ -219,7 +278,7 @@ public final class CriterionDecl<O> implements Decl<O> {
      * {@link #tolerating(double)}.
      */
     public CriterionDecl<O> atPower(double power) {
-        return new CriterionDecl<>(posture.withPower(power), postconditions, name);
+        return new CriterionDecl<>(posture.withPower(power), postconditions, name, optionalSlack);
     }
 
     /**
@@ -235,7 +294,7 @@ public final class CriterionDecl<O> implements Decl<O> {
      * override the framework defaults (0.80 and 0.95).
      */
     public CriterionDecl<O> tolerating(double rate) {
-        return new CriterionDecl<>(posture.withToleratedRate(rate), postconditions, name);
+        return new CriterionDecl<>(posture.withToleratedRate(rate), postconditions, name, optionalSlack);
     }
 
     /**
@@ -352,15 +411,15 @@ public final class CriterionDecl<O> implements Decl<O> {
         }
         List<Postcondition<O>> clauses = new ArrayList<>(postconditions.size());
         for (NamedPostcondition<O> p : postconditions) {
-            clauses.add(new Postcondition.Leaf<>(p.name(), p.check()));
+            clauses.add(new Postcondition.Leaf<>(p.name(), p.check(), p.required()));
         }
-        return new DirectCriterion<>(id, clauses).withPosture(posture);
+        return new DirectCriterion<>(id, clauses, optionalSlack).withPosture(posture);
     }
 
     private CriterionDecl<O> appendPostcondition(String postconditionName, PostconditionCheck<O> check) {
         List<NamedPostcondition<O>> next = new ArrayList<>(postconditions.size() + 1);
         next.addAll(postconditions);
         next.add(new NamedPostcondition<>(postconditionName, check));
-        return new CriterionDecl<>(posture, next, name);
+        return new CriterionDecl<>(posture, next, name, optionalSlack);
     }
 }

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/DirectCriterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/DirectCriterion.java
@@ -25,20 +25,28 @@ final class DirectCriterion<O> implements Criterion<O> {
     private final String id;
     private final List<Postcondition<O>> postconditions;
     private final CriterionPosture posture;
+    private final Optional<OptionalSlack> optionalSlack;
 
     DirectCriterion(String id, List<Postcondition<O>> postconditions) {
-        this(id, postconditions, CriterionPosture.implicit());
+        this(id, postconditions, Optional.empty(), CriterionPosture.implicit());
     }
 
-    DirectCriterion(String id, List<Postcondition<O>> postconditions, CriterionPosture posture) {
+    DirectCriterion(String id, List<Postcondition<O>> postconditions,
+            Optional<OptionalSlack> optionalSlack) {
+        this(id, postconditions, optionalSlack, CriterionPosture.implicit());
+    }
+
+    DirectCriterion(String id, List<Postcondition<O>> postconditions,
+            Optional<OptionalSlack> optionalSlack, CriterionPosture posture) {
         this.id = Objects.requireNonNull(id, "id");
         this.postconditions = List.copyOf(
                 Objects.requireNonNull(postconditions, "postconditions"));
+        this.optionalSlack = Objects.requireNonNull(optionalSlack, "optionalSlack");
         this.posture = Objects.requireNonNull(posture, "posture");
     }
 
     DirectCriterion<O> withPosture(CriterionPosture replacement) {
-        return new DirectCriterion<>(id, postconditions, replacement);
+        return new DirectCriterion<>(id, postconditions, optionalSlack, replacement);
     }
 
     @Override
@@ -53,12 +61,12 @@ final class DirectCriterion<O> implements Criterion<O> {
 
     @Override
     public CriterionSampleResult evaluate(O value) {
-        return evaluateChain(id, postconditions, value, Optional.empty());
+        return evaluateChain(id, postconditions, value, Optional.empty(), optionalSlack);
     }
 
     @Override
     public CriterionSampleResult evaluate(O value, Optional<O> expected) {
-        return evaluateChain(id, postconditions, value, expected);
+        return evaluateChain(id, postconditions, value, expected, optionalSlack);
     }
 
     @Override
@@ -90,8 +98,25 @@ final class DirectCriterion<O> implements Criterion<O> {
      */
     static <T> CriterionSampleResult evaluateChain(
             String id, List<Postcondition<T>> chain, T value, Optional<T> expected) {
+        return evaluateChain(id, chain, value, expected, Optional.empty());
+    }
+
+    /**
+     * As above, with the criterion's optional-check failure budget.
+     * The trial's acceptance predicate (partial credit, a double
+     * opt-in): every required check must pass, and failed optional
+     * checks must stay within the resolved budget — absent budget,
+     * zero, so an optional mark alone weakens nothing. Recorded
+     * per-check outcomes stay true regardless: the standings see
+     * reality, not the softened verdict.
+     */
+    static <T> CriterionSampleResult evaluateChain(
+            String id, List<Postcondition<T>> chain, T value, Optional<T> expected,
+            Optional<OptionalSlack> optionalSlack) {
         List<PostconditionResult> results = new ArrayList<>();
-        boolean anyFailed = false;
+        boolean requiredFailed = false;
+        int optionalApplicable = 0;
+        int optionalFailed = 0;
         for (Postcondition<T> p : chain) {
             List<PostconditionResult> pResults = switch (p) {
                 case Postcondition.Leaf<T> leaf -> leaf.evaluateAll(value);
@@ -106,12 +131,22 @@ final class DirectCriterion<O> implements Criterion<O> {
             };
             results.addAll(pResults);
             for (PostconditionResult r : pResults) {
-                if (r.failed()) {
-                    anyFailed = true;
+                if (r.required()) {
+                    if (r.failed()) {
+                        requiredFailed = true;
+                    }
+                } else {
+                    optionalApplicable++;
+                    if (r.failed()) {
+                        optionalFailed++;
+                    }
                 }
             }
         }
-        return anyFailed
+        final int applicable = optionalApplicable;
+        int budget = optionalSlack.map(slack -> slack.resolve(applicable)).orElse(0);
+        boolean failed = requiredFailed || optionalFailed > budget;
+        return failed
                 ? CriterionSampleResult.fail(id, results)
                 : CriterionSampleResult.pass(id, results);
     }

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/DirectCriterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/DirectCriterion.java
@@ -60,6 +60,11 @@ final class DirectCriterion<O> implements Criterion<O> {
     }
 
     @Override
+    public Optional<OptionalSlack> optionalSlack() {
+        return optionalSlack;
+    }
+
+    @Override
     public CriterionSampleResult evaluate(O value) {
         return evaluateChain(id, postconditions, value, Optional.empty(), optionalSlack);
     }

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/LatencyCriterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/LatencyCriterion.java
@@ -390,7 +390,7 @@ public final class LatencyCriterion {
         if (contractRef.isPresent()) {
             posture = posture.withContractRef(contractRef.get());
         }
-        return new DirectCriterion<>(ID, List.of(), posture);
+        return new DirectCriterion<>(ID, List.of(), java.util.Optional.empty(), posture);
     }
 
     private static void applyCeiling(LatencySpec.Builder b, Ceiling c) {

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/NamedPostcondition.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/NamedPostcondition.java
@@ -19,5 +19,21 @@ import org.mavai.punit.api.PostconditionCheck;
 // mavai-ref: JVI-BD4F1AB — do not remove (resolves in mavai-orchestrator)
 public record NamedPostcondition<O>(
         String name,
-        PostconditionCheck<O> check
-) { }
+        PostconditionCheck<O> check,
+        boolean required
+) {
+
+    /** A required postcondition — the default; every check is non-negotiable until marked. */
+    public NamedPostcondition(String name, PostconditionCheck<O> check) {
+        this(name, check, true);
+    }
+
+    /**
+     * This postcondition marked optional: relaxable within its
+     * criterion's optional-slack budget (partial credit is a double
+     * opt-in — without a budget the mark weakens nothing).
+     */
+    public NamedPostcondition<O> asOptional() {
+        return new NamedPostcondition<>(name, check, false);
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/OptionalSlack.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/OptionalSlack.java
@@ -1,0 +1,90 @@
+package org.mavai.punit.api.criterion;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A criterion's optional-check failure budget — how many of its
+ * optional postconditions may fail per trial before the trial fails:
+ * an absolute count, or an explicit percentage of the trial's
+ * applicable optional checks, resolved by <strong>floor</strong> (the
+ * conservative reading). The {@code %} suffix is the family's
+ * disambiguator — {@code 2} is always a count, {@code "20%"} always a
+ * fraction; a bare fraction is refused, never guessed at.
+ *
+ * <p>Partial credit is a double opt-in: a budget weakens nothing until
+ * a postcondition is also marked optional, and an optional mark
+ * weakens nothing without a budget (absent budget = zero). This is an
+ * acceptance-predicate quantity — counting, not statistics; the
+ * criterion's interval, sizing, and verdict machinery consume the
+ * per-trial outcome unchanged.
+ *
+ * @param count the absolute budget, or {@code null} for a percentage
+ * @param percent the percentage (of applicable optional checks), or
+ *     {@code null} for a count
+ * @param display the budget exactly as the author spelled it —
+ *     {@code "2"}, {@code "20%"} — carried verbatim into every stated
+ *     standings shape
+ */
+public record OptionalSlack(Integer count, BigDecimal percent, String display) {
+
+    private static final Pattern PERCENT = Pattern.compile("^([0-9]+(?:\\.[0-9]+)?)%$");
+
+    public OptionalSlack {
+        if ((count == null) == (percent == null)) {
+            throw new IllegalArgumentException(
+                    "an optional-slack budget is a count or a percentage, exactly one");
+        }
+        Objects.requireNonNull(display, "display");
+    }
+
+    /** An absolute budget: at most {@code count} optional checks may fail. */
+    public static OptionalSlack count(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException(
+                    "optional-slack takes a non-negative count of optional checks "
+                            + "that may fail, got " + count);
+        }
+        return new OptionalSlack(count, null, String.valueOf(count));
+    }
+
+    /**
+     * A percentage budget, spelled with the {@code %} suffix
+     * ({@code "20%"}), resolved by floor of the trial's applicable
+     * optional checks.
+     *
+     * @throws IllegalArgumentException on any other spelling — a bare
+     *     fraction is never guessed at
+     */
+    public static OptionalSlack percent(String spelling) {
+        Objects.requireNonNull(spelling, "spelling");
+        Matcher matcher = PERCENT.matcher(spelling.strip());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                    "optional-slack takes a non-negative whole count, or an explicit "
+                            + "percentage like \"20%\" — got \"" + spelling + "\" (a bare "
+                            + "fraction is never guessed at)");
+        }
+        return new OptionalSlack(null, new BigDecimal(matcher.group(1)), spelling.strip());
+    }
+
+    /**
+     * The budget for a trial with the given number of applicable
+     * optional checks: the count as declared, or the percentage
+     * resolved by floor. A budget exceeding the applicable count is
+     * legal and means "all may fail" — a failure budget cannot be
+     * configured into an impossible state.
+     */
+    public int resolve(int applicableOptional) {
+        if (count != null) {
+            return count;
+        }
+        return percent
+                .multiply(BigDecimal.valueOf(applicableOptional))
+                .divide(BigDecimal.valueOf(100), 0, RoundingMode.FLOOR)
+                .intValue();
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingCriterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingCriterion.java
@@ -76,6 +76,11 @@ final class TransformingCriterion<O, D> implements Criterion<O> {
     }
 
     @Override
+    public Optional<OptionalSlack> optionalSlack() {
+        return optionalSlack;
+    }
+
+    @Override
     public CriterionSampleResult evaluate(O value) {
         Outcome<D> derived;
         try {

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingCriterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingCriterion.java
@@ -29,29 +29,40 @@ final class TransformingCriterion<O, D> implements Criterion<O> {
     private final String id;
     private final Function<O, Outcome<D>> transform;
     private final List<Postcondition<D>> postconditions;
+    private final Optional<OptionalSlack> optionalSlack;
     private final CriterionPosture posture;
 
     TransformingCriterion(
             String id,
             Function<O, Outcome<D>> transform,
             List<Postcondition<D>> postconditions) {
-        this(id, transform, postconditions, CriterionPosture.implicit());
+        this(id, transform, postconditions, Optional.empty(), CriterionPosture.implicit());
     }
 
     TransformingCriterion(
             String id,
             Function<O, Outcome<D>> transform,
             List<Postcondition<D>> postconditions,
+            Optional<OptionalSlack> optionalSlack) {
+        this(id, transform, postconditions, optionalSlack, CriterionPosture.implicit());
+    }
+
+    TransformingCriterion(
+            String id,
+            Function<O, Outcome<D>> transform,
+            List<Postcondition<D>> postconditions,
+            Optional<OptionalSlack> optionalSlack,
             CriterionPosture posture) {
         this.id = Objects.requireNonNull(id, "id");
         this.transform = Objects.requireNonNull(transform, "transform");
         this.postconditions = List.copyOf(
                 Objects.requireNonNull(postconditions, "postconditions"));
+        this.optionalSlack = Objects.requireNonNull(optionalSlack, "optionalSlack");
         this.posture = Objects.requireNonNull(posture, "posture");
     }
 
     TransformingCriterion<O, D> withPosture(CriterionPosture replacement) {
-        return new TransformingCriterion<>(id, transform, postconditions, replacement);
+        return new TransformingCriterion<>(id, transform, postconditions, optionalSlack, replacement);
     }
 
     @Override
@@ -79,7 +90,8 @@ final class TransformingCriterion<O, D> implements Criterion<O> {
         }
         return switch (derived) {
             case Outcome.Ok<D> ok ->
-                    DirectCriterion.evaluateChain(id, postconditions, ok.value(), Optional.empty());
+                    DirectCriterion.evaluateChain(
+                            id, postconditions, ok.value(), Optional.empty(), optionalSlack);
             case Outcome.Fail<D> f ->
                     CriterionSampleResult.failedTransform(id, f);
         };

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingDecl.java
@@ -147,6 +147,12 @@ public final class TransformingDecl<O, T> implements Decl<O> {
                 Optional.of(OptionalSlack.percent(percentage)));
     }
 
+    /** Declare the optional-check failure budget from a constructed value. */
+    public TransformingDecl<O, T> optionalSlack(OptionalSlack slack) {
+        Objects.requireNonNull(slack, "slack");
+        return new TransformingDecl<>(posture, transform, postconditions, name, Optional.of(slack));
+    }
+
     /**
      * Add a named postcondition over the transformed value. The
      * predicate returns {@code true} for pass; the framework

--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingDecl.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/TransformingDecl.java
@@ -40,12 +40,13 @@ public final class TransformingDecl<O, T> implements Decl<O> {
     private final Function<O, Outcome<T>> transform;
     private final List<NamedPostcondition<T>> postconditions;
     private final Optional<String> name;
+    private final Optional<OptionalSlack> optionalSlack;
 
     TransformingDecl(
             CriterionPosture posture,
             Function<O, Outcome<T>> transform,
             List<NamedPostcondition<T>> postconditions) {
-        this(posture, transform, postconditions, Optional.empty());
+        this(posture, transform, postconditions, Optional.empty(), Optional.empty());
     }
 
     TransformingDecl(
@@ -53,10 +54,20 @@ public final class TransformingDecl<O, T> implements Decl<O> {
             Function<O, Outcome<T>> transform,
             List<NamedPostcondition<T>> postconditions,
             Optional<String> name) {
+        this(posture, transform, postconditions, name, Optional.empty());
+    }
+
+    TransformingDecl(
+            CriterionPosture posture,
+            Function<O, Outcome<T>> transform,
+            List<NamedPostcondition<T>> postconditions,
+            Optional<String> name,
+            Optional<OptionalSlack> optionalSlack) {
         this.posture = Objects.requireNonNull(posture, "posture");
         this.transform = Objects.requireNonNull(transform, "transform");
         this.postconditions = List.copyOf(postconditions);
         this.name = Objects.requireNonNull(name, "name");
+        this.optionalSlack = Objects.requireNonNull(optionalSlack, "optionalSlack");
     }
 
     @Override
@@ -84,7 +95,7 @@ public final class TransformingDecl<O, T> implements Decl<O> {
                     ".name(...) already supplied as '" + this.name.get()
                             + "'; cannot reassign to '" + name + "'");
         }
-        return new TransformingDecl<>(posture, transform, postconditions, Optional.of(name));
+        return new TransformingDecl<>(posture, transform, postconditions, Optional.of(name), optionalSlack);
     }
 
     /** The posture inherited from the parent {@link CriterionDecl}. */
@@ -95,6 +106,45 @@ public final class TransformingDecl<O, T> implements Decl<O> {
     /** Named post-transform postconditions in declaration order. May be empty. */
     public List<NamedPostcondition<T>> postconditions() {
         return postconditions;
+    }
+
+    /** The declared optional-check failure budget, when one is declared. */
+    public Optional<OptionalSlack> optionalSlack() {
+        return optionalSlack;
+    }
+
+    /**
+     * Mark the most recently declared postcondition optional —
+     * relaxable within this criterion's optional-slack budget; see
+     * {@link CriterionDecl#optional()} for the double-opt-in rule.
+     *
+     * @throws IllegalStateException when no postcondition has been
+     *     declared yet — the mark follows the check it relaxes
+     */
+    public TransformingDecl<O, T> optional() {
+        if (postconditions.isEmpty()) {
+            throw new IllegalStateException(
+                    ".optional() marks the postcondition declared before it — declare a "
+                            + ".where(...) / .satisfies(...) check first");
+        }
+        List<NamedPostcondition<T>> next = new ArrayList<>(postconditions);
+        next.set(next.size() - 1, next.get(next.size() - 1).asOptional());
+        return new TransformingDecl<>(posture, transform, next, name, optionalSlack);
+    }
+
+    /** Declare the optional-check failure budget as an absolute count. */
+    public TransformingDecl<O, T> optionalSlack(int count) {
+        return new TransformingDecl<>(posture, transform, postconditions, name,
+                Optional.of(OptionalSlack.count(count)));
+    }
+
+    /**
+     * Declare the optional-check failure budget as an explicit
+     * percentage ({@code "20%"}), resolved by floor.
+     */
+    public TransformingDecl<O, T> optionalSlack(String percentage) {
+        return new TransformingDecl<>(posture, transform, postconditions, name,
+                Optional.of(OptionalSlack.percent(percentage)));
     }
 
     /**
@@ -152,15 +202,16 @@ public final class TransformingDecl<O, T> implements Decl<O> {
         }
         List<Postcondition<T>> clauses = new ArrayList<>(postconditions.size());
         for (NamedPostcondition<T> p : postconditions) {
-            clauses.add(new Postcondition.Leaf<>(p.name(), p.check()));
+            clauses.add(new Postcondition.Leaf<>(p.name(), p.check(), p.required()));
         }
-        return new TransformingCriterion<>(id, transform, clauses).withPosture(posture);
+        return new TransformingCriterion<>(id, transform, clauses, optionalSlack)
+                .withPosture(posture);
     }
 
     private TransformingDecl<O, T> appendPostcondition(String postconditionName, PostconditionCheck<T> check) {
         List<NamedPostcondition<T>> next = new ArrayList<>(postconditions.size() + 1);
         next.addAll(postconditions);
         next.add(new NamedPostcondition<>(postconditionName, check));
-        return new TransformingDecl<>(posture, transform, next, name);
+        return new TransformingDecl<>(posture, transform, next, name, optionalSlack);
     }
 }

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/PostconditionStandings.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/PostconditionStandings.java
@@ -1,0 +1,182 @@
+package org.mavai.punit.api.spec;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.mavai.punit.api.PostconditionResult;
+import org.mavai.punit.api.ServiceContractOutcome;
+import org.mavai.punit.api.criterion.Criterion;
+import org.mavai.punit.api.criterion.CriterionSampleResult;
+
+/**
+ * The postcondition standings: per {@code (input, check)}, how many
+ * trials passed, failed, or were skipped, with the observed pass
+ * fraction — the per-check tally the evaluator already computes per
+ * sample and previously discarded once the criterion's statistics were
+ * taken.
+ *
+ * <p><strong>Descriptive only, by design.</strong> No interval, no
+ * threshold, no per-check verdict: the run is sized to support the
+ * criterion's claim, not one claim per check, and postconditions on one
+ * response are correlated. The criterion remains the only judged unit;
+ * the standings say <em>which</em> checks miss and how often. Each
+ * check carries its required/optional standing and each criterion its
+ * declared optional-slack budget verbatim, so a consumer can flag
+ * partial credit from the stated data alone.
+ *
+ * <p>Derived post-hoc from a {@link SampleSummary}'s full trial
+ * history — a pure aggregation of recorded per-check outcomes, which
+ * stay true even when the acceptance predicate softened the trial.
+ */
+public record PostconditionStandings(List<CriterionStandings> criteria) {
+
+    public PostconditionStandings {
+        criteria = List.copyOf(Objects.requireNonNull(criteria, "criteria"));
+    }
+
+    /** Whether any criterion states any rows. */
+    public boolean isEmpty() {
+        return criteria.stream().allMatch(criterion -> criterion.rows().isEmpty());
+    }
+
+    /**
+     * One criterion's standings: its declared optional-slack budget —
+     * verbatim, exactly as the author spelled it, absent iff
+     * undeclared — and one row per {@code (input, check)}.
+     */
+    public record CriterionStandings(
+            String criterionId, Optional<String> optionalSlack, List<Row> rows) {
+
+        public CriterionStandings {
+            Objects.requireNonNull(criterionId, "criterionId");
+            Objects.requireNonNull(optionalSlack, "optionalSlack");
+            rows = List.copyOf(Objects.requireNonNull(rows, "rows"));
+        }
+    }
+
+    /**
+     * One {@code (input, check)} tally. A skip records a trial the
+     * check was applicable to but never judged — the criterion's chain
+     * did not run (a transform failure, or no delivered value).
+     */
+    public record Row(
+            int inputIndex, String check, boolean optional,
+            int passed, int failed, int skipped) {
+
+        /** Trials this check was applicable to. */
+        public int trials() {
+            return passed + failed + skipped;
+        }
+
+        /** The observed pass fraction over the check's applicable trials. */
+        public double observedFraction() {
+            int total = trials();
+            return total == 0 ? 0.0 : (double) passed / total;
+        }
+    }
+
+    /**
+     * Derives the standings from a summary's trial history, grouped by
+     * the given criteria (which carry each criterion's declared slack).
+     * A criterion whose chain never ran on any trial states no rows —
+     * there is nothing to stand.
+     */
+    public static PostconditionStandings from(
+            SampleSummary<?> summary, List<? extends Criterion<?>> criteria) {
+        Map<String, Map<RowKey, MutableTally>> tallies = new LinkedHashMap<>();
+        Map<String, Set<CheckIdentity>> knownChecks = new LinkedHashMap<>();
+        for (Criterion<?> criterion : criteria) {
+            tallies.put(criterion.id(), new LinkedHashMap<>());
+            knownChecks.put(criterion.id(), new LinkedHashSet<>());
+        }
+        // First pass: judged trials — true per-check outcomes, and the
+        // check vocabulary each criterion actually exercises.
+        for (Trial<?, ?> trial : summary.trials()) {
+            for (CriterionSampleResult result : trial.outcome().criterionSampleResults()) {
+                Map<RowKey, MutableTally> rows = tallies.get(result.criterionId());
+                if (rows == null || result.reason().isPresent()) {
+                    continue;
+                }
+                for (PostconditionResult check : result.postconditionResults()) {
+                    knownChecks.get(result.criterionId())
+                            .add(new CheckIdentity(check.description(), check.required()));
+                    MutableTally tally = rows.computeIfAbsent(
+                            new RowKey(trial.inputIndex(), check.description()),
+                            key -> new MutableTally(!check.required()));
+                    if (check.passed()) {
+                        tally.passed++;
+                    } else {
+                        tally.failed++;
+                    }
+                }
+            }
+        }
+        // Second pass: skipped trials — the chain never ran (transform
+        // failure, or an apply-level failure that skipped every
+        // criterion), so every known check of the criterion was
+        // applicable but unjudged.
+        for (Trial<?, ?> trial : summary.trials()) {
+            skippedCriterionIds(trial.outcome(), tallies.keySet()).forEach(criterionId -> {
+                Map<RowKey, MutableTally> rows = tallies.get(criterionId);
+                for (CheckIdentity check : knownChecks.get(criterionId)) {
+                    rows.computeIfAbsent(
+                            new RowKey(trial.inputIndex(), check.description()),
+                            key -> new MutableTally(!check.required())).skipped++;
+                }
+            });
+        }
+        List<CriterionStandings> standings = new ArrayList<>();
+        for (Criterion<?> criterion : criteria) {
+            List<Row> rows = new ArrayList<>();
+            tallies.get(criterion.id()).forEach((key, tally) -> rows.add(new Row(
+                    key.inputIndex(), key.check(), tally.optional,
+                    tally.passed, tally.failed, tally.skipped)));
+            rows.sort(java.util.Comparator
+                    .comparingInt(Row::inputIndex)
+                    .thenComparing(Row::check));
+            standings.add(new CriterionStandings(
+                    criterion.id(),
+                    criterion.optionalSlack().map(slack -> slack.display()),
+                    rows));
+        }
+        return new PostconditionStandings(standings);
+    }
+
+    private static Set<String> skippedCriterionIds(
+            ServiceContractOutcome<?, ?> outcome, Set<String> allCriterionIds) {
+        if (outcome.criterionSampleResults().isEmpty()) {
+            // No per-criterion detail at all — an apply-level failure
+            // (or a synthesised defect outcome): every criterion's
+            // checks were applicable and unjudged.
+            return allCriterionIds;
+        }
+        Set<String> skipped = new LinkedHashSet<>();
+        for (CriterionSampleResult result : outcome.criterionSampleResults()) {
+            if (result.reason().isPresent()) {
+                skipped.add(result.criterionId());
+            }
+        }
+        return skipped;
+    }
+
+    private record RowKey(int inputIndex, String check) {}
+
+    private record CheckIdentity(String description, boolean required) {}
+
+    private static final class MutableTally {
+        final boolean optional;
+        int passed;
+        int failed;
+        int skipped;
+
+        MutableTally(boolean optional) {
+            this.optional = optional;
+        }
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTest.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTest.java
@@ -290,7 +290,8 @@ public final class ProbabilisticTest implements Spec {
                     contractRefFromContract,
                     s.failuresByPostcondition(),
                     engineSummary,
-                    perCriterionEvaluation);
+                    perCriterionEvaluation,
+                    Optional.of(PostconditionStandings.from(s, contract.effectiveCriteria())));
         }
 
         /**

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTestResult.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/ProbabilisticTestResult.java
@@ -63,7 +63,28 @@ public record ProbabilisticTestResult(
         Optional<String> contractRef,
         Map<String, FailureCount> failuresByPostcondition,
         EngineRunSummary engineSummary,
-        PerCriterionEvaluation perCriterionEvaluation) implements EngineResult {
+        PerCriterionEvaluation perCriterionEvaluation,
+        Optional<PostconditionStandings> postconditionStandings) implements EngineResult {
+
+    /**
+     * Backward-compatible constructor without the postcondition
+     * standings; defaults them absent.
+     */
+    public ProbabilisticTestResult(
+            Verdict verdict,
+            FactorBundle factors,
+            List<EvaluatedCriterion> criterionResults,
+            TestIntent intent,
+            List<String> warnings,
+            CovariateAlignment covariates,
+            Optional<String> contractRef,
+            Map<String, FailureCount> failuresByPostcondition,
+            EngineRunSummary engineSummary,
+            PerCriterionEvaluation perCriterionEvaluation) {
+        this(verdict, factors, criterionResults, intent, warnings, covariates, contractRef,
+                failuresByPostcondition, engineSummary, perCriterionEvaluation,
+                Optional.empty());
+    }
 
     public ProbabilisticTestResult {
         Objects.requireNonNull(verdict, "verdict");
@@ -76,6 +97,7 @@ public record ProbabilisticTestResult(
         Objects.requireNonNull(failuresByPostcondition, "failuresByPostcondition");
         Objects.requireNonNull(engineSummary, "engineSummary");
         Objects.requireNonNull(perCriterionEvaluation, "perCriterionEvaluation");
+        Objects.requireNonNull(postconditionStandings, "postconditionStandings");
         criterionResults = List.copyOf(criterionResults);
         warnings = List.copyOf(warnings);
         failuresByPostcondition = Map.copyOf(failuresByPostcondition);

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineRecord.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineRecord.java
@@ -64,7 +64,27 @@ public record BaselineRecord(
         CovariateProfile covariateProfile,
         LatencyIndicator latencyIndicator,
         int expiresInDays,
-        List<NormativeJudgement> normativeJudgements) {
+        List<NormativeJudgement> normativeJudgements,
+        java.util.Optional<org.mavai.punit.api.spec.PostconditionStandings>
+                postconditionStandings) {
+
+    /** Backward-compatible constructor without the standings; defaults them absent. */
+    public BaselineRecord(
+            String serviceContractId,
+            String methodName,
+            String factorsFingerprint,
+            String inputsIdentity,
+            int sampleCount,
+            Instant generatedAt,
+            Map<String, BaselineStatistics> statisticsByCriterionName,
+            CovariateProfile covariateProfile,
+            LatencyIndicator latencyIndicator,
+            int expiresInDays,
+            List<NormativeJudgement> normativeJudgements) {
+        this(serviceContractId, methodName, factorsFingerprint, inputsIdentity, sampleCount,
+                generatedAt, statisticsByCriterionName, covariateProfile, latencyIndicator,
+                expiresInDays, normativeJudgements, java.util.Optional.empty());
+    }
 
     public BaselineRecord {
         Objects.requireNonNull(serviceContractId, "serviceContractId");

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/baseline/BaselineWriter.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -156,7 +157,49 @@ public final class BaselineWriter {
                     latency.totalSamples())
                 .ifPresent(block -> root.put("latency", block));
         }
+        // The postcondition standings — the descriptive per-(input,
+        // check) tally the measure run states, carried on the baseline
+        // so drift in per-check health is inspectable beside the rates.
+        // Descriptive only: counts and the observed fraction, the
+        // per-check optional flag, and the criterion's declared
+        // optional-slack budget verbatim. Positioned before the
+        // appended contentFingerprint, so it falls under the integrity
+        // hash.
+        record.postconditionStandings()
+                .filter(standings -> !standings.isEmpty())
+                .ifPresent(standings -> root.put("postconditionStandings",
+                        standingsBlock(standings)));
         return root;
+    }
+
+    private List<Map<String, Object>> standingsBlock(
+            org.mavai.punit.api.spec.PostconditionStandings standings) {
+        List<Map<String, Object>> criteria = new java.util.ArrayList<>();
+        for (var criterion : standings.criteria()) {
+            if (criterion.rows().isEmpty()) {
+                continue;
+            }
+            Map<String, Object> block = new LinkedHashMap<>();
+            block.put("criterion", criterion.criterionId());
+            criterion.optionalSlack().ifPresent(slack -> block.put("optionalSlack", slack));
+            List<Map<String, Object>> rows = new java.util.ArrayList<>();
+            for (var row : criterion.rows()) {
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("inputIndex", row.inputIndex());
+                entry.put("check", row.check());
+                entry.put("optional", row.optional());
+                entry.put("passed", row.passed());
+                entry.put("failed", row.failed());
+                entry.put("skipped", row.skipped());
+                entry.put("observedFraction",
+                        Double.parseDouble(String.format(
+                                java.util.Locale.ROOT, "%.6f", row.observedFraction())));
+                rows.add(entry);
+            }
+            block.put("rows", rows);
+            criteria.add(block);
+        }
+        return criteria;
     }
 
     private Map<String, Object> serialiseStatisticsEntry(

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/StandingsBlocks.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/StandingsBlocks.java
@@ -1,0 +1,54 @@
+package org.mavai.punit.internal.engine.emit;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.mavai.punit.api.spec.PostconditionStandings;
+
+/**
+ * The postcondition-standings block as artefact YAML maps — the family
+ * interchange shape (camelCase keys; the optional {@code optionalSlack}
+ * verbatim; one row per {@code (input, check)} with the tally and
+ * observed fraction). Shared by the explore and optimize writers per
+ * the identical-statistics-shape rule; descriptive only, exactly as
+ * stated by the derivation.
+ */
+public final class StandingsBlocks {
+
+    private StandingsBlocks() { }
+
+    /**
+     * Each criterion's standings block, keyed by its bounded criterion
+     * id — criteria stating no rows are absent (binding when present,
+     * never fabricated).
+     */
+    public static Map<String, Map<String, Object>> byCriterion(PostconditionStandings standings) {
+        Map<String, Map<String, Object>> blocks = new LinkedHashMap<>();
+        for (PostconditionStandings.CriterionStandings criterion : standings.criteria()) {
+            if (criterion.rows().isEmpty()) {
+                continue;
+            }
+            Map<String, Object> block = new LinkedHashMap<>();
+            criterion.optionalSlack().ifPresent(slack -> block.put("optionalSlack", slack));
+            List<Map<String, Object>> rows = new ArrayList<>();
+            for (PostconditionStandings.Row row : criterion.rows()) {
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("inputIndex", row.inputIndex());
+                entry.put("check", EmittedKeys.bound(row.check()));
+                entry.put("optional", row.optional());
+                entry.put("passed", row.passed());
+                entry.put("failed", row.failed());
+                entry.put("skipped", row.skipped());
+                entry.put("observedFraction", Double.parseDouble(
+                        String.format(Locale.ROOT, "%.6f", row.observedFraction())));
+                rows.add(entry);
+            }
+            block.put("rows", rows);
+            blocks.put(EmittedKeys.bound(criterion.criterionId()), block);
+        }
+        return blocks;
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -67,6 +67,18 @@ public final class ExploreOutputWriter {
      * @return YAML matching the canonical exploration interchange schema.
      */
     public String writeYaml(String serviceContractId, FactorBundle factorBundle, PerConfigSummary<?, ?> entry) {
+        return writeYaml(serviceContractId, factorBundle, entry, java.util.List.of());
+    }
+
+    /**
+     * As above, with the run's criteria — the configuration's
+     * per-criterion statistics then state the postcondition standings
+     * (the {@code mavai-explore-1} schema's binding-when-present
+     * {@code standings} block).
+     */
+    public String writeYaml(String serviceContractId, FactorBundle factorBundle,
+            PerConfigSummary<?, ?> entry,
+            java.util.List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteria) {
         Map<String, Object> root = new LinkedHashMap<>();
         root.put("schemaVersion", SCHEMA_VERSION);
         root.put("serviceContractId", serviceContractId);
@@ -74,7 +86,7 @@ public final class ExploreOutputWriter {
         root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
         root.put("factors", factorsBlock(factorBundle));
         root.put("execution", executionBlock(entry));
-        root.put("statistics", statisticsBlock(entry.summary()));
+        root.put("statistics", statisticsBlock(entry.summary(), criteria));
         root.put("cost", costBlock(entry.summary()));
         // Latency block - passing-only percentiles + population
         // indicator. Inserted before resultProjection so the
@@ -132,7 +144,8 @@ public final class ExploreOutputWriter {
         return block;
     }
 
-    private static Map<String, Object> statisticsBlock(SampleSummary<?> summary) {
+    private static Map<String, Object> statisticsBlock(SampleSummary<?> summary,
+            java.util.List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteriaDecls) {
         Map<String, Object> block = new LinkedHashMap<>();
         block.put("observed", summary.passRate());
         block.put("successes", summary.successes());
@@ -150,6 +163,11 @@ public final class ExploreOutputWriter {
         // compare explore vs measure emissions of the same contract
         // criterion-by-criterion. conditionFail / transformFail are
         // permitted informational extras beyond the canonical fields.
+        Map<String, Map<String, Object>> standingsByCriterion = criteriaDecls.isEmpty()
+                ? Map.of()
+                : org.mavai.punit.internal.engine.emit.StandingsBlocks.byCriterion(
+                        org.mavai.punit.api.spec.PostconditionStandings.from(
+                                summary, criteriaDecls));
         Map<String, Object> criteria = new LinkedHashMap<>();
         for (org.mavai.punit.api.spec.CriterionSampleCounts counts
                 : summary.criterionSampleCounts()) {
@@ -159,6 +177,11 @@ public final class ExploreOutputWriter {
             row.put("fail", counts.fail());
             row.put("conditionFail", counts.conditionFail());
             row.put("transformFail", counts.transformFail());
+            Map<String, Object> standings =
+                    standingsByCriterion.get(EmittedKeys.bound(counts.criterionId()));
+            if (standings != null) {
+                row.put("standings", standings);
+            }
             criteria.put(EmittedKeys.bound(counts.criterionId()), row);
         }
         block.put("criteria", criteria);

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
@@ -18,6 +18,7 @@ import org.mavai.punit.internal.engine.emit.EmittedKeys;
 import org.mavai.punit.internal.engine.emit.FailureDistributions;
 import org.mavai.punit.internal.engine.emit.LatencySection;
 import org.mavai.punit.internal.engine.emit.ResultProjections;
+import org.mavai.punit.internal.engine.emit.StandingsBlocks;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -75,6 +76,27 @@ public final class OptimizeOutputWriter {
             List<? extends SampleSummary<?>> iterationSummaries,
             IterationResult<?> bestIteration,
             String terminationReason) {
+        return writeYaml(serviceContractId, experimentId, objective, scorerName,
+                history, iterationSummaries, bestIteration, terminationReason, List.of());
+    }
+
+    /**
+     * As above, with the run's criteria — each iteration's
+     * per-criterion statistics then state the postcondition standings
+     * (the {@code mavai-optimize-1} schema's binding-when-present
+     * {@code standings} block, identical in shape to the exploration
+     * artefact's per the family's identical-statistics-shape rule).
+     */
+    public String writeYaml(
+            String serviceContractId,
+            String experimentId,
+            String objective,
+            String scorerName,
+            List<? extends IterationResult<?>> history,
+            List<? extends SampleSummary<?>> iterationSummaries,
+            IterationResult<?> bestIteration,
+            String terminationReason,
+            List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteria) {
 
         Map<String, Object> root = new LinkedHashMap<>();
         root.put("schemaVersion", SCHEMA_VERSION);
@@ -85,7 +107,7 @@ public final class OptimizeOutputWriter {
             root.put("scorer", scorerName);
         }
         root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
-        root.put("iterations", iterationsBlock(history, iterationSummaries));
+        root.put("iterations", iterationsBlock(history, iterationSummaries, criteria));
         root.put("convergence", convergenceBlock(history, bestIteration, terminationReason));
 
         String dump = yaml().dump(root);
@@ -109,7 +131,8 @@ public final class OptimizeOutputWriter {
 
     private static List<Map<String, Object>> iterationsBlock(
             List<? extends IterationResult<?>> history,
-            List<? extends SampleSummary<?>> iterationSummaries) {
+            List<? extends SampleSummary<?>> iterationSummaries,
+            List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteria) {
         List<Map<String, Object>> out = new ArrayList<>(history.size());
         for (int idx = 0; idx < history.size(); idx++) {
             IterationResult<?> ir = history.get(idx);
@@ -126,7 +149,7 @@ public final class OptimizeOutputWriter {
             SampleSummary<?> iterSummary = idx < iterationSummaries.size()
                     ? iterationSummaries.get(idx) : null;
             entry.put("execution", executionBlock(ir, iterSummary));
-            entry.put("statistics", statisticsBlock(ir, iterSummary));
+            entry.put("statistics", statisticsBlock(ir, iterSummary, criteria));
             if (iterSummary != null) {
                 entry.put("cost", costBlock(iterSummary));
                 LatencySection.blockFor(iterSummary)
@@ -150,7 +173,8 @@ public final class OptimizeOutputWriter {
     }
 
     private static Map<String, Object> statisticsBlock(
-            IterationResult<?> ir, SampleSummary<?> iterSummary) {
+            IterationResult<?> ir, SampleSummary<?> iterSummary,
+            List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteria) {
         Map<String, Object> block = new LinkedHashMap<>();
         int total = ir.samplesExecuted();
         double observed = total == 0 ? 0.0 : (double) ir.successes() / (double) total;
@@ -169,7 +193,15 @@ public final class OptimizeOutputWriter {
         // single-criterion case). conditionFail / transformFail are
         // permitted informational extras beyond the canonical fields.
         if (iterSummary != null) {
-            Map<String, Object> criteria = new LinkedHashMap<>();
+            // The iteration's standings, derived once and joined onto
+            // each criterion's row — the per-check tally is stated
+            // beside the counts, binding when present.
+            Map<String, Map<String, Object>> standingsByCriterion = criteria.isEmpty()
+                    ? Map.of()
+                    : StandingsBlocks.byCriterion(
+                            org.mavai.punit.api.spec.PostconditionStandings.from(
+                                    iterSummary, criteria));
+            Map<String, Object> criteriaBlock = new LinkedHashMap<>();
             for (CriterionSampleCounts c : iterSummary.criterionSampleCounts()) {
                 Map<String, Object> row = new LinkedHashMap<>();
                 row.put("observedPassRate", c.observedPassRate());
@@ -177,9 +209,14 @@ public final class OptimizeOutputWriter {
                 row.put("fail", c.fail());
                 row.put("conditionFail", c.conditionFail());
                 row.put("transformFail", c.transformFail());
-                criteria.put(EmittedKeys.bound(c.criterionId()), row);
+                Map<String, Object> standings =
+                        standingsByCriterion.get(EmittedKeys.bound(c.criterionId()));
+                if (standings != null) {
+                    row.put("standings", standings);
+                }
+                criteriaBlock.put(EmittedKeys.bound(c.criterionId()), row);
             }
-            block.put("criteria", criteria);
+            block.put("criteria", criteriaBlock);
         }
         return block;
     }

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/ConsoleVerdictSink.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/ConsoleVerdictSink.java
@@ -79,6 +79,14 @@ public final class ConsoleVerdictSink implements VerdictSink {
             sb.append(PUnitReporter.labelValueLn("Termination:", term.reason().getDescription()));
         }
 
+        // The postcondition standings — descriptive per-(input, check)
+        // tallies, stated by the run; rendered verbatim, never derived.
+        verdict.postconditionStandings().ifPresent(standings -> {
+            for (String line : StandingsTextRenderer.render(standings)) {
+                sb.append(line).append('\n');
+            }
+        });
+
         sb.append(PUnitReporter.labelValue("Elapsed:", exec.elapsedMs() + "ms"));
 
         out.println(reporter.headerDivider(title));

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/StandingsTextRenderer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/StandingsTextRenderer.java
@@ -1,0 +1,61 @@
+package org.mavai.punit.internal.reporting;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.mavai.punit.api.spec.PostconditionStandings;
+
+/**
+ * Text rendering of the postcondition standings — the descriptive
+ * per-{@code (input, check)} tally every run surfaces. Descriptive
+ * vocabulary only: counts and observed fractions, never an interval, a
+ * threshold, or a per-check verdict — the criterion stays the only
+ * judged unit, and this renderer computes nothing (the observed
+ * fraction is the row's own statement).
+ */
+public final class StandingsTextRenderer {
+
+    private StandingsTextRenderer() { }
+
+    /**
+     * The standings as indent-ready lines; empty when nothing is
+     * stated. One heading per criterion (with its declared
+     * optional-slack budget, verbatim, when one is declared), one line
+     * per {@code (input, check)} row.
+     */
+    public static List<String> render(PostconditionStandings standings) {
+        List<String> lines = new ArrayList<>();
+        for (PostconditionStandings.CriterionStandings criterion : standings.criteria()) {
+            if (criterion.rows().isEmpty()) {
+                continue;
+            }
+            if (lines.isEmpty()) {
+                lines.add("Postcondition standings (descriptive):");
+            }
+            lines.add("  criterion '" + criterion.criterionId() + "'"
+                    + criterion.optionalSlack()
+                            .map(slack -> " (optional-slack " + slack + ")")
+                            .orElse("")
+                    + ":");
+            for (PostconditionStandings.Row row : criterion.rows()) {
+                StringBuilder line = new StringBuilder("    input ")
+                        .append(row.inputIndex())
+                        .append(" · ")
+                        .append(row.check());
+                if (row.optional()) {
+                    line.append(" [optional]");
+                }
+                line.append(": ")
+                        .append(row.passed()).append('/').append(row.trials())
+                        .append(" passed");
+                if (row.skipped() > 0) {
+                    line.append(", ").append(row.skipped()).append(" skipped");
+                }
+                line.append(String.format(Locale.ROOT, " (%.2f)", row.observedFraction()));
+                lines.add(line.toString());
+            }
+        }
+        return lines;
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
@@ -220,7 +220,9 @@ public final class BaselineEmitter {
                 profile,
                 latencyIndicator,
                 expiresInDays,
-                judgeNormativeCriteria(serviceContract, summary));
+                judgeNormativeCriteria(serviceContract, summary),
+                java.util.Optional.of(org.mavai.punit.api.spec.PostconditionStandings.from(
+                        summary, serviceContract.effectiveCriteria())));
     }
 
     /**

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/ExploreEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/ExploreEmitter.java
@@ -102,10 +102,12 @@ public final class ExploreEmitter {
                 for (PerConfigSummary<?, ?> entry : entries) {
                     @SuppressWarnings("unchecked")
                     FT factors = (FT) entry.factors();
-                    String serviceContractId = typed.serviceContractFactory().apply(factors).id();
+                    var contract = typed.serviceContractFactory().apply(factors);
+                    String serviceContractId = contract.id();
                     FactorBundle bundle = FactorBundle.of(factors);
                     String stem = writer.filenameFor(bundle);
-                    String yaml = writer.writeYaml(serviceContractId, bundle, entry);
+                    String yaml = writer.writeYaml(
+                            serviceContractId, bundle, entry, contract.effectiveCriteria());
                     sink.accept(serviceContractId + "/" + stem + ".yaml", yaml);
                 }
                 return null;

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/OptimizeEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/OptimizeEmitter.java
@@ -108,6 +108,8 @@ public final class OptimizeEmitter {
 
         OptimizeOutputWriter writer = new OptimizeOutputWriter();
         String serviceContractId = serviceContractIdFor(experiment, history.get(0).factors());
+        List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteria =
+                criteriaFor(experiment, history.get(0).factors());
         String yaml = writer.writeYaml(
                 serviceContractId,
                 experimentId,
@@ -116,8 +118,22 @@ public final class OptimizeEmitter {
                 history,
                 iterationSummaries,
                 best.orElse(null),
-                terminationReason);
+                terminationReason,
+                criteria);
         sink.accept(serviceContractId + "/" + experimentId + ".yaml", yaml);
+    }
+
+    private static List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteriaFor(
+            Experiment experiment, Object factors) {
+        return experiment.dispatch(new Spec.Dispatcher<
+                List<? extends org.mavai.punit.api.criterion.Criterion<?>>>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <FT, IT, OT> List<? extends org.mavai.punit.api.criterion.Criterion<?>> apply(
+                    TypedSpec<FT, IT, OT> typed) {
+                return typed.serviceContractFactory().apply((FT) factors).effectiveCriteria();
+            }
+        });
     }
 
     private static String serviceContractIdFor(Experiment experiment, Object factors) {

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/VerdictAdapter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/VerdictAdapter.java
@@ -200,6 +200,11 @@ public final class VerdictAdapter {
         // evaluations leave the field absent.
         b.perCriterion(translatePerCriterion(result.perCriterionEvaluation()));
 
+        // The postcondition standings — descriptive per-(input, check)
+        // tallies, stated first-class in the record (and the verdict
+        // XML's standings element from schema revision 1.3).
+        result.postconditionStandings().ifPresent(b::postconditionStandings);
+
         return b.build();
     }
 

--- a/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdict.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdict.java
@@ -44,7 +44,8 @@ public record ProbabilisticTestVerdict(
         PUnitVerdict punitVerdict,
         String verdictReason,
         Map<String, FailureCount> postconditionFailures,
-        Optional<PerCriterionStructure> perCriterion
+        Optional<PerCriterionStructure> perCriterion,
+        Optional<org.mavai.punit.api.spec.PostconditionStandings> postconditionStandings
 ) {
 
     public ProbabilisticTestVerdict {
@@ -55,6 +56,38 @@ public record ProbabilisticTestVerdict(
                 ? Collections.unmodifiableMap(new LinkedHashMap<>(postconditionFailures))
                 : Map.of();
         perCriterion = perCriterion != null ? perCriterion : Optional.empty();
+        postconditionStandings = postconditionStandings != null
+                ? postconditionStandings
+                : Optional.empty();
+    }
+
+    /**
+     * Backward-compatible constructor for the 18-component shape that
+     * predates the postcondition standings; defaults them absent.
+     */
+    public ProbabilisticTestVerdict(
+            String correlationId,
+            Instant timestamp,
+            TestIdentity identity,
+            ExecutionSummary execution,
+            Optional<FunctionalDimension> functional,
+            Optional<LatencyDimension> latency,
+            StatisticalAnalysis statistics,
+            CovariateStatus covariates,
+            CostSummary cost,
+            Optional<PacingSummary> pacing,
+            Optional<SpecProvenance> provenance,
+            Termination termination,
+            Map<String, String> environmentMetadata,
+            boolean junitPassed,
+            PUnitVerdict punitVerdict,
+            String verdictReason,
+            Map<String, FailureCount> postconditionFailures,
+            Optional<PerCriterionStructure> perCriterion) {
+        this(correlationId, timestamp, identity, execution, functional, latency,
+                statistics, covariates, cost, pacing, provenance, termination,
+                environmentMetadata, junitPassed, punitVerdict, verdictReason,
+                postconditionFailures, perCriterion, Optional.empty());
     }
 
     /**
@@ -84,7 +117,7 @@ public record ProbabilisticTestVerdict(
         this(correlationId, timestamp, identity, execution, functional, latency,
                 statistics, covariates, cost, pacing, provenance, termination,
                 environmentMetadata, junitPassed, punitVerdict, verdictReason,
-                postconditionFailures, Optional.empty());
+                postconditionFailures, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -112,7 +145,7 @@ public record ProbabilisticTestVerdict(
         this(correlationId, timestamp, identity, execution, functional, latency,
                 statistics, covariates, cost, pacing, provenance, termination,
                 environmentMetadata, junitPassed, punitVerdict, verdictReason,
-                Map.of(), Optional.empty());
+                Map.of(), Optional.empty(), Optional.empty());
     }
 
     // ── TestIdentity ──────────────────────────────────────────────────────

--- a/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
+++ b/punit-core/src/main/java/org/mavai/punit/verdict/ProbabilisticTestVerdictBuilder.java
@@ -125,6 +125,8 @@ public class ProbabilisticTestVerdictBuilder {
     // ProbabilisticTestResult.perCriterionEvaluation() on every normal
     // run; empty for apply-level-failure paths.
     private Optional<PerCriterionStructure> perCriterion = Optional.empty();
+    private Optional<org.mavai.punit.api.spec.PostconditionStandings> postconditionStandings =
+            Optional.empty();
 
     // ── Builder methods ───────────────────────────────────────────────────
 
@@ -352,6 +354,18 @@ public class ProbabilisticTestVerdictBuilder {
      * {@code ProbabilisticTestResult.perCriterionEvaluation()}.
      * {@code null} leaves the field empty.
      */
+    /**
+     * The postcondition standings the run surfaces — descriptive per
+     * {@code (input, check)} tallies, stated first-class in the
+     * verdict record.
+     */
+    public ProbabilisticTestVerdictBuilder postconditionStandings(
+            org.mavai.punit.api.spec.PostconditionStandings standings) {
+        this.postconditionStandings = Optional.ofNullable(standings)
+                .filter(s -> !s.isEmpty());
+        return this;
+    }
+
     public ProbabilisticTestVerdictBuilder perCriterion(PerCriterionStructure perCriterion) {
         this.perCriterion = Optional.ofNullable(perCriterion);
         return this;
@@ -381,7 +395,8 @@ public class ProbabilisticTestVerdictBuilder {
                 covariates, cost, pacing, provenance, termination,
                 environment, junitPassed, punitVerdict, verdictReason,
                 postconditionFailures,
-                perCriterion
+                perCriterion,
+                postconditionStandings
         );
     }
 

--- a/punit-core/src/test/java/org/mavai/punit/api/criterion/PartialCreditTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/api/criterion/PartialCreditTest.java
@@ -1,0 +1,159 @@
+package org.mavai.punit.api.criterion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mavai.punit.api.criterion.Criteria.meeting;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mavai.outcome.Outcome;
+
+@DisplayName("Partial credit — optional checks and the slack budget")
+class PartialCreditTest {
+
+    /** A criterion whose second and third checks fail on any value. */
+    private CriterionDecl<String> twoFailingOptionals() {
+        return meeting().<String>passRate(0.5)
+                .where("has content", v -> !v.isEmpty())
+                .where("always trips", v -> false).optional()
+                .where("also trips", v -> false).optional();
+    }
+
+    @Nested
+    @DisplayName("the acceptance predicate")
+    class AcceptancePredicate {
+
+        @Test
+        @DisplayName("an optional mark alone weakens nothing — the budget defaults to zero")
+        void doubleOptIn() {
+            Criterion<String> criterion = meeting().<String>passRate(0.5)
+                    .where("always trips", v -> false).optional()
+                    .toRuntime("c");
+            assertThat(criterion.evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.FAIL);
+        }
+
+        @Test
+        @DisplayName("failed optional checks within the budget pass the trial")
+        void withinBudget() {
+            Criterion<String> criterion = twoFailingOptionals().optionalSlack(2).toRuntime("c");
+            assertThat(criterion.evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.PASS);
+        }
+
+        @Test
+        @DisplayName("failed optional checks beyond the budget fail the trial")
+        void beyondBudget() {
+            Criterion<String> criterion = twoFailingOptionals().optionalSlack(1).toRuntime("c");
+            assertThat(criterion.evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.FAIL);
+        }
+
+        @Test
+        @DisplayName("a failed required check fails the trial regardless of any budget")
+        void requiredIsNonNegotiable() {
+            Criterion<String> criterion = meeting().<String>passRate(0.5)
+                    .where("required trips", v -> false)
+                    .where("optional trips", v -> false).optional()
+                    .optionalSlack(5)
+                    .toRuntime("c");
+            assertThat(criterion.evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.FAIL);
+        }
+
+        @Test
+        @DisplayName("a percentage budget resolves by floor of the applicable optional checks")
+        void percentageFloor() {
+            // 50% of 3 applicable optional checks -> floor(1.5) = 1.
+            CriterionDecl<String> threeOptionals = meeting().<String>passRate(0.5)
+                    .where("trips", v -> false).optional()
+                    .where("holds", v -> true).optional()
+                    .where("trips too", v -> false).optional();
+            assertThat(threeOptionals.optionalSlack("50%").toRuntime("c")
+                    .evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.FAIL);
+            assertThat(threeOptionals.optionalSlack("67%").toRuntime("c")
+                    .evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.PASS);
+        }
+
+        @Test
+        @DisplayName("a budget beyond the optional count means all may fail — never impossible")
+        void budgetBeyondCount() {
+            Criterion<String> criterion = twoFailingOptionals().optionalSlack(9).toRuntime("c");
+            assertThat(criterion.evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.PASS);
+        }
+
+        @Test
+        @DisplayName("the recorded per-check outcomes stay true under a softened verdict")
+        void standingsSeeReality() {
+            Criterion<String> criterion = twoFailingOptionals().optionalSlack(2).toRuntime("c");
+            CriterionSampleResult result = criterion.evaluate("value");
+            assertThat(result.outcome()).isEqualTo(CriterionSampleOutcome.PASS);
+            assertThat(result.postconditionResults())
+                    .filteredOn(r -> !r.required())
+                    .hasSize(2)
+                    .allMatch(r -> r.failed());
+        }
+
+        @Test
+        @DisplayName("the softened per-sample outcome flows through a transforming criterion")
+        void transformingChain() {
+            Criteria<String> criteria = meeting().<String>passRate(0.5)
+                    .transforming(v -> Outcome.ok(v.length()))
+                    .where("long enough", length -> length > 3)
+                    .where("very long", length -> length > 100).optional()
+                    .optionalSlack(1);
+            assertThat(criteria.asList().get(0).evaluate("value").outcome())
+                    .isEqualTo(CriterionSampleOutcome.PASS);
+        }
+    }
+
+    @Nested
+    @DisplayName("the authoring surface")
+    class AuthoringSurface {
+
+        @Test
+        @DisplayName("the optional mark follows the check it relaxes")
+        void optionalNeedsACheck() {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> meeting().<String>passRate(0.5).optional())
+                    .withMessageContaining("declare a");
+        }
+
+        @Test
+        @DisplayName("a bare fraction is never guessed at")
+        void bareFractionRefused() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> OptionalSlack.percent("0.2"))
+                    .withMessageContaining("never guessed at");
+        }
+
+        @Test
+        @DisplayName("a negative count is refused")
+        void negativeCountRefused() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> OptionalSlack.count(-1));
+        }
+
+        @Test
+        @DisplayName("the slack keeps the author's spelling verbatim")
+        void verbatimDisplay() {
+            assertThat(OptionalSlack.count(2).display()).isEqualTo("2");
+            assertThat(OptionalSlack.percent("20%").display()).isEqualTo("20%");
+        }
+
+        @Test
+        @DisplayName("the slack survives posture chaining")
+        void slackSurvivesChaining() {
+            CriterionDecl<String> decl = meeting().<String>passRate(0.5)
+                    .where("holds", v -> true).optional()
+                    .optionalSlack(1)
+                    .contractRef("SLA v1 §2");
+            assertThat(decl.optionalSlack()).isPresent();
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/emit/StandingsBlocksTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/emit/StandingsBlocksTest.java
@@ -1,0 +1,76 @@
+package org.mavai.punit.internal.engine.emit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mavai.punit.api.spec.PostconditionStandings;
+import org.mavai.punit.api.spec.PostconditionStandings.CriterionStandings;
+import org.mavai.punit.api.spec.PostconditionStandings.Row;
+
+@DisplayName("Standings artefact blocks")
+class StandingsBlocksTest {
+
+    private static PostconditionStandings standings() {
+        return new PostconditionStandings(List.of(new CriterionStandings(
+                "quality",
+                Optional.of("10%"),
+                List.of(
+                        new Row(0, "mentions greeting", false, 18, 2, 0),
+                        new Row(1, "mentions farewell", true, 12, 6, 2)))));
+    }
+
+    @Test
+    @DisplayName("emits one block per criterion, keyed by bounded criterion id")
+    void emitsBlockPerCriterion() {
+        Map<String, Map<String, Object>> blocks = StandingsBlocks.byCriterion(standings());
+
+        assertThat(blocks).containsOnlyKeys("quality");
+        Map<String, Object> block = blocks.get("quality");
+        assertThat(block.get("optionalSlack")).isEqualTo("10%");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> rows = (List<Map<String, Object>>) block.get("rows");
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0)).containsOnlyKeys(
+                "inputIndex", "check", "optional", "passed", "failed", "skipped",
+                "observedFraction");
+        assertThat(rows.get(0).get("check")).isEqualTo("mentions greeting");
+        assertThat(rows.get(0).get("passed")).isEqualTo(18);
+        assertThat(rows.get(0).get("observedFraction")).isEqualTo(0.9);
+        assertThat(rows.get(1).get("skipped")).isEqualTo(2);
+        assertThat(rows.get(1).get("observedFraction")).isEqualTo(0.6);
+    }
+
+    @Test
+    @DisplayName("criteria stating no rows are absent, never fabricated")
+    void rowlessCriteriaAbsent() {
+        PostconditionStandings empty = new PostconditionStandings(List.of(
+                new CriterionStandings("quality", Optional.empty(), List.of())));
+
+        assertThat(StandingsBlocks.byCriterion(empty)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("block keys stay descriptive — no judgement vocabulary")
+    void descriptiveVocabularyOnly() {
+        Map<String, Object> block = StandingsBlocks.byCriterion(standings()).get("quality");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> rows = (List<Map<String, Object>>) block.get("rows");
+        List<String> keys = rows.stream().flatMap(r -> r.keySet().stream()).distinct().toList();
+
+        // Counts and observed fractions only — never an interval, a
+        // threshold, or a per-check verdict key.
+        assertThat(keys).allSatisfy(key -> assertThat(key.toLowerCase(java.util.Locale.ROOT))
+                .doesNotContain("interval")
+                .doesNotContain("threshold")
+                .doesNotContain("verdict")
+                .doesNotContain("confidence")
+                .doesNotContain("bound"));
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/internal/reporting/StandingsTextRendererTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/reporting/StandingsTextRendererTest.java
@@ -1,0 +1,63 @@
+package org.mavai.punit.internal.reporting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mavai.punit.api.spec.PostconditionStandings;
+import org.mavai.punit.api.spec.PostconditionStandings.CriterionStandings;
+import org.mavai.punit.api.spec.PostconditionStandings.Row;
+
+@DisplayName("Postcondition standings text renderer")
+class StandingsTextRendererTest {
+
+    private static PostconditionStandings standings() {
+        return new PostconditionStandings(List.of(new CriterionStandings(
+                "quality",
+                Optional.of("1"),
+                List.of(
+                        new Row(0, "mentions greeting", false, 18, 2, 0),
+                        new Row(0, "mentions farewell", true, 12, 6, 2)))));
+    }
+
+    @Test
+    @DisplayName("renders one heading per criterion and one line per (input, check) row")
+    void rendersHeadingAndRows() {
+        List<String> lines = StandingsTextRenderer.render(standings());
+
+        assertThat(lines).containsExactly(
+                "Postcondition standings (descriptive):",
+                "  criterion 'quality' (optional-slack 1):",
+                "    input 0 · mentions greeting: 18/20 passed (0.90)",
+                "    input 0 · mentions farewell [optional]: 12/20 passed, 2 skipped (0.60)");
+    }
+
+    @Test
+    @DisplayName("empty standings render nothing")
+    void emptyStandingsRenderNothing() {
+        assertThat(StandingsTextRenderer.render(new PostconditionStandings(List.of()))).isEmpty();
+        assertThat(StandingsTextRenderer.render(new PostconditionStandings(
+                List.of(new CriterionStandings("quality", Optional.empty(), List.of())))))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("standings lines stay descriptive — no judgement vocabulary")
+    void descriptiveVocabularyOnly() {
+        String rendered = String.join("\n", StandingsTextRenderer.render(standings()))
+                .toLowerCase(java.util.Locale.ROOT);
+
+        // The criterion is the only judged unit; a standings line never
+        // states an interval, a threshold, or a per-check verdict.
+        assertThat(rendered)
+                .doesNotContain("interval")
+                .doesNotContain("threshold")
+                .doesNotContain("verdict")
+                .doesNotContain("confidence")
+                .doesNotContain("required")
+                .doesNotContain("pass rate");
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/CriterionDeclaration.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/CriterionDeclaration.java
@@ -29,7 +29,14 @@ public record CriterionDeclaration(
         String thresholdOrigin,
         String contractRef,
         Double tolerate,
-        Double confidence) {
+        Double confidence,
+        org.mavai.punit.api.criterion.OptionalSlack optionalSlack) {
+
+    /** A criterion with no optional-check failure budget declared. */
+    public CriterionDeclaration(String name, List<FormDeclaration> forms, Double threshold,
+            String thresholdOrigin, String contractRef, Double tolerate, Double confidence) {
+        this(name, forms, threshold, thresholdOrigin, contractRef, tolerate, confidence, null);
+    }
 
     public CriterionDeclaration {
         forms = List.copyOf(forms);

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/FormDeclaration.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/FormDeclaration.java
@@ -19,13 +19,19 @@ package org.mavai.punit.decl.internal.model;
  * @param path the selection expression, or {@code null} when the form
  *     judges its subject whole
  */
-public record FormDeclaration(PostconditionForm form, Object argument, String view, String path) {
+public record FormDeclaration(
+        PostconditionForm form, Object argument, String view, String path, boolean optional) {
+
+    /** A required form — the default; every check is non-negotiable until marked. */
+    public FormDeclaration(PostconditionForm form, Object argument, String view, String path) {
+        this(form, argument, view, path, false);
+    }
 
     /** The reserved name of the untransformed response. */
     public static final String RAW_VIEW = "raw";
 
     /** This form with its defaulted subject resolved to the given view. */
     public FormDeclaration withView(String resolved) {
-        return new FormDeclaration(form, argument, resolved, path);
+        return new FormDeclaration(form, argument, resolved, path, optional);
     }
 }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
@@ -152,7 +152,8 @@ public final class ContractParser {
             }
             resolved.add(new CriterionDeclaration(
                     criterion.name(), forms, criterion.threshold(), criterion.thresholdOrigin(),
-                    criterion.contractRef(), criterion.tolerate(), criterion.confidence()));
+                    criterion.contractRef(), criterion.tolerate(), criterion.confidence(),
+                    criterion.optionalSlack()));
         }
         return resolved;
     }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/CriteriaParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/CriteriaParser.java
@@ -35,6 +35,7 @@ final class CriteriaParser {
                 "contract-ref",
                 "tolerate",
                 "confidence",
+                "optional-slack",
                 "postconditions"));
         // Every form has a single-form spelling directly on the entry.
         for (PostconditionForm form : PostconditionForm.values()) {
@@ -111,6 +112,32 @@ final class CriteriaParser {
             origin = name;
         }
 
+        org.mavai.punit.api.criterion.OptionalSlack optionalSlack = null;
+        Object slackValue = data.get("optional-slack");
+        if (slackValue != null) {
+            // The %-suffix is the count/fraction disambiguator (partial
+            // credit, 2026-07-27): 2 is always a count, "2%" always a
+            // fraction of the applicable optional checks (resolved by
+            // floor at evaluation); a bare fraction, a negative value,
+            // or a non-integer count is refused, never guessed at.
+            if (slackValue instanceof Integer count && !(slackValue instanceof Boolean)
+                    && count >= 0) {
+                optionalSlack = org.mavai.punit.api.criterion.OptionalSlack.count(count);
+            } else if (slackValue instanceof String spelling) {
+                try {
+                    optionalSlack = org.mavai.punit.api.criterion.OptionalSlack.percent(spelling);
+                } catch (IllegalArgumentException malformed) {
+                    optionalSlack = null;
+                }
+            }
+            if (optionalSlack == null) {
+                throw fail(where + ": `optional-slack:` takes a non-negative whole count of "
+                        + "optional checks that may fail, or an explicit percentage like `20%` "
+                        + "— got " + Yaml.display(slackValue) + " (a bare fraction is never "
+                        + "guessed at)");
+            }
+        }
+
         String contractRef = null;
         Object contractRefValue = data.get("contract-ref");
         if (contractRefValue != null) {
@@ -150,6 +177,7 @@ final class CriteriaParser {
             name = declared;
         }
 
-        return new CriterionDeclaration(name, forms, threshold, origin, contractRef, tolerate, confidence);
+        return new CriterionDeclaration(
+                name, forms, threshold, origin, contractRef, tolerate, confidence, optionalSlack);
     }
 }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
@@ -47,6 +47,15 @@ final class FormParser {
             path = expression;
             keys.remove("path");
         }
+        boolean optional = false;
+        if (keys.contains("optional")) {
+            if (!Boolean.TRUE.equals(entry.get("optional"))) {
+                throw fail(where + ": `optional:` takes the literal `true` and nothing else — "
+                        + "required is the default, not a spelling");
+            }
+            optional = true;
+            keys.remove("optional");
+        }
         if (keys.size() != 1) {
             throw fail(where + ": each postcondition declares exactly one form");
         }
@@ -82,6 +91,11 @@ final class FormParser {
                     + "(there is no collection over the raw text or a scalar)");
         }
         if (form == PostconditionForm.PARSES) {
+            if (optional) {
+                throw fail(where + ": `optional:` on `parses:` is refused — a transform "
+                        + "failure hard-fails the trial regardless of any optional-slack "
+                        + "budget, so the mark would be inert");
+            }
             if (!view.equals(FormDeclaration.RAW_VIEW)) {
                 throw fail(where + ": `parses:` takes no `in:` — it names its view directly");
             }
@@ -90,7 +104,7 @@ final class FormParser {
                         + declared(views) + ")");
             }
         }
-        return new FormDeclaration(form, argument, view, path);
+        return new FormDeclaration(form, argument, view, path, optional);
     }
 
     private static void checkArgument(PostconditionForm form, Object argument, String where) {

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
@@ -110,32 +110,42 @@ final class CriteriaCompiler {
         for (FormDeclaration form : criterion.forms()) {
             Check check = compileForm(form);
             decl = decl.satisfies(check.name(), response -> check.evaluate((String) response));
+            if (form.optional()) {
+                decl = decl.optional();
+            }
         }
         if (!expectations.isEmpty() && declaration.criteria().size() == 1) {
-            decl = decl.satisfies("input-specific expectations",
-                    response -> evaluateExpectations((String) response));
+            // Each per-input expectation is its own check, dispatching on
+            // the sample's input — so an optional mark counts individually
+            // against the criterion's budget, exactly as a global check.
+            // A check passes neutrally on the inputs it does not apply to.
+            java.util.List<org.mavai.punit.decl.internal.model.InputDeclaration> inputs =
+                    declaration.inputs();
+            for (int index = 0; index < inputs.size(); index++) {
+                Object inputValue = inputs.get(index).value();
+                for (FormDeclaration form : inputs.get(index).expected()) {
+                    Check check = compileExpectedForm(form, inputValue);
+                    String name = "input " + index + ": " + check.name();
+                    // Identity, not equality: inputs with equal values are
+                    // never conflated — the dispatched object IS the list's.
+                    decl = decl.satisfies(name, response ->
+                            inputValue == currentInput.get()
+                                    ? check.evaluate((String) response)
+                                    : Outcome.ok());
+                    if (form.optional()) {
+                        decl = decl.optional();
+                    }
+                }
+            }
+        }
+        if (criterion.optionalSlack() != null) {
+            decl = decl.optionalSlack(criterion.optionalSlack());
         }
         return decl;
     }
 
     private static ThresholdOrigin origin(String key) {
         return ThresholdOrigin.valueOf(key.toUpperCase(Locale.ROOT));
-    }
-
-    private Outcome<?> evaluateExpectations(String response) {
-        Object input = currentInput.get();
-        List<FormDeclaration> forms = expectations.get(input);
-        if (forms == null) {
-            return Outcome.ok();
-        }
-        for (FormDeclaration form : forms) {
-            Check check = compileExpectedForm(form, input);
-            Outcome<?> result = check.evaluate(response);
-            if (result instanceof Outcome.Fail<?>) {
-                return result;
-            }
-        }
-        return Outcome.ok();
     }
 
     // ── Form compilation ──────────────────────────────────────────

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
@@ -46,6 +46,126 @@ class ContractParserTest {
     }
 
     @Nested
+    @DisplayName("partial credit")
+    class PartialCredit {
+
+        @Test
+        @DisplayName("optional marks and both slack spellings parse — the corpus's double opt-in")
+        void partialCreditAccepted() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: extraction-with-partial-credit
+                    service: quote-extractor
+                    transforms:
+                      parsed: json
+                    criteria:
+                      - name: non-negotiables-hold-with-counted-slack
+                        threshold: 0.9
+                        optional-slack: 2
+                        postconditions:
+                          - in: parsed
+                            path: "$.offerId"
+                            equals-ci: "T802739355"
+                          - in: parsed
+                            path: "$.premium"
+                            eq: 2637.8
+                            optional: true
+                      - name: percent-slack-spelling
+                        threshold: 0.9
+                        optional-slack: "20%"
+                        postconditions:
+                          - matches: '^\\s*\\{'
+                          - in: parsed
+                            path: "$.currency"
+                            one-of: ["CHF", "EUR"]
+                            optional: true
+                    inputs: ["quote for the standard bundle"]
+                    """);
+            var first = declaration.criteria().get(0);
+            assertThat(first.optionalSlack().display()).isEqualTo("2");
+            assertThat(first.forms().get(0).optional()).isFalse();
+            assertThat(first.forms().get(1).optional()).isTrue();
+            assertThat(declaration.criteria().get(1).optionalSlack().display()).isEqualTo("20%");
+        }
+
+        @Test
+        @DisplayName("a bare-fraction slack is never guessed at")
+        void bareFractionSlack() {
+            assertRefused("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    criteria:
+                      - threshold: 0.9
+                        optional-slack: 0.2
+                        postconditions:
+                          - contains: "ok"
+                          - matches: '\\w'
+                            optional: true
+                    inputs: ["Alice"]
+                    """, "a bare fraction is never guessed at");
+        }
+
+        @Test
+        @DisplayName("required is the default, not a spelling — optional: false is refused")
+        void optionalFalseRefused() {
+            assertRefused("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - contains: "ok"
+                            optional: false
+                    inputs: ["Alice"]
+                    """, "required is the default, not a spelling");
+        }
+
+        @Test
+        @DisplayName("optional on parses is refused — the mark would be inert")
+        void optionalOnParsesRefused() {
+            assertRefused("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - parses: doc
+                            optional: true
+                          - contains: "ok"
+                    inputs: ["Alice"]
+                    """, "would be inert");
+        }
+
+        @Test
+        @DisplayName("a per-input expectation takes the optional mark like a global check")
+        void optionalInExpected() {
+            ContractDeclaration declaration = ContractParser.parse("""
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        optional-slack: 1
+                        parses: doc
+                    inputs:
+                      - input: "Alice"
+                        expected:
+                          - path: "$.name"
+                            equals: "Alice"
+                            optional: true
+                    """);
+            assertThat(declaration.inputs().get(0).expected().get(0).optional()).isTrue();
+        }
+    }
+
+    @Nested
     @DisplayName("acceptance")
     class Acceptance {
 

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -51,6 +51,22 @@ class DeclaredRunTest {
         }
 
         @Test
+        @DisplayName("a failing optional check within the slack budget passes the trial")
+        void partialCreditForgivesWithinBudget() {
+            assertThatCode(() ->
+                    PUnit.declared("partial-credit-forgives-within-budget").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("an optional mark alone weakens nothing — the double opt-in binds")
+        void partialCreditDoubleOptInBinds() {
+            Declared run = PUnit.declared("partial-credit-double-opt-in-binds").samples(20);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(AssertionFailedError.class);
+        }
+
+        @Test
         @DisplayName("a contract spelt with the default subject view runs identically")
         void defaultedViewRunsEndToEnd() {
             // The basket contract with every path check's `in: basket`

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/partial-bare.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/partial-bare.yaml
@@ -1,0 +1,11 @@
+format: mavai-contract/1
+contract: partial-credit-double-opt-in-binds
+service: greeting-service
+criteria:
+  - name: greeting-quality
+    threshold: 0.8
+    postconditions:
+      - contains: "hello"
+      - contains: "goodbye"
+        optional: true
+inputs: ["Alice", "Bob"]

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/partial.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/partial.yaml
@@ -1,0 +1,12 @@
+format: mavai-contract/1
+contract: partial-credit-forgives-within-budget
+service: greeting-service
+criteria:
+  - name: greeting-quality
+    threshold: 0.8
+    optional-slack: 1
+    postconditions:
+      - contains: "hello"
+      - contains: "goodbye"
+        optional: true
+inputs: ["Alice", "Bob"]

--- a/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlReader.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlReader.java
@@ -89,6 +89,10 @@ public final class VerdictXmlReader {
                 optionalElement(root, "per-criterion")
                         .flatMap(this::readPerCriterionStructure);
 
+        Optional<org.mavai.punit.api.spec.PostconditionStandings> standings =
+                optionalElement(root, "postcondition-standings")
+                        .map(this::readPostconditionStandings);
+
         return new ProbabilisticTestVerdict(
                 correlationId, timestamp, identity, execution,
                 functional, latency, statistics, covariates,
@@ -99,8 +103,45 @@ public final class VerdictXmlReader {
                 environment,
                 junitPassed, punitVerdict, verdictReason,
                 Map.of(),
-                perCriterion
+                perCriterion,
+                standings
         );
+    }
+
+    /**
+     * The postcondition standings element (schema revision 1.3; 1.4's
+     * structured-row attributes are read permissively and ignored —
+     * the counts and identities are the binding content this reader
+     * consumes).
+     */
+    private org.mavai.punit.api.spec.PostconditionStandings readPostconditionStandings(
+            Element standingsEl) {
+        java.util.List<org.mavai.punit.api.spec.PostconditionStandings.CriterionStandings>
+                criteria = new java.util.ArrayList<>();
+        NodeList criterionNodes = standingsEl.getElementsByTagNameNS(
+                VerdictXmlWriter.NAMESPACE, "criterion");
+        for (int i = 0; i < criterionNodes.getLength(); i++) {
+            Element criterionEl = (Element) criterionNodes.item(i);
+            java.util.List<org.mavai.punit.api.spec.PostconditionStandings.Row> rows =
+                    new java.util.ArrayList<>();
+            NodeList rowNodes = criterionEl.getElementsByTagNameNS(
+                    VerdictXmlWriter.NAMESPACE, "row");
+            for (int j = 0; j < rowNodes.getLength(); j++) {
+                Element rowEl = (Element) rowNodes.item(j);
+                rows.add(new org.mavai.punit.api.spec.PostconditionStandings.Row(
+                        Integer.parseInt(rowEl.getAttribute("input-index")),
+                        rowEl.getAttribute("check"),
+                        Boolean.parseBoolean(rowEl.getAttribute("optional")),
+                        Integer.parseInt(rowEl.getAttribute("passed")),
+                        Integer.parseInt(rowEl.getAttribute("failed")),
+                        Integer.parseInt(rowEl.getAttribute("skipped"))));
+            }
+            criteria.add(new org.mavai.punit.api.spec.PostconditionStandings.CriterionStandings(
+                    criterionEl.getAttribute("name"),
+                    optionalAttribute(criterionEl, "optional-slack"),
+                    rows));
+        }
+        return new org.mavai.punit.api.spec.PostconditionStandings(criteria);
     }
 
     private Optional<org.mavai.punit.verdict.PerCriterionStructure> readPerCriterionStructure(

--- a/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlWriter.java
+++ b/punit-report/src/main/java/org/mavai/punit/report/VerdictXmlWriter.java
@@ -36,6 +36,7 @@ public final class VerdictXmlWriter {
     static final String NAMESPACE = "http://mavai.org/verdict/1.0";
     static final String VERSION_1_0 = "1.0";
     static final String VERSION_1_2 = "1.2";
+    static final String VERSION_1_4 = "1.4";
 
     private static final XMLOutputFactory OUTPUT_FACTORY = XMLOutputFactory.newFactory();
 
@@ -67,11 +68,15 @@ public final class VerdictXmlWriter {
     private void writeVerdictRecord(XMLStreamWriter w, ProbabilisticTestVerdict v) throws XMLStreamException {
         w.writeStartElement("verdict-record");
         w.writeDefaultNamespace(NAMESPACE);
-        // version="1.2" when <per-criterion> content is populated;
+        // version="1.4" when the postcondition-standings element is
+        // populated (1.3-shaped rows are valid 1.4 rows, so one revision
+        // covers both); "1.2" when only <per-criterion> content is;
         // "1.0" otherwise. Consumers inspecting the attribute remain
         // correctly informed about which optional elements may appear.
-        w.writeAttribute("version",
-                v.perCriterion().isPresent() ? VERSION_1_2 : VERSION_1_0);
+        String version = v.postconditionStandings().isPresent() ? VERSION_1_4
+                : v.perCriterion().isPresent() ? VERSION_1_2
+                : VERSION_1_0;
+        w.writeAttribute("version", version);
         w.writeAttribute("timestamp", v.timestamp().toString());
         w.writeAttribute("generator", resolveGenerator());
         if (v.correlationId() != null && !v.correlationId().isEmpty()) {
@@ -93,9 +98,56 @@ public final class VerdictXmlWriter {
         writeEnvironment(w, v.environmentMetadata());
         writePostconditionFailures(w, v.postconditionFailures());
         writePerCriterion(w, v);
+        writePostconditionStandings(w, v);
         writeVerdictElement(w, v);
 
         w.writeEndElement();
+    }
+
+    /**
+     * The postcondition standings (schema revision 1.3): one
+     * {@code <criterion>} per criterion carrying standings — its
+     * declared optional-slack budget verbatim where declared — and one
+     * {@code <row>} per (input, check) with the passed/failed/skipped
+     * tally and observed fraction. Descriptive by construction; check
+     * identities are bounded per the schema's 256-character cap.
+     */
+    private void writePostconditionStandings(XMLStreamWriter w, ProbabilisticTestVerdict v)
+            throws XMLStreamException {
+        if (v.postconditionStandings().isEmpty()) {
+            return;
+        }
+        org.mavai.punit.api.spec.PostconditionStandings standings =
+                v.postconditionStandings().get();
+        w.writeStartElement("postcondition-standings");
+        for (var criterion : standings.criteria()) {
+            if (criterion.rows().isEmpty()) {
+                continue;
+            }
+            w.writeStartElement("criterion");
+            w.writeAttribute("name", bounded(criterion.criterionId()));
+            if (criterion.optionalSlack().isPresent()) {
+                w.writeAttribute("optional-slack", criterion.optionalSlack().get());
+            }
+            for (var row : criterion.rows()) {
+                w.writeStartElement("row");
+                w.writeAttribute("input-index", Integer.toString(row.inputIndex()));
+                w.writeAttribute("check", bounded(row.check()));
+                w.writeAttribute("optional", Boolean.toString(row.optional()));
+                w.writeAttribute("passed", Integer.toString(row.passed()));
+                w.writeAttribute("failed", Integer.toString(row.failed()));
+                w.writeAttribute("skipped", Integer.toString(row.skipped()));
+                w.writeAttribute("observed-fraction",
+                        String.format(java.util.Locale.ROOT, "%.6f", row.observedFraction()));
+                w.writeEndElement();
+            }
+            w.writeEndElement();
+        }
+        w.writeEndElement();
+    }
+
+    private static String bounded(String identity) {
+        return identity.length() <= 256 ? identity : identity.substring(0, 256);
     }
 
     private void writePerCriterion(XMLStreamWriter w, ProbabilisticTestVerdict v)

--- a/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.3.xsd
+++ b/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.3.xsd
@@ -1,0 +1,557 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://mavai.org/verdict/1.0"
+           targetNamespace="http://mavai.org/verdict/1.0"
+           elementFormDefault="qualified">
+
+  <!-- ===================================================================
+       Root elements
+       =================================================================== -->
+
+  <xs:element name="verdict-record" type="tns:VerdictRecordType"/>
+  <xs:element name="verdict-suite"  type="tns:VerdictSuiteType"/>
+
+  <!-- ===================================================================
+       Suite envelope (for batch processing / XSLT input)
+       =================================================================== -->
+
+  <xs:complexType name="VerdictSuiteType">
+    <xs:sequence>
+      <xs:element ref="tns:verdict-record" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="timestamp" type="xs:dateTime" use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Verdict record (one per test execution)
+       =================================================================== -->
+
+  <xs:complexType name="VerdictRecordType">
+    <xs:all>
+      <xs:element name="identity"     type="tns:IdentityType"/>
+      <xs:element name="execution"    type="tns:ExecutionType"/>
+      <xs:element name="factors"      type="tns:FactorsType"      minOccurs="0"/>
+      <xs:element name="functional"   type="tns:FunctionalType"   minOccurs="0"/>
+      <xs:element name="latency"      type="tns:LatencyType"      minOccurs="0"/>
+      <xs:element name="statistics"   type="tns:StatisticsType"   minOccurs="0"/>
+      <xs:element name="covariates"   type="tns:CovariatesType"/>
+      <xs:element name="provenance"   type="tns:ProvenanceType"   minOccurs="0"/>
+      <xs:element name="baseline"     type="tns:BaselineType"     minOccurs="0"/>
+      <xs:element name="termination"  type="tns:TerminationType"/>
+      <xs:element name="cost"         type="tns:CostType"         minOccurs="0"/>
+      <xs:element name="warnings"     type="tns:WarningsType"     minOccurs="0"/>
+      <xs:element name="pacing"       type="tns:PacingType"       minOccurs="0"/>
+      <xs:element name="environment"  type="tns:EnvironmentType"  minOccurs="0"/>
+      <xs:element name="postcondition-failures" type="tns:PostconditionFailuresType" minOccurs="0"/>
+      <xs:element name="per-criterion" type="tns:PerCriterionType" minOccurs="0"/>
+      <xs:element name="postcondition-standings" type="tns:PostconditionStandingsType" minOccurs="0"/>
+      <xs:element name="verdict"      type="tns:VerdictType"/>
+    </xs:all>
+    <!-- version: "1.0", "1.2", or "1.3". 1.2 emitters set version="1.2"
+         when <per-criterion> content is populated; otherwise stay
+         at "1.0" so consumers inspecting the version attribute
+         remain correctly informed. 1.3 emitters set version="1.3":
+         the <postcondition-standings> element is available (emitted
+         whenever the run produced standings). -->
+    <!-- 1.3 addition: the <postcondition-standings> element — the
+         descriptive per-(input, check) tally of per-trial check
+         outcomes, first-class. It supersedes the transitional
+         environment-entry carriage (postcondition-standings:* keys)
+         some 1.2 emitters used; 1.3 emitters do not write those
+         entries. -->
+    <!-- 1.2 withdrawal: the <legacy-aggregate> child of <per-criterion>,
+         present in 1.1 as a one-release audit-trail element, is gone.
+         Producers emitting 1.2-shaped content do not write the
+         element; permissive readers may continue to ignore it when
+         encountered in 1.1-shaped content from older emitters in
+         service. -->
+    <xs:attribute name="version"        type="xs:string"   use="required"/>
+    <xs:attribute name="timestamp"      type="xs:dateTime"  use="required"/>
+    <xs:attribute name="generator"      type="xs:string"    use="required"/>
+    <xs:attribute name="correlation-id" type="xs:string"    use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Identity
+       =================================================================== -->
+
+  <xs:complexType name="IdentityType">
+    <xs:attribute name="use-case-id" type="xs:string" use="required"/>
+    <xs:attribute name="test-name"   type="xs:string" use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Execution
+       =================================================================== -->
+
+  <xs:complexType name="ExecutionType">
+    <xs:attribute name="planned-samples"  type="xs:int"    use="required"/>
+    <xs:attribute name="samples-executed" type="xs:int"    use="required"/>
+    <xs:attribute name="successes"        type="xs:int"    use="required"/>
+    <xs:attribute name="failures"         type="xs:int"    use="required"/>
+    <xs:attribute name="elapsed-ms"       type="xs:long"   use="required"/>
+    <xs:attribute name="intent"           type="tns:IntentEnum" use="required"/>
+    <xs:attribute name="confidence"       type="xs:double" use="required"/>
+    <xs:attribute name="warmup"           type="xs:int"    use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="IntentEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="VERIFICATION"/>
+      <xs:enumeration value="SMOKE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Factor bundle (FT instance the test ran under; shape-symmetric
+       with the baseline factors block)
+       =================================================================== -->
+
+  <xs:complexType name="FactorsType">
+    <xs:sequence>
+      <xs:element name="entry" type="tns:FactorEntryType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="FactorEntryType">
+    <xs:attribute name="key"   type="xs:string"           use="required"/>
+    <xs:attribute name="value" type="xs:string"           use="required"/>
+    <xs:attribute name="type"  type="tns:FactorTypeEnum"  use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="FactorTypeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="number"/>
+      <xs:enumeration value="boolean"/>
+      <xs:enumeration value="enum"/>
+      <xs:enumeration value="duration"/>
+      <xs:enumeration value="instant"/>
+      <xs:enumeration value="uri"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Functional dimension
+       =================================================================== -->
+
+  <xs:complexType name="FunctionalType">
+    <xs:sequence>
+      <xs:element name="failure-distribution" type="tns:FailureDistributionType"
+                  minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="successes" type="xs:int"    use="required"/>
+    <xs:attribute name="failures"  type="xs:int"    use="required"/>
+    <xs:attribute name="pass-rate" type="xs:double" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="FailureDistributionType">
+    <xs:sequence>
+      <xs:element name="check" type="tns:CheckType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CheckType">
+    <xs:attribute name="name"  type="xs:string" use="required"/>
+    <xs:attribute name="count" type="xs:int"    use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Latency dimension
+       =================================================================== -->
+
+  <xs:complexType name="LatencyType">
+    <xs:sequence>
+      <xs:element name="observed"    type="tns:ObservedPercentilesType" minOccurs="0"/>
+      <xs:element name="evaluations" type="tns:EvaluationsType"        minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="successful-samples"  type="xs:int" use="required"/>
+    <xs:attribute name="strict-violations"   type="xs:int" use="required"/>
+    <xs:attribute name="advisory-violations" type="xs:int" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="ObservedPercentilesType">
+    <xs:sequence>
+      <xs:element name="percentile" type="tns:ObservedPercentileType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="ObservedPercentileType">
+    <xs:attribute name="label"    type="tns:PercentileLabelEnum" use="required"/>
+    <xs:attribute name="value-ms" type="xs:long"                 use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="EvaluationsType">
+    <xs:sequence>
+      <xs:element name="evaluation" type="tns:EvaluationType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EvaluationType">
+    <xs:attribute name="percentile"          type="tns:PercentileLabelEnum"   use="required"/>
+    <xs:attribute name="observed-ms"         type="xs:long"                   use="optional"/>
+    <xs:attribute name="threshold-ms"        type="xs:long"                   use="required"/>
+    <xs:attribute name="provenance"          type="tns:LatencyProvenanceEnum" use="required"/>
+    <xs:attribute name="mode"                type="tns:EnforcementModeEnum"   use="required"/>
+    <xs:attribute name="status"              type="tns:EvaluationStatusEnum"  use="required"/>
+    <!-- Present only when provenance="baseline-derived" -->
+    <xs:attribute name="baseline-confidence" type="xs:double"                 use="optional"/>
+    <xs:attribute name="baseline-rank"       type="xs:int"                    use="optional"/>
+    <xs:attribute name="baseline-n"          type="xs:int"                    use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="PercentileLabelEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="p50"/>
+      <xs:enumeration value="p90"/>
+      <xs:enumeration value="p95"/>
+      <xs:enumeration value="p99"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="LatencyProvenanceEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="explicit"/>
+      <xs:enumeration value="baseline-derived"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EnforcementModeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="strict"/>
+      <xs:enumeration value="advisory"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EvaluationStatusEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PASS"/>
+      <xs:enumeration value="STRICT_FAIL"/>
+      <xs:enumeration value="ADVISORY_WARN"/>
+      <xs:enumeration value="INFEASIBLE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Statistical analysis
+       =================================================================== -->
+
+  <xs:complexType name="StatisticsType">
+    <xs:attribute name="confidence-level" type="xs:double"               use="required"/>
+    <xs:attribute name="standard-error"   type="xs:double"               use="required"/>
+    <xs:attribute name="wilson-lower"     type="xs:double"               use="required"/>
+    <xs:attribute name="threshold"        type="xs:double"               use="required"/>
+    <xs:attribute name="threshold-origin" type="tns:ThresholdOriginEnum" use="required"/>
+    <xs:attribute name="test-statistic"   type="xs:double"               use="optional"/>
+    <xs:attribute name="p-value"          type="xs:double"               use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ThresholdOriginEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SLA"/>
+      <xs:enumeration value="SLO"/>
+      <xs:enumeration value="POLICY"/>
+      <xs:enumeration value="EMPIRICAL"/>
+      <xs:enumeration value="UNSPECIFIED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Covariates
+       =================================================================== -->
+
+  <xs:complexType name="CovariatesType">
+    <xs:sequence>
+      <xs:element name="misalignment" type="tns:MisalignmentType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="aligned" type="xs:boolean" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="MisalignmentType">
+    <xs:attribute name="key"            type="xs:string" use="required"/>
+    <xs:attribute name="baseline-value" type="xs:string" use="required"/>
+    <xs:attribute name="observed-value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Provenance (policy context)
+       =================================================================== -->
+
+  <xs:complexType name="ProvenanceType">
+    <xs:sequence>
+      <xs:element name="expiration" type="tns:ExpirationType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="origin"        type="tns:ThresholdOriginEnum" use="required"/>
+    <xs:attribute name="spec-filename" type="xs:string"               use="optional"/>
+    <xs:attribute name="contract-ref"  type="xs:string"               use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="ExpirationType">
+    <xs:attribute name="status"           type="tns:ExpirationStatusEnum" use="required"/>
+    <xs:attribute name="expires-at"       type="xs:dateTime"              use="optional"/>
+    <xs:attribute name="requires-warning" type="xs:boolean"               use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ExpirationStatusEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NO_EXPIRATION"/>
+      <xs:enumeration value="VALID"/>
+      <xs:enumeration value="EXPIRING_SOON"/>
+      <xs:enumeration value="EXPIRING_IMMINENTLY"/>
+      <xs:enumeration value="EXPIRED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Baseline (measurement context)
+       =================================================================== -->
+
+  <xs:complexType name="BaselineType">
+    <xs:attribute name="source-file"       type="xs:string"   use="required"/>
+    <xs:attribute name="generated-at"      type="xs:dateTime" use="required"/>
+    <xs:attribute name="samples"           type="xs:int"      use="required"/>
+    <xs:attribute name="baseline-rate"     type="xs:double"   use="required"/>
+    <xs:attribute name="derived-threshold" type="xs:double"   use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Termination
+       =================================================================== -->
+
+  <xs:complexType name="TerminationType">
+    <xs:attribute name="reason" type="tns:TerminationReasonEnum" use="required"/>
+    <xs:attribute name="detail" type="xs:string"                 use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="TerminationReasonEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="COMPLETED"/>
+      <xs:enumeration value="FAILURE_INEVITABLE"/>
+      <xs:enumeration value="SUCCESS_GUARANTEED"/>
+      <xs:enumeration value="TIME_BUDGET_EXHAUSTED"/>
+      <xs:enumeration value="TOKEN_BUDGET_EXHAUSTED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Cost
+       =================================================================== -->
+
+  <xs:complexType name="CostType">
+    <xs:attribute name="total-time-ms"         type="xs:long" use="required"/>
+    <xs:attribute name="total-tokens"          type="xs:long" use="required"/>
+    <xs:attribute name="avg-time-per-sample-ms" type="xs:long" use="required"/>
+    <xs:attribute name="avg-tokens-per-sample" type="xs:long" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Warnings
+       =================================================================== -->
+
+  <xs:complexType name="WarningsType">
+    <xs:sequence>
+      <xs:element name="warning" type="tns:WarningType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="WarningType" mixed="true">
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Postcondition failures (per-clause histogram with bounded exemplars)
+       =================================================================== -->
+
+  <xs:complexType name="PostconditionFailuresType">
+    <xs:sequence>
+      <xs:element name="clause" type="tns:PostconditionClauseFailureType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="PostconditionClauseFailureType">
+    <xs:sequence>
+      <xs:element name="exemplar" type="tns:PostconditionExemplarType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="description" type="xs:string" use="required"/>
+    <xs:attribute name="count"       type="xs:int"    use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="PostconditionExemplarType">
+    <xs:attribute name="input"  type="xs:string" use="required"/>
+    <xs:attribute name="reason" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Pacing
+       =================================================================== -->
+
+  <xs:complexType name="PacingType">
+    <xs:attribute name="max-rps"                type="xs:double" use="required"/>
+    <xs:attribute name="max-rpm"                type="xs:double" use="required"/>
+    <xs:attribute name="max-concurrent"         type="xs:int"    use="required"/>
+    <xs:attribute name="effective-min-delay-ms" type="xs:long"   use="required"/>
+    <xs:attribute name="effective-concurrency"  type="xs:int"    use="required"/>
+    <xs:attribute name="effective-rps"          type="xs:double" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Environment metadata
+       =================================================================== -->
+
+  <xs:complexType name="EnvironmentType">
+    <xs:sequence>
+      <xs:element name="entry" type="tns:EnvironmentEntryType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EnvironmentEntryType">
+    <xs:attribute name="key"   type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Verdict
+       =================================================================== -->
+
+  <xs:complexType name="VerdictType">
+    <xs:attribute name="value"  type="tns:VerdictEnum" use="required"/>
+    <xs:attribute name="reason" type="xs:string"       use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="VerdictEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PASS"/>
+      <xs:enumeration value="FAIL"/>
+      <xs:enumeration value="INCONCLUSIVE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Per-criterion methodology-level decomposition (1.1 addition,
+       1.2 refinement)
+
+       Carries each criterion's three-valued aggregate verdict
+       and the composite verdict over them.
+
+       The bundle is optional under <verdict-record>. Present when the
+       producing run had per-criterion data (every normal run on every
+       contract post-step-4); absent for apply-level-failure runs where
+       the per-criterion evaluation never fired.
+
+       1.2 refinement: the <legacy-aggregate> child element of 1.1
+       (one-release audit-trail of the pre-cutover Verdict.compose
+       result) is withdrawn. Producers do not emit it; permissive
+       readers ignore it when encountered in 1.1-shaped content from
+       older emitters in service.
+       =================================================================== -->
+
+  <xs:complexType name="PerCriterionType">
+    <xs:sequence>
+      <xs:element name="criterion" type="tns:CriterionRowType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="composite" type="tns:CompositeType"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CriterionRowType">
+    <xs:attribute name="id"            type="xs:string"       use="required"/>
+    <xs:attribute name="verdict"       type="tns:VerdictEnum" use="required"/>
+    <xs:attribute name="pass"          type="xs:int"          use="required"/>
+    <xs:attribute name="fail"          type="xs:int"          use="required"/>
+    <xs:attribute name="inconclusive"  type="xs:int"          use="required"/>
+    <xs:attribute name="total"         type="xs:int"          use="required"/>
+    <!-- observed-rate and threshold are optional because the in-memory
+         values may be NaN (zero-sample criterion; threshold not yet
+         resolved). Emitters omit the attribute when the value is NaN. -->
+    <xs:attribute name="observed-rate" type="xs:double"       use="optional"/>
+    <xs:attribute name="threshold"     type="xs:double"       use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="CompositeType">
+    <xs:attribute name="value" type="tns:VerdictEnum" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Postcondition standings (1.3 addition)
+
+       The descriptive per-(input, check) tally of the per-trial check
+       outcomes the run's evaluator computed: passed / failed / skipped
+       counts and the observed pass fraction, exactly as stated by the
+       emitter. One <criterion> per criterion carrying standings, rows in
+       the emitter's stated order (the schema does not constrain it).
+
+       Descriptive only, by construction: the element carries counts and
+       the observed fraction and offers no place for a confidence
+       interval, a threshold, or a per-check verdict — the criterion
+       remains the family's only judged unit.
+
+       Partial-credit facts travel with the tallies so consumers can
+       flag partial credit without reading the contract: every row
+       states whether its check is optional, and a criterion that
+       declares an optional-check failure budget states it verbatim as
+       authored ("2" is a count, "20%" a percentage; the attribute is
+       absent iff no budget is declared — absence is distinguishable
+       from "0", which is the explicit budget of zero).
+       =================================================================== -->
+
+  <xs:complexType name="PostconditionStandingsType">
+    <xs:sequence>
+      <xs:element name="criterion" type="tns:StandingsCriterionType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="StandingsCriterionType">
+    <xs:sequence>
+      <xs:element name="row" type="tns:StandingsRowType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name"           type="xs:string"              use="required"/>
+    <xs:attribute name="optional-slack" type="tns:OptionalSlackType"  use="optional"/>
+  </xs:complexType>
+
+  <!-- The declared budget, verbatim as authored: digits for a count,
+       digits + % for a percentage. -->
+  <xs:simpleType name="OptionalSlackType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9]+%?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="StandingsRowType">
+    <!-- check: the check's bounded identity, as the contract declares
+         it — never embedding input or response content; the input
+         travels structurally in input-index (the interchange area's
+         key discipline). -->
+    <xs:attribute name="input-index"       type="xs:int"                    use="required"/>
+    <xs:attribute name="check"             type="tns:BoundedIdentityType"   use="required"/>
+    <xs:attribute name="optional"          type="xs:boolean"                use="required"/>
+    <xs:attribute name="passed"            type="xs:int"                    use="required"/>
+    <xs:attribute name="failed"            type="xs:int"                    use="required"/>
+    <xs:attribute name="skipped"           type="xs:int"                    use="required"/>
+    <xs:attribute name="observed-fraction" type="tns:ObservedFractionType"  use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="BoundedIdentityType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="256"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ObservedFractionType">
+    <xs:restriction base="xs:double">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.4.xsd
+++ b/punit-report/src/main/resources/org/mavai/punit/report/verdict-1.4.xsd
@@ -1,0 +1,583 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://mavai.org/verdict/1.0"
+           targetNamespace="http://mavai.org/verdict/1.0"
+           elementFormDefault="qualified">
+
+  <!-- ===================================================================
+       Root elements
+       =================================================================== -->
+
+  <xs:element name="verdict-record" type="tns:VerdictRecordType"/>
+  <xs:element name="verdict-suite"  type="tns:VerdictSuiteType"/>
+
+  <!-- ===================================================================
+       Suite envelope (for batch processing / XSLT input)
+       =================================================================== -->
+
+  <xs:complexType name="VerdictSuiteType">
+    <xs:sequence>
+      <xs:element ref="tns:verdict-record" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="timestamp" type="xs:dateTime" use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Verdict record (one per test execution)
+       =================================================================== -->
+
+  <xs:complexType name="VerdictRecordType">
+    <xs:all>
+      <xs:element name="identity"     type="tns:IdentityType"/>
+      <xs:element name="execution"    type="tns:ExecutionType"/>
+      <xs:element name="factors"      type="tns:FactorsType"      minOccurs="0"/>
+      <xs:element name="functional"   type="tns:FunctionalType"   minOccurs="0"/>
+      <xs:element name="latency"      type="tns:LatencyType"      minOccurs="0"/>
+      <xs:element name="statistics"   type="tns:StatisticsType"   minOccurs="0"/>
+      <xs:element name="covariates"   type="tns:CovariatesType"/>
+      <xs:element name="provenance"   type="tns:ProvenanceType"   minOccurs="0"/>
+      <xs:element name="baseline"     type="tns:BaselineType"     minOccurs="0"/>
+      <xs:element name="termination"  type="tns:TerminationType"/>
+      <xs:element name="cost"         type="tns:CostType"         minOccurs="0"/>
+      <xs:element name="warnings"     type="tns:WarningsType"     minOccurs="0"/>
+      <xs:element name="pacing"       type="tns:PacingType"       minOccurs="0"/>
+      <xs:element name="environment"  type="tns:EnvironmentType"  minOccurs="0"/>
+      <xs:element name="postcondition-failures" type="tns:PostconditionFailuresType" minOccurs="0"/>
+      <xs:element name="per-criterion" type="tns:PerCriterionType" minOccurs="0"/>
+      <xs:element name="postcondition-standings" type="tns:PostconditionStandingsType" minOccurs="0"/>
+      <xs:element name="verdict"      type="tns:VerdictType"/>
+    </xs:all>
+    <!-- version: "1.0", "1.2", "1.3", or "1.4". 1.2 emitters set version="1.2"
+         when <per-criterion> content is populated; otherwise stay
+         at "1.0" so consumers inspecting the version attribute
+         remain correctly informed. 1.3 emitters set version="1.3":
+         the <postcondition-standings> element is available (emitted
+         whenever the run produced standings). -->
+    <!-- 1.4 addition: standings rows may state structure — path, form,
+         a bounded expected excerpt, and <observed> obtained-value
+         exemplars (failing first, capped, with an elided remainder) —
+         beside the unchanged check identity. All optional: a 1.3-shaped
+         row is a valid 1.4 row. -->
+    <!-- 1.3 addition: the <postcondition-standings> element — the
+         descriptive per-(input, check) tally of per-trial check
+         outcomes, first-class. It supersedes the transitional
+         environment-entry carriage (postcondition-standings:* keys)
+         some 1.2 emitters used; 1.3 emitters do not write those
+         entries. -->
+    <!-- 1.2 withdrawal: the <legacy-aggregate> child of <per-criterion>,
+         present in 1.1 as a one-release audit-trail element, is gone.
+         Producers emitting 1.2-shaped content do not write the
+         element; permissive readers may continue to ignore it when
+         encountered in 1.1-shaped content from older emitters in
+         service. -->
+    <xs:attribute name="version"        type="xs:string"   use="required"/>
+    <xs:attribute name="timestamp"      type="xs:dateTime"  use="required"/>
+    <xs:attribute name="generator"      type="xs:string"    use="required"/>
+    <xs:attribute name="correlation-id" type="xs:string"    use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Identity
+       =================================================================== -->
+
+  <xs:complexType name="IdentityType">
+    <xs:attribute name="use-case-id" type="xs:string" use="required"/>
+    <xs:attribute name="test-name"   type="xs:string" use="optional"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Execution
+       =================================================================== -->
+
+  <xs:complexType name="ExecutionType">
+    <xs:attribute name="planned-samples"  type="xs:int"    use="required"/>
+    <xs:attribute name="samples-executed" type="xs:int"    use="required"/>
+    <xs:attribute name="successes"        type="xs:int"    use="required"/>
+    <xs:attribute name="failures"         type="xs:int"    use="required"/>
+    <xs:attribute name="elapsed-ms"       type="xs:long"   use="required"/>
+    <xs:attribute name="intent"           type="tns:IntentEnum" use="required"/>
+    <xs:attribute name="confidence"       type="xs:double" use="required"/>
+    <xs:attribute name="warmup"           type="xs:int"    use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="IntentEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="VERIFICATION"/>
+      <xs:enumeration value="SMOKE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Factor bundle (FT instance the test ran under; shape-symmetric
+       with the baseline factors block)
+       =================================================================== -->
+
+  <xs:complexType name="FactorsType">
+    <xs:sequence>
+      <xs:element name="entry" type="tns:FactorEntryType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="FactorEntryType">
+    <xs:attribute name="key"   type="xs:string"           use="required"/>
+    <xs:attribute name="value" type="xs:string"           use="required"/>
+    <xs:attribute name="type"  type="tns:FactorTypeEnum"  use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="FactorTypeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="string"/>
+      <xs:enumeration value="number"/>
+      <xs:enumeration value="boolean"/>
+      <xs:enumeration value="enum"/>
+      <xs:enumeration value="duration"/>
+      <xs:enumeration value="instant"/>
+      <xs:enumeration value="uri"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Functional dimension
+       =================================================================== -->
+
+  <xs:complexType name="FunctionalType">
+    <xs:sequence>
+      <xs:element name="failure-distribution" type="tns:FailureDistributionType"
+                  minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="successes" type="xs:int"    use="required"/>
+    <xs:attribute name="failures"  type="xs:int"    use="required"/>
+    <xs:attribute name="pass-rate" type="xs:double" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="FailureDistributionType">
+    <xs:sequence>
+      <xs:element name="check" type="tns:CheckType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CheckType">
+    <xs:attribute name="name"  type="xs:string" use="required"/>
+    <xs:attribute name="count" type="xs:int"    use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Latency dimension
+       =================================================================== -->
+
+  <xs:complexType name="LatencyType">
+    <xs:sequence>
+      <xs:element name="observed"    type="tns:ObservedPercentilesType" minOccurs="0"/>
+      <xs:element name="evaluations" type="tns:EvaluationsType"        minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="successful-samples"  type="xs:int" use="required"/>
+    <xs:attribute name="strict-violations"   type="xs:int" use="required"/>
+    <xs:attribute name="advisory-violations" type="xs:int" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="ObservedPercentilesType">
+    <xs:sequence>
+      <xs:element name="percentile" type="tns:ObservedPercentileType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="ObservedPercentileType">
+    <xs:attribute name="label"    type="tns:PercentileLabelEnum" use="required"/>
+    <xs:attribute name="value-ms" type="xs:long"                 use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="EvaluationsType">
+    <xs:sequence>
+      <xs:element name="evaluation" type="tns:EvaluationType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EvaluationType">
+    <xs:attribute name="percentile"          type="tns:PercentileLabelEnum"   use="required"/>
+    <xs:attribute name="observed-ms"         type="xs:long"                   use="optional"/>
+    <xs:attribute name="threshold-ms"        type="xs:long"                   use="required"/>
+    <xs:attribute name="provenance"          type="tns:LatencyProvenanceEnum" use="required"/>
+    <xs:attribute name="mode"                type="tns:EnforcementModeEnum"   use="required"/>
+    <xs:attribute name="status"              type="tns:EvaluationStatusEnum"  use="required"/>
+    <!-- Present only when provenance="baseline-derived" -->
+    <xs:attribute name="baseline-confidence" type="xs:double"                 use="optional"/>
+    <xs:attribute name="baseline-rank"       type="xs:int"                    use="optional"/>
+    <xs:attribute name="baseline-n"          type="xs:int"                    use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="PercentileLabelEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="p50"/>
+      <xs:enumeration value="p90"/>
+      <xs:enumeration value="p95"/>
+      <xs:enumeration value="p99"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="LatencyProvenanceEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="explicit"/>
+      <xs:enumeration value="baseline-derived"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EnforcementModeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="strict"/>
+      <xs:enumeration value="advisory"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EvaluationStatusEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PASS"/>
+      <xs:enumeration value="STRICT_FAIL"/>
+      <xs:enumeration value="ADVISORY_WARN"/>
+      <xs:enumeration value="INFEASIBLE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Statistical analysis
+       =================================================================== -->
+
+  <xs:complexType name="StatisticsType">
+    <xs:attribute name="confidence-level" type="xs:double"               use="required"/>
+    <xs:attribute name="standard-error"   type="xs:double"               use="required"/>
+    <xs:attribute name="wilson-lower"     type="xs:double"               use="required"/>
+    <xs:attribute name="threshold"        type="xs:double"               use="required"/>
+    <xs:attribute name="threshold-origin" type="tns:ThresholdOriginEnum" use="required"/>
+    <xs:attribute name="test-statistic"   type="xs:double"               use="optional"/>
+    <xs:attribute name="p-value"          type="xs:double"               use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ThresholdOriginEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SLA"/>
+      <xs:enumeration value="SLO"/>
+      <xs:enumeration value="POLICY"/>
+      <xs:enumeration value="EMPIRICAL"/>
+      <xs:enumeration value="UNSPECIFIED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Covariates
+       =================================================================== -->
+
+  <xs:complexType name="CovariatesType">
+    <xs:sequence>
+      <xs:element name="misalignment" type="tns:MisalignmentType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="aligned" type="xs:boolean" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="MisalignmentType">
+    <xs:attribute name="key"            type="xs:string" use="required"/>
+    <xs:attribute name="baseline-value" type="xs:string" use="required"/>
+    <xs:attribute name="observed-value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Provenance (policy context)
+       =================================================================== -->
+
+  <xs:complexType name="ProvenanceType">
+    <xs:sequence>
+      <xs:element name="expiration" type="tns:ExpirationType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="origin"        type="tns:ThresholdOriginEnum" use="required"/>
+    <xs:attribute name="spec-filename" type="xs:string"               use="optional"/>
+    <xs:attribute name="contract-ref"  type="xs:string"               use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="ExpirationType">
+    <xs:attribute name="status"           type="tns:ExpirationStatusEnum" use="required"/>
+    <xs:attribute name="expires-at"       type="xs:dateTime"              use="optional"/>
+    <xs:attribute name="requires-warning" type="xs:boolean"               use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ExpirationStatusEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NO_EXPIRATION"/>
+      <xs:enumeration value="VALID"/>
+      <xs:enumeration value="EXPIRING_SOON"/>
+      <xs:enumeration value="EXPIRING_IMMINENTLY"/>
+      <xs:enumeration value="EXPIRED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Baseline (measurement context)
+       =================================================================== -->
+
+  <xs:complexType name="BaselineType">
+    <xs:attribute name="source-file"       type="xs:string"   use="required"/>
+    <xs:attribute name="generated-at"      type="xs:dateTime" use="required"/>
+    <xs:attribute name="samples"           type="xs:int"      use="required"/>
+    <xs:attribute name="baseline-rate"     type="xs:double"   use="required"/>
+    <xs:attribute name="derived-threshold" type="xs:double"   use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Termination
+       =================================================================== -->
+
+  <xs:complexType name="TerminationType">
+    <xs:attribute name="reason" type="tns:TerminationReasonEnum" use="required"/>
+    <xs:attribute name="detail" type="xs:string"                 use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="TerminationReasonEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="COMPLETED"/>
+      <xs:enumeration value="FAILURE_INEVITABLE"/>
+      <xs:enumeration value="SUCCESS_GUARANTEED"/>
+      <xs:enumeration value="TIME_BUDGET_EXHAUSTED"/>
+      <xs:enumeration value="TOKEN_BUDGET_EXHAUSTED"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Cost
+       =================================================================== -->
+
+  <xs:complexType name="CostType">
+    <xs:attribute name="total-time-ms"         type="xs:long" use="required"/>
+    <xs:attribute name="total-tokens"          type="xs:long" use="required"/>
+    <xs:attribute name="avg-time-per-sample-ms" type="xs:long" use="required"/>
+    <xs:attribute name="avg-tokens-per-sample" type="xs:long" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Warnings
+       =================================================================== -->
+
+  <xs:complexType name="WarningsType">
+    <xs:sequence>
+      <xs:element name="warning" type="tns:WarningType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="WarningType" mixed="true">
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Postcondition failures (per-clause histogram with bounded exemplars)
+       =================================================================== -->
+
+  <xs:complexType name="PostconditionFailuresType">
+    <xs:sequence>
+      <xs:element name="clause" type="tns:PostconditionClauseFailureType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="PostconditionClauseFailureType">
+    <xs:sequence>
+      <xs:element name="exemplar" type="tns:PostconditionExemplarType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="description" type="xs:string" use="required"/>
+    <xs:attribute name="count"       type="xs:int"    use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="PostconditionExemplarType">
+    <xs:attribute name="input"  type="xs:string" use="required"/>
+    <xs:attribute name="reason" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Pacing
+       =================================================================== -->
+
+  <xs:complexType name="PacingType">
+    <xs:attribute name="max-rps"                type="xs:double" use="required"/>
+    <xs:attribute name="max-rpm"                type="xs:double" use="required"/>
+    <xs:attribute name="max-concurrent"         type="xs:int"    use="required"/>
+    <xs:attribute name="effective-min-delay-ms" type="xs:long"   use="required"/>
+    <xs:attribute name="effective-concurrency"  type="xs:int"    use="required"/>
+    <xs:attribute name="effective-rps"          type="xs:double" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Environment metadata
+       =================================================================== -->
+
+  <xs:complexType name="EnvironmentType">
+    <xs:sequence>
+      <xs:element name="entry" type="tns:EnvironmentEntryType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EnvironmentEntryType">
+    <xs:attribute name="key"   type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Verdict
+       =================================================================== -->
+
+  <xs:complexType name="VerdictType">
+    <xs:attribute name="value"  type="tns:VerdictEnum" use="required"/>
+    <xs:attribute name="reason" type="xs:string"       use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="VerdictEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PASS"/>
+      <xs:enumeration value="FAIL"/>
+      <xs:enumeration value="INCONCLUSIVE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ===================================================================
+       Per-criterion methodology-level decomposition (1.1 addition,
+       1.2 refinement)
+
+       Carries each criterion's three-valued aggregate verdict
+       and the composite verdict over them.
+
+       The bundle is optional under <verdict-record>. Present when the
+       producing run had per-criterion data (every normal run on every
+       contract post-step-4); absent for apply-level-failure runs where
+       the per-criterion evaluation never fired.
+
+       1.2 refinement: the <legacy-aggregate> child element of 1.1
+       (one-release audit-trail of the pre-cutover Verdict.compose
+       result) is withdrawn. Producers do not emit it; permissive
+       readers ignore it when encountered in 1.1-shaped content from
+       older emitters in service.
+       =================================================================== -->
+
+  <xs:complexType name="PerCriterionType">
+    <xs:sequence>
+      <xs:element name="criterion" type="tns:CriterionRowType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="composite" type="tns:CompositeType"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CriterionRowType">
+    <xs:attribute name="id"            type="xs:string"       use="required"/>
+    <xs:attribute name="verdict"       type="tns:VerdictEnum" use="required"/>
+    <xs:attribute name="pass"          type="xs:int"          use="required"/>
+    <xs:attribute name="fail"          type="xs:int"          use="required"/>
+    <xs:attribute name="inconclusive"  type="xs:int"          use="required"/>
+    <xs:attribute name="total"         type="xs:int"          use="required"/>
+    <!-- observed-rate and threshold are optional because the in-memory
+         values may be NaN (zero-sample criterion; threshold not yet
+         resolved). Emitters omit the attribute when the value is NaN. -->
+    <xs:attribute name="observed-rate" type="xs:double"       use="optional"/>
+    <xs:attribute name="threshold"     type="xs:double"       use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="CompositeType">
+    <xs:attribute name="value" type="tns:VerdictEnum" use="required"/>
+  </xs:complexType>
+
+  <!-- ===================================================================
+       Postcondition standings (1.3 addition)
+
+       The descriptive per-(input, check) tally of the per-trial check
+       outcomes the run's evaluator computed: passed / failed / skipped
+       counts and the observed pass fraction, exactly as stated by the
+       emitter. One <criterion> per criterion carrying standings, rows in
+       the emitter's stated order (the schema does not constrain it).
+
+       Descriptive only, by construction: the element carries counts and
+       the observed fraction and offers no place for a confidence
+       interval, a threshold, or a per-check verdict — the criterion
+       remains the family's only judged unit.
+
+       Partial-credit facts travel with the tallies so consumers can
+       flag partial credit without reading the contract: every row
+       states whether its check is optional, and a criterion that
+       declares an optional-check failure budget states it verbatim as
+       authored ("2" is a count, "20%" a percentage; the attribute is
+       absent iff no budget is declared — absence is distinguishable
+       from "0", which is the explicit budget of zero).
+       =================================================================== -->
+
+  <xs:complexType name="PostconditionStandingsType">
+    <xs:sequence>
+      <xs:element name="criterion" type="tns:StandingsCriterionType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="StandingsCriterionType">
+    <xs:sequence>
+      <xs:element name="row" type="tns:StandingsRowType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name"           type="xs:string"              use="required"/>
+    <xs:attribute name="optional-slack" type="tns:OptionalSlackType"  use="optional"/>
+  </xs:complexType>
+
+  <!-- The declared budget, verbatim as authored: digits for a count,
+       digits + % for a percentage. -->
+  <xs:simpleType name="OptionalSlackType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9]+%?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="StandingsRowType">
+    <!-- check: the check's bounded identity, as the contract declares
+         it — never embedding input or response content; the input
+         travels structurally in input-index (the interchange area's
+         key discipline). 1.4: path/form/expected state the check's
+         structure beside the identity (never derived from it), and
+         <observed> children carry obtained-value exemplars — content
+         in values only. -->
+    <xs:sequence>
+      <xs:element name="observed" type="tns:StandingsObservedType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="input-index"       type="xs:int"                    use="required"/>
+    <xs:attribute name="check"             type="tns:BoundedIdentityType"   use="required"/>
+    <xs:attribute name="optional"          type="xs:boolean"                use="required"/>
+    <xs:attribute name="passed"            type="xs:int"                    use="required"/>
+    <xs:attribute name="failed"            type="xs:int"                    use="required"/>
+    <xs:attribute name="skipped"           type="xs:int"                    use="required"/>
+    <xs:attribute name="observed-fraction" type="tns:ObservedFractionType"  use="required"/>
+    <xs:attribute name="path"              type="tns:BoundedIdentityType"   use="optional"/>
+    <xs:attribute name="form"              type="tns:BoundedIdentityType"   use="optional"/>
+    <xs:attribute name="expected"          type="tns:BoundedIdentityType"   use="optional"/>
+    <xs:attribute name="elided"            type="xs:int"                    use="optional"/>
+  </xs:complexType>
+
+  <!-- One obtained-value exemplar: a bounded excerpt of what the service
+       returned under the check's view, how many trials returned it, and
+       whether the check held for them. Failing exemplars are stated
+       first. -->
+  <xs:complexType name="StandingsObservedType">
+    <xs:attribute name="excerpt" type="tns:BoundedIdentityType" use="required"/>
+    <xs:attribute name="count"   type="xs:int"                  use="required"/>
+    <xs:attribute name="held"    type="xs:boolean"              use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="BoundedIdentityType">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="256"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ObservedFractionType">
+    <xs:restriction base="xs:double">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/punit-report/src/test/java/org/mavai/punit/report/VerdictXmlWriterTest.java
+++ b/punit-report/src/test/java/org/mavai/punit/report/VerdictXmlWriterTest.java
@@ -535,6 +535,54 @@ class VerdictXmlWriterTest {
     }
 
     @Nested
+    @DisplayName("postcondition standings")
+    class PostconditionStandingsElement {
+
+        @Test
+        @DisplayName("a verdict with standings steps to version 1.4 and validates against the XSD")
+        void standingsValidateAgainstSchema14() throws Exception {
+            String xml = writeToString(verdictWithStandings());
+            assertThat(xml).contains("version=\"1.4\"");
+            assertThat(xml).contains("<postcondition-standings>");
+            assertThat(xml).contains("optional-slack=\"2\"");
+            assertThat(xml).contains(
+                    "input-index=\"1\" check=\"terms are the agreed set\" optional=\"true\" "
+                            + "passed=\"12\" failed=\"6\" skipped=\"2\"");
+            validateAgainstSchema14(xml);
+        }
+
+        @Test
+        @DisplayName("the standings round-trip through punit's own reader")
+        void standingsRoundTrip() throws Exception {
+            ProbabilisticTestVerdict original = verdictWithStandings();
+            String xml = writeToString(original);
+            ProbabilisticTestVerdict read = new VerdictXmlReader()
+                    .read(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            assertThat(read.postconditionStandings()).isPresent();
+            assertThat(read.postconditionStandings().get())
+                    .isEqualTo(original.postconditionStandings().get());
+        }
+
+        @Test
+        @DisplayName("the standings element is descriptive — no verdict vocabulary, no intervals")
+        void standingsAreDescriptive() throws Exception {
+            String xml = writeToString(verdictWithStandings());
+            String element = xml.substring(
+                    xml.indexOf("<postcondition-standings>"),
+                    xml.indexOf("</postcondition-standings>"));
+            assertThat(element).doesNotContain("threshold", "confidence", "bound", "verdict");
+        }
+
+        @Test
+        @DisplayName("a verdict without standings stays at its prior version")
+        void noStandingsNoVersionStep() throws Exception {
+            String xml = writeToString(minimalVerdict(true, PUnitVerdict.PASS));
+            assertThat(xml).doesNotContain("postcondition-standings");
+            assertThat(xml).contains("version=\"1.0\"");
+        }
+    }
+
+    @Nested
     @DisplayName("schema validation")
     class SchemaValidation {
 
@@ -1004,6 +1052,36 @@ class VerdictXmlWriterTest {
             Validator validator = schema.newValidator();
             validator.validate(new StreamSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));
         }
+    }
+
+    private void validateAgainstSchema14(String xml) throws Exception {
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        try (InputStream xsdStream = getClass().getResourceAsStream("/org/mavai/punit/report/verdict-1.4.xsd")) {
+            assertThat(xsdStream).as("XSD 1.4 resource must be available").isNotNull();
+            Schema schema = schemaFactory.newSchema(new StreamSource(xsdStream));
+            Validator validator = schema.newValidator();
+            validator.validate(new StreamSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));
+        }
+    }
+
+    private ProbabilisticTestVerdict verdictWithStandings() {
+        ProbabilisticTestVerdict base = minimalVerdict(true, PUnitVerdict.PASS);
+        var standings = new org.mavai.punit.api.spec.PostconditionStandings(List.of(
+                new org.mavai.punit.api.spec.PostconditionStandings.CriterionStandings(
+                        "extraction-matches",
+                        Optional.of("2"),
+                        List.of(
+                                new org.mavai.punit.api.spec.PostconditionStandings.Row(
+                                        0, "premium is exact", false, 18, 2, 0),
+                                new org.mavai.punit.api.spec.PostconditionStandings.Row(
+                                        1, "terms are the agreed set", true, 12, 6, 2)))));
+        return new ProbabilisticTestVerdict(
+                base.correlationId(), base.timestamp(), base.identity(), base.execution(),
+                base.functional(), base.latency(), base.statistics(), base.covariates(),
+                base.cost(), base.pacing(), base.provenance(), base.termination(),
+                base.environmentMetadata(), base.junitPassed(), base.punitVerdict(),
+                base.verdictReason(), base.postconditionFailures(), base.perCriterion(),
+                Optional.of(standings));
     }
 
     private void validateAgainstSchema12(String xml) throws Exception {


### PR DESCRIPTION
Implements the family partial-credit ruling and the postcondition-standings surface for punit — parity item 2 of the baseltest-parity programme (orchestrator directives `DIR-PU-EXPECTED-partial-credit`, `DIR-PU-DA-baseltest-parity`).

## Partial credit

- A check may be declared **optional** — programmatic `.optional()` on the criterion builder, declarative `optional: true` on a form (non-`true` spellings refuse: required is the default, not a spelling; `optional` on a `parses:` form refuses as inert).
- A criterion may grant an **optional-slack** budget: an absolute count or an `"N%"` floor over the applicable optional checks (`OptionalSlack`, resolved by flooring; a bare fraction is never guessed at).
- **Double opt-in**: `optional` without slack binds exactly as before; slack without optional checks is inert.
- A trial stays **one Bernoulli outcome**: it fails when any required check fails or when failed optional checks exceed the budget. Transform failure still hard-fails. Recorded per-check outcomes stay true — only the acceptance predicate changes (`DirectCriterion.evaluateChain`; `ServiceContractOutcome.value()` now defers to the criterion's own acceptance when criterion sample results are present).

## Postcondition standings

- Every run states a **descriptive** per-`(input, check)` tally — passed / failed / skipped and the observed fraction — with the declared slack verbatim (`PostconditionStandings.from`, derived post-hoc from recorded trials; no engine mutation). No intervals, no thresholds, no per-check verdicts: the criterion stays the only judged unit, and regression tests pin the vocabulary on every surface.
- Surfaces: console verdict (shared `StandingsTextRenderer`), verdict XML (**schema version 1.4**, first-class `<postcondition-standings>` element; XSDs 1.3/1.4 vendored from mavai-R; validated + round-tripped in tests), MEASURE baseline YAML (`postconditionStandings` block), and the per-criterion statistics of the explore and optimize artefacts (shared `StandingsBlocks`).

## Notes

- Declarative per-input expectations now compile to individual per-input checks (identity dispatch), so standings rows resolve per input.
- Structured 1.4 rows (path/form/expected/observed exemplars) are a recorded decl-layer follow-up; this PR emits 1.3-shaped rows in version-1.4 records, valid per the additive schema.
- Full build green, including the new descriptive-vocabulary regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM