### PR TITLE
The check verb: zero-sample validation and the mavaiCheck task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **The `mavaiCheck` task — zero-sample contract validation.** The
+  authoring loop's compile step: `./gradlew mavaiCheck` scans the test
+  resource roots for `mavai-contract/1` files and validates every
+  load-time join — parse, views, selection expressions, criteria, the
+  service definition's strict configuration, the per-input admission
+  gate, the exploration grid, the declared optimizations — without
+  invoking anything, resolving each contract's conventional
+  `MavaiBindings` class when present. One line per validated fact; the
+  first failing join fails the task with the same refusal a run would
+  give. Includes the **stale-artefact advisory**: exploration artefacts
+  no current grid point writes are named (with a multi-vintage note),
+  never deleted. The entry point is `ContractCheck.run`, public for
+  programmatic use.
+
 - **Named path anchors (declarative contracts and services).** The
   optional top-level `roots:` block declares directory anchors once
   per file — names to relative directories, resolved against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Graduation: the `mavaiMaterialise` task.** For each declared
+  contract, emits the equivalent contract as Java source the developer
+  owns — the same criteria, thresholds, and declaration order,
+  expressed against punit's authoring surface, with a stub invocation
+  (graduation transfers invocation ownership) and TODOs where the
+  reader's private machinery — selection engines, registered
+  predicates, views — becomes the developer's own code. One-shot
+  scaffolding under `build/punit/materialised/`: nothing round-trips.
+  The emitted source compiles cleanly against punit-core (asserted by
+  test). Entry point `ContractMaterialise.run`.
+
 - **The `mavaiCheck` task — zero-sample contract validation.** The
   authoring loop's compile step: `./gradlew mavaiCheck` scans the test
   resource roots for `mavai-contract/1` files and validates every

--- a/punit-core/src/main/java/module-info.java
+++ b/punit-core/src/main/java/module-info.java
@@ -36,6 +36,8 @@ module org.mavai.punit.core {
     //    consumers.
     exports org.mavai.punit.internal.engine.emit
         to org.mavai.punit.report;
+    exports org.mavai.punit.internal.engine.explore
+        to org.mavai.punit.decl;
     exports org.mavai.punit.internal.reporting
         to org.mavai.punit.report,
            org.mavai.punit.sentinel;

--- a/punit-decl/src/main/java/org/mavai/punit/decl/ContractCheck.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/ContractCheck.java
@@ -1,0 +1,50 @@
+package org.mavai.punit.decl;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * The check verb — validate a declared contract's every load-time join
+ * with zero samples: the authoring loop's compile step, and the
+ * {@code mavaiCheck} Gradle task's entry point.
+ *
+ * <p>Loads the contract file, resolves the conventional bindings class
+ * (when one exists on the classpath) and the {@code mavai-services.yaml}
+ * beside the contract, and constructs everything a run would construct —
+ * views, selection expressions, criteria, the service's strict
+ * configuration, the per-input admission gate, the exploration grid,
+ * the declared optimizations — without invoking anything. A missing
+ * baseline is not checked: absence is a run-time fact, not a
+ * configuration defect.
+ *
+ * <p>Returns one line per validated fact, including the stale-artefact
+ * advisory (exploration artefacts no current grid point writes —
+ * named, never deleted). The first failing join throws
+ * {@link ContractConfigurationException} with the same refusal a run
+ * would give.
+ */
+public final class ContractCheck {
+
+    private ContractCheck() {}
+
+    /**
+     * Checks one contract file.
+     *
+     * @param contractFile the contract file on disk
+     * @param bindingsClassName the fully-qualified bindings class to
+     *     resolve code registrations against, or {@code null} for none;
+     *     a named class absent from the classpath is noted, not refused
+     *     — the conventional name is a convention, not a requirement
+     * @param explorationsDir the explorations output directory the
+     *     stale-artefact advisory scans (the convention path is
+     *     {@code build/punit/explorations})
+     * @return one line per validated fact
+     * @throws ContractConfigurationException on the first failing join,
+     *     with the same refusal a run would give
+     */
+    public static List<String> run(Path contractFile, String bindingsClassName,
+            Path explorationsDir) {
+        return org.mavai.punit.decl.internal.run.ContractChecker.check(
+                contractFile, bindingsClassName, explorationsDir);
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/ContractMaterialise.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/ContractMaterialise.java
@@ -1,0 +1,39 @@
+package org.mavai.punit.decl;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Graduation — emit the equivalent contract as Java source the
+ * developer owns: the {@code mavaiMaterialise} Gradle task's entry
+ * point. The emitted class is the contract the contract file
+ * instantiates — same criteria, same thresholds, same declaration
+ * order — expressed against punit's authoring surface, with a stub
+ * invocation (graduation transfers invocation ownership) and TODOs
+ * where the reader's private machinery (selection engines, registered
+ * predicates, views) becomes the developer's own code. One-shot
+ * scaffolding: nothing round-trips.
+ */
+public final class ContractMaterialise {
+
+    private ContractMaterialise() {}
+
+    /** Renders the contract file as a standalone Java class's source. */
+    public static String run(Path contractFile) {
+        String text;
+        try {
+            text = Files.readString(contractFile);
+        } catch (IOException error) {
+            throw new UncheckedIOException(error);
+        }
+        return org.mavai.punit.decl.internal.run.Materialiser.materialise(
+                org.mavai.punit.decl.internal.parser.ContractParser.parse(text, contractFile));
+    }
+
+    /** The emitted class's simple name for a contract id — names the file. */
+    public static String className(String contractId) {
+        return org.mavai.punit.decl.internal.run.Materialiser.typeName(contractId);
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ContractChecker.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ContractChecker.java
@@ -1,0 +1,190 @@
+package org.mavai.punit.decl.internal.run;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+import org.mavai.punit.api.FactorBundle;
+import org.mavai.punit.decl.ContractConfigurationException;
+import org.mavai.punit.decl.internal.model.ContractDeclaration;
+import org.mavai.punit.decl.internal.model.InputDeclaration;
+import org.mavai.punit.decl.internal.parser.ContractParser;
+import org.mavai.punit.decl.spi.ConfiguredService;
+import org.mavai.punit.internal.engine.explore.ExploreOutputWriter;
+
+/**
+ * The check verb: validate every load-time join with zero samples —
+ * the authoring loop's compile step. Loads the contract, resolves the
+ * bindings class and the services file, and runs every load-time join
+ * (views, selection expressions, criteria, service configuration, the
+ * per-input admission gate) exactly as a run would, without invoking
+ * anything. A missing baseline is not checked: absence is a run-time
+ * fact, not a configuration defect.
+ *
+ * <p>Returns one line per validated fact; the first failing join
+ * throws with the same refusal a run would give. The stale-artefact
+ * advisory names exploration artefacts no current grid point writes —
+ * grid contraction within unchanged swept keys strands points, and the
+ * pre-flight names what it sees, deleting nothing (the artefact tree
+ * is regenerable working output, operator-owned).
+ */
+public final class ContractChecker {
+
+    private ContractChecker() {}
+
+    /** The empty-registry stand-in when no bindings class exists. */
+    static final class NoBindings {}
+
+    public static List<String> check(Path contractFile, String bindingsClassName, Path explorationsDir) {
+        String text;
+        try {
+            text = Files.readString(contractFile);
+        } catch (IOException error) {
+            throw new ContractConfigurationException(
+                    "cannot read contract file " + contractFile + ": " + error.getMessage(),
+                    error);
+        }
+        ContractDeclaration declaration = ContractParser.parse(text, contractFile);
+        List<String> facts = new ArrayList<>();
+        facts.add("contract '" + declaration.contract() + "': "
+                + declaration.criteria().size() + " criteria, "
+                + declaration.inputs().size() + " inputs");
+
+        BindingsRegistry registry = registry(bindingsClassName, facts);
+        StockViews views = new StockViews(declaration, registry);
+        CriteriaCompiler compiler = new CriteriaCompiler(
+                declaration, views, new AtomicReference<>(), Map.of(), null, registry);
+        compiler.validateEagerly();
+        compiler.compile();
+
+        Path servicesFile = contractFile.getParent() != null
+                && Files.isRegularFile(contractFile.getParent().resolve("mavai-services.yaml"))
+                ? contractFile.getParent().resolve("mavai-services.yaml")
+                : null;
+        // The facade class anchors conventional discovery: its package
+        // carries no resources, so with no file beside the contract the
+        // lookup falls through to the project root — nearest first,
+        // never this module's own internals.
+        ServicesResolver services = ServicesResolver.resolve(
+                org.mavai.punit.decl.ContractCheck.class, servicesFile, registry,
+                ServicesResolver.Posture.STRICT);
+        String serviceName = declaration.service();
+        if (services.isDefined(serviceName)) {
+            ConfiguredService configured = services.lookup(serviceName);
+            for (InputDeclaration input : declaration.inputs()) {
+                configured.admit(input.value());
+            }
+            facts.add("service '" + serviceName + "': definition configured strictly, "
+                    + "every input admitted");
+            List<Map<String, Object>> grid = services.explorationGrid(serviceName);
+            if (grid.size() > 1) {
+                int entries = grid.size() - 1;
+                facts.add("exploration grid: " + entries
+                        + (entries == 1 ? " entry" : " entries") + " constructed and joined");
+            }
+            // Explore artefacts land under the contract's own id — the
+            // declarative explore contract is named by the contract file.
+            facts.addAll(staleArtefactAdvisory(declaration.contract(), grid, explorationsDir));
+            int optimizations = services.optimizations(serviceName).size();
+            if (optimizations > 0) {
+                facts.add("optimizations: " + optimizations
+                        + (optimizations == 1 ? " entry" : " entries") + " validated");
+            }
+        } else if (registry.hasBinding(serviceName)) {
+            facts.add("service '" + serviceName + "': bare code binding resolved");
+        } else {
+            throw new ContractConfigurationException(
+                    "service '" + serviceName + "' resolves to nothing — no "
+                            + "mavai-services.yaml definition and no @Binding of that name "
+                            + "(registered types: " + services.registeredTypeNames() + ")");
+        }
+        return List.copyOf(facts);
+    }
+
+    private static BindingsRegistry registry(String bindingsClassName, List<String> facts) {
+        if (bindingsClassName == null) {
+            return BindingsRegistry.of(NoBindings.class);
+        }
+        try {
+            return BindingsRegistry.of(Class.forName(
+                    bindingsClassName, false, ContractChecker.class.getClassLoader()));
+        } catch (ClassNotFoundException absent) {
+            // The conventional name is a convention, not a requirement:
+            // a contract whose service lives entirely in the services
+            // file needs no bindings class at all.
+            facts.add("no bindings class '" + bindingsClassName
+                    + "' — code registrations unavailable to this check");
+            return BindingsRegistry.of(NoBindings.class);
+        }
+    }
+
+    /**
+     * Names artefacts in the active experiment directory that no
+     * current grid point writes, plus a multi-vintage note — advisory
+     * only, never deletion.
+     */
+    private static List<String> staleArtefactAdvisory(String serviceContractId,
+            List<Map<String, Object>> grid, Path explorationsDir) {
+        ExploreOutputWriter writer = new ExploreOutputWriter();
+        List<FactorBundle> bundles = grid.stream().map(FactorBundle::of).toList();
+        Path active = explorationsDir
+                .resolve(serviceContractId)
+                .resolve(writer.experimentDirectory(bundles));
+        if (!Files.isDirectory(active)) {
+            return List.of();
+        }
+        Set<String> currentStems = new LinkedHashSet<>();
+        for (FactorBundle bundle : bundles) {
+            currentStems.add(writer.filenameFor(bundle));
+        }
+        List<String> advisories = new ArrayList<>();
+        Set<String> vintages = new TreeSet<>();
+        try (var artefacts = Files.list(active)) {
+            for (Path artefact : artefacts.sorted().toList()) {
+                String name = artefact.getFileName().toString();
+                if (!name.endsWith(".yaml")) {
+                    continue;
+                }
+                String vintage = generatedDate(artefact);
+                if (vintage != null) {
+                    vintages.add(vintage);
+                }
+                if (!currentStems.contains(name.substring(0, name.length() - ".yaml".length()))) {
+                    advisories.add("stale: " + name
+                            + " — no current grid point resolves to this configuration");
+                }
+            }
+        } catch (IOException error) {
+            throw new ContractConfigurationException(
+                    "cannot scan explorations directory " + active + ": " + error.getMessage(),
+                    error);
+        }
+        if (vintages.size() > 1) {
+            advisories.add("note: artefacts span " + vintages.size() + " run vintages ("
+                    + String.join(", ", vintages) + ")");
+        }
+        return advisories;
+    }
+
+    /** The artefact's generation date (the timestamp's date part), or null. */
+    private static String generatedDate(Path artefact) {
+        try {
+            for (String line : Files.readAllLines(artefact)) {
+                if (line.startsWith("generatedAt:")) {
+                    String stamp = line.substring("generatedAt:".length()).strip()
+                            .replace("\"", "").replace("'", "");
+                    return stamp.length() >= 10 ? stamp.substring(0, 10) : null;
+                }
+            }
+        } catch (IOException unreadable) {
+            return null;
+        }
+        return null;
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/Materialiser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/Materialiser.java
@@ -1,0 +1,169 @@
+package org.mavai.punit.decl.internal.run;
+
+import java.util.List;
+import java.util.Map;
+import org.mavai.punit.decl.internal.model.ContractDeclaration;
+import org.mavai.punit.decl.internal.model.CriterionDeclaration;
+import org.mavai.punit.decl.internal.model.FormDeclaration;
+import org.mavai.punit.decl.internal.model.SetOfDeclaration;
+
+/**
+ * Graduation: emit the equivalent contract as Java source the developer
+ * owns. The emitted class is the contract the contract file
+ * instantiates — the same criteria, thresholds, and declaration order —
+ * expressed directly against punit's authoring surface. One-shot
+ * scaffolding: after materialising, the source is the developer's;
+ * nothing round-trips. Graduation transfers ownership deliberately:
+ * the invocation is a stub (the binding was the reader's), and
+ * path-qualified checks carry a TODO directing the developer to their
+ * own selection library (the JSONPath/XPath engines are private to the
+ * reader).
+ */
+public final class Materialiser {
+
+    private Materialiser() {}
+
+    public static String materialise(ContractDeclaration declaration) {
+        String className = typeName(declaration.contract());
+        StringBuilder out = new StringBuilder();
+        out.append("// Materialised from the contract file declaring '")
+                .append(declaration.contract()).append("'.\n")
+                .append("// This is now your code. The contract file instantiated exactly\n")
+                .append("// this contract; edit it freely — the declarative surface is no\n")
+                .append("// longer involved.\n\n");
+        out.append("import static org.mavai.punit.api.criterion.Criteria.*;\n\n");
+        out.append("import org.mavai.outcome.Outcome;\n");
+        out.append("import org.mavai.punit.api.NoFactors;\n");
+        out.append("import org.mavai.punit.api.ServiceContract;\n");
+        out.append("import org.mavai.punit.api.TokenTracker;\n");
+        out.append("import org.mavai.punit.api.criterion.Criteria;\n\n");
+        out.append("public final class ").append(className)
+                .append(" implements ServiceContract<NoFactors, String, String> {\n\n");
+        out.append("    @Override\n    public String id() {\n        return \"")
+                .append(declaration.contract()).append("\";\n    }\n\n");
+        out.append("    @Override\n")
+                .append("    public Outcome<String> invoke(String input, TokenTracker tracker) {\n")
+                .append("        // TODO: your service call — the contract file used the "
+                        + "binding '")
+                .append(declaration.service()).append("'.\n")
+                .append("        throw new UnsupportedOperationException(\"graduate the "
+                        + "invocation\");\n    }\n\n");
+        out.append("    @Override\n    public Criteria<String> criteria() {\n");
+        if (!declaration.transforms().isEmpty()) {
+            for (Map.Entry<String, String> view : declaration.transforms().entrySet()) {
+                out.append("        // TODO: view '").append(view.getKey())
+                        .append("' was the reader's ").append(view.getValue())
+                        .append(" transformation — express it with .transforming(...) and\n")
+                        .append("        // your own parser; a failed transform returns "
+                                + "Outcome.fail.\n");
+            }
+        }
+        List<CriterionDeclaration> criteria = declaration.criteria();
+        if (criteria.size() == 1) {
+            out.append("        return ").append(criterionSource(criteria.get(0), "                "))
+                    .append(";\n");
+        } else {
+            out.append("        return Criteria.<String>of(\n");
+            for (int i = 0; i < criteria.size(); i++) {
+                out.append("                ")
+                        .append(criterionSource(criteria.get(i), "                        "));
+                out.append(i < criteria.size() - 1 ? ",\n" : "\n");
+            }
+            out.append("        );\n");
+        }
+        out.append("    }\n}\n");
+        return out.toString();
+    }
+
+    private static String criterionSource(CriterionDeclaration criterion, String indent) {
+        StringBuilder out = new StringBuilder();
+        // The explicit witness pins the chain's subject type — chained
+        // generic calls are not poly expressions, so inference cannot
+        // reach back from the enclosing of(...).
+        out.append(criterion.threshold() != null
+                ? "meeting().<String>passRate(" + criterion.threshold() + ")"
+                : "empirical().<String>passRate()");
+        if (criterion.name() != null) {
+            out.append("\n").append(indent).append(".name(\"")
+                    .append(escape(criterion.name())).append("\")");
+        }
+        for (FormDeclaration form : criterion.forms()) {
+            out.append("\n").append(indent).append(formSource(form, indent));
+        }
+        if (criterion.optionalSlack() != null) {
+            var slack = criterion.optionalSlack();
+            out.append("\n").append(indent).append(".optionalSlack(")
+                    .append(slack.count() != null
+                            ? String.valueOf(slack.count())
+                            : "\"" + slack.display() + "\"")
+                    .append(")");
+        }
+        return out.toString();
+    }
+
+    private static String formSource(FormDeclaration form, String indent) {
+        String key = form.form().key();
+        String base;
+        if (form.form() == org.mavai.punit.decl.internal.model.PostconditionForm.PARSES) {
+            base = "// TODO: `parses: " + form.argument() + "` — forcing your view's "
+                    + "computation is the check";
+            return base;
+        } else if (form.form() == org.mavai.punit.decl.internal.model.PostconditionForm.SATISFIES) {
+            base = ".satisfies(\"" + escape(String.valueOf(form.argument()))
+                    + "\", response -> Outcome.ok()) // TODO: inline your registered "
+                    + "'" + form.argument() + "' predicate";
+        } else if (form.argument() instanceof SetOfDeclaration claim) {
+            base = ".satisfies(\"" + key + "\", response -> Outcome.ok()) // TODO: the "
+                    + "graded set claim (" + claim.required().size() + " required, "
+                    + claim.optional().size() + " optional, min-present "
+                    + claim.minPresent() + ") — judge the selection with your own "
+                    + "collection code";
+        } else {
+            base = ".satisfies(\"" + key + " " + escape(display(form.argument()))
+                    + "\", response -> Outcome.ok()) // TODO: judge `" + key + ": "
+                    + display(form.argument()) + "`";
+        }
+        if (form.optional()) {
+            base += "\n" + indent + ".optional()";
+        }
+        if (form.path() != null) {
+            base = ".satisfies(\"" + key + " at " + escape(form.path())
+                    + "\", response -> Outcome.ok()) // TODO: `path: " + form.path()
+                    + "` in view '" + form.view() + "' — select with your JSONPath/XPath "
+                    + "library of choice, then judge `" + key + ": "
+                    + display(form.argument()) + "`"
+                    + (form.optional() ? "\n" + indent + ".optional()" : "");
+        }
+        return base;
+    }
+
+    private static String display(Object argument) {
+        String text = String.valueOf(argument);
+        return text.length() <= 40 ? text : text.substring(0, 37) + "...";
+    }
+
+    private static String escape(String text) {
+        return text.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    /** The contract id as a Java type name: kebab-case to UpperCamel + suffix. */
+    public static String typeName(String contractId) {
+        StringBuilder name = new StringBuilder();
+        boolean upper = true;
+        for (char c : contractId.toCharArray()) {
+            if (c == '-' || c == '_' || c == '.') {
+                upper = true;
+            } else {
+                name.append(upper ? Character.toUpperCase(c) : c);
+                upper = false;
+            }
+        }
+        if (name.length() == 0) {
+            name.append("Materialised");
+        }
+        if (Character.isDigit(name.charAt(0))) {
+            name.insert(0, "Contract");
+        }
+        return name.append("ServiceContract").toString();
+    }
+}

--- a/punit-decl/src/test/java/org/mavai/punit/decl/ContractCheckTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/ContractCheckTest.java
@@ -1,0 +1,128 @@
+package org.mavai.punit.decl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("The check verb — zero-sample load validation")
+class ContractCheckTest {
+
+    private static final String BINDINGS =
+            "org.mavai.punit.decl.internal.run.MavaiBindings";
+
+    private Path writeContract(Path directory, String service) throws IOException {
+        Path contract = directory.resolve("contract.yaml");
+        Files.writeString(contract, """
+                format: mavai-contract/1
+                contract: checked-contract
+                service: %s
+                criteria:
+                  - threshold: 0.9
+                    contains: "hello"
+                inputs: ["Alice", "Bob"]
+                """.formatted(service));
+        return contract;
+    }
+
+    @Test
+    @DisplayName("a bare code binding resolves and the facts state the joins")
+    void bareBindingResolves(@TempDir Path directory) throws IOException {
+        List<String> facts = ContractCheck.run(
+                writeContract(directory, "greeting-service"), BINDINGS,
+                directory.resolve("explorations"));
+        assertThat(facts).contains(
+                "contract 'checked-contract': 1 criteria, 2 inputs",
+                "service 'greeting-service': bare code binding resolved");
+    }
+
+    @Test
+    @DisplayName("a services definition configures strictly and admits every input")
+    void definitionConfigures(@TempDir Path directory) throws IOException {
+        Files.writeString(directory.resolve("mavai-services.yaml"), """
+                format: mavai-services/1
+                services:
+                  echoed:
+                    type: echo-model
+                    configuration:
+                      prefix: "hello"
+                    explorations:
+                      - prefix: "howdy"
+                      - prefix: "hey"
+                """);
+        List<String> facts = ContractCheck.run(
+                writeContract(directory, "echoed"), BINDINGS,
+                directory.resolve("explorations"));
+        assertThat(facts).contains(
+                "service 'echoed': definition configured strictly, every input admitted",
+                "exploration grid: 2 entries constructed and joined");
+    }
+
+    @Test
+    @DisplayName("an unresolvable service is refused with the run's own vocabulary")
+    void unresolvableServiceRefused(@TempDir Path directory) throws IOException {
+        Path contract = writeContract(directory, "nowhere-service");
+        assertThatThrownBy(() -> ContractCheck.run(contract, BINDINGS,
+                directory.resolve("explorations")))
+                .isInstanceOf(ContractConfigurationException.class)
+                .hasMessageContaining("resolves to nothing");
+    }
+
+    @Test
+    @DisplayName("a named-but-absent bindings class is noted, never refused")
+    void absentBindingsClassNoted(@TempDir Path directory) throws IOException {
+        Files.writeString(directory.resolve("mavai-services.yaml"), """
+                format: mavai-services/1
+                services:
+                  echoed:
+                    type: echo-model
+                    configuration:
+                      prefix: "hello"
+                """);
+        List<String> facts = ContractCheck.run(
+                writeContract(directory, "echoed"), "com.example.NoSuchBindings",
+                directory.resolve("explorations"));
+        assertThat(facts).anySatisfy(fact ->
+                assertThat(fact).contains("no bindings class 'com.example.NoSuchBindings'"));
+    }
+
+    @Test
+    @DisplayName("the stale-artefact advisory names strays and vintages, deletes nothing")
+    void staleArtefactAdvisory(@TempDir Path directory) throws IOException {
+        Files.writeString(directory.resolve("mavai-services.yaml"), """
+                format: mavai-services/1
+                services:
+                  echoed:
+                    type: echo-model
+                    configuration:
+                      prefix: "hello"
+                    explorations:
+                      - prefix: "howdy"
+                """);
+        // The active experiment directory: <contract-id>/<swept-keys>/.
+        // The current grid writes prefix-hello / prefix-howdy; a stray
+        // from a re-gridded sweep sits beside them.
+        Path active = directory.resolve("explorations")
+                .resolve("checked-contract").resolve("prefix");
+        Files.createDirectories(active);
+        Files.writeString(active.resolve("prefix-hello.yaml"),
+                "generatedAt: \"2026-07-28T10:00:00Z\"\n");
+        Files.writeString(active.resolve("prefix-bonjour.yaml"),
+                "generatedAt: \"2026-07-30T10:00:00Z\"\n");
+        List<String> facts = ContractCheck.run(
+                writeContract(directory, "echoed"), BINDINGS,
+                directory.resolve("explorations"));
+        assertThat(facts).contains(
+                "stale: prefix-bonjour.yaml — no current grid point resolves to this "
+                        + "configuration",
+                "note: artefacts span 2 run vintages (2026-07-28, 2026-07-30)");
+        // Advisory only: both artefacts are still on disk.
+        assertThat(active.resolve("prefix-bonjour.yaml")).exists();
+    }
+}

--- a/punit-decl/src/test/java/org/mavai/punit/decl/ContractMaterialiseTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/ContractMaterialiseTest.java
@@ -1,0 +1,91 @@
+package org.mavai.punit.decl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("Graduation — the source projection")
+class ContractMaterialiseTest {
+
+    private Path writeContract(Path directory) throws IOException {
+        Path contract = directory.resolve("contract.yaml");
+        Files.writeString(contract, """
+                format: mavai-contract/1
+                contract: basket-builder-returns-valid-baskets
+                service: basket-builder
+                transforms:
+                  basket: json
+                criteria:
+                  - name: baskets-parse-and-mention-eggs
+                    threshold: 0.9
+                    optional-slack: 1
+                    parses: basket
+                    postconditions:
+                      - contains: "egg"
+                      - in: basket
+                        path: "$.items[*].name"
+                        equals-set: ["egg", "milk"]
+                      - contains: "fresh"
+                        optional: true
+                  - name: never-rude
+                    threshold: 0.99
+                    not-equals: "go away"
+                inputs: ["a dozen eggs", "two bottles of milk"]
+                """);
+        return contract;
+    }
+
+    @Test
+    @DisplayName("the emitted source states the same claims in declaration order")
+    void emissionStatesTheClaims(@TempDir Path directory) throws IOException {
+        String source = ContractMaterialise.run(writeContract(directory));
+        assertThat(source)
+                .contains("public final class BasketBuilderReturnsValidBasketsServiceContract")
+                .contains("return \"basket-builder-returns-valid-baskets\";")
+                .contains("binding 'basket-builder'")
+                .contains("meeting().<String>passRate(0.9)")
+                .contains(".name(\"baskets-parse-and-mention-eggs\")")
+                .contains(".optionalSlack(1)")
+                .contains("meeting().<String>passRate(0.99)")
+                .contains(".optional()")
+                .contains("JSONPath/XPath");
+        // Graduation transfers ownership: the reader's internals never leak.
+        assertThat(source).doesNotContain("org.mavai.punit.decl");
+    }
+
+    @Test
+    @DisplayName("the emitted source compiles cleanly against punit's authoring surface")
+    void emissionCompiles(@TempDir Path directory) throws IOException {
+        String source = ContractMaterialise.run(writeContract(directory));
+        String className = ContractMaterialise.className("basket-builder-returns-valid-baskets");
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        JavaFileObject unit = new SimpleJavaFileObject(
+                URI.create("string:///" + className + ".java"),
+                JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return source;
+            }
+        };
+        var diagnostics = new javax.tools.DiagnosticCollector<JavaFileObject>();
+        boolean compiled = compiler.getTask(null, null, diagnostics,
+                List.of("-d", directory.resolve("classes").toString(),
+                        "-classpath", System.getProperty("java.class.path")),
+                null, List.of(unit)).call();
+        assertThat(compiled)
+                .as("emitted source compiles: " + diagnostics.getDiagnostics())
+                .isTrue();
+    }
+}

--- a/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
@@ -56,6 +56,9 @@ class DeclArchitectureTest {
                 // The check verb's entry point — deliberately public:
                 // the mavaiCheck Gradle task invokes it reflectively.
                 .orShould().haveSimpleName("ContractCheck")
+                // Graduation's entry point — deliberately public: the
+                // mavaiMaterialise Gradle task invokes it reflectively.
+                .orShould().haveSimpleName("ContractMaterialise")
                 .because("everything beyond the author surface is internal enablement — "
                         + "new public types belong under internal.* unless they are "
                         + "deliberately part of the authoring API");

--- a/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
@@ -53,6 +53,9 @@ class DeclArchitectureTest {
                 .orShould().haveSimpleName("Stepper")
                 .orShould().haveSimpleName("Scorer")
                 .orShould().haveSimpleName("ContractConfigurationException")
+                // The check verb's entry point — deliberately public:
+                // the mavaiCheck Gradle task invokes it reflectively.
+                .orShould().haveSimpleName("ContractCheck")
                 .because("everything beyond the author surface is internal enablement — "
                         + "new public types belong under internal.* unless they are "
                         + "deliberately part of the authoring API");

--- a/punit-gradle-plugin/src/functionalTest/kotlin/org/mavai/punit/gradle/PUnitPluginFunctionalTest.kt
+++ b/punit-gradle-plugin/src/functionalTest/kotlin/org/mavai/punit/gradle/PUnitPluginFunctionalTest.kt
@@ -66,6 +66,17 @@ class PUnitPluginFunctionalTest {
         }
 
         @Test
+        @DisplayName("mavaiCheck is registered and reports an empty contract scan")
+        fun mavaiCheckRegistered() {
+            buildFile.writeText(buildFileWithPlugin())
+
+            val result = runner("mavaiCheck").build()
+
+            assertTrue(result.output.contains(
+                "no mavai-contract/1 files under the test resource roots"))
+        }
+
+        @Test
         @DisplayName("experiment and exp tasks are registered")
         fun experimentTasksRegistered() {
             buildFile.writeText(buildFileWithPlugin())

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitCheckTask.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitCheckTask.kt
@@ -1,0 +1,111 @@
+package org.mavai.punit.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import java.lang.reflect.InvocationTargetException
+import java.net.URLClassLoader
+import java.nio.file.Path
+
+/**
+ * The `mavaiCheck` task: validates every declared contract's load-time
+ * joins with zero samples — the authoring loop's compile step, runnable
+ * without executing a single sample.
+ *
+ * Scans the test resource roots for `mavai-contract/1` files and drives
+ * punit-decl's check entry over each: parse, views, selection
+ * expressions, criteria, the service definition's strict configuration,
+ * the per-input admission gate, the exploration grid, the declared
+ * optimizations — plus the stale-artefact advisory naming exploration
+ * artefacts no current grid point writes (named, never deleted). Each
+ * contract's conventional bindings class (`<package>.MavaiBindings`,
+ * the package derived from the contract's location under its resource
+ * root) is resolved when present.
+ *
+ * Uses classpath isolation via [URLClassLoader] over the test runtime
+ * classpath — the same approach as the report tasks — so the consumer's
+ * bindings classes and service types resolve exactly as a test run
+ * would see them.
+ */
+@DisableCachingByDefault(because = "Validation is cheap and its value is the console output")
+abstract class PUnitCheckTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val contractFiles: ConfigurableFileCollection
+
+    /** The test resource roots — a contract's package derives from its location under one. */
+    @get:Input
+    abstract val resourceRoots: ListProperty<String>
+
+    @get:Input
+    abstract val explorationsRootPath: Property<String>
+
+    @get:Classpath
+    abstract val checkClasspath: ConfigurableFileCollection
+
+    @TaskAction
+    fun check() {
+        val contracts = contractFiles.files
+            .filter { it.isFile && it.name.endsWith(".yaml") && isContract(it) }
+            .sortedBy { it.absolutePath }
+        if (contracts.isEmpty()) {
+            logger.lifecycle("mavaiCheck: no mavai-contract/1 files under the test resource roots")
+            return
+        }
+        val urls = checkClasspath.files
+            .filter { it.exists() }
+            .map { it.toURI().toURL() }
+            .toTypedArray()
+        val classLoader = URLClassLoader(urls, ClassLoader.getSystemClassLoader())
+        try {
+            val entry = classLoader.loadClass("org.mavai.punit.decl.ContractCheck")
+            val run = entry.getMethod(
+                "run", Path::class.java, String::class.java, Path::class.java)
+            var failures = 0
+            for (contract in contracts) {
+                val bindingsClass = packageOf(contract)?.let { "$it.MavaiBindings" }
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    val facts = run.invoke(null, contract.toPath(), bindingsClass,
+                        Path.of(explorationsRootPath.get())) as List<String>
+                    logger.lifecycle("OK ${contract.name}")
+                    facts.forEach { logger.lifecycle("   $it") }
+                } catch (refusal: InvocationTargetException) {
+                    failures++
+                    logger.error("REFUSED ${contract.name}: ${refusal.cause?.message}")
+                }
+            }
+            if (failures > 0) {
+                throw GradleException(
+                    "mavaiCheck: $failures contract file(s) refused — see the messages above")
+            }
+        } finally {
+            classLoader.close()
+        }
+    }
+
+    private fun isContract(file: File): Boolean =
+        file.useLines { lines -> lines.take(20).any { it.trim() == "format: mavai-contract/1" } }
+
+    /** The package a contract's location under its resource root implies, or null. */
+    private fun packageOf(contract: File): String? {
+        for (root in resourceRoots.get()) {
+            val rootFile = File(root)
+            if (contract.absolutePath.startsWith(rootFile.absolutePath + File.separator)) {
+                val relative = contract.parentFile.relativeTo(rootFile).path
+                if (relative.isEmpty()) {
+                    return null
+                }
+                return relative.replace(File.separatorChar, '.')
+            }
+        }
+        return null
+    }
+}

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitMaterialiseTask.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitMaterialiseTask.kt
@@ -1,0 +1,72 @@
+package org.mavai.punit.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.*
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Path
+
+/**
+ * The `mavaiMaterialise` task: graduation's source projection. For each
+ * `mavai-contract/1` file under the test resource roots, emits the
+ * equivalent contract as Java source the developer owns — same
+ * criteria, same thresholds, a stub invocation, TODOs where the
+ * reader's private machinery becomes the developer's code — under
+ * `build/punit/materialised/`. One-shot scaffolding: the output is a
+ * starting point to copy into the source tree, never compiled by the
+ * build and never round-tripped.
+ */
+@DisableCachingByDefault(because = "One-shot scaffolding; the output is a starting point, not a build artefact")
+abstract class PUnitMaterialiseTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val contractFiles: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @get:Classpath
+    abstract val materialiseClasspath: ConfigurableFileCollection
+
+    @TaskAction
+    fun materialise() {
+        val contracts = contractFiles.files
+            .filter { it.isFile && it.name.endsWith(".yaml") && isContract(it) }
+            .sortedBy { it.absolutePath }
+        if (contracts.isEmpty()) {
+            logger.lifecycle("mavaiMaterialise: no mavai-contract/1 files under the test resource roots")
+            return
+        }
+        val urls = materialiseClasspath.files
+            .filter { it.exists() }
+            .map { it.toURI().toURL() }
+            .toTypedArray()
+        val classLoader = URLClassLoader(urls, ClassLoader.getSystemClassLoader())
+        try {
+            val entry = classLoader.loadClass("org.mavai.punit.decl.ContractMaterialise")
+            val run = entry.getMethod("run", Path::class.java)
+            val className = entry.getMethod("className", String::class.java)
+            val target = outputDir.get().asFile
+            target.mkdirs()
+            for (contract in contracts) {
+                val source = run.invoke(null, contract.toPath()) as String
+                val id = contract.useLines { lines ->
+                    lines.first { it.startsWith("contract:") }.substringAfter(":").trim()
+                }
+                val file = File(target, "${className.invoke(null, id)}.java")
+                file.writeText(source)
+                logger.lifecycle("materialised ${contract.name} -> ${file.relativeTo(project.projectDir)}")
+            }
+        } finally {
+            classLoader.close()
+        }
+    }
+
+    private fun isContract(file: File): Boolean =
+        file.useLines { lines -> lines.take(20).any { it.trim() == "format: mavai-contract/1" } }
+}

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitPlugin.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitPlugin.kt
@@ -90,6 +90,7 @@ class PUnitPlugin : Plugin<Project> {
             registerExplorationReportTask(project, extension, reportConfig)
             registerOptimizationReportTask(project, extension, reportConfig)
             registerPUnitVerifyTask(project, reportConfig)
+            registerMavaiCheckTask(project, extension)
         }
     }
 
@@ -508,6 +509,26 @@ class PUnitPlugin : Plugin<Project> {
             optimizationFiles.from(rootPath.map { project.fileTree(it) { include("**/*.yaml") } })
             htmlDir.set(project.layout.buildDirectory.dir("reports/punit-optimizations/html"))
             reportClasspath.from(reportConfig)
+        }
+    }
+
+    private fun registerMavaiCheckTask(
+        project: Project,
+        extension: PUnitExperimentExtension
+    ) {
+        project.tasks.register("mavaiCheck", PUnitCheckTask::class.java).configure {
+            description = "Validates every declared contract's load-time joins with zero samples"
+            group = "verification"
+            val test = project.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets.getByName("test")
+            contractFiles.from(test.resources.srcDirs.map { dir ->
+                project.fileTree(dir) { include("**/*.yaml") }
+            })
+            resourceRoots.set(test.resources.srcDirs.map { it.absolutePath })
+            explorationsRootPath.set(extension.explorationsDir)
+            checkClasspath.from(test.runtimeClasspath)
+            dependsOn(project.tasks.named("testClasses"))
         }
     }
 

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitPlugin.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitPlugin.kt
@@ -91,6 +91,7 @@ class PUnitPlugin : Plugin<Project> {
             registerOptimizationReportTask(project, extension, reportConfig)
             registerPUnitVerifyTask(project, reportConfig)
             registerMavaiCheckTask(project, extension)
+            registerMavaiMaterialiseTask(project)
         }
     }
 
@@ -528,6 +529,22 @@ class PUnitPlugin : Plugin<Project> {
             resourceRoots.set(test.resources.srcDirs.map { it.absolutePath })
             explorationsRootPath.set(extension.explorationsDir)
             checkClasspath.from(test.runtimeClasspath)
+            dependsOn(project.tasks.named("testClasses"))
+        }
+    }
+
+    private fun registerMavaiMaterialiseTask(project: Project) {
+        project.tasks.register("mavaiMaterialise", PUnitMaterialiseTask::class.java).configure {
+            description = "Emits each declared contract as Java source the developer owns (graduation)"
+            group = "verification"
+            val test = project.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets.getByName("test")
+            contractFiles.from(test.resources.srcDirs.map { dir ->
+                project.fileTree(dir) { include("**/*.yaml") }
+            })
+            outputDir.set(project.layout.buildDirectory.dir("punit/materialised"))
+            materialiseClasspath.from(test.runtimeClasspath)
             dependsOn(project.tasks.named("testClasses"))
         }
     }

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitReportTask.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitReportTask.kt
@@ -1,6 +1,7 @@
 package org.mavai.punit.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.work.DisableCachingByDefault
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.*
@@ -12,6 +13,7 @@ import java.net.URLClassLoader
  * Uses classpath isolation via [URLClassLoader] to invoke [ReportGenerator]
  * from the punit-report module without a compile-time dependency.
  */
+@DisableCachingByDefault(because = "Cheap validation over local files; the value is the console output")
 abstract class PUnitReportTask : DefaultTask() {
 
     @get:InputDirectory

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitVerifyTask.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitVerifyTask.kt
@@ -1,6 +1,7 @@
 package org.mavai.punit.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.work.DisableCachingByDefault
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
@@ -18,6 +19,7 @@ import java.net.URLClassLoader
  * Wired into the `check` lifecycle so `./gradlew check` catches
  * verdict failures even when individual sample failures are suppressed.
  */
+@DisableCachingByDefault(because = "Cheap validation over local files; the value is the console output")
 abstract class PUnitVerifyTask : DefaultTask() {
 
     @get:Internal


### PR DESCRIPTION
First slice of the declarative programme's Phase 6 remainder (orchestrator directive `DIR-PU-DA-declarative-surface`; reference: baseltest's `basel check`). Graduation (DA03) and the honest-output review (DA04) follow as their own PRs.

- **`ContractCheck.run(contractFile, bindingsClassName, explorationsDir)`** — public entry; validates every load-time join with zero samples: parse, views, selection expressions, criteria compile, strict service configuration, the per-input admission gate, grid construction, optimizations. One line per validated fact; the first failing join throws the run's own refusal. A missing baseline is deliberately not checked (a run-time fact, not a configuration defect); a named-but-absent bindings class is noted, not refused.
- **Stale-artefact advisory** (the residual edge the swept-keys layout leaves — grid contraction within unchanged swept keys): names artefacts in the active experiment directory no current grid point writes, plus a multi-vintage note; deletes nothing. Stems and directory names come from the explore emitter's own derivation via a **targeted export** of `internal.engine.explore` to punit-decl — no re-implementation to drift.
- **`mavaiCheck` Gradle task**: scans test resource roots for `mavai-contract/1` files, derives each contract's conventional `MavaiBindings` from its package path, runs over the test runtime classpath (the report tasks' classloader-isolation pattern). Fails with a per-contract refusal listing.
- Housekeeping the plugin's `validatePlugins` demanded: caching annotations on the two pre-existing report/verify tasks.
- punit-decl's public-surface architecture pin extended by exactly `ContractCheck`.

Blast radius: 11 files. Full build + plugin functionalTest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwCM