### PR TITLE
Load SPI services through the defining classloader

### DIFF
--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -303,7 +303,9 @@ public final class DeclaredRun implements Declared {
         Map<String, org.mavai.punit.decl.spi.StepperProvider> builtIns =
                 new java.util.LinkedHashMap<>();
         for (org.mavai.punit.decl.spi.StepperProvider provider
-                : java.util.ServiceLoader.load(org.mavai.punit.decl.spi.StepperProvider.class)) {
+                : java.util.ServiceLoader.load(
+                        org.mavai.punit.decl.spi.StepperProvider.class,
+                        org.mavai.punit.decl.spi.StepperProvider.class.getClassLoader())) {
             builtIns.put(provider.name(), provider);
         }
         for (String name : builtIns.keySet()) {

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/ServicesResolver.java
@@ -50,7 +50,11 @@ final class ServicesResolver {
     static ServicesResolver resolve(
             Class<?> caller, Path explicitFile, BindingsRegistry registry, Posture posture) {
         ServicesResolver resolver = new ServicesResolver(posture);
-        for (ServiceType builtIn : ServiceLoader.load(ServiceType.class)) {
+        // The defining classloader, not the thread-context one: under a
+        // classloader-isolated Gradle task (mavaiCheck) the context
+        // loader is the build's and would discover nothing.
+        for (ServiceType builtIn
+                : ServiceLoader.load(ServiceType.class, ServiceType.class.getClassLoader())) {
             resolver.types.put(builtIn.name(), builtIn);
         }
         for (Map.Entry<String, java.lang.reflect.Method> factory : registry.factories().entrySet()) {


### PR DESCRIPTION
Found by punitexamples' first pure-services example: under `mavaiCheck`'s classloader-isolated task, `ServiceLoader.load(X)` consults the thread-context loader (the build's), so the `language-model` type and built-in steppers silently vanished — "registered types: none registered" against a classpath that plainly carried punit-lm. Both SPI loads (`ServiceType` in the resolver, `StepperProvider` in the run) now name the defining classloader, correct in every context the module runs in (test JVM, sentinel, isolated task).

Two-line fix; full build green; verified against the live example (`mavaiCheck` now validates a `type: language-model` service, its grid, and its optimization through the task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM