### PR TITLE
Anchor the named-path-anchors class

### DIFF
--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/Roots.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/Roots.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
  * by content, never by path — a root changes only the path resolution
  * ahead of the read.
  */
+// mavai-ref: JVI-W9D0VWD — do not remove (resolves in mavai-orchestrator)
 public final class Roots {
 
     private static final Pattern NAME = Pattern.compile("^[a-z][a-z0-9-]*$");


### PR DESCRIPTION
Cross-reference chore following #262: embeds the orchestrator registry anchor on the roots class — the same anchor baseltest's twin module carries. Opaque comment only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM