### PR TITLE
Token usage into the declarative cost blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Token usage reaches the artefact cost blocks.** The declarative
+  path now listens for token cost: `ConfiguredService` gains an
+  additive token-sink invocation default, the language-model type
+  reports each exchange's total through it, and the declarative
+  contract adapters feed punit's existing token tracking — so the
+  explore and optimize artefacts state `totalTokens`/
+  `avgTokensPerSample` in their cost blocks whenever a run tracked
+  tokens (absent when untracked; token-less artefacts stay
+  shape-stable). The shared `mavai` renderer's cost cells show
+  "ms · tok" with no renderer change — the interchange fields
+  existed all along, waiting to be fed.
+
 - **The programmatic language-model client (`org.mavai.punit.lm.api`).**
   punit-lm opens one exported package: `LanguageModels.configure(Map)`
   takes the services file's `configuration:` block verbatim — the same

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -228,6 +228,14 @@ public final class ExploreOutputWriter {
         block.put("totalTimeMs", totalMs);
         int total = summary.total();
         block.put("avgTimePerSampleMs", total == 0 ? 0L : totalMs / total);
+        // Token totals when the run tracked any (the schema's
+        // informational cost fields; absent when untracked, so
+        // token-less runs stay shape-stable).
+        long tokens = summary.tokensConsumed();
+        if (tokens > 0) {
+            block.put("totalTokens", tokens);
+            block.put("avgTokensPerSample", total == 0 ? 0L : tokens / total);
+        }
         return block;
     }
 

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/optimize/OptimizeOutputWriter.java
@@ -228,6 +228,14 @@ public final class OptimizeOutputWriter {
         block.put("totalTimeMs", totalMs);
         int total = summary.total();
         block.put("avgTimePerSampleMs", total == 0 ? 0L : totalMs / total);
+        // Token totals when the run tracked any (the schema's
+        // informational cost fields; absent when untracked, so
+        // token-less runs stay shape-stable).
+        long tokens = summary.tokensConsumed();
+        if (tokens > 0) {
+            block.put("totalTokens", tokens);
+            block.put("avgTokensPerSample", total == 0 ? 0L : tokens / total);
+        }
         return block;
     }
 

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -388,7 +388,7 @@ public final class DeclaredRun implements Declared {
             @Override
             public Outcome<String> invoke(Object input, TokenTracker tracker) {
                 currentInput.set(input);
-                return point.invoke(input);
+                return point.invoke(input, tracker::recordTokens);
             }
 
             @Override
@@ -489,7 +489,8 @@ public final class DeclaredRun implements Declared {
         BindingsRegistry registry = BindingsRegistry.of(resolveBindingsClass());
         ServicesResolver services = ServicesResolver.resolve(
                 caller, servicesFile, registry, ServicesResolver.Posture.STRICT);
-        org.mavai.punit.decl.spi.ConfiguredService defined = services.lookup(declaration.service());
+        final org.mavai.punit.decl.spi.ConfiguredService defined =
+                services.lookup(declaration.service());
         final BindingsRegistry.Invoker invoker;
         Map<String, String> configurationCovariates;
         if (defined != null) {
@@ -539,6 +540,12 @@ public final class DeclaredRun implements Declared {
             @Override
             public Outcome<String> invoke(Object input, TokenTracker tracker) {
                 currentInput.set(input);
+                // A configured service keeps its token channel — the
+                // cost accounting listens through the sink; a bare code
+                // binding has no token notion.
+                if (defined != null) {
+                    return defined.invoke(input, tracker::recordTokens);
+                }
                 return invoker.invoke(input);
             }
 

--- a/punit-decl/src/main/java/org/mavai/punit/decl/spi/ConfiguredService.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/spi/ConfiguredService.java
@@ -28,6 +28,19 @@ public interface ConfiguredService {
     }
 
     /**
+     * Invokes the service once, reporting any known per-invocation
+     * token cost to the sink before returning — the seam punit's cost
+     * accounting listens on. The default ignores the sink: most
+     * services have no token notion, and the plain {@link #invoke}
+     * stays their whole obligation. A token-aware service (the
+     * language-model type) overrides this and reports its exchange's
+     * total.
+     */
+    default Outcome<String> invoke(Object input, java.util.function.LongConsumer tokenSink) {
+        return invoke(input);
+    }
+
+    /**
      * Admits one declared input before any sample runs: the load-time
      * gate for inputs this configured service cannot carry (punit-lm's
      * media capability gate is the first implementation — an undeclared

--- a/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
@@ -65,6 +65,15 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
         return exchange(input).map(org.mavai.punit.lm.api.LmReply::text);
     }
 
+    @Override
+    public Outcome<String> invoke(Object input, java.util.function.LongConsumer tokenSink) {
+        Outcome<org.mavai.punit.lm.api.LmReply> reply = exchange(input);
+        if (reply instanceof Outcome.Ok<org.mavai.punit.lm.api.LmReply> ok) {
+            ok.value().usage().ifPresent(usage -> tokenSink.accept(usage.totalTokens()));
+        }
+        return reply.map(org.mavai.punit.lm.api.LmReply::text);
+    }
+
     /**
      * The full exchange — the reply with its reported token usage.
      * The declarative seam collapses this to text ({@link #invoke});

--- a/punit-lm/src/test/java/org/mavai/punit/lm/LanguageModelsApiTest.java
+++ b/punit-lm/src/test/java/org/mavai/punit/lm/LanguageModelsApiTest.java
@@ -92,6 +92,30 @@ class LanguageModelsApiTest {
     }
 
     @Test
+    @DisplayName("the declarative seam reports tokens through the sink")
+    void declarativeSeamReportsTokens() throws Exception {
+        try (StubLlm stub = StubLlm.start()) {
+            System.setProperty("mavai.llm.endpoint", stub.endpoint());
+            stub.respond(200, """
+                    {"choices": [{"message": {"content": "forty-two"}}],
+                     "usage": {"prompt_tokens": 12, "completion_tokens": 3}}
+                    """);
+            var configured = new LanguageModelServiceType().configure("language-model", Map.of(
+                    "system-prompt", "You answer briefly.",
+                    "model", "conformance-model"));
+            java.util.concurrent.atomic.AtomicLong sunk = new java.util.concurrent.atomic.AtomicLong();
+            try {
+                Outcome<String> outcome = configured.invoke("six times seven?", sunk::addAndGet);
+                assertThat(outcome).isInstanceOf(Outcome.Ok.class);
+            } finally {
+                System.clearProperty("mavai.llm.endpoint");
+            }
+            // The exchange's total — what punit's cost accounting sums.
+            assertThat(sunk.get()).isEqualTo(15);
+        }
+    }
+
+    @Test
     @DisplayName("a failed delivery is an Outcome failure, never a throw")
     void failedDeliveryIsAnOutcome() throws Exception {
         try (StubLlm stub = StubLlm.start()) {


### PR DESCRIPTION
The punit half of the LM token-usage pair (orchestrator directives `DIR-PU-LM-token-usage` + `DIR-BAS-LM-token-usage`) — promoting punit#269's recorded follow-up to shipped: the interchange cost fields and the `mavai` renderer's "ms · tok" cells have existed all along; no framework fed them.

- **`ConfiguredService` additive default**: `invoke(input, LongConsumer tokenSink)` delegating to the plain `invoke` — most services have no token notion; nothing changes for them.
- **The language-model override**: reports each exchange's usage total (from #269's `LmReply`) through the sink before collapsing to text.
- **The declarative adapters** pass `TokenTracker::recordTokens` on both configured-service paths (explore points and the strict test/measure route); bare code bindings unchanged. From there punit's existing token machinery (`SampleSummary.tokensConsumed`) carries the totals.
- **The explore and optimize writers** state `totalTokens`/`avgTokensPerSample` in the cost block when a run tracked tokens — absent when zero, so untracked artefacts stay shape-stable (the fields are schema-informational).

Regression: the sink test drives a configured language-model service against the stub and asserts the exchange total lands. Blast radius: 7 files. Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM