### PR TITLE
Move the version line to 0.10.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.stdlib.default.dependency=false
-punitVersion=0.9.4-SNAPSHOT
+punitVersion=0.10.0-SNAPSHOT

--- a/punit-gradle-plugin/gradle.properties
+++ b/punit-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-punitVersion=0.9.4-SNAPSHOT
+punitVersion=0.10.0-SNAPSHOT


### PR DESCRIPTION
Owner direction: the declarative surface (punit-decl, punit-lm, the check/graduation tasks, the format-conformance gate, DA07-DA11 and the LM area) is a minor version's worth of capability — the next release is 0.10.0, not 0.9.4. Snapshot bump only; the release itself follows the release checklist when cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM