### PR TITLE
Named path anchors: roots, @-references, and prompt files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Named path anchors (declarative contracts and services).** The
+  optional top-level `roots:` block declares directory anchors once
+  per file — names to relative directories, resolved against the
+  declaring file — and every file-referencing position may reach
+  through one with `@<name>/…` instead of a `../../..` hop-chain (a
+  literal `@`-initial filename is spelled `./@…`; a reference that
+  climbs out of its anchor is refused). The `mavai.root.<name>` system
+  property, then the `MAVAI_ROOT_<NAME>` environment variable,
+  replaces a declared value entirely — the machine-local channel.
+  Roots are per-file namespaces. The services format gains its first
+  file-referencing position, `system-prompt: {file: <path>}`, resolved
+  to the plain string before the type sees the configuration —
+  baseline and exploration deltas alike — so identity, provenance,
+  and the steppers see the prompt exactly as if written inline.
+  Identity is untouched by construction: file inputs fingerprint by
+  content, never by path. Per the family amendment (2026-07-29;
+  conformance corpus mavai-R v0.10.5 — the gate's known-unmet ledger
+  is empty again).
+
 ### Changed
 
 - **Exploration output is laid out by swept keys.** Each EXPLORE run

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/ServicesDeclaration.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/model/ServicesDeclaration.java
@@ -14,7 +14,10 @@ import java.util.Map;
  * @param sourcePath the file the definitions were loaded from, or
  *     {@code null} when parsed from text
  */
-public record ServicesDeclaration(Map<String, ServiceEntry> services, Path sourcePath) {
+public record ServicesDeclaration(
+        Map<String, ServiceEntry> services,
+        Path sourcePath,
+        org.mavai.punit.decl.internal.parser.Roots roots) {
 
     /** The format identifier this declaration parses from. */
     public static final String FORMAT_IDENTIFIER = "mavai-services/1";

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
@@ -40,7 +40,7 @@ public final class ContractParser {
 
     private static final Set<String> TOP_LEVEL_KEYS = Set.of(
             "format", "contract", "service", "transforms", "inputs", "criteria",
-            "intent", "confidence", "latency");
+            "intent", "confidence", "latency", "roots");
     private static final Set<String> RESERVED_TOP_LEVEL = Set.of("facets", "covariates", "budget");
 
     private ContractParser() {}
@@ -73,7 +73,12 @@ public final class ContractParser {
 
         Map<String, String> views = parseTransforms(data);
         Path baseDir = sourcePath != null ? sourcePath.getParent() : null;
-        List<InputDeclaration> inputs = InputsParser.parse(data.get("inputs"), views, baseDir);
+        // Named path anchors: resolve the block before inputs parse (the
+        // file-referencing positions consume it), refuse dead
+        // declarations after (usage coherence is a whole-file property).
+        Roots roots = Roots.parse(data.get("roots"), baseDir, "the contract file");
+        List<InputDeclaration> inputs = InputsParser.parse(data.get("inputs"), views, baseDir, roots);
+        roots.refuseDead();
 
         Object criteriaValue = data.get("criteria");
         if (!(criteriaValue instanceof List<?> entries) || entries.isEmpty()) {

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/InputsParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/InputsParser.java
@@ -33,7 +33,8 @@ final class InputsParser {
 
     private InputsParser() {}
 
-    static List<InputDeclaration> parse(Object value, Map<String, String> views, Path baseDir) {
+    static List<InputDeclaration> parse(Object value, Map<String, String> views, Path baseDir,
+            Roots roots) {
         if (!(value instanceof List<?> entries) || entries.isEmpty()) {
             throw fail("`inputs:` must be a non-empty list");
         }
@@ -46,7 +47,7 @@ final class InputsParser {
                     && mapping.keySet().stream().map(String::valueOf).collect(Collectors.toSet())
                             .equals(Set.of("input", "expected"))) {
                 Map<String, Object> pair = requireMapping(entry, where);
-                Object inputValue = normalised(pair.get("input"), where, baseDir);
+                Object inputValue = normalised(pair.get("input"), where, baseDir, roots);
                 String expectedWhere = "expected for input '" + display(inputValue) + "'";
                 Object expected = pair.get("expected");
                 List<?> expectedEntries = expected instanceof Map<?, ?> single
@@ -66,7 +67,7 @@ final class InputsParser {
                 }
                 inputs.add(new InputDeclaration(inputValue, forms));
             } else {
-                inputs.add(InputDeclaration.bare(normalised(entry, where, baseDir)));
+                inputs.add(InputDeclaration.bare(normalised(entry, where, baseDir, roots)));
             }
         }
         return inputs;
@@ -77,12 +78,12 @@ final class InputsParser {
      * tuple), a file-sourced part, or a list of parts (an ordered
      * multimodal message; a single-part list is the bare part).
      */
-    private static Object normalised(Object entry, String where, Path baseDir) {
+    private static Object normalised(Object entry, String where, Path baseDir, Roots roots) {
         if (isScalar(entry)) {
             return entry;
         }
         if (entry instanceof Map<?, ?>) {
-            return part(requireMapping(entry, where), where, baseDir);
+            return part(requireMapping(entry, where), where, baseDir, roots);
         }
         if (entry instanceof List<?> list) {
             if (list.isEmpty()) {
@@ -94,7 +95,7 @@ final class InputsParser {
             if (list.stream().allMatch(item -> item instanceof Map<?, ?>)) {
                 List<Object> parts = new ArrayList<>();
                 for (Object item : list) {
-                    parts.add(part(requireMapping(item, where), where, baseDir));
+                    parts.add(part(requireMapping(item, where), where, baseDir, roots));
                 }
                 return parts.size() == 1 ? parts.get(0) : new MessageParts(parts);
             }
@@ -106,7 +107,8 @@ final class InputsParser {
     }
 
     /** A single-key input part mapping — text or a media reference. */
-    private static Object part(Map<String, Object> mapping, String where, Path baseDir) {
+    private static Object part(Map<String, Object> mapping, String where, Path baseDir,
+            Roots roots) {
         if (mapping.size() != 1) {
             String keys = mapping.keySet().stream().sorted().collect(Collectors.joining(", "));
             throw fail(where + ": an input part is a single-key mapping (" + PART_KEYS + "), got "
@@ -117,14 +119,14 @@ final class InputsParser {
         String key = single.getKey();
         Object value = single.getValue();
         if (key.equals("text")) {
-            return textPart(value, where, baseDir);
+            return textPart(value, where, baseDir, roots);
         }
         MediaKind kind = MediaKind.forKey(key);
         if (kind != null) {
             if (!(value instanceof String rawPath) || rawPath.isEmpty()) {
                 throw fail(where + ": `" + key + ":` is a file path string");
             }
-            Resolved resolved = resolveAndRead(rawPath, where, baseDir);
+            Resolved resolved = resolveAndRead(rawPath, where, baseDir, roots);
             return new FileInput(resolved.path(), kind, resolved.data());
         }
         throw fail(where + ": unknown input part `" + key + ":` — a part is one of " + PART_KEYS
@@ -132,7 +134,7 @@ final class InputsParser {
     }
 
     /** A {@code text:} part — an inline string, or {@code {file: <path>}} decoded as UTF-8 text. */
-    private static String textPart(Object value, String where, Path baseDir) {
+    private static String textPart(Object value, String where, Path baseDir, Roots roots) {
         if (value instanceof String text) {
             return text;
         }
@@ -140,7 +142,7 @@ final class InputsParser {
                 && reference.size() == 1
                 && reference.containsKey("file")
                 && reference.get("file") instanceof String rawPath) {
-            Resolved resolved = resolveAndRead(rawPath, where, baseDir);
+            Resolved resolved = resolveAndRead(rawPath, where, baseDir, roots);
             try {
                 return StandardCharsets.UTF_8.newDecoder()
                         .decode(java.nio.ByteBuffer.wrap(resolved.data()))
@@ -159,12 +161,19 @@ final class InputsParser {
      * and reads it — resolution is never against the working directory,
      * and a file that cannot be read is a load-time authoring error.
      */
-    private static Resolved resolveAndRead(String rawPath, String where, Path baseDir) {
-        if (baseDir == null) {
-            throw fail(where + ": a file-sourced input needs a contract loaded from disk to "
-                    + "resolve '" + rawPath + "' relative to it");
+    private static Resolved resolveAndRead(String rawPath, String where, Path baseDir,
+            Roots roots) {
+        Path rooted = roots.resolve(rawPath, where);
+        Path resolved;
+        if (rooted != null) {
+            resolved = rooted;
+        } else {
+            if (baseDir == null) {
+                throw fail(where + ": a file-sourced input needs a contract loaded from disk to "
+                        + "resolve '" + rawPath + "' relative to it");
+            }
+            resolved = baseDir.resolve(rawPath).normalize();
         }
-        Path resolved = baseDir.resolve(rawPath).normalize();
         try {
             return new Resolved(resolved, Files.readAllBytes(resolved));
         } catch (IOException error) {

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/Roots.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/Roots.java
@@ -1,0 +1,170 @@
+package org.mavai.punit.decl.internal.parser;
+
+import static org.mavai.punit.decl.internal.parser.Yaml.fail;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+/**
+ * Named path anchors — the {@code roots:} block both declarative
+ * loaders share. A file declares directory anchors once
+ * ({@code roots: {corpus: ../shared}}), and every file-referencing
+ * position may reach through one with {@code @<name>/…} instead of
+ * encoding the file's own location into a {@code ../../..} hop-chain.
+ * Roots are per-file: the contract file's and the services file's
+ * roots are independent namespaces — nothing shared, inherited, or
+ * discovered upward.
+ *
+ * <p>The override channel replaces a declared value entirely and may
+ * be absolute — the machine-local channel, which keeps committed files
+ * portable. Per punit's configuration tier it is the
+ * {@code mavai.root.<name>} system property first, then the family's
+ * {@code MAVAI_ROOT_<NAME>} environment variable; read once per file
+ * load, never per sample.
+ *
+ * <p>Identity is untouched by design: file-sourced inputs fingerprint
+ * by content, never by path — a root changes only the path resolution
+ * ahead of the read.
+ */
+public final class Roots {
+
+    private static final Pattern NAME = Pattern.compile("^[a-z][a-z0-9-]*$");
+    private static final Pattern DRIVE_ABSOLUTE = Pattern.compile("^[A-Za-z]:[/\\\\].*");
+
+    /** name → (resolved directory, declared value, overridden). */
+    private final Map<String, Anchor> anchors;
+    private final String fileWhat;
+    private final Set<String> used = new LinkedHashSet<>();
+
+    private record Anchor(Path resolved, String declared, boolean overridden) {}
+
+    private Roots(Map<String, Anchor> anchors, String fileWhat) {
+        this.anchors = anchors;
+        this.fileWhat = fileWhat;
+    }
+
+    /** No block declared: every reference through {@code @} refuses as undeclared. */
+    public static Roots none(String fileWhat) {
+        return new Roots(Map.of(), fileWhat);
+    }
+
+    /**
+     * Validates a {@code roots:} block and resolves each anchor —
+     * refusals surface at load, zero samples.
+     */
+    public static Roots parse(Object block, Path baseDir, String fileWhat) {
+        if (block == null) {
+            return none(fileWhat);
+        }
+        if (!(block instanceof Map<?, ?> mapping) || mapping.isEmpty()) {
+            throw fail(fileWhat + ": `roots:` must be a non-empty mapping of root names to "
+                    + "relative directory paths — omit the block to declare no roots");
+        }
+        if (baseDir == null) {
+            throw fail(fileWhat + ": `roots:` needs a file loaded from disk — the anchors "
+                    + "resolve relative to the declaring file's directory");
+        }
+        Map<String, Anchor> anchors = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : mapping.entrySet()) {
+            String name = String.valueOf(entry.getKey());
+            if (!NAME.matcher(name).matches()) {
+                throw fail(fileWhat + ": root name '" + name + "' must match "
+                        + "[a-z][a-z0-9-]* — lower-case, digits, hyphens");
+            }
+            if (!(entry.getValue() instanceof String declared) || declared.isEmpty()) {
+                throw fail(fileWhat + ": root `" + name + ":` declares no directory — its "
+                        + "value is a non-empty relative path");
+            }
+            if (isAbsolute(declared)) {
+                throw fail(fileWhat + ": root `" + name + ":` is absolute (" + declared
+                        + ") — a declared root is relative to the declaring file; an "
+                        + "absolute location is the " + overrideVariable(name)
+                        + " override's job");
+            }
+            String override = override(name);
+            boolean overridden = override != null;
+            String effective = overridden ? override : declared;
+            Path resolved = (Path.of(effective).isAbsolute()
+                    ? Path.of(effective)
+                    : baseDir.resolve(effective)).normalize().toAbsolutePath();
+            if (!java.nio.file.Files.isDirectory(resolved)) {
+                throw fail(fileWhat + ": root `" + name + ":` resolves to " + resolved
+                        + ", which is not an existing directory"
+                        + (overridden ? " (via " + overrideVariable(name) + ")" : ""));
+            }
+            anchors.put(name, new Anchor(resolved, declared, overridden));
+        }
+        return new Roots(anchors, fileWhat);
+    }
+
+    /**
+     * The absolute location a {@code @<name>/…} reference names, or
+     * {@code null} when the path is not a root reference (a literal
+     * {@code @}-initial filename is written {@code ./@…}).
+     */
+    public Path resolve(String rawPath, String where) {
+        if (!rawPath.startsWith("@")) {
+            return null;
+        }
+        int separator = rawPath.indexOf('/');
+        String name = separator < 0 ? rawPath.substring(1) : rawPath.substring(1, separator);
+        String remainder = separator < 0 ? "" : rawPath.substring(separator + 1);
+        if (remainder.isEmpty()) {
+            throw fail(where + ": `" + rawPath + "` — a root is a directory; reference a "
+                    + "file within it (`@" + name + "/<path>`)");
+        }
+        Anchor anchor = anchors.get(name);
+        if (anchor == null) {
+            String declared = anchors.isEmpty()
+                    ? "none"
+                    : String.join(", ", new TreeSet<>(anchors.keySet()));
+            throw fail(where + ": `@" + name + "/` references an undeclared root — "
+                    + fileWhat + " declares: " + declared);
+        }
+        Path resolved = anchor.resolved().resolve(remainder).normalize();
+        if (!resolved.startsWith(anchor.resolved())) {
+            throw fail(where + ": `" + rawPath + "` escapes its root — the reference "
+                    + "resolves above `" + name + ":`; a path below the root needs no "
+                    + "`..` climbing, and one above it belongs to a different root");
+        }
+        used.add(name);
+        return resolved;
+    }
+
+    /**
+     * A declared root referenced by nothing in the file is a dead
+     * declaration — most likely a leftover; remove it.
+     */
+    public void refuseDead() {
+        for (String name : anchors.keySet()) {
+            if (!used.contains(name)) {
+                throw fail(fileWhat + ": root `" + name + ":` is declared but referenced "
+                        + "by nothing in the file — remove the dead declaration");
+            }
+        }
+    }
+
+    private static String override(String name) {
+        String property = System.getProperty("mavai.root." + name);
+        if (property != null) {
+            return property;
+        }
+        return System.getenv(overrideVariable(name));
+    }
+
+    private static String overrideVariable(String name) {
+        return "MAVAI_ROOT_" + name.toUpperCase(java.util.Locale.ROOT).replace('-', '_');
+    }
+
+    private static boolean isAbsolute(String value) {
+        return Path.of(value).isAbsolute()
+                || value.startsWith("/")
+                || value.startsWith("\\")
+                || DRIVE_ABSOLUTE.matcher(value).matches();
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ServicesParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ServicesParser.java
@@ -57,11 +57,17 @@ public final class ServicesParser {
                     + data.get("format") + "'");
         }
         for (String key : data.keySet()) {
-            if (!key.equals("format") && !key.equals("services")) {
+            if (!key.equals("format") && !key.equals("roots") && !key.equals("services")) {
                 throw fail("the services file has unknown key `" + key + ":` — it holds "
-                        + "`format:` and the `services:` block, nothing else");
+                        + "`format:`, an optional `roots:` block, and the `services:` "
+                        + "block, nothing else");
             }
         }
+        // Named path anchors — the services file's own namespace, never a
+        // contract's. References resolve in the resolver (where the type's
+        // file-capable keys are known); dead declarations refuse there too.
+        Roots roots = Roots.parse(data.get("roots"),
+                sourcePath != null ? sourcePath.getParent() : null, "the services file");
         Object servicesValue = data.get("services");
         if (!(servicesValue instanceof Map<?, ?> raw) || raw.isEmpty()) {
             throw fail("`services:` must be a non-empty mapping");
@@ -74,7 +80,7 @@ public final class ServicesParser {
             }
             services.put(name, definition(name, requireMapping(entry.getValue(), "service '" + name + "'")));
         }
-        return new ServicesDeclaration(services, sourcePath);
+        return new ServicesDeclaration(services, sourcePath, roots);
     }
 
     /** Reads and parses a services file from disk. */

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
@@ -66,9 +66,15 @@ final class ServicesResolver {
         }
         ServicesDeclaration declaration = discover(caller, explicitFile);
         if (declaration != null) {
+            Path baseDir = declaration.sourcePath() != null
+                    ? declaration.sourcePath().getParent()
+                    : null;
             for (ServiceEntry entry : declaration.services().values()) {
-                resolver.configure(entry);
+                resolver.configure(entry, declaration.roots(), baseDir);
             }
+            // Usage coherence is a whole-file property: a declared root
+            // referenced by nothing is a dead declaration.
+            declaration.roots().refuseDead();
         }
         return resolver;
     }
@@ -130,7 +136,8 @@ final class ServicesResolver {
         return types.isEmpty() ? "none registered" : String.join(", ", new TreeMap<>(types).keySet());
     }
 
-    private void configure(ServiceEntry entry) {
+    private void configure(ServiceEntry entry,
+            org.mavai.punit.decl.internal.parser.Roots roots, Path baseDir) {
         ServiceType type = types.get(entry.type());
         if (type == null) {
             throw new ContractConfigurationException(
@@ -139,12 +146,85 @@ final class ServicesResolver {
                             + "ship via their module; user types are registered in the bindings "
                             + "class with @BindingFactory(\"" + entry.type() + "\"))");
         }
+        entry = withResolvedFileValues(entry, type, roots, baseDir);
         configured.put(entry.name(), posture == Posture.STRICT
                 ? type.configure(entry.name(), entry.configuration())
                 : type.explorePoint(entry.name(), entry.configuration()).service());
         entries.put(entry.name(), entry);
         validateExplorations(entry, type);
         validateOptimizations(entry, type);
+    }
+
+    /**
+     * The {@code {file: <path>}} values a type admits, resolved to plain
+     * strings — root references included, the file read once at load,
+     * decoded UTF-8 — before the type parses the configuration, so
+     * covariates, fingerprints, and steppers see the string exactly as
+     * if written inline (resolved-as-used). Baseline configuration and
+     * exploration deltas alike.
+     */
+    private static ServiceEntry withResolvedFileValues(ServiceEntry entry, ServiceType type,
+            org.mavai.punit.decl.internal.parser.Roots roots, Path baseDir) {
+        java.util.List<String> keys = type.fileValueKeys();
+        if (keys.isEmpty()) {
+            return entry;
+        }
+        Map<String, Object> configuration = resolvedFileValues(
+                entry.name(), entry.configuration(), keys, "configuration", roots, baseDir);
+        java.util.List<Map<String, Object>> explorations = new java.util.ArrayList<>();
+        int index = 0;
+        for (Map<String, Object> deltas : entry.explorations()) {
+            index++;
+            explorations.add(resolvedFileValues(
+                    entry.name(), deltas, keys, "exploration entry " + index, roots, baseDir));
+        }
+        return new ServiceEntry(
+                entry.name(), entry.type(), configuration, explorations, entry.optimizations());
+    }
+
+    private static Map<String, Object> resolvedFileValues(String name,
+            Map<String, Object> mapping, java.util.List<String> keys, String where,
+            org.mavai.punit.decl.internal.parser.Roots roots, Path baseDir) {
+        Map<String, Object> resolved = new LinkedHashMap<>(mapping);
+        for (String key : keys) {
+            Object value = resolved.get(key);
+            if (!(value instanceof Map<?, ?> reference)) {
+                continue;
+            }
+            String location = "service '" + name + "': " + where + ": `" + key + ":`";
+            if (reference.size() != 1
+                    || !(reference.get("file") instanceof String rawPath)
+                    || rawPath.isEmpty()) {
+                throw new ContractConfigurationException(location + " file form is "
+                        + "`{file: <path>}` with a non-empty path and no other key");
+            }
+            Path rooted = roots.resolve(rawPath, location);
+            Path file;
+            if (rooted != null) {
+                file = rooted;
+            } else if (baseDir == null) {
+                throw new ContractConfigurationException(location + ": a `{file:}` value "
+                        + "needs a services file loaded from disk to resolve '" + rawPath
+                        + "' relative to it");
+            } else {
+                file = baseDir.resolve(rawPath).normalize();
+            }
+            byte[] data;
+            try {
+                data = java.nio.file.Files.readAllBytes(file);
+            } catch (java.io.IOException error) {
+                throw new ContractConfigurationException(location + ": cannot read file "
+                        + file + ": " + error.getMessage(), error);
+            }
+            try {
+                resolved.put(key, java.nio.charset.StandardCharsets.UTF_8.newDecoder()
+                        .decode(java.nio.ByteBuffer.wrap(data)).toString());
+            } catch (java.nio.charset.CharacterCodingException error) {
+                throw new ContractConfigurationException(location + ": file " + file
+                        + " is not valid UTF-8 text: " + error, error);
+            }
+        }
+        return resolved;
     }
 
     /**

--- a/punit-decl/src/main/java/org/mavai/punit/decl/spi/ServiceType.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/spi/ServiceType.java
@@ -20,6 +20,18 @@ public interface ServiceType {
     String name();
 
     /**
+     * Configuration keys whose value may be the {@code {file: <path>}}
+     * form — resolved by the services loader (root references included,
+     * the file read once at load, decoded UTF-8) before this type sees
+     * the configuration, so identity, provenance, and the steppers see
+     * the plain resolved string (resolved-as-used). Empty by default:
+     * a type opts its keys in.
+     */
+    default java.util.List<String> fileValueKeys() {
+        return java.util.List.of();
+    }
+
+    /**
      * Validates a definition's complete {@code configuration:} record
      * against this type's schema and returns the configured, invocable
      * service. Runs at contract-load time — a misfit throws (an

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/parser/ContractParserTest.java
@@ -1137,6 +1137,124 @@ class ContractParserTest {
     }
 
     @Nested
+    @DisplayName("named path anchors")
+    class NamedPathAnchors {
+
+        private Path writeTree(Path directory) throws IOException {
+            Files.createDirectories(directory.resolve("shared"));
+            Files.writeString(directory.resolve("shared/note.txt"), "the note");
+            Path contract = directory.resolve("contract.yaml");
+            Files.writeString(contract, """
+                    format: mavai-contract/1
+                    contract: reads-the-corpus
+                    service: reader
+                    roots:
+                      corpus: ./shared
+                    criteria:
+                      - threshold: 0.9
+                        matches: '\\w'
+                    inputs:
+                      - - text: { file: "@corpus/note.txt" }
+                    """);
+            return contract;
+        }
+
+        @Test
+        @DisplayName("a root reference reads through the anchor")
+        void rootReferenceReads(@TempDir Path directory) throws IOException {
+            ContractDeclaration declaration = ContractParser.parse(
+                    Files.readString(writeTree(directory)), directory.resolve("contract.yaml"));
+            assertThat(declaration.inputs().get(0).value()).isEqualTo("the note");
+        }
+
+        @Test
+        @DisplayName("a literal @-filename is spelled ./@")
+        void literalAtFilename(@TempDir Path directory) throws IOException {
+            Files.writeString(directory.resolve("@note.txt"), "at-note");
+            Path contract = directory.resolve("contract.yaml");
+            Files.writeString(contract, """
+                    format: mavai-contract/1
+                    contract: c
+                    service: s
+                    criteria:
+                      - threshold: 0.9
+                        matches: '\\w'
+                    inputs:
+                      - - text: { file: "./@note.txt" }
+                    """);
+            ContractDeclaration declaration =
+                    ContractParser.parse(Files.readString(contract), contract);
+            assertThat(declaration.inputs().get(0).value()).isEqualTo("at-note");
+        }
+
+        @Test
+        @DisplayName("a reference climbing out of its root is refused")
+        void escapeRefused(@TempDir Path directory) throws IOException {
+            Path contract = writeTree(directory);
+            Files.writeString(directory.resolve("secret.txt"), "outside");
+            String text = Files.readString(contract)
+                    .replace("@corpus/note.txt", "@corpus/../secret.txt");
+            assertThatThrownBy(() -> ContractParser.parse(text, contract))
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("escapes its root");
+        }
+
+        @Test
+        @DisplayName("the property override wins and must resolve to a directory")
+        void overridePrecedence(@TempDir Path directory) throws IOException {
+            Path contract = writeTree(directory);
+            Path copy = directory.resolve("detached");
+            Files.createDirectories(copy);
+            Files.writeString(copy.resolve("note.txt"), "the note");
+            System.setProperty("mavai.root.corpus", copy.toString());
+            try {
+                ContractDeclaration declaration =
+                        ContractParser.parse(Files.readString(contract), contract);
+                // Identity is content-borne: the override points at a copy,
+                // and the input value is byte-identical.
+                assertThat(declaration.inputs().get(0).value()).isEqualTo("the note");
+
+                System.setProperty("mavai.root.corpus",
+                        directory.resolve("missing").toString());
+                assertThatThrownBy(() -> ContractParser.parse(Files.readString(contract), contract))
+                        .isInstanceOf(ContractConfigurationException.class)
+                        .hasMessageContaining("not an existing directory")
+                        .hasMessageContaining("MAVAI_ROOT_CORPUS");
+            } finally {
+                System.clearProperty("mavai.root.corpus");
+            }
+        }
+
+        @Test
+        @DisplayName("an ambient override naming no declared root is ignored")
+        void ambientOverrideIgnored(@TempDir Path directory) throws IOException {
+            System.setProperty("mavai.root.elsewhere", "/nowhere/at/all");
+            try {
+                ContractDeclaration declaration = ContractParser.parse(
+                        Files.readString(writeTree(directory)),
+                        directory.resolve("contract.yaml"));
+                assertThat(declaration.inputs().get(0).value()).isEqualTo("the note");
+            } finally {
+                System.clearProperty("mavai.root.elsewhere");
+            }
+        }
+
+        @Test
+        @DisplayName("a relocated contract and corpus read identical content")
+        void relocationPreservesContent(@TempDir Path first, @TempDir Path second)
+                throws IOException {
+            ContractDeclaration a = ContractParser.parse(
+                    Files.readString(writeTree(first)), first.resolve("contract.yaml"));
+            ContractDeclaration b = ContractParser.parse(
+                    Files.readString(writeTree(second)), second.resolve("contract.yaml"));
+            // A file-sourced input contributes its content, never its path
+            // — the two locations produce byte-identical input values, so
+            // every content-derived identity downstream agrees.
+            assertThat(a.inputs().get(0).value()).isEqualTo(b.inputs().get(0).value());
+        }
+    }
+
+    @Nested
     @DisplayName("transform refusals")
     class TransformRefusals {
 

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/FormatConformanceTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/FormatConformanceTest.java
@@ -88,10 +88,6 @@ class FormatConformanceTest {
         }
     }
 
-    private static final String ROOTS_PENDING =
-            "named path anchors (`roots:`) — family amendment 2026-07-29 "
-                    + "(DIR-FAM-ROOTS-named-path-anchors), punit twin not yet executed";
-
     /**
      * category → a fragment of THIS reader's refusal message.
      * Informational by the manifest's contract (categories bind, wording
@@ -145,6 +141,12 @@ class FormatConformanceTest {
             Map.entry("is-null-operand", "takes the literal `true`"),
             Map.entry("set-operand-empty", "non-empty list of scalar values"),
             Map.entry("is-operand-not-boolean", "`is:` takes a boolean"),
+            Map.entry("roots-block-malformed", "`roots:` must be a non-empty mapping"),
+            Map.entry("roots-name-shape", "must match [a-z][a-z0-9-]*"),
+            Map.entry("roots-value-malformed", "root `corpus:`"),
+            Map.entry("roots-reference-undeclared", "references an undeclared root"),
+            Map.entry("roots-dead-declaration", "referenced by nothing in the file"),
+            Map.entry("roots-directory-missing", "not an existing directory"),
             Map.entry("set-of-without-optional", "— say that"),
             Map.entry("set-of-min-present-malformed", "a bare fraction is never guessed at"),
             Map.entry("set-of-lists-overlap", "in both `required:` and `optional:`"),
@@ -182,7 +184,9 @@ class FormatConformanceTest {
             Map.entry("exploration-duplicate-point", "distinct covariate point"),
             Map.entry("optimization-duplicate-id", "is already used"),
             Map.entry("optimization-id-required-when-multiple", "`id:` is required when"),
-            Map.entry("optimization-initial-restates-baseline", "merely restates"));
+            Map.entry("optimization-initial-restates-baseline", "merely restates"),
+            Map.entry("lm-system-prompt-file-malformed", "file form is `{file: <path>}`"),
+            Map.entry("services-roots-reference-undeclared", "references an undeclared root"));
 
     /**
      * The known-unmet ledger — corpus obligations this reader does not
@@ -190,20 +194,10 @@ class FormatConformanceTest {
      * ledger case is asserted <em>inverted</em>: the day the reader
      * starts meeting the obligation, its test fails and the entry must
      * be removed — the ledger only shrinks, truthfully. Never add an
-     * entry without a directive reference.
+     * entry without a directive reference. Empty since the named-path-
+     * anchors twin landed.
      */
-    private static final Map<String, String> KNOWN_UNMET = Map.ofEntries(
-            Map.entry("contract-roots.yaml", ROOTS_PENDING),
-            Map.entry("services-roots-prompt-file.yaml", ROOTS_PENDING),
-            Map.entry("roots-block-empty.yaml", ROOTS_PENDING),
-            Map.entry("roots-name-shape.yaml", ROOTS_PENDING),
-            Map.entry("roots-value-empty.yaml", ROOTS_PENDING),
-            Map.entry("roots-value-absolute.yaml", ROOTS_PENDING),
-            Map.entry("roots-reference-undeclared.yaml", ROOTS_PENDING),
-            Map.entry("roots-dead-declaration.yaml", ROOTS_PENDING),
-            Map.entry("roots-directory-missing.yaml", ROOTS_PENDING),
-            Map.entry("lm-system-prompt-file-malformed.yaml", ROOTS_PENDING),
-            Map.entry("services-roots-reference-undeclared.yaml", ROOTS_PENDING));
+    private static final Map<String, String> KNOWN_UNMET = Map.of();
 
     // ── The drive ─────────────────────────────────────────────────
 

--- a/punit-lm/src/main/java/org/mavai/punit/lm/LanguageModelServiceType.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/LanguageModelServiceType.java
@@ -31,6 +31,14 @@ public final class LanguageModelServiceType implements ServiceType {
     }
 
     @Override
+    public List<String> fileValueKeys() {
+        // The services format's first file-referencing position: the
+        // system prompt (a long tuned prompt lives in a file, not a
+        // YAML block scalar).
+        return List.of("system-prompt");
+    }
+
+    @Override
     public ConfiguredService configure(String serviceName, Map<String, Object> configuration) {
         LanguageModelParameters parameters =
                 ParameterValidation.validated(serviceName, configuration);


### PR DESCRIPTION
The punit DA11 twin (orchestrator directive `DIR-PU-ROOTS-named-path-anchors`; family amendment 2026-07-29; reference realisation baseltest#89). Spec: MAVAI-CONTRACT-FORMAT Part I *Named path anchors*, MAVAI-SERVICES-FORMAT Part I / §II.3.

## What ships

- **`roots:` in both loaders** — named directory anchors, per-file namespaces, declared relative to the declaring file. One parser-owned `Roots` class holds validation, `@<name>/` resolution with containment (escaping the anchor refuses; `./@…` spells a literal `@`-filename), used-name tracking (dead declarations refuse), and the override.
- **Override channel, punit's tier**: `mavai.root.<name>` system property first, then the family's `MAVAI_ROOT_<NAME>` — mirroring the `mavai.llm.*` precedent; ambient overrides naming no declared root are ignored; an override must still resolve to a directory (refusal names the variable).
- **`system-prompt: {file: <path>}`** — the services format's first file-referencing position. The `ServiceType` SPI grows an **additive default** `fileValueKeys()` (the exported-SPI pin is unaffected); punit-lm's language-model type opts in `system-prompt`, and `ServicesResolver` resolves the file form (root references included, UTF-8, read once at load) to the plain string **before** the type parses the configuration — baseline and exploration deltas alike — so covariates, fingerprints, and the prompt-engineer stepper see it exactly as if written inline (resolved-as-used).
- **The conformance ledger empties**: all eleven v0.10.5 roots cases now meet their binding obligations; the eight new categories join the message map; the gate is green with `KNOWN_UNMET = Map.of()` — exactly the red-to-green the gate was built for.
- **Edge tests** beyond the corpus: containment, the `./@` spelling, override precedence + missing-directory refusal, ambient-override neutrality, relocation content-identity.

## Recorded deviation

punit baselines carry no free-form provenance map, so the family's roots-disclosure obligation (declared value + overridden flag in emitted provenance) has no punit slot today — deferred to the declarative programme's honest-output review (Phase 6/DA04) rather than inventing a baseline-format field here. Noted in the directive.

Blast radius: 11 files, +~400. Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM