### PR TITLE
Phase 7: the declarative part of the user guide, anchors, guard prefixes

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -10,6 +10,7 @@
   - [Why probabilistic testing](#why-probabilistic-testing)
   - [What PUnit is](#what-punit-is)
   - [Quick start](#quick-start)
+- [The declarative surface — contracts as files](#the-declarative-surface--contracts-as-files)
 - [Part 1: The Service Contract — the shared correctness target](#part-1-the-service-contract--the-shared-correctness-target)
 - [Part 2: The lifecycle](#part-2-the-lifecycle)
 - [Part 3: Testing](#part-3-testing)
@@ -234,6 +235,117 @@ factors; when factors are in play, pass the factor instance explicitly
 via `testing(sampling, factors)`.
 
 That is the whole pattern. The rest of this guide unpacks it.
+
+---
+
+## The declarative surface — contracts as files
+
+The fastest way in. A probabilistic test can be a YAML file plus a
+one-line test method — no builder vocabulary, no statistics on the
+first contact. The file carries the *claim*; the invocation carries the
+*budget*; punit derives everything else.
+
+**The contract file** (`src/test/resources/<your test package>/greeting.yaml`):
+
+```yaml
+format: mavai-contract/1
+contract: greeting-service-is-polite
+service: greeting-service
+
+criteria:
+  - threshold: 0.95
+    contains: "hello"
+
+inputs:
+  - "Alice"
+  - "Bob"
+```
+
+**The test** — the method name kebab-cases and resolves against the
+file's `contract:` key (`PUnit.declared("explicit-name")` overrides):
+
+```java
+class GreetingTest {
+
+    @ProbabilisticTest
+    void greetingServiceIsPolite() {
+        PUnit.declared().assertPasses();
+    }
+}
+```
+
+**The binding** — the contract's `service:` resolves against a class
+named `MavaiBindings` in the same package (override with
+`.bindings(YourBindings.class)`):
+
+```java
+class MavaiBindings {
+
+    @Binding("greeting-service")
+    String greet(String name) {
+        return myClient.complete(name);   // your service call
+    }
+}
+```
+
+That is the whole newcomer path: the run sizes itself to the smallest
+sample count the declared threshold can support, samples the binding
+over the inputs, and judges the criterion with the same Wilson
+machinery as every other punit test.
+
+**Richer contracts.** The same file grows with the claim: named
+transforms (`transforms: {basket: json}`) and per-check subjects
+(`in:`/`path:` with RFC 9535 JSONPath), the full postcondition
+vocabulary (string, numeric, boolean, set forms, the graded
+`set-of:` claim), per-input `expected:` blocks, `optional:` checks
+under a criterion's `optional-slack:` budget, explicit `latency:`
+ceilings, and `roots:` named path anchors for file-sourced inputs.
+The format is shared with the whole mavai family — a contract file is
+portable between punit, baseltest, and feotest hosts.
+
+**Language-model services.** Declare configured services in a
+`mavai-services.yaml` beside the contracts — the built-in
+`language-model` type covers openai/anthropic/mistral/ollama/apertus,
+LiteLLM, and any OpenAI-compatible endpoint, with the system prompt
+inline or from a file (`system-prompt: {file: prompts/agent.md}`).
+Credentials live in the environment only.
+
+**The verbs.** The terminal carries the posture, mirroring the
+family's CLI verbs:
+
+```java
+PUnit.declared().assertPasses();               // test: judge the declared bars
+PUnit.declared().samples(1000).measure();      // measure: record + persist the baseline
+PUnit.declared().samplesPerConfig(5).explore(); // explore: one recording per grid point
+PUnit.declared().samplesPerIteration(5).optimize("tune"); // optimize: iterate a stepper
+```
+
+Two Gradle tasks close the authoring loop: `./gradlew mavaiCheck`
+validates every contract's load-time joins with zero samples (and
+names stale exploration artefacts, deleting nothing), and the
+per-contract system property `-Dpunit.samples.<contract-name>=N`
+sizes any run without touching code.
+
+### Graduation — when the file runs out
+
+The declarative surface is an on-ramp, not a silo. The gentlest steps
+stay in the file: `satisfies: <name>` names one registered `@Check`
+predicate in code, a registered `@Transform` does the same for views.
+When the claim outgrows the format — a computed expected value, a
+bespoke comparison, control flow — take authorship of the object you
+were already running:
+
+```
+./gradlew mavaiMaterialise
+```
+
+emits, under `build/punit/materialised/`, the equivalent
+`ServiceContract` class for each contract file — the same criteria,
+thresholds, and declaration order the file instantiated, as Java
+source that is now yours. Copy it into the test tree, fill the
+invocation stub and the TODOs, delete the YAML. Nothing round-trips:
+from that moment the class is the contract, and the rest of this
+guide is its manual.
 
 ---
 

--- a/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/reporting/NormativeJudgementRenderer.java
@@ -32,6 +32,7 @@ import org.mavai.punit.statistics.NormativeJudgementEvaluator;
  * is computed upstream (statistics package) before the record
  * reaches this renderer.
  */
+// mavai-ref: JVI-51ASAR0 — do not remove (resolves in mavai-orchestrator)
 public final class NormativeJudgementRenderer {
 
     private NormativeJudgementRenderer() { }

--- a/punit-core/src/test/java/org/mavai/punit/architecture/RequirementCodeIsolationTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/architecture/RequirementCodeIsolationTest.java
@@ -78,7 +78,7 @@ class RequirementCodeIsolationTest {
      * wire-format constants.
      */
     private static final Pattern REQUIREMENT_CODE = Pattern.compile(
-            "\\b(CR|CT|EX|LT|PT|RC|RP|SC|SN|TH|UC|XM|DG)\\d{2}\\b");
+            "\\b(CR|CT|EX|LT|PT|RC|RP|SC|SN|TH|UC|XM|DG|DA|LM)\\d{2}\\b");
 
     /**
      * Filenames that legitimately mention the prefixes - this test

--- a/punit-decl/build.gradle.kts
+++ b/punit-decl/build.gradle.kts
@@ -109,6 +109,7 @@ tasks.test {
     // exactly as it provisions the registrations; nothing connects.
     environment("MAVAI_LLM_ENDPOINT", "https://conformance.invalid/v1")
     environment("MAVAI_LLM_MODEL", "conformance-model")
+    environment("MAVAI_LLM_API_KEY", "conformance-placeholder")
     systemProperty(
         "punit.formats.dir",
         publishedFormatsDir.get().asFile.resolve("formats").absolutePath

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ContractParser.java
@@ -33,6 +33,7 @@ import org.mavai.punit.statistics.StatisticalDefaults;
  * time — before any invocation, so a configuration defect never costs
  * a sample.
  */
+// mavai-ref: JVI-E2WH9DE — do not remove (resolves in mavai-orchestrator)
 public final class ContractParser {
 
     static final String SEAM_POINTER = "reserved by the mavai contract format for a future "

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ServicesParser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/parser/ServicesParser.java
@@ -27,6 +27,7 @@ import org.mavai.punit.decl.internal.model.ServicesDeclaration;
  * registries exist; everything checkable from the document alone is
  * checked here.
  */
+// mavai-ref: JVI-GGCWP5H — do not remove (resolves in mavai-orchestrator)
 public final class ServicesParser {
 
     private static final Set<String> DEFINITION_KEYS =

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/BindingsRegistry.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/BindingsRegistry.java
@@ -28,6 +28,7 @@ import org.mavai.punit.decl.internal.model.FormDeclaration;
  * resolved by name at load time with fail-fast duplicate and
  * unresolvable semantics.
  */
+// mavai-ref: JVI-59T5EPU — do not remove (resolves in mavai-orchestrator)
 final class BindingsRegistry {
 
     private final Class<?> bindingsClass;

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/CriteriaCompiler.java
@@ -47,6 +47,7 @@ import org.w3c.dom.NodeList;
  * {@code json}/{@code yaml} views, XPath 1.0 for {@code xml} views), so
  * a malformed expression refuses at load, never mid-run.
  */
+// mavai-ref: JVI-RKBJ882 — do not remove (resolves in mavai-orchestrator)
 final class CriteriaCompiler {
 
     private final ContractDeclaration declaration;

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/Materialiser.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/Materialiser.java
@@ -19,6 +19,7 @@ import org.mavai.punit.decl.internal.model.SetOfDeclaration;
  * own selection library (the JSONPath/XPath engines are private to the
  * reader).
  */
+// mavai-ref: JVI-CP4XG45 — do not remove (resolves in mavai-orchestrator)
 public final class Materialiser {
 
     private Materialiser() {}


### PR DESCRIPTION
The punit-side close of the declarative programme's Phase 7 (orchestrator directive `DIR-PU-DA-declarative-surface`; the punitexamples worked example is the remaining closure requirement, cut as its own directive).

- **USER-GUIDE: "The declarative surface — contracts as files"**, inserted between the introduction and Part 1 — taught as the newcomer path per the design ruling: the contract file + one-line test first contact, the conventional bindings class, `mavai-services.yaml` and the language-model type, the terminal-carried verbs, `mavaiCheck` and the per-contract sizing property. The **graduation moment** gets its own subsection at exactly the point the guide says the file has run out — `mavaiMaterialise`, copy, fill the stubs, delete the YAML, "the rest of this guide is its manual" (this also completes the graduation capability's documentation criterion).
- **Cross-reference anchors** embedded on the six owning artifacts the programme's inventory rows track (parser, compiler, materialiser, judgement renderer, services parser, bindings registry) — registry check clean at 0 errors.
- **Requirement-code isolation guard** learns the two newly-in-use prefixes.

Orchestrator side already landed: DA01–DA06 punit columns flipped, the language-model inventory area minted (concept already in the ontology — no lockstep change), and the two Phase 7 twins cut (punitexamples worked example — the hard closure requirement — and the mavai.org quickstart).

Blast radius: 8 files, docs-dominant. Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM