### PR TITLE
The graded set claim: set-of in the declarative vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **The graded set claim (declarative contracts).** A new composite
+  postcondition form, `set-of:`, states a graded membership claim over
+  a path's selection as one check: `required:` members must all
+  appear, `optional:` members may, `min-present:` sets a floor over
+  the distinct optional members (a count, or `"N%"` resolved by
+  floor), and `refuse-extras:` (default true) forbids unlisted
+  members. Membership semantics throughout — a set is a set:
+  duplicates collapse on both sides, an operand duplicate draws a
+  load-time console warning (never a refusal), and a duplicated
+  subject element is one member present, never an extra. Degenerate
+  spellings a sharper form owns are refused naming that form
+  (`equals-set:`, `contains-set:`), and the failure reason states the
+  arithmetic — missing required members, present-versus-floor count,
+  extras — each list bounded. Per the family's graded-set-claims
+  amendment (2026-07-29; conformance corpus mavai-R ≥ v0.10.4).
+
 - **Partial credit for optional postconditions.** A criterion check may
   be declared `optional` (programmatic `.optional()`, declarative
   `optional: true`), and the criterion may grant an `optional-slack`

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/PostconditionForm.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/PostconditionForm.java
@@ -32,7 +32,8 @@ public enum PostconditionForm {
     IS("is", Category.SCALAR_VALUE),
     EQUALS_SET("equals-set", Category.COLLECTIVE),
     CONTAINS_SET("contains-set", Category.COLLECTIVE),
-    COUNT_EQUALS("count-equals", Category.COLLECTIVE);
+    COUNT_EQUALS("count-equals", Category.COLLECTIVE),
+    SET_OF("set-of", Category.COLLECTIVE);
 
     private enum Category { STRING, STRUCTURAL, NUMERIC, SCALAR_VALUE, COLLECTIVE }
 

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/SetElements.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/SetElements.java
@@ -1,0 +1,41 @@
+package org.mavai.punit.decl.internal.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strict JSON-value equality for set-form elements, as a type-tagged
+ * key: numbers compare numerically (decimal), strings exactly, booleans
+ * and null by identity — a number never equals its string spelling, and
+ * JSON {@code true} never equals {@code 1}. The one element-identity
+ * rule for every set form, shared by the parser (member-list
+ * normalisation) and the compiler (selection judgement).
+ */
+public final class SetElements {
+
+    private SetElements() {}
+
+    /** The element under the strict JSON-value rule, as a comparable key. */
+    public static Object key(Object value) {
+        if (value instanceof Boolean) {
+            return List.of("bool", value);
+        }
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Number) {
+            return List.of("num", NumericValue.of(value).stripTrailingZeros());
+        }
+        return List.of("str", String.valueOf(value));
+    }
+
+    /** The values as a multiset over element keys (duplicates significant). */
+    public static Map<Object, Long> multiset(List<?> values) {
+        Map<Object, Long> counts = new HashMap<>();
+        for (Object value : values) {
+            counts.merge(key(value), 1L, Long::sum);
+        }
+        return counts;
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/SetOfDeclaration.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/SetOfDeclaration.java
@@ -1,0 +1,32 @@
+package org.mavai.punit.decl.internal.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@code set-of:} operand, normalised at parse: the member lists
+ * deduplicated under membership semantics (a set is a set), the
+ * {@code min-present:} floor resolved to a distinct-member count, and
+ * {@code refuse-extras:} defaulted. Every contradiction, unsatisfiable
+ * or saturated floor, and sharper-form spelling has already been
+ * refused — the compiler consumes this record without re-validating.
+ *
+ * @param required members that must all appear in the selection
+ * @param optional members that may appear
+ * @param minPresent how many distinct optional members must appear
+ * @param refuseExtras whether an unlisted selected element fails the check
+ */
+public record SetOfDeclaration(
+        List<Object> required,
+        List<Object> optional,
+        int minPresent,
+        boolean refuseExtras) {
+
+    public SetOfDeclaration {
+        // Not List.copyOf: null is a legal member (the family's JSON-value
+        // rule admits it), and copyOf rejects null elements.
+        required = Collections.unmodifiableList(new ArrayList<>(required));
+        optional = Collections.unmodifiableList(new ArrayList<>(optional));
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/FormParser.java
@@ -66,6 +66,12 @@ final class FormParser {
         }
         Object argument = entry.get(formKey);
         checkArgument(form, argument, where);
+        if (form == PostconditionForm.SET_OF) {
+            // The composite operand parses to its normalised declaration:
+            // member lists deduplicated (membership semantics), the
+            // min-present floor resolved, refuse-extras defaulted.
+            argument = SetOfParser.parse(argument, where);
+        }
         boolean explicitIn = entry.containsKey("in");
         if (path != null) {
             if (!form.pathCapable()) {
@@ -174,6 +180,10 @@ final class FormParser {
                     throw fail(where + ": `" + form.key() + ":` takes a non-empty list of "
                             + "scalar values (an empty-selection assertion is `count-equals: 0`)");
                 }
+            }
+            case SET_OF -> {
+                // Validated and normalised by SetOfParser in parse() —
+                // the composite operand owns its own refusal battery.
             }
             case COUNT_EQUALS -> {
                 boolean nonNegativeInteger = !(argument instanceof Boolean)

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/SetOfParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/SetOfParser.java
@@ -1,0 +1,151 @@
+package org.mavai.punit.decl.internal.parser;
+
+import static org.mavai.punit.decl.internal.parser.Yaml.fail;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.mavai.punit.decl.internal.model.SetElements;
+import org.mavai.punit.decl.internal.model.SetOfDeclaration;
+
+/**
+ * The {@code set-of:} operand — the composite graded set claim —
+ * normalised at parse under membership semantics: a set is a set.
+ * Duplicates in a declared list collapse to one entry with a console
+ * warning (most likely an authoring typo), never a refusal; every
+ * contradiction and unsatisfiable or saturated floor refuses at load;
+ * a spelling a sharper form owns is refused naming that form.
+ */
+final class SetOfParser {
+
+    private static final List<String> KEYS =
+            List.of("required", "optional", "min-present", "refuse-extras");
+    private static final Pattern PERCENT = Pattern.compile("^([0-9]+(?:\\.[0-9]+)?)%$");
+
+    private SetOfParser() {}
+
+    static SetOfDeclaration parse(Object argument, String where) {
+        if (!(argument instanceof Map<?, ?> mapping)) {
+            throw fail(where + ": `set-of:` takes a mapping — required:/optional: member "
+                    + "lists, min-present:, refuse-extras:");
+        }
+        for (Object key : mapping.keySet()) {
+            if (!KEYS.contains(key)) {
+                throw fail(where + ": `set-of:` has unknown key `" + key + ":` — its keys "
+                        + "are " + String.join(", ", KEYS));
+            }
+        }
+        List<Object> required = memberList(mapping, "required", where);
+        List<Object> optional = memberList(mapping, "optional", where);
+        if (required.isEmpty() && optional.isEmpty()) {
+            throw fail(where + ": `set-of:` states nothing — declare `required:` and/or "
+                    + "`optional:` members");
+        }
+        Object refuseExtrasValue = mapping.containsKey("refuse-extras")
+                ? mapping.get("refuse-extras")
+                : Boolean.TRUE;
+        if (!(refuseExtrasValue instanceof Boolean refuseExtras)) {
+            throw fail(where + ": `refuse-extras:` takes a boolean");
+        }
+        if (optional.isEmpty()) {
+            // A sharper name for the stated claim exists — refuse and name it.
+            String sharper = refuseExtras ? "equals-set" : "contains-set";
+            throw fail(where + ": a `set-of:` without `optional:` members states `"
+                    + sharper + ":` — say that");
+        }
+        int minPresent = minPresent(mapping.get("min-present"), optional.size(), where);
+        if (minPresent > optional.size()) {
+            throw fail(where + ": `min-present: " + mapping.get("min-present") + "` exceeds "
+                    + "the `optional:` list's distinct size (" + optional.size() + ")");
+        }
+        if (minPresent == optional.size()) {
+            throw fail(where + ": `min-present: " + mapping.get("min-present") + "` equals "
+                    + "the `optional:` list's distinct size (" + optional.size() + ") — "
+                    + "every optional member is required; move them to `required:`");
+        }
+        Set<Object> optionalKeys = new HashSet<>();
+        for (Object member : optional) {
+            optionalKeys.add(SetElements.key(member));
+        }
+        for (Object member : required) {
+            if (optionalKeys.contains(SetElements.key(member))) {
+                throw fail(where + ": " + Yaml.display(member) + " appears in both "
+                        + "`required:` and `optional:` — a member is one or the other");
+            }
+        }
+        return new SetOfDeclaration(required, optional, minPresent, refuseExtras);
+    }
+
+    /**
+     * One declared member list as a set: order kept, duplicates
+     * collapsed with a console warning.
+     */
+    private static List<Object> memberList(Map<?, ?> mapping, String name, String where) {
+        Object value = mapping.get(name);
+        if (value == null) {
+            return List.of();
+        }
+        if (!(value instanceof List<?> items) || items.isEmpty()
+                || !items.stream().allMatch(SetOfParser::scalarElement)) {
+            throw fail(where + ": `set-of:` `" + name + ":` takes a non-empty list of "
+                    + "scalar values");
+        }
+        List<Object> members = new ArrayList<>();
+        Set<Object> seen = new HashSet<>();
+        for (Object item : items) {
+            Object key = SetElements.key(item);
+            if (seen.contains(key)) {
+                System.err.println("warning: " + where + ": `set-of:` `" + name + ":` lists "
+                        + Yaml.display(item) + " more than once — duplicates collapse to "
+                        + "one entry (likely a typo)");
+            } else {
+                seen.add(key);
+                members.add(item);
+            }
+        }
+        return members;
+    }
+
+    /**
+     * The floor over the optional list: a distinct-member count, or an
+     * explicit percentage resolved by floor (the {@code %} suffix is
+     * the disambiguator, exactly as {@code optional-slack:}).
+     */
+    private static int minPresent(Object value, int optionalSize, String where) {
+        if (value == null) {
+            return 0;
+        }
+        boolean nonNegativeInteger = !(value instanceof Boolean)
+                && value instanceof Number count
+                && count.longValue() >= 0
+                && !(value instanceof Double || value instanceof Float);
+        if (nonNegativeInteger) {
+            return ((Number) value).intValue();
+        }
+        if (value instanceof String spelling) {
+            Matcher matcher = PERCENT.matcher(spelling.strip());
+            if (matcher.matches()) {
+                return new BigDecimal(matcher.group(1))
+                        .multiply(BigDecimal.valueOf(optionalSize))
+                        .divide(BigDecimal.valueOf(100), 0, RoundingMode.FLOOR)
+                        .intValue();
+            }
+        }
+        throw fail(where + ": `min-present:` takes a non-negative whole count of distinct "
+                + "optional members, or an explicit percentage like `80%` — got "
+                + Yaml.display(value) + " (a bare fraction is never guessed at)");
+    }
+
+    private static boolean scalarElement(Object element) {
+        return element == null
+                || element instanceof String
+                || element instanceof Number
+                || element instanceof Boolean;
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -11,6 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
@@ -29,6 +31,8 @@ import org.mavai.punit.decl.internal.model.FormDeclaration;
 import org.mavai.punit.decl.internal.model.InputDeclaration;
 import org.mavai.punit.decl.internal.model.NumericValue;
 import org.mavai.punit.decl.internal.model.PostconditionForm;
+import org.mavai.punit.decl.internal.model.SetElements;
+import org.mavai.punit.decl.internal.model.SetOfDeclaration;
 import org.w3c.dom.NodeList;
 
 /**
@@ -454,17 +458,17 @@ final class CriteriaCompiler {
         return switch (form.form()) {
             case EQUALS_SET -> {
                 List<?> operand = (List<?>) form.argument();
-                Map<Object, Long> expected = multiset(operand);
-                yield selected -> multiset(selected).equals(expected)
+                Map<Object, Long> expected = SetElements.multiset(operand);
+                yield selected -> SetElements.multiset(selected).equals(expected)
                         ? null
                         : "selected values " + Display.of(selected) + " do not equal "
                                 + Display.of(operand) + " as a multiset";
             }
             case CONTAINS_SET -> {
                 List<?> operand = (List<?>) form.argument();
-                Map<Object, Long> expected = multiset(operand);
+                Map<Object, Long> expected = SetElements.multiset(operand);
                 yield selected -> {
-                    Map<Object, Long> actual = multiset(selected);
+                    Map<Object, Long> actual = SetElements.multiset(selected);
                     boolean missing = expected.entrySet().stream()
                             .anyMatch(entry -> actual.getOrDefault(entry.getKey(), 0L) < entry.getValue());
                     return missing
@@ -479,34 +483,76 @@ final class CriteriaCompiler {
                         ? null
                         : "path selected " + selected.size() + " value(s), not " + expected;
             }
+            case SET_OF -> setOfJudge((SetOfDeclaration) form.argument());
             default -> throw new IllegalStateException("not a set form: " + form.form());
         };
     }
 
-    private static Map<Object, Long> multiset(List<?> values) {
-        Map<Object, Long> counts = new HashMap<>();
-        for (Object value : values) {
-            counts.merge(elementKey(value), 1L, Long::sum);
-        }
-        return counts;
+    /**
+     * The graded set claim, judged by membership — a set is a set.
+     * Holds iff every required member appears in the selection, at
+     * least min-present distinct optional members appear, and — under
+     * refuse-extras — every selected element is a declared member.
+     * Duplicates collapse to membership on both sides: a subject
+     * element appearing twice is one member present, never an extra.
+     * The failure reason states the arithmetic — the missing required
+     * members, the present-versus-floor count, and any extras — each
+     * list bounded.
+     */
+    private static CollectiveJudge setOfJudge(SetOfDeclaration claim) {
+        Map<Object, Object> requiredKeys = memberKeys(claim.required());
+        Map<Object, Object> optionalKeys = memberKeys(claim.optional());
+        return selected -> {
+            Map<Object, Object> selectedKeys = new LinkedHashMap<>();
+            for (Object value : selected) {
+                selectedKeys.putIfAbsent(SetElements.key(value), value);
+            }
+            List<Object> missing = new ArrayList<>();
+            requiredKeys.forEach((key, member) -> {
+                if (!selectedKeys.containsKey(key)) {
+                    missing.add(member);
+                }
+            });
+            long present = optionalKeys.keySet().stream().filter(selectedKeys::containsKey).count();
+            List<Object> extras = new ArrayList<>();
+            selectedKeys.forEach((key, value) -> {
+                if (!requiredKeys.containsKey(key) && !optionalKeys.containsKey(key)) {
+                    extras.add(value);
+                }
+            });
+            List<String> parts = new ArrayList<>();
+            if (!missing.isEmpty()) {
+                parts.add("missing required: " + memberDisplay(missing));
+            }
+            if (present < claim.minPresent()) {
+                parts.add("optional members present " + present + " of "
+                        + claim.optional().size() + " (min-present " + claim.minPresent() + ")");
+            }
+            if (claim.refuseExtras() && !extras.isEmpty()) {
+                parts.add("extras: " + memberDisplay(extras));
+            }
+            return parts.isEmpty() ? null : "set-of: " + String.join("; ", parts);
+        };
     }
 
-    /**
-     * Strict JSON-value equality as a type-tagged key: numbers compare
-     * numerically (decimal), strings exactly, booleans and null by
-     * identity — a number never equals its string spelling.
-     */
-    private static Object elementKey(Object value) {
-        if (value instanceof Boolean) {
-            return List.of("bool", value);
+    /** The declared members by element key, insertion order kept for display. */
+    private static Map<Object, Object> memberKeys(List<Object> members) {
+        Map<Object, Object> keys = new LinkedHashMap<>();
+        for (Object member : members) {
+            keys.putIfAbsent(SetElements.key(member), member);
         }
-        if (value == null) {
-            return "null";
-        }
-        if (value instanceof Number) {
-            return List.of("num", NumericValue.of(value).stripTrailingZeros());
-        }
-        return List.of("str", String.valueOf(value));
+        return keys;
+    }
+
+    /** A bounded member listing for reasons: the first few, the rest counted. */
+    private static String memberDisplay(List<Object> members) {
+        int limit = 3;
+        String shown = members.stream()
+                .limit(limit)
+                .map(Display::of)
+                .collect(Collectors.joining(", "));
+        int remainder = members.size() - limit;
+        return remainder <= 0 ? shown : shown + " (+" + remainder + " more)";
     }
 
     // ── String forms ──────────────────────────────────────────────
@@ -638,8 +684,23 @@ final class CriteriaCompiler {
         if (form.path() != null) {
             description.append(form.path()).append(' ');
         }
-        description.append(form.form().key()).append(' ').append(Display.of(form.argument()));
+        description.append(form.form().key()).append(' ').append(argumentDisplay(form));
         return description.toString();
+    }
+
+    /**
+     * The form's operand for a check name: the composite claim as its
+     * summary arithmetic — never a raw record dump — everything else
+     * bounded verbatim.
+     */
+    private static String argumentDisplay(FormDeclaration form) {
+        if (form.argument() instanceof SetOfDeclaration claim) {
+            return "(" + claim.required().size() + " required, "
+                    + claim.optional().size() + " optional, min-present "
+                    + claim.minPresent()
+                    + (claim.refuseExtras() ? "" : ", extras allowed") + ")";
+        }
+        return Display.of(form.argument());
     }
 
     static final class Display {

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
@@ -21,6 +21,7 @@ import org.mavai.punit.decl.internal.model.InputDeclaration;
 import org.mavai.punit.decl.spi.MediaKind;
 import org.mavai.punit.decl.spi.MessageParts;
 import org.mavai.punit.decl.internal.model.PostconditionForm;
+import org.mavai.punit.decl.internal.model.SetOfDeclaration;
 
 @DisplayName("Contract-file parser")
 class ContractParserTest {
@@ -983,6 +984,155 @@ class ContractParserTest {
                             %s
                     inputs: ["Alice"]
                     """.formatted(form);
+        }
+    }
+
+    @Nested
+    @DisplayName("graded set claim")
+    class GradedSetClaim {
+
+        @Test
+        @DisplayName("the composite form parses to its normalised declaration")
+        void parsesAndNormalises() {
+            java.io.PrintStream stderr = System.err;
+            var captured = new java.io.ByteArrayOutputStream();
+            SetOfDeclaration claim;
+            try {
+                System.setErr(new java.io.PrintStream(captured));
+                ContractDeclaration declaration = ContractParser.parse(withDocForm("""
+                        set-of:
+                              required: ["Hauptgebäude"]
+                              optional: ["Nebengebäude", "Anbau", "Nebengebäude"]
+                              min-present: "50%"
+                        """));
+                claim = (SetOfDeclaration) declaration.criteria().get(0)
+                        .forms().get(0).argument();
+            } finally {
+                System.setErr(stderr);
+            }
+            assertThat(claim.required()).containsExactly("Hauptgebäude");
+            // Membership semantics: the duplicate collapses to one entry —
+            // with a console warning, never a refusal.
+            assertThat(claim.optional()).containsExactly("Nebengebäude", "Anbau");
+            assertThat(captured.toString())
+                    .contains("warning:")
+                    .contains("more than once");
+            // "50%" of 2 distinct optional members, by floor.
+            assertThat(claim.minPresent()).isEqualTo(1);
+            // Omission keeps the strictest reading.
+            assertThat(claim.refuseExtras()).isTrue();
+        }
+
+        @Test
+        @DisplayName("a shared member is a contradiction, refused by name")
+        void listsOverlap() {
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          optional: ["Hauptgebäude", "Anbau"]
+                    """), "appears in both `required:` and `optional:`");
+        }
+
+        @Test
+        @DisplayName("an unsatisfiable or saturated min-present floor is refused")
+        void minPresentBounds() {
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          optional: ["Nebengebäude", "Anbau"]
+                          min-present: 3
+                    """), "exceeds the `optional:` list's distinct size");
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          optional: ["Nebengebäude", "Anbau"]
+                          min-present: 2
+                    """), "every optional member is required; move them to `required:`");
+        }
+
+        @Test
+        @DisplayName("a malformed min-present is refused — a bare fraction is never guessed at")
+        void minPresentMalformed() {
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          optional: ["Nebengebäude", "Anbau"]
+                          min-present: 0.8
+                    """), "a bare fraction is never guessed at");
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          optional: ["Nebengebäude", "Anbau"]
+                          min-present: -1
+                    """), "non-negative whole count");
+        }
+
+        @Test
+        @DisplayName("a spelling a sharper form owns is refused naming that form")
+        void sharperFormRefusals() {
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                    """), "states `equals-set:` — say that");
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          refuse-extras: false
+                    """), "states `contains-set:` — say that");
+        }
+
+        @Test
+        @DisplayName("a vacuous or malformed composite is refused")
+        void structuralRefusals() {
+            assertRefused(withDocForm("set-of: []"), "`set-of:` takes a mapping");
+            assertRefused(withDocForm("""
+                    set-of:
+                          min-present: 1
+                    """), "`set-of:` states nothing");
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          optional: ["Anbau"]
+                          members: ["x"]
+                    """), "unknown key `members:`");
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: []
+                          optional: ["Anbau"]
+                    """), "`required:` takes a non-empty list of scalar values");
+            assertRefused(withDocForm("""
+                    set-of:
+                          required: ["Hauptgebäude"]
+                          optional: ["Anbau"]
+                          refuse-extras: "yes"
+                    """), "`refuse-extras:` takes a boolean");
+        }
+
+        /**
+         * The minimal contract around one postcondition form. A composite
+         * form spans lines; continuation lines are re-indented as direct
+         * sub-keys of the form key, whatever their spelling here.
+         */
+        private static String withDocForm(String form) {
+            String[] lines = form.strip().split("\n");
+            StringBuilder block = new StringBuilder(lines[0].strip());
+            for (int i = 1; i < lines.length; i++) {
+                block.append("\n          ").append(lines[i].strip());
+            }
+            return """
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    transforms:
+                      doc: json
+                    criteria:
+                      - threshold: 0.9
+                        postconditions:
+                          - in: doc
+                            path: "$.buildings[*].name"
+                            %s
+                    inputs: ["Alice"]
+                    """.formatted(block.toString());
         }
     }
 

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -155,6 +155,27 @@ class DeclaredRunTest {
         }
 
         @Test
+        @DisplayName("the graded set claim judges membership — a set is a set")
+        void annotatorStatesTheGradedSet() {
+            // Required membership, distinct-optional floors (count and
+            // percent-by-floor), extras refused by default, a duplicated
+            // subject element as one member present.
+            assertThatCode(() ->
+                    PUnit.declared("annotator-states-the-graded-set").assertPasses())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("a graded set claim falling short fails per sample")
+        void annotatorMissesTheGradedSet() {
+            // A missing required member and an undeclared extra — the
+            // stated arithmetic fails every trial.
+            Declared run = PUnit.declared("annotator-misses-the-graded-set").samples(30);
+            assertThatThrownBy(run::assertPasses)
+                    .isInstanceOf(AssertionFailedError.class);
+        }
+
+        @Test
         @DisplayName("the boolean form judges JSON true/false by identity")
         void annotatorFlagsCoverage() {
             assertThatCode(() ->

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/graded-set-miss.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/graded-set-miss.yaml
@@ -1,0 +1,17 @@
+format: mavai-contract/1
+contract: annotator-misses-the-graded-set
+service: buildings-annotator
+transforms:
+  doc: json
+criteria:
+  - name: annotated-sets-fall-short-of-the-claim
+    threshold: 0.9
+    postconditions:
+      - in: doc
+        path: "$.buildings[*].name"
+        set-of:
+          required: ["Verwaltungsgebäude"]
+          optional: ["Hauptgebäude", "Anbau"]
+          min-present: 1
+inputs:
+  - "annotate the sample lease"

--- a/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/graded-set.yaml
+++ b/punit-decl/src/test/resources/org/mavai/punit/decl/internal/run/graded-set.yaml
@@ -1,0 +1,23 @@
+format: mavai-contract/1
+contract: annotator-states-the-graded-set
+service: buildings-annotator
+transforms:
+  doc: json
+criteria:
+  - name: annotated-sets-hold-as-graded-claims
+    threshold: 0.9
+    postconditions:
+      - in: doc
+        path: "$.buildings[*].name"
+        set-of:
+          required: ["Hauptgebäude"]
+          optional: ["Nebengebäude", "Anbau"]
+          min-present: 1
+      - in: doc
+        path: "$.tenants[*].name"
+        set-of:
+          required: ["Muster AG"]
+          optional: ["Beispiel GmbH", "Dritte AG"]
+          min-present: "50%"
+inputs:
+  - "annotate the sample lease"


### PR DESCRIPTION
Parity item 3 of the baseltest-parity programme — the punit twin of baseltest#85 (orchestrator directives `DIR-PU-FORMS-set-of`, `DIR-PU-DA-baseltest-parity`). Spec: MAVAI-CONTRACT-FORMAT "Graded set claims" (2026-07-29); corpus reference: mavai-R v0.10.4.

- **One composite form, `set-of:`** — `required:`/`optional:` member lists, `min-present:` floor over the distinct optional members (count, or `"N%"` by floor; a bare fraction refused), `refuse-extras:` defaulting **true**.
- **Membership semantics — a set is a set**: declared lists and the selection judged as sets; an operand duplicate collapses with a load-time console warning (never a refusal); a duplicated subject element is one member present, never an extra. Element identity is the family's strict JSON-value rule, moved to a shared `SetElements` and reused by the sharp multiset forms unchanged.
- **The full refusal battery** in author vocabulary: required∩optional contradiction (named member), unsatisfiable/saturated `min-present`, sharper-form reductions ("states `equals-set:`/`contains-set:` — say that"), vacuous claim, unknown keys, malformed floor, non-boolean `refuse-extras:`.
- **Textual-only reporting (v1 owner ruling)**: the failure reason states the arithmetic — missing required members, present-versus-floor, extras — each list bounded; check names carry a summary, never a record dump.
- The operand normalises at parse to `SetOfDeclaration`; the compiler consumes it without re-validating.

Blast radius: 11 files, +550 (6 main, 4 test, CHANGELOG) — parser + compiler only; no emission, schema, or core surface touched. Unit tests mirror the v0.10.4 corpus categories until the Phase 6 conformance gate consumes the corpus directly. Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM