### PR TITLE
Anchor the partial-credit acceptance and the postcondition standings

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/api/criterion/DirectCriterion.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/criterion/DirectCriterion.java
@@ -20,6 +20,7 @@ import org.mavai.punit.api.PostconditionResult;
  * lowered to its runtime criterion. Authors do not reference this
  * type directly.
  */
+// mavai-ref: JVI-2GV36P= — do not remove (resolves in mavai-orchestrator)
 final class DirectCriterion<O> implements Criterion<O> {
 
     private final String id;

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/PostconditionStandings.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/PostconditionStandings.java
@@ -34,6 +34,7 @@ import org.mavai.punit.api.criterion.CriterionSampleResult;
  * history — a pure aggregation of recorded per-check outcomes, which
  * stay true even when the acceptance predicate softened the trial.
  */
+// mavai-ref: JVI-N9ZEY24 — do not remove (resolves in mavai-orchestrator)
 public record PostconditionStandings(List<CriterionStandings> criteria) {
 
     public PostconditionStandings {


### PR DESCRIPTION
Cross-reference chore following #256: embeds the orchestrator registry anchors on the two owning artifacts (the acceptance-predicate evaluator and the standings record). Opaque comments only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM