### PR TITLE
Honest-output review: name the persisted artefact under measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Measure output names its persisted artefact.** A recording's
+  product is the baseline, not a verdict — every MEASURE run now
+  prints `baseline recorded: <path>` as the artefact lands, closing an
+  honest-output gap (the shape rule: a recording is labelled, renders
+  no composite verdict, and names what it persisted — the first two
+  already held, pinned by a new regression test alongside the fix).
+
 ### Added
 
 - **Graduation: the `mavaiMaterialise` task.** For each declared

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/BaselineEmitter.java
@@ -92,6 +92,10 @@ public final class BaselineEmitter {
                 Files.createDirectories(baselineDir);
                 Path target = baselineDir.resolve(relativePath);
                 Files.writeString(target, content, StandardCharsets.UTF_8);
+                // Honest output: a recording always names its persisted
+                // artefact — the run's product is the baseline, not a
+                // verdict, and the operator should not have to hunt for it.
+                System.out.println("[PUNIT] baseline recorded: " + target);
             } catch (IOException e) {
                 throw new UncheckedIOException(
                         "Failed to write baseline " + relativePath + " under " + baselineDir, e);

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/DeclaredRunTest.java
@@ -207,6 +207,28 @@ class DeclaredRunTest {
         }
 
         @Test
+        @DisplayName("measure output names the artefact and renders no composite verdict")
+        void measureOutputIsHonest(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory) {
+            System.setProperty("punit.baseline.dir", directory.toString());
+            java.io.PrintStream stdout = System.out;
+            var captured = new java.io.ByteArrayOutputStream();
+            try {
+                System.setOut(new java.io.PrintStream(captured));
+                PUnit.declared("greeting-service-is-polite").samples(40).measure();
+            } finally {
+                System.setOut(stdout);
+                System.clearProperty("punit.baseline.dir");
+            }
+            String output = captured.toString();
+            // §-honest-output shape: a recording names its persisted
+            // artefact, and no composite verdict is rendered — declared
+            // bars are noted against the evidence, never judged.
+            org.assertj.core.api.Assertions.assertThat(output)
+                    .contains("[PUNIT] baseline recorded: ")
+                    .doesNotContain("VERDICT:");
+        }
+
+        @Test
         @DisplayName("a measure run records and always persists the baseline artefact")
         void measurePersists(@org.junit.jupiter.api.io.TempDir java.nio.file.Path directory)
                 throws java.io.IOException {


### PR DESCRIPTION
Third and final slice of the declarative programme's Phase 6 remainder — the honest-output review against the format's §II.5 shapes, findings dispositioned:

## Findings

1. **Fixed here**: measure output did not name its persisted baseline artefact (a §II.5 MUST — "the persisted baseline artefact is always named"). The emitter now prints `[PUNIT] baseline recorded: <path>` as the artefact lands; a regression test pins the recording shape (artefact named, no composite verdict rendered).
2. **Verified, already honest**: the test-posture per-criterion shape (verdict, observed rate, confidence bound, N, composite via the existing machinery) and the measure-posture recorded-fact vocabulary (the normative-judgement markers as noted-against-evidence, established in the family disclosure arc) hold as specified; existing renderer tests cover them.
3. **Verified by scan**: first-contact refusal messages carry no extension-seam vocabulary — the only "budget" occurrences are the sizing refusals quoting the format's own claim-versus-budget rule, which is first-contact vocabulary by specification.
4. **Dispositioned, deferred**: the prompt-engineer stepper's resolved meta identity stays a run note — punit-core's `NextFactor` carries no provenance channel; a core amendment remains logged, not urgent while the note is honest and the stepper is the sole consumer.
5. **Dispositioned, deferred**: the roots-disclosure deviation (punit baselines carry no free-form provenance map) needs a family-coordinated baseline-format field, not a unilateral punit slot — recorded for the interchange consolidation thread.

Blast radius: 3 files. Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM