### PR TITLE
The programmatic language-model client: org.mavai.punit.lm.api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **The programmatic language-model client (`org.mavai.punit.lm.api`).**
+  punit-lm opens one exported package: `LanguageModels.configure(Map)`
+  takes the services file's `configuration:` block verbatim — the same
+  keys, the same validation catalogue and refusal messages, the same
+  strict capability gate and provider vetoes, the same
+  `mavai.llm.*`/`MAVAI_LLM_*` environment tier — and returns a
+  configured `LanguageModel`: one request per invocation, no retries,
+  4xx rejection = defect (throws), failed delivery = `Outcome`
+  failure. The reply is **usage-bearing**: `LmReply` carries the text
+  plus the vendor-reported token usage (input/output/total;
+  absent-tolerant), newly extracted from every adapter's wire shape —
+  a language model responds with more than a string, and token counts
+  feed cost reporting. Providers, wire shapes, and validation stay
+  internal; the module's exports pin moves from exports-nothing to
+  exports-exactly-`api`.
+
 ### Fixed
 
 - **Measure output names its persisted artefact.** A recording's

--- a/punit-lm/src/main/java/module-info.java
+++ b/punit-lm/src/main/java/module-info.java
@@ -9,11 +9,15 @@
  * enables {@code type: language-model} — punit-core and punit-decl
  * carry no LLM assumptions.
  *
- * <p>Deliberately exports nothing: the module is declarative-only, its
- * adapters serve the declarative surface and expose no supported
- * programmatic API. Builder-style authors bring their own clients.
+ * <p>Exports exactly one package — {@code org.mavai.punit.lm.api},
+ * the thin programmatic surface (a configured {@code LanguageModel},
+ * its usage-bearing {@code LmReply}, and the config-map factory) over
+ * the same machinery the declarative route uses. Providers, wire
+ * shapes, and validation stay internal.
  */
 module org.mavai.punit.lm {
+
+    exports org.mavai.punit.lm.api;
 
     // ── Required modules ──────────────────────────────────────
     requires transitive org.mavai.punit.decl;

--- a/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
@@ -27,7 +27,7 @@ import org.mavai.punit.lm.providers.Providers;
  * body not matching the vendor shape) is a failed sample on the
  * {@code Outcome} channel with its cause as the reason.
  */
-final class ConfiguredLanguageModel implements ConfiguredService {
+public final class ConfiguredLanguageModel implements ConfiguredService {
 
     private final LmProvider provider;
     private final LanguageModelParameters parameters;
@@ -62,6 +62,15 @@ final class ConfiguredLanguageModel implements ConfiguredService {
 
     @Override
     public Outcome<String> invoke(Object input) {
+        return exchange(input).map(org.mavai.punit.lm.api.LmReply::text);
+    }
+
+    /**
+     * The full exchange — the reply with its reported token usage.
+     * The declarative seam collapses this to text ({@link #invoke});
+     * the programmatic api surfaces it whole.
+     */
+    public Outcome<org.mavai.punit.lm.api.LmReply> exchange(Object input) {
         String body = Json.write(provider.body().build(parameters, model, input));
         HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(endpoint))
                 .POST(HttpRequest.BodyPublishers.ofString(body));

--- a/punit-lm/src/main/java/org/mavai/punit/lm/api/LanguageModel.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/api/LanguageModel.java
@@ -1,0 +1,36 @@
+package org.mavai.punit.lm.api;
+
+import java.util.Map;
+import org.mavai.outcome.Outcome;
+
+/**
+ * A configured language model, ready to invoke — punit-lm's thin
+ * programmatic surface over the same machinery the declarative
+ * {@code type: language-model} route uses.
+ *
+ * <p>The semantics are the declarative route's, verbatim: one request
+ * per invocation — no retries, no caching, no client-side
+ * sophistication (a silently retried failure is a resampled trial);
+ * a provider <em>rejection</em> (HTTP 4xx — bad schema, unknown
+ * model, expired credential) is a defect and throws; a failed
+ * <em>delivery</em> (5xx, unreachable endpoint, an off-shape reply)
+ * travels back as an {@link Outcome} failure with its cause as the
+ * reason — the expected-failure channel the criteria judge.
+ */
+public interface LanguageModel {
+
+    /**
+     * Invokes the model once with the given input — a prompt string,
+     * or the declarative surface's message-part shapes.
+     *
+     * @return the usage-bearing reply, or an {@code Outcome} failure
+     *     for a failed delivery
+     */
+    Outcome<LmReply> invoke(Object input);
+
+    /**
+     * The resolved configuration as covariate values — every parameter
+     * as actually used, fit for run and baseline provenance.
+     */
+    Map<String, String> configurationCovariates();
+}

--- a/punit-lm/src/main/java/org/mavai/punit/lm/api/LanguageModels.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/api/LanguageModels.java
@@ -1,0 +1,54 @@
+package org.mavai.punit.lm.api;
+
+import java.util.Map;
+import org.mavai.punit.lm.ConfiguredLanguageModel;
+import org.mavai.punit.lm.LanguageModelServiceType;
+
+/**
+ * The factory: a configured {@link LanguageModel} from a configuration
+ * map — the services file's {@code configuration:} block, verbatim.
+ *
+ * <p>The map takes exactly the declarative keys ({@code system-prompt},
+ * {@code provider}, {@code model}, {@code temperature}, {@code top-p},
+ * {@code thinking}, {@code prompt-caching}, {@code response-schema},
+ * {@code max-tokens}, {@code capabilities}) and goes through the same
+ * validation catalogue, the same strict capability gate, the same
+ * provider vetoes, and the same environment tier
+ * ({@code mavai.llm.*} system properties, then {@code MAVAI_LLM_*}
+ * variables, then each vendor's conventional credential fallback) as a
+ * {@code type: language-model} service definition — one vocabulary,
+ * one set of refusals, no second schema. A misfit configuration throws
+ * at configure time, before any request.
+ */
+// mavai-ref: JVI-AT423AB — do not remove (resolves in mavai-orchestrator)
+public final class LanguageModels {
+
+    private LanguageModels() {}
+
+    /**
+     * Configures a language model from the declarative configuration
+     * map.
+     *
+     * @throws org.mavai.punit.decl.ContractConfigurationException on
+     *     any configuration misfit, with the declarative route's own
+     *     refusal message
+     */
+    public static LanguageModel configure(Map<String, Object> configuration) {
+        // The whole strict path, reused: validation, capability
+        // allowance, provider resolution and veto — parity with the
+        // services file by construction, not by parallel code.
+        ConfiguredLanguageModel configured = (ConfiguredLanguageModel)
+                new LanguageModelServiceType().configure("language-model", configuration);
+        return new LanguageModel() {
+            @Override
+            public org.mavai.outcome.Outcome<LmReply> invoke(Object input) {
+                return configured.exchange(input);
+            }
+
+            @Override
+            public Map<String, String> configurationCovariates() {
+                return configured.configurationCovariates();
+            }
+        };
+    }
+}

--- a/punit-lm/src/main/java/org/mavai/punit/lm/api/LmReply.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/api/LmReply.java
@@ -1,0 +1,47 @@
+package org.mavai.punit.lm.api;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * One language-model response: the text, and the token usage the
+ * vendor reported beside it. A language model responds with more than
+ * a string — token counts feed cost accounting and reporting — so the
+ * programmatic surface carries them first-class. Usage is
+ * absent-tolerant: a vendor (or gateway) that omits it yields a reply
+ * whose {@link #usage()} is empty, never a failure.
+ *
+ * @param text the response text, exactly as the adapter extracted it
+ * @param usage the reported token usage, when the vendor stated it
+ */
+public record LmReply(String text, Optional<TokenUsage> usage) {
+
+    public LmReply {
+        Objects.requireNonNull(text, "text");
+        Objects.requireNonNull(usage, "usage");
+    }
+
+    /** A reply with no reported usage. */
+    public static LmReply of(String text) {
+        return new LmReply(text, Optional.empty());
+    }
+
+    /** A reply with reported input/output token counts. */
+    public static LmReply of(String text, long inputTokens, long outputTokens) {
+        return new LmReply(text, Optional.of(new TokenUsage(inputTokens, outputTokens)));
+    }
+
+    /**
+     * The reported token counts for one exchange.
+     *
+     * @param inputTokens tokens the request consumed (prompt side)
+     * @param outputTokens tokens the response produced
+     */
+    public record TokenUsage(long inputTokens, long outputTokens) {
+
+        /** Input plus output — the exchange's total. */
+        public long totalTokens() {
+            return inputTokens + outputTokens;
+        }
+    }
+}

--- a/punit-lm/src/main/java/org/mavai/punit/lm/providers/LmProvider.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/providers/LmProvider.java
@@ -43,8 +43,9 @@ import org.mavai.punit.lm.LanguageModelParameters;
  *        {@code null} when the combination is fine; checked at load
  * @param body composes one request body from (parameters, model, input)
  * @param headers composes the request headers from the resolved credential
- * @param extract pulls the response text out of the vendor's reply
- *        shape; a delivered-but-odd shape throws {@link ServiceDeliveryException}
+ * @param extract pulls the reply — response text plus any reported
+ *        token usage — out of the vendor's reply shape; a
+ *        delivered-but-odd shape throws {@link ServiceDeliveryException}
  */
 public record LmProvider(
         String name,
@@ -59,7 +60,7 @@ public record LmProvider(
         Function<LanguageModelParameters, String> constraint,
         BodyBuilder body,
         Function<String, Map<String, String>> headers,
-        Function<JsonNode, String> extract) {
+        Function<JsonNode, org.mavai.punit.lm.api.LmReply> extract) {
 
     /**
      * The provider-neutral capability vocabulary an author may name in

--- a/punit-lm/src/main/java/org/mavai/punit/lm/providers/OpenAiCompatible.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/providers/OpenAiCompatible.java
@@ -99,14 +99,24 @@ public final class OpenAiCompatible {
         return body;
     }
 
-    /** {@code choices[0].message.content}. */
-    public static String extract(JsonNode payload) {
+    /**
+     * {@code choices[0].message.content}, with the protocol's
+     * {@code usage.prompt_tokens}/{@code completion_tokens} beside it
+     * when the endpoint reports them (a gateway may not).
+     */
+    public static org.mavai.punit.lm.api.LmReply extract(JsonNode payload) {
         JsonNode content = payload.path("choices").path(0).path("message").path("content");
         if (!content.isTextual()) {
             throw new ServiceDeliveryException("service delivered a response with no text "
                     + "content (choices[0].message.content held "
                     + content.getNodeType().name().toLowerCase(Locale.ROOT) + ")");
         }
-        return content.asText();
+        JsonNode usage = payload.path("usage");
+        if (usage.path("prompt_tokens").isNumber() && usage.path("completion_tokens").isNumber()) {
+            return org.mavai.punit.lm.api.LmReply.of(content.asText(),
+                    usage.path("prompt_tokens").asLong(),
+                    usage.path("completion_tokens").asLong());
+        }
+        return org.mavai.punit.lm.api.LmReply.of(content.asText());
     }
 }

--- a/punit-lm/src/main/java/org/mavai/punit/lm/providers/anthropic/Anthropic.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/providers/anthropic/Anthropic.java
@@ -117,10 +117,17 @@ public final class Anthropic {
      * block — thinking blocks precede it. The assistant text is the
      * first block of type {@code text}, wherever it sits.
      */
-    private static String extract(JsonNode payload) {
+    private static org.mavai.punit.lm.api.LmReply extract(JsonNode payload) {
         for (JsonNode block : payload.path("content")) {
             if ("text".equals(block.path("type").asText())) {
-                return block.path("text").asText();
+                JsonNode usage = payload.path("usage");
+                if (usage.path("input_tokens").isNumber()
+                        && usage.path("output_tokens").isNumber()) {
+                    return org.mavai.punit.lm.api.LmReply.of(block.path("text").asText(),
+                            usage.path("input_tokens").asLong(),
+                            usage.path("output_tokens").asLong());
+                }
+                return org.mavai.punit.lm.api.LmReply.of(block.path("text").asText());
             }
         }
         StringBuilder kinds = new StringBuilder();

--- a/punit-lm/src/main/java/org/mavai/punit/lm/providers/ollama/Ollama.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/providers/ollama/Ollama.java
@@ -72,13 +72,19 @@ public final class Ollama {
         return body;
     }
 
-    private static String extract(JsonNode payload) {
+    private static org.mavai.punit.lm.api.LmReply extract(JsonNode payload) {
         JsonNode content = payload.path("message").path("content");
         if (!content.isTextual()) {
             throw new ServiceDeliveryException("service delivered a response with no text "
                     + "content (the ollama message.content field held "
                     + content.getNodeType().name().toLowerCase(Locale.ROOT) + ")");
         }
-        return content.asText();
+        if (payload.path("prompt_eval_count").isNumber()
+                && payload.path("eval_count").isNumber()) {
+            return org.mavai.punit.lm.api.LmReply.of(content.asText(),
+                    payload.path("prompt_eval_count").asLong(),
+                    payload.path("eval_count").asLong());
+        }
+        return org.mavai.punit.lm.api.LmReply.of(content.asText());
     }
 }

--- a/punit-lm/src/test/java/org/mavai/punit/lm/LanguageModelsApiTest.java
+++ b/punit-lm/src/test/java/org/mavai/punit/lm/LanguageModelsApiTest.java
@@ -1,0 +1,112 @@
+package org.mavai.punit.lm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.decl.ContractConfigurationException;
+import org.mavai.punit.lm.api.LanguageModel;
+import org.mavai.punit.lm.api.LanguageModels;
+import org.mavai.punit.lm.api.LmReply;
+
+@DisplayName("The programmatic surface — LanguageModels.configure")
+class LanguageModelsApiTest {
+
+    @Test
+    @DisplayName("the config map is the services-file block — identical refusals, by construction")
+    void validationParityWithTheDeclarativeRoute() {
+        // The same misfit configurations through both doors; the factory
+        // must speak the declarative route's exact refusal. Parity is by
+        // construction (one code path), pinned here against regression.
+        Map<String, Object>[] misfits = new Map[] {
+                Map.of("model", "m"),                                     // no system-prompt
+                Map.of("system-prompt", "job", "flavour", "mint"),        // unknown key
+                Map.of("system-prompt", "job", "provider", "acme"),       // unknown provider
+                Map.of("system-prompt", "job", "top-p", 1.5),             // top-p range
+                Map.of("system-prompt", "job", "thinking", "deep"),       // thinking vocabulary
+        };
+        for (Map<String, Object> misfit : misfits) {
+            Throwable declarative = catchThrowable(() ->
+                    new LanguageModelServiceType().configure("language-model", misfit));
+            Throwable programmatic = catchThrowable(() -> LanguageModels.configure(misfit));
+            assertThat(programmatic)
+                    .as("programmatic refusal for " + misfit)
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessage(declarative.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("a configured model invokes and carries the reported usage")
+    void invokeCarriesUsage() throws Exception {
+        try (StubLlm stub = StubLlm.start()) {
+            System.setProperty("mavai.llm.endpoint", stub.endpoint());
+            stub.respond(200, """
+                    {"choices": [{"message": {"content": "forty-two"}}],
+                     "usage": {"prompt_tokens": 12, "completion_tokens": 3}}
+                    """);
+            LanguageModel model = LanguageModels.configure(Map.of(
+                    "system-prompt", "You answer briefly.",
+                    "model", "conformance-model"));
+            Outcome<LmReply> outcome;
+            try {
+                outcome = model.invoke("what is six times seven?");
+            } finally {
+                System.clearProperty("mavai.llm.endpoint");
+            }
+            assertThat(outcome).isInstanceOf(Outcome.Ok.class);
+            LmReply reply = ((Outcome.Ok<LmReply>) outcome).value();
+            assertThat(reply.text()).isEqualTo("forty-two");
+            assertThat(reply.usage()).hasValueSatisfying(usage -> {
+                assertThat(usage.inputTokens()).isEqualTo(12);
+                assertThat(usage.outputTokens()).isEqualTo(3);
+                assertThat(usage.totalTokens()).isEqualTo(15);
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("absent usage is tolerated — the reply simply carries none")
+    void absentUsageTolerated() throws Exception {
+        try (StubLlm stub = StubLlm.start()) {
+            System.setProperty("mavai.llm.endpoint", stub.endpoint());
+            stub.respond(200, """
+                    {"choices": [{"message": {"content": "forty-two"}}]}
+                    """);
+            LanguageModel model = LanguageModels.configure(Map.of(
+                    "system-prompt", "You answer briefly.",
+                    "model", "conformance-model"));
+            Outcome<LmReply> outcome;
+            try {
+                outcome = model.invoke("what is six times seven?");
+            } finally {
+                System.clearProperty("mavai.llm.endpoint");
+            }
+            LmReply reply = ((Outcome.Ok<LmReply>) outcome).value();
+            assertThat(reply.usage()).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("a failed delivery is an Outcome failure, never a throw")
+    void failedDeliveryIsAnOutcome() throws Exception {
+        try (StubLlm stub = StubLlm.start()) {
+            System.setProperty("mavai.llm.endpoint", stub.endpoint());
+            stub.respond(503, "overloaded");
+            LanguageModel model = LanguageModels.configure(Map.of(
+                    "system-prompt", "You answer briefly.",
+                    "model", "conformance-model"));
+            Outcome<LmReply> outcome;
+            try {
+                outcome = model.invoke("hello?");
+            } finally {
+                System.clearProperty("mavai.llm.endpoint");
+            }
+            assertThat(outcome).isInstanceOf(Outcome.Fail.class);
+        }
+    }
+}

--- a/punit-lm/src/test/java/org/mavai/punit/lm/architecture/LmArchitectureTest.java
+++ b/punit-lm/src/test/java/org/mavai/punit/lm/architecture/LmArchitectureTest.java
@@ -16,8 +16,10 @@ import org.junit.jupiter.api.Test;
  *
  * <p>punit-lm is a plug-in behind punit-decl's SPI: it depends on
  * punit-decl (and through it punit-core) only, is JUnit-free, adds no
- * statistics, and — declarative-only in v1 — exports nothing: its two
- * ServiceLoader registrations are the whole of its surface.
+ * statistics, and exports exactly one package — {@code lm.api}, the
+ * thin programmatic surface — beside its two ServiceLoader
+ * registrations. Providers, wire shapes, and validation stay
+ * unexported.
  */
 @DisplayName("punit-lm Architecture Rules")
 class LmArchitectureTest {
@@ -32,8 +34,8 @@ class LmArchitectureTest {
     }
 
     @Test
-    @DisplayName("the module exports nothing — the ServiceLoader registrations are the surface")
-    void moduleExportsNothing() throws Exception {
+    @DisplayName("the module exports exactly the api package — internals stay sealed")
+    void moduleExportsExactlyTheApiPackage() throws Exception {
         java.nio.file.Path classes = java.nio.file.Paths.get("build", "classes", "java", "main");
         var descriptor = java.lang.module.ModuleFinder.of(classes).findAll().stream()
                 .map(reference -> reference.descriptor())
@@ -41,9 +43,10 @@ class LmArchitectureTest {
                 .findFirst()
                 .orElseThrow();
         org.assertj.core.api.Assertions.assertThat(descriptor.exports())
-                .as("packages exported by org.mavai.punit.lm — declarative-only, no "
-                        + "programmatic adapter API")
-                .isEmpty();
+                .as("packages exported by org.mavai.punit.lm — the thin programmatic "
+                        + "surface and nothing else")
+                .extracting(java.lang.module.ModuleDescriptor.Exports::source)
+                .containsExactly("org.mavai.punit.lm.api");
         org.assertj.core.api.Assertions.assertThat(descriptor.provides())
                 .as("the two ServiceLoader registrations")
                 .hasSize(2);


### PR DESCRIPTION
Implements `DIR-PU-LM-programmatic-api` (owner rulings 2026-07-30: config-map surface; usage-bearing reply). MAPPING-java.md was amended first, per its rule; inventory row LM03 flips on merge.

## The surface (one exported package, three types)

- **`LanguageModels.configure(Map<String,Object>)`** — the services file's `configuration:` block verbatim. Parity with the declarative route is **by construction**: the factory calls the same strict configure path (validation catalogue, capability allowance, provider resolution, vendor vetoes), pinned by a test asserting byte-identical refusal messages through both doors over the same misfit configurations.
- **`LanguageModel`** — `Outcome<LmReply> invoke(Object)` + `configurationCovariates()`. Delivery taxonomy verbatim: one request per invocation, no retries; 4xx rejection = defect (throws); 5xx/unreachable/off-shape = `Outcome` failure.
- **`LmReply`** — text + `Optional<TokenUsage>` (input/output/total). Usage extraction is new in every adapter, parsed beside the text extraction it belongs with (openai/mistral/apertus/litellm/generic: `usage.prompt_tokens`/`completion_tokens`; anthropic: `usage.input_tokens`/`output_tokens`; ollama: `prompt_eval_count`/`eval_count`) — absent-tolerant, so a gateway that omits usage yields an empty usage, never a failure.

## Internals

- The provider seam's `extract` now returns the reply whole; `ConfiguredLanguageModel` gains an internal `exchange` the api wraps, and the declarative `ConfiguredService.invoke` collapses it to text unchanged (no behaviour change on the declarative path).
- The `LmArchitectureTest` exports pin moves from **exports-nothing** to **exports-exactly-`api`** — providers, wire shapes, and validation stay sealed.
- Anchor `JVI-AT423AB` (LM03) embedded on the factory.

Tests: validation parity, usage populated against the stub, absent-usage tolerance, failed-delivery-as-Outcome. Blast radius: 12 files. Full build green.

Successor (gated on this + the 0.10.0 release): `DIR-PUEX-LM-CONSOLIDATION` — punitexamples deletes its ChatLlm gateway; its mock becomes a plain `LanguageModel` implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM