### PR TITLE
Graduation: the source projection and the mavaiMaterialise task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Graduation: the `mavaiMaterialise` task.** For each declared
+  contract, emits the equivalent contract as Java source the developer
+  owns — the same criteria, thresholds, and declaration order,
+  expressed against punit's authoring surface, with a stub invocation
+  (graduation transfers invocation ownership) and TODOs where the
+  reader's private machinery — selection engines, registered
+  predicates, views — becomes the developer's own code. One-shot
+  scaffolding under `build/punit/materialised/`: nothing round-trips.
+  The emitted source compiles cleanly against punit-core (asserted by
+  test). Entry point `ContractMaterialise.run`.
+
 - **The `mavaiCheck` task — zero-sample contract validation.** The
   authoring loop's compile step: `./gradlew mavaiCheck` scans the test
   resource roots for `mavai-contract/1` files and validates every

--- a/punit-decl/src/main/java/org/mavai/punit/decl/ContractMaterialise.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/ContractMaterialise.java
@@ -1,0 +1,39 @@
+package org.mavai.punit.decl;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Graduation — emit the equivalent contract as Java source the
+ * developer owns: the {@code mavaiMaterialise} Gradle task's entry
+ * point. The emitted class is the contract the contract file
+ * instantiates — same criteria, same thresholds, same declaration
+ * order — expressed against punit's authoring surface, with a stub
+ * invocation (graduation transfers invocation ownership) and TODOs
+ * where the reader's private machinery (selection engines, registered
+ * predicates, views) becomes the developer's own code. One-shot
+ * scaffolding: nothing round-trips.
+ */
+public final class ContractMaterialise {
+
+    private ContractMaterialise() {}
+
+    /** Renders the contract file as a standalone Java class's source. */
+    public static String run(Path contractFile) {
+        String text;
+        try {
+            text = Files.readString(contractFile);
+        } catch (IOException error) {
+            throw new UncheckedIOException(error);
+        }
+        return org.mavai.punit.decl.internal.run.Materialiser.materialise(
+                org.mavai.punit.decl.internal.parser.ContractParser.parse(text, contractFile));
+    }
+
+    /** The emitted class's simple name for a contract id — names the file. */
+    public static String className(String contractId) {
+        return org.mavai.punit.decl.internal.run.Materialiser.typeName(contractId);
+    }
+}

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/Materialiser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/Materialiser.java
@@ -1,0 +1,169 @@
+package org.mavai.punit.decl.internal.run;
+
+import java.util.List;
+import java.util.Map;
+import org.mavai.punit.decl.internal.model.ContractDeclaration;
+import org.mavai.punit.decl.internal.model.CriterionDeclaration;
+import org.mavai.punit.decl.internal.model.FormDeclaration;
+import org.mavai.punit.decl.internal.model.SetOfDeclaration;
+
+/**
+ * Graduation: emit the equivalent contract as Java source the developer
+ * owns. The emitted class is the contract the contract file
+ * instantiates — the same criteria, thresholds, and declaration order —
+ * expressed directly against punit's authoring surface. One-shot
+ * scaffolding: after materialising, the source is the developer's;
+ * nothing round-trips. Graduation transfers ownership deliberately:
+ * the invocation is a stub (the binding was the reader's), and
+ * path-qualified checks carry a TODO directing the developer to their
+ * own selection library (the JSONPath/XPath engines are private to the
+ * reader).
+ */
+public final class Materialiser {
+
+    private Materialiser() {}
+
+    public static String materialise(ContractDeclaration declaration) {
+        String className = typeName(declaration.contract());
+        StringBuilder out = new StringBuilder();
+        out.append("// Materialised from the contract file declaring '")
+                .append(declaration.contract()).append("'.\n")
+                .append("// This is now your code. The contract file instantiated exactly\n")
+                .append("// this contract; edit it freely — the declarative surface is no\n")
+                .append("// longer involved.\n\n");
+        out.append("import static org.mavai.punit.api.criterion.Criteria.*;\n\n");
+        out.append("import org.mavai.outcome.Outcome;\n");
+        out.append("import org.mavai.punit.api.NoFactors;\n");
+        out.append("import org.mavai.punit.api.ServiceContract;\n");
+        out.append("import org.mavai.punit.api.TokenTracker;\n");
+        out.append("import org.mavai.punit.api.criterion.Criteria;\n\n");
+        out.append("public final class ").append(className)
+                .append(" implements ServiceContract<NoFactors, String, String> {\n\n");
+        out.append("    @Override\n    public String id() {\n        return \"")
+                .append(declaration.contract()).append("\";\n    }\n\n");
+        out.append("    @Override\n")
+                .append("    public Outcome<String> invoke(String input, TokenTracker tracker) {\n")
+                .append("        // TODO: your service call — the contract file used the "
+                        + "binding '")
+                .append(declaration.service()).append("'.\n")
+                .append("        throw new UnsupportedOperationException(\"graduate the "
+                        + "invocation\");\n    }\n\n");
+        out.append("    @Override\n    public Criteria<String> criteria() {\n");
+        if (!declaration.transforms().isEmpty()) {
+            for (Map.Entry<String, String> view : declaration.transforms().entrySet()) {
+                out.append("        // TODO: view '").append(view.getKey())
+                        .append("' was the reader's ").append(view.getValue())
+                        .append(" transformation — express it with .transforming(...) and\n")
+                        .append("        // your own parser; a failed transform returns "
+                                + "Outcome.fail.\n");
+            }
+        }
+        List<CriterionDeclaration> criteria = declaration.criteria();
+        if (criteria.size() == 1) {
+            out.append("        return ").append(criterionSource(criteria.get(0), "                "))
+                    .append(";\n");
+        } else {
+            out.append("        return Criteria.<String>of(\n");
+            for (int i = 0; i < criteria.size(); i++) {
+                out.append("                ")
+                        .append(criterionSource(criteria.get(i), "                        "));
+                out.append(i < criteria.size() - 1 ? ",\n" : "\n");
+            }
+            out.append("        );\n");
+        }
+        out.append("    }\n}\n");
+        return out.toString();
+    }
+
+    private static String criterionSource(CriterionDeclaration criterion, String indent) {
+        StringBuilder out = new StringBuilder();
+        // The explicit witness pins the chain's subject type — chained
+        // generic calls are not poly expressions, so inference cannot
+        // reach back from the enclosing of(...).
+        out.append(criterion.threshold() != null
+                ? "meeting().<String>passRate(" + criterion.threshold() + ")"
+                : "empirical().<String>passRate()");
+        if (criterion.name() != null) {
+            out.append("\n").append(indent).append(".name(\"")
+                    .append(escape(criterion.name())).append("\")");
+        }
+        for (FormDeclaration form : criterion.forms()) {
+            out.append("\n").append(indent).append(formSource(form, indent));
+        }
+        if (criterion.optionalSlack() != null) {
+            var slack = criterion.optionalSlack();
+            out.append("\n").append(indent).append(".optionalSlack(")
+                    .append(slack.count() != null
+                            ? String.valueOf(slack.count())
+                            : "\"" + slack.display() + "\"")
+                    .append(")");
+        }
+        return out.toString();
+    }
+
+    private static String formSource(FormDeclaration form, String indent) {
+        String key = form.form().key();
+        String base;
+        if (form.form() == org.mavai.punit.decl.internal.model.PostconditionForm.PARSES) {
+            base = "// TODO: `parses: " + form.argument() + "` — forcing your view's "
+                    + "computation is the check";
+            return base;
+        } else if (form.form() == org.mavai.punit.decl.internal.model.PostconditionForm.SATISFIES) {
+            base = ".satisfies(\"" + escape(String.valueOf(form.argument()))
+                    + "\", response -> Outcome.ok()) // TODO: inline your registered "
+                    + "'" + form.argument() + "' predicate";
+        } else if (form.argument() instanceof SetOfDeclaration claim) {
+            base = ".satisfies(\"" + key + "\", response -> Outcome.ok()) // TODO: the "
+                    + "graded set claim (" + claim.required().size() + " required, "
+                    + claim.optional().size() + " optional, min-present "
+                    + claim.minPresent() + ") — judge the selection with your own "
+                    + "collection code";
+        } else {
+            base = ".satisfies(\"" + key + " " + escape(display(form.argument()))
+                    + "\", response -> Outcome.ok()) // TODO: judge `" + key + ": "
+                    + display(form.argument()) + "`";
+        }
+        if (form.optional()) {
+            base += "\n" + indent + ".optional()";
+        }
+        if (form.path() != null) {
+            base = ".satisfies(\"" + key + " at " + escape(form.path())
+                    + "\", response -> Outcome.ok()) // TODO: `path: " + form.path()
+                    + "` in view '" + form.view() + "' — select with your JSONPath/XPath "
+                    + "library of choice, then judge `" + key + ": "
+                    + display(form.argument()) + "`"
+                    + (form.optional() ? "\n" + indent + ".optional()" : "");
+        }
+        return base;
+    }
+
+    private static String display(Object argument) {
+        String text = String.valueOf(argument);
+        return text.length() <= 40 ? text : text.substring(0, 37) + "...";
+    }
+
+    private static String escape(String text) {
+        return text.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    /** The contract id as a Java type name: kebab-case to UpperCamel + suffix. */
+    public static String typeName(String contractId) {
+        StringBuilder name = new StringBuilder();
+        boolean upper = true;
+        for (char c : contractId.toCharArray()) {
+            if (c == '-' || c == '_' || c == '.') {
+                upper = true;
+            } else {
+                name.append(upper ? Character.toUpperCase(c) : c);
+                upper = false;
+            }
+        }
+        if (name.length() == 0) {
+            name.append("Materialised");
+        }
+        if (Character.isDigit(name.charAt(0))) {
+            name.insert(0, "Contract");
+        }
+        return name.append("ServiceContract").toString();
+    }
+}

--- a/punit-decl/src/test/java/org/mavai/punit/decl/ContractMaterialiseTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/ContractMaterialiseTest.java
@@ -1,0 +1,91 @@
+package org.mavai.punit.decl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("Graduation — the source projection")
+class ContractMaterialiseTest {
+
+    private Path writeContract(Path directory) throws IOException {
+        Path contract = directory.resolve("contract.yaml");
+        Files.writeString(contract, """
+                format: mavai-contract/1
+                contract: basket-builder-returns-valid-baskets
+                service: basket-builder
+                transforms:
+                  basket: json
+                criteria:
+                  - name: baskets-parse-and-mention-eggs
+                    threshold: 0.9
+                    optional-slack: 1
+                    parses: basket
+                    postconditions:
+                      - contains: "egg"
+                      - in: basket
+                        path: "$.items[*].name"
+                        equals-set: ["egg", "milk"]
+                      - contains: "fresh"
+                        optional: true
+                  - name: never-rude
+                    threshold: 0.99
+                    not-equals: "go away"
+                inputs: ["a dozen eggs", "two bottles of milk"]
+                """);
+        return contract;
+    }
+
+    @Test
+    @DisplayName("the emitted source states the same claims in declaration order")
+    void emissionStatesTheClaims(@TempDir Path directory) throws IOException {
+        String source = ContractMaterialise.run(writeContract(directory));
+        assertThat(source)
+                .contains("public final class BasketBuilderReturnsValidBasketsServiceContract")
+                .contains("return \"basket-builder-returns-valid-baskets\";")
+                .contains("binding 'basket-builder'")
+                .contains("meeting().<String>passRate(0.9)")
+                .contains(".name(\"baskets-parse-and-mention-eggs\")")
+                .contains(".optionalSlack(1)")
+                .contains("meeting().<String>passRate(0.99)")
+                .contains(".optional()")
+                .contains("JSONPath/XPath");
+        // Graduation transfers ownership: the reader's internals never leak.
+        assertThat(source).doesNotContain("org.mavai.punit.decl");
+    }
+
+    @Test
+    @DisplayName("the emitted source compiles cleanly against punit's authoring surface")
+    void emissionCompiles(@TempDir Path directory) throws IOException {
+        String source = ContractMaterialise.run(writeContract(directory));
+        String className = ContractMaterialise.className("basket-builder-returns-valid-baskets");
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        JavaFileObject unit = new SimpleJavaFileObject(
+                URI.create("string:///" + className + ".java"),
+                JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return source;
+            }
+        };
+        var diagnostics = new javax.tools.DiagnosticCollector<JavaFileObject>();
+        boolean compiled = compiler.getTask(null, null, diagnostics,
+                List.of("-d", directory.resolve("classes").toString(),
+                        "-classpath", System.getProperty("java.class.path")),
+                null, List.of(unit)).call();
+        assertThat(compiled)
+                .as("emitted source compiles: " + diagnostics.getDiagnostics())
+                .isTrue();
+    }
+}

--- a/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/architecture/DeclArchitectureTest.java
@@ -56,6 +56,9 @@ class DeclArchitectureTest {
                 // The check verb's entry point — deliberately public:
                 // the mavaiCheck Gradle task invokes it reflectively.
                 .orShould().haveSimpleName("ContractCheck")
+                // Graduation's entry point — deliberately public: the
+                // mavaiMaterialise Gradle task invokes it reflectively.
+                .orShould().haveSimpleName("ContractMaterialise")
                 .because("everything beyond the author surface is internal enablement — "
                         + "new public types belong under internal.* unless they are "
                         + "deliberately part of the authoring API");

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitMaterialiseTask.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitMaterialiseTask.kt
@@ -1,0 +1,72 @@
+package org.mavai.punit.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.*
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Path
+
+/**
+ * The `mavaiMaterialise` task: graduation's source projection. For each
+ * `mavai-contract/1` file under the test resource roots, emits the
+ * equivalent contract as Java source the developer owns — same
+ * criteria, same thresholds, a stub invocation, TODOs where the
+ * reader's private machinery becomes the developer's code — under
+ * `build/punit/materialised/`. One-shot scaffolding: the output is a
+ * starting point to copy into the source tree, never compiled by the
+ * build and never round-tripped.
+ */
+@DisableCachingByDefault(because = "One-shot scaffolding; the output is a starting point, not a build artefact")
+abstract class PUnitMaterialiseTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val contractFiles: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @get:Classpath
+    abstract val materialiseClasspath: ConfigurableFileCollection
+
+    @TaskAction
+    fun materialise() {
+        val contracts = contractFiles.files
+            .filter { it.isFile && it.name.endsWith(".yaml") && isContract(it) }
+            .sortedBy { it.absolutePath }
+        if (contracts.isEmpty()) {
+            logger.lifecycle("mavaiMaterialise: no mavai-contract/1 files under the test resource roots")
+            return
+        }
+        val urls = materialiseClasspath.files
+            .filter { it.exists() }
+            .map { it.toURI().toURL() }
+            .toTypedArray()
+        val classLoader = URLClassLoader(urls, ClassLoader.getSystemClassLoader())
+        try {
+            val entry = classLoader.loadClass("org.mavai.punit.decl.ContractMaterialise")
+            val run = entry.getMethod("run", Path::class.java)
+            val className = entry.getMethod("className", String::class.java)
+            val target = outputDir.get().asFile
+            target.mkdirs()
+            for (contract in contracts) {
+                val source = run.invoke(null, contract.toPath()) as String
+                val id = contract.useLines { lines ->
+                    lines.first { it.startsWith("contract:") }.substringAfter(":").trim()
+                }
+                val file = File(target, "${className.invoke(null, id)}.java")
+                file.writeText(source)
+                logger.lifecycle("materialised ${contract.name} -> ${file.relativeTo(project.projectDir)}")
+            }
+        } finally {
+            classLoader.close()
+        }
+    }
+
+    private fun isContract(file: File): Boolean =
+        file.useLines { lines -> lines.take(20).any { it.trim() == "format: mavai-contract/1" } }
+}

--- a/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitPlugin.kt
+++ b/punit-gradle-plugin/src/main/kotlin/org/mavai/punit/gradle/PUnitPlugin.kt
@@ -91,6 +91,7 @@ class PUnitPlugin : Plugin<Project> {
             registerOptimizationReportTask(project, extension, reportConfig)
             registerPUnitVerifyTask(project, reportConfig)
             registerMavaiCheckTask(project, extension)
+            registerMavaiMaterialiseTask(project)
         }
     }
 
@@ -528,6 +529,22 @@ class PUnitPlugin : Plugin<Project> {
             resourceRoots.set(test.resources.srcDirs.map { it.absolutePath })
             explorationsRootPath.set(extension.explorationsDir)
             checkClasspath.from(test.runtimeClasspath)
+            dependsOn(project.tasks.named("testClasses"))
+        }
+    }
+
+    private fun registerMavaiMaterialiseTask(project: Project) {
+        project.tasks.register("mavaiMaterialise", PUnitMaterialiseTask::class.java).configure {
+            description = "Emits each declared contract as Java source the developer owns (graduation)"
+            group = "verification"
+            val test = project.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets.getByName("test")
+            contractFiles.from(test.resources.srcDirs.map { dir ->
+                project.fileTree(dir) { include("**/*.yaml") }
+            })
+            outputDir.set(project.layout.buildDirectory.dir("punit/materialised"))
+            materialiseClasspath.from(test.runtimeClasspath)
             dependsOn(project.tasks.named("testClasses"))
         }
     }


### PR DESCRIPTION
Second slice of the declarative programme's Phase 6 remainder, stacked on #264 (the check verb). The honest-output review (DA04) follows as the third slice.

- **`ContractMaterialise.run(contractFile)`** — graduation's source projection per the Java mapping document: emits a standalone `ServiceContract` class with the same criteria, thresholds, names, optional-slack, and declaration order the reader instantiates, expressed against the authoring surface (`meeting().<String>passRate(…)` chains — the explicit witness is needed because chained generic calls are not poly expressions).
- **Ownership transfers, deliberately**: the invocation is a stub naming the binding it replaces; path-qualified checks, `satisfies:` predicates, and views carry TODOs directing the developer to their own selection library / predicate / parser — the reader's JSONPath/XPath engines are private by design. The emitted source never references `org.mavai.punit.decl` (asserted).
- **The projection is held honest by compilation**: a golden-shaped test materialises a contract exercising thresholds, names, slack, per-view paths, optional marks, and multiple criteria, and compiles the emitted source in-memory against punit-core — zero diagnostics.
- **`mavaiMaterialise` Gradle task**: emits every declared contract's projection under `build/punit/materialised/` — one-shot scaffolding, never compiled by the build, never round-tripped.

Blast radius: 7 files. Full build + plugin build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM