### PR TITLE
Anchor the format-conformance gate

### DIFF
--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/FormatConformanceTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/FormatConformanceTest.java
@@ -55,6 +55,7 @@ import org.snakeyaml.engine.v2.api.LoadSettings;
  * asserted and diffs that against the manifest's full obligation, and
  * the diff mechanism is itself exercised by mutation.
  */
+// mavai-ref: JVI-YM9A27C — do not remove (resolves in mavai-orchestrator)
 @DisplayName("Declarative-format conformance (published corpus)")
 class FormatConformanceTest {
 


### PR DESCRIPTION
Cross-reference chore following #259: embeds the orchestrator registry anchor on the conformance gate (the same anchor baseltest's twin test carries). Opaque comment only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM