### PR TITLE
The conventional bindings class is a convention, not a requirement

### DIFF
--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -608,9 +608,13 @@ public final class DeclaredRun implements Declared {
         try {
             return Class.forName(conventional, false, caller.getClassLoader());
         } catch (ClassNotFoundException absent) {
-            throw new ContractConfigurationException(
-                    "no bindings class: define " + conventional + " (the conventional name) or "
-                            + "pass one explicitly with .bindings(YourBindings.class)", absent);
+            // The conventional name is a convention, not a requirement: a
+            // contract whose service lives entirely in the services file
+            // needs no bindings class at all. Anything that actually
+            // needs a code registration — a binding, a @Check, a
+            // registered transform — refuses downstream naming the
+            // registration it misses.
+            return ContractChecker.NoBindings.class;
         }
     }
 }


### PR DESCRIPTION
Found by punitexamples' consolidated pure-services example (a contract + a services-file language model, deliberately no Java): `ContractCheck` already treated the conventional `MavaiBindings` class as optional, but `DeclaredRun` refused eagerly on its absence. Absence now yields the empty registry; anything that actually needs a code registration (a binding, a `@Check`, a registered transform) refuses downstream naming what it misses. One hunk; full build green; verified against the live example (test, explore, optimize all pass with no bindings class present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM