### PR TITLE
State which configuration the sweep was built around

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/api/spec/Experiment.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/Experiment.java
@@ -213,6 +213,19 @@ public final class Experiment implements Spec {
     }
 
     /**
+     * The explored grid point the sweep was built around, when the
+     * experiment declared one. Empty for a grid that is a plain product
+     * of factor values — such a grid has no base, and the artefacts
+     * state none. Consumed by the EXPLORE artefact emitter.
+     */
+    public Optional<Object> baseConfiguration() {
+        if (internal instanceof ExploreInternal<?, ?, ?> e) {
+            return Optional.ofNullable(e.baseConfiguration);
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Diagnostic accessor populated only after an optimize experiment
      * has run. Returns the best-scoring iteration per the
      * optimisation's declared direction (maximise / minimise).
@@ -378,12 +391,14 @@ public final class Experiment implements Spec {
     private static final class ExploreInternal<FT, IT, OT> extends Internal<FT, IT, OT> {
 
         private final List<FT> grid;
+        private final FT baseConfiguration;
         private final Map<FT, SampleSummary<OT>> perConfig = new LinkedHashMap<>();
         private final Map<FT, Integer> perConfigSamplesPlanned = new LinkedHashMap<>();
 
         private ExploreInternal(ExploreBuilder<FT, IT, OT> b) {
             super(b.sampling, b.experimentId != null ? b.experimentId : defaultId("explore"));
             this.grid = b.grid;
+            this.baseConfiguration = b.baseConfiguration;
         }
 
         @Override public Iterator<Configuration<FT, IT, OT>> configurations() {
@@ -466,6 +481,7 @@ public final class Experiment implements Spec {
         private final Sampling<FT, IT, OT> sampling;
         private List<FT> grid;
         private String experimentId;
+        private FT baseConfiguration;
 
         private ExploreBuilder(Sampling<FT, IT, OT> sampling) {
             this.sampling = sampling;
@@ -495,9 +511,30 @@ public final class Experiment implements Spec {
             return this;
         }
 
+        /**
+         * Names the grid element the sweep was built around — the base
+         * configuration whose factor values the other grid points vary.
+         * Optional: a grid that is a plain product of factor values has
+         * no base, and states none. Where there is one, stating it is
+         * what lets a consumer present the comparison as deviations
+         * from a known original instead of guessing an anchor, which a
+         * balanced grid makes impossible.
+         *
+         * @param factors the base configuration, which must be a grid element.
+         */
+        public ExploreBuilder<FT, IT, OT> baseConfiguration(FT factors) {
+            this.baseConfiguration = Objects.requireNonNull(factors, "baseConfiguration");
+            return this;
+        }
+
         public Experiment build() {
             if (grid == null) {
                 throw new IllegalStateException("grid is required — call .grid(...)");
+            }
+            if (baseConfiguration != null && !grid.contains(baseConfiguration)) {
+                throw new IllegalArgumentException(
+                        "the base configuration is not a grid element — it names the grid "
+                                + "point the sweep was built around, so it must be explored too");
             }
             return new Experiment(Kind.EXPLORE, new ExploreInternal<>(this));
         }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -79,10 +79,27 @@ public final class ExploreOutputWriter {
     public String writeYaml(String serviceContractId, FactorBundle factorBundle,
             PerConfigSummary<?, ?> entry,
             java.util.List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteria) {
+        return writeYaml(serviceContractId, factorBundle, entry, criteria, false);
+    }
+
+    /**
+     * As above, stating whether this configuration is the one the sweep
+     * was built around — the {@code mavai-explore-1} schema's additive
+     * {@code baseConfiguration} marker. Stated only on the base, and
+     * only as {@code true}: an absent marker means this emitter said
+     * nothing, never "not the base".
+     */
+    public String writeYaml(String serviceContractId, FactorBundle factorBundle,
+            PerConfigSummary<?, ?> entry,
+            java.util.List<? extends org.mavai.punit.api.criterion.Criterion<?>> criteria,
+            boolean baseConfiguration) {
         Map<String, Object> root = new LinkedHashMap<>();
         root.put("schemaVersion", SCHEMA_VERSION);
         root.put("serviceContractId", serviceContractId);
         root.put("configuration", filenameFor(factorBundle));
+        if (baseConfiguration) {
+            root.put("baseConfiguration", Boolean.TRUE);
+        }
         root.put("generatedAt", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
         root.put("factors", factorsBlock(factorBundle));
         root.put("execution", executionBlock(entry));

--- a/punit-core/src/main/java/org/mavai/punit/internal/runtime/ExploreEmitter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/runtime/ExploreEmitter.java
@@ -107,6 +107,10 @@ public final class ExploreEmitter {
                 .map(entry -> FactorBundle.of(entry.factors()))
                 .toList();
         String experimentDirectory = writer.experimentDirectory(grid);
+        // The base is stated by identity against the declared grid point,
+        // never by position: the emitter reports what the experiment
+        // declared, and an experiment declaring none states none.
+        java.util.Optional<Object> base = experiment.baseConfiguration();
         experiment.dispatch(new Spec.Dispatcher<Void>() {
             @Override
             public <FT, IT, OT> Void apply(TypedSpec<FT, IT, OT> typed) {
@@ -118,7 +122,8 @@ public final class ExploreEmitter {
                     FactorBundle bundle = FactorBundle.of(factors);
                     String stem = writer.filenameFor(bundle);
                     String yaml = writer.writeYaml(
-                            serviceContractId, bundle, entry, contract.effectiveCriteria());
+                            serviceContractId, bundle, entry, contract.effectiveCriteria(),
+                            base.isPresent() && base.get().equals(factors));
                     sink.accept(serviceContractId + "/" + experimentDirectory + "/"
                             + stem + ".yaml", yaml);
                 }

--- a/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
+++ b/punit-core/src/main/java/org/mavai/punit/runtime/PUnit.java
@@ -860,6 +860,17 @@ public final class PUnit {
             return this;
         }
 
+        /**
+         * Names the grid element the sweep was built around — the base
+         * configuration whose factor values the other grid points vary.
+         * Optional; a grid that is a plain product of factor values has
+         * no base and states none.
+         */
+        public ExploreBuilder<FT, IT, OT> baseConfiguration(FT factors) {
+            delegate.baseConfiguration(factors);
+            return this;
+        }
+
         public Experiment build() {
             return delegate.build();
         }

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriterTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriterTest.java
@@ -3,6 +3,7 @@ package org.mavai.punit.internal.engine.explore;
 import static org.mavai.punit.api.criterion.Criteria.meeting;
 import org.mavai.punit.api.criterion.Criteria;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -45,6 +46,63 @@ class ExploreOutputWriterTest {
             return meeting().<Integer>zeroFailures();
         }
 
+    }
+
+    @Test
+    @DisplayName("only the declared base configuration states the base marker")
+    void baseConfigurationIsStatedOnlyWhereDeclared() {
+        // The sweep's base is a fact the author holds and the artefact
+        // must carry: a balanced grid gives a consumer nothing to infer
+        // it from, every point holding each value equally often.
+        LlmFactors base = new LlmFactors("gpt-4o", 0.3);
+        LlmFactors other = new LlmFactors("gpt-4o-mini", 0.7);
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .serviceContractFactory(f -> new LengthServiceContract())
+                .inputs("a")
+                .samples(1)
+                .build();
+        Experiment experiment = Experiment.exploring(sampling)
+                .grid(List.of(base, other))
+                .baseConfiguration(base)
+                .build();
+        new Engine().run(experiment);
+
+        ExploreOutputWriter writer = new ExploreOutputWriter();
+        PerConfigSummary<?, ?> baseEntry = experiment.perConfigSummaries().stream()
+                .filter(e -> e.factors().equals(base)).findFirst().orElseThrow();
+        PerConfigSummary<?, ?> otherEntry = experiment.perConfigSummaries().stream()
+                .filter(e -> e.factors().equals(other)).findFirst().orElseThrow();
+
+        Map<String, Object> marked = new Yaml().load(writer.writeYaml(
+                "LengthServiceContract", FactorBundle.of(baseEntry.factors()), baseEntry,
+                List.of(), true));
+        assertThat(marked).containsEntry("baseConfiguration", Boolean.TRUE);
+
+        // Absence, never a stated false: a consumer must not read silence
+        // as "not the base".
+        String unmarked = writer.writeYaml(
+                "LengthServiceContract", FactorBundle.of(otherEntry.factors()), otherEntry,
+                List.of(), false);
+        assertThat(unmarked).doesNotContain("baseConfiguration");
+        assertThat(new Yaml().load(unmarked).toString()).doesNotContain("baseConfiguration");
+    }
+
+    @Test
+    @DisplayName("a base configuration outside the grid is a misuse defect")
+    void baseConfigurationMustBeAGridElement() {
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .serviceContractFactory(f -> new LengthServiceContract())
+                .inputs("a")
+                .samples(1)
+                .build();
+        assertThatThrownBy(() -> Experiment.exploring(sampling)
+                .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
+                .baseConfiguration(new LlmFactors("never-explored", 0.1))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a grid element");
     }
 
     @Test

--- a/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
+++ b/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mavai-org/mavai-R/schema/mavai-explore-1.schema.json",
   "title": "mavai exploration interchange artefact",
-  "description": "One document per explored experiment configuration: the configuration's identity and the descriptive results its run observed. Framework-neutral: emitted by any mavai-family framework, consumed by shared tooling such as the report renderer. This schema is the machine-checkable structural projection of the canonical format specification; it validates the parsed data model of the YAML document. Statistics are stated by the emitter (percentiles value-or-absent under the emitter's own minimum-sample gate) — consumers never derive them. Additive evolution: emitters may add fields anywhere; consumers ignore what they do not know.",
+  "description": "One document per explored experiment configuration: the configuration's identity and the descriptive results its run observed. Framework-neutral: emitted by any mavai-family framework, consumed by shared tooling such as the report renderer. This schema is the machine-checkable structural projection of the canonical format specification; it validates the parsed data model of the YAML document. Statistics are stated by the emitter (percentiles value-or-absent under the emitter's own minimum-sample gate) \u2014 consumers never derive them. Additive evolution: emitters may add fields anywhere; consumers ignore what they do not know.",
   "type": "object",
   "required": [
     "schemaVersion",
@@ -32,6 +32,11 @@
       "minLength": 1,
       "description": "The configuration's display name. Cross-document identity for consumers; filenames are never parsed."
     },
+    "baseConfiguration": {
+      "type": "boolean",
+      "const": true,
+      "description": "Marks this document's configuration as the one the sweep was built around \u2014 the base whose factor values the other configurations override. Stated by the emitter, which holds the authored fact; a consumer never infers it from a balanced design, where every configuration is structurally interchangeable. Additive and stated only on the base: at most one document per service contract carries it, and its absence means unstated, never 'not the base'. Named for the Experiment Configuration it marks \u2014 'baseline' belongs to the Empirical Baseline and is deliberately not reused here."
+    },
     "generatedAt": {
       "type": "string",
       "format": "date-time",
@@ -41,16 +46,30 @@
       "type": "object",
       "description": "The configuration's factor values, keyed by factor name. May be absent for a single-configuration exploration with no varied factors.",
       "additionalProperties": {
-        "type": ["string", "number", "boolean"]
+        "type": [
+          "string",
+          "number",
+          "boolean"
+        ]
       }
     },
     "execution": {
       "type": "object",
-      "required": ["samplesPlanned", "samplesExecuted", "terminationReason"],
+      "required": [
+        "samplesPlanned",
+        "samplesExecuted",
+        "terminationReason"
+      ],
       "additionalProperties": true,
       "properties": {
-        "samplesPlanned": { "type": "integer", "minimum": 0 },
-        "samplesExecuted": { "type": "integer", "minimum": 0 },
+        "samplesPlanned": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "samplesExecuted": {
+          "type": "integer",
+          "minimum": 0
+        },
         "terminationReason": {
           "type": "string",
           "minLength": 1,
@@ -58,9 +77,15 @@
         }
       }
     },
-    "statistics": { "$ref": "#/$defs/statistics" },
-    "cost": { "$ref": "#/$defs/cost" },
-    "latency": { "$ref": "#/$defs/latency" },
+    "statistics": {
+      "$ref": "#/$defs/statistics"
+    },
+    "cost": {
+      "$ref": "#/$defs/cost"
+    },
+    "latency": {
+      "$ref": "#/$defs/latency"
+    },
     "resultProjection": {
       "description": "Informational per-sample detail, emitter-formatted. Consumers must not require it."
     }
@@ -68,7 +93,12 @@
   "$defs": {
     "statistics": {
       "type": "object",
-      "required": ["observed", "successes", "failures", "criteria"],
+      "required": [
+        "observed",
+        "successes",
+        "failures",
+        "criteria"
+      ],
       "additionalProperties": true,
       "properties": {
         "observed": {
@@ -77,38 +107,193 @@
           "maximum": 1,
           "description": "Overall observed pass rate (successes / executed)."
         },
-        "successes": { "type": "integer", "minimum": 0 },
-        "failures": { "type": "integer", "minimum": 0 },
-        "failureDistribution": { "$ref": "#/$defs/failureDistribution" },
+        "successes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failureDistribution": {
+          "$ref": "#/$defs/failureDistribution"
+        },
         "criteria": {
           "type": "object",
           "minProperties": 1,
-          "description": "One entry per declared criterion, keyed by criterion name — including the single-criterion case.",
-          "additionalProperties": { "$ref": "#/$defs/criterion" }
+          "description": "One entry per declared criterion, keyed by criterion name \u2014 including the single-criterion case.",
+          "additionalProperties": {
+            "$ref": "#/$defs/criterion"
+          }
         }
       },
       "if": {
-        "properties": { "failures": { "exclusiveMinimum": 0 } },
-        "required": ["failures"]
+        "properties": {
+          "failures": {
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": [
+          "failures"
+        ]
       },
       "then": {
-        "required": ["failureDistribution"]
+        "required": [
+          "failureDistribution"
+        ]
       }
     },
     "criterion": {
       "type": "object",
-      "required": ["observedPassRate", "pass", "fail"],
+      "required": [
+        "observedPassRate",
+        "pass",
+        "fail"
+      ],
       "additionalProperties": true,
       "properties": {
-        "observedPassRate": { "type": "number", "minimum": 0, "maximum": 1 },
-        "pass": { "type": "integer", "minimum": 0 },
-        "fail": { "type": "integer", "minimum": 0 },
-        "failureDistribution": { "$ref": "#/$defs/failureDistribution" }
+        "observedPassRate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "pass": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fail": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failureDistribution": {
+          "$ref": "#/$defs/failureDistribution"
+        },
+        "standings": {
+          "$ref": "#/$defs/standings"
+        }
+      }
+    },
+    "standings": {
+      "type": "object",
+      "description": "The criterion's descriptive postcondition standings (amendment 2026-07-28): the per-(input, check) tally of the per-trial check outcomes the evaluator computes. Binding when present, additive \u2014 absent in pre-amendment emissions; consumers render absence as absence and never reconstruct standings from resultProjection. Counts and the observed fraction only \u2014 never a confidence interval, a threshold, or per-check verdict vocabulary; the criterion remains the family's only judged unit.",
+      "required": [
+        "rows"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "optionalSlack": {
+          "type": "string",
+          "pattern": "^[0-9]+%?$",
+          "description": "The criterion's declared optional-check failure budget, verbatim as authored: digits for a count ('2'), digits + % for a percentage ('20%'). Absent iff the contract declares none \u2014 absence is distinguishable from '0', the explicit budget of zero."
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "description": "One row per (input, check), in the emitter's stated order.",
+          "items": {
+            "type": "object",
+            "required": [
+              "inputIndex",
+              "check",
+              "optional",
+              "passed",
+              "failed",
+              "skipped",
+              "observedFraction"
+            ],
+            "additionalProperties": true,
+            "properties": {
+              "inputIndex": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Zero-based structural input reference, as in failureDistribution."
+              },
+              "check": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "description": "The check's bounded identity, as the contract declares it \u2014 never embedding input or response content."
+              },
+              "optional": {
+                "type": "boolean",
+                "description": "Whether the contract marks this check optional \u2014 stated explicitly for every row."
+              },
+              "passed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "failed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "skipped": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Trials on which the check was not judged because an earlier transform failed."
+              },
+              "observedFraction": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "passed / (passed + failed + skipped), as stated by the emitter."
+              },
+              "path": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "description": "The structural address the check judges, as declared (amendment 2026-07-28, structured rows). Present iff path-addressed; the by-path grouping key \u2014 never derived from check."
+              },
+              "form": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "description": "The comparison form's domain name, as the contract format spells it."
+              },
+              "expected": {
+                "type": "string",
+                "maxLength": 256,
+                "description": "Bounded excerpt of the declared operand, for display \u2014 never an identity."
+              },
+              "observed": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Obtained-value exemplars, failing exemplars first; distinct excerpts capped by the emitter, counts summing to at most the row's trials.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "excerpt",
+                    "count",
+                    "held"
+                  ],
+                  "additionalProperties": true,
+                  "properties": {
+                    "excerpt": {
+                      "type": "string",
+                      "maxLength": 256
+                    },
+                    "count": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "held": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "elided": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Trials whose obtained values were not exemplified."
+              }
+            }
+          }
+        }
       }
     },
     "failureDistribution": {
       "type": "array",
-      "description": "A sequence of failure entries aggregated over the run (amendment 2026-07-17: the earlier check-name-keyed mapping is withdrawn — no mapping key may derive from input or response content, per the interchange area's key discipline). Each failed trial is attributed to its first failing condition; the entries' counts sum to the enclosing failures total.",
+      "description": "A sequence of failure entries aggregated over the run (amendment 2026-07-17: the earlier check-name-keyed mapping is withdrawn \u2014 no mapping key may derive from input or response content, per the interchange area's key discipline). Each failed trial is attributed to its first failing condition; the entries' counts sum to the enclosing failures total.",
       "items": {
         "type": "object",
         "required": [
@@ -121,7 +306,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
-            "description": "The violating condition's bounded identity, as the contract declares it — never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex."
+            "description": "The violating condition's bounded identity, as the contract declares it \u2014 never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex."
           },
           "count": {
             "type": "integer",
@@ -131,12 +316,12 @@
           "inputIndex": {
             "type": "integer",
             "minimum": 0,
-            "description": "Zero-based index into the inputs list, present when the condition is per-input — the structural input reference; the input value itself is never serialised as identity."
+            "description": "Zero-based index into the inputs list, present when the condition is per-input \u2014 the structural input reference; the input value itself is never serialised as identity."
           },
           "inputExcerpt": {
             "type": "string",
             "maxLength": 256,
-            "description": "Informational bounded excerpt of the driving input, for human orientation only — consumers correlate via inputIndex."
+            "description": "Informational bounded excerpt of the driving input, for human orientation only \u2014 consumers correlate via inputIndex."
           }
         }
       }
@@ -146,28 +331,65 @@
       "description": "Informational wall-clock and token totals/averages.",
       "additionalProperties": true,
       "properties": {
-        "totalTimeMs": { "type": "integer", "minimum": 0 },
-        "avgTimePerSampleMs": { "type": "integer", "minimum": 0 },
-        "totalTokens": { "type": "integer", "minimum": 0 },
-        "avgTokensPerSample": { "type": "integer", "minimum": 0 }
+        "totalTimeMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "avgTimePerSampleMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalTokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "avgTokensPerSample": {
+          "type": "integer",
+          "minimum": 0
+        }
       }
     },
     "latency": {
       "type": "object",
       "description": "Absent as a whole when no sample passed. Percentiles are STATED value-or-absent: an absent key means 'not stateable at this sample count under the emitter's gate', never zero.",
-      "required": ["basis", "contributingSamples", "totalSamples", "sortedPassingLatenciesMs"],
+      "required": [
+        "basis",
+        "contributingSamples",
+        "totalSamples",
+        "sortedPassingLatenciesMs"
+      ],
       "additionalProperties": true,
       "properties": {
-        "basis": { "const": "passing-samples" },
-        "contributingSamples": { "type": "integer", "minimum": 1 },
-        "totalSamples": { "type": "integer", "minimum": 1 },
-        "p50Ms": { "type": "number", "minimum": 0 },
-        "p95Ms": { "type": "number", "minimum": 0 },
-        "p99Ms": { "type": "number", "minimum": 0 },
+        "basis": {
+          "const": "passing-samples"
+        },
+        "contributingSamples": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "totalSamples": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "p50Ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "p95Ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "p99Ms": {
+          "type": "number",
+          "minimum": 0
+        },
         "sortedPassingLatenciesMs": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "number", "minimum": 0 },
+          "items": {
+            "type": "number",
+            "minimum": 0
+          },
           "description": "Recorded passing-trial durations, milliseconds, ascending. For shape-only consumption."
         }
       }

--- a/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
+++ b/punit-decl/src/main/java/org/mavai/punit/decl/internal/run/DeclaredRun.java
@@ -181,7 +181,11 @@ public final class DeclaredRun implements Declared {
         System.out.println("[PUNIT] run plan: contract '" + declaration.contract() + "', "
                 + grid.size() + " configurations x " + perConfig + " samples — explore");
 
-        PUnit.exploring(sampling).grid(grid).run();
+        // The grid is the services file's own `configuration:` followed
+        // by each `explorations:` delta merged over it, so its first
+        // point is the authored base — a fact only this side holds, and
+        // one no consumer can recover from a balanced sweep.
+        PUnit.exploring(sampling).grid(grid).baseConfiguration(grid.get(0)).run();
     }
 
     @Override


### PR DESCRIPTION
punit's side of the base-configuration amendment (mavai-org/mavai-R#15; baseltest first mover in mavai-org/baseltest#95). Schema vendored from mavai-R 0.10.6.

## Why

An explore artefact carries its configuration's fully-resolved factor set, so the overlay structure a services file declares — a baseline `configuration:` plus `explorations:` deltas merged over it — is lost at serialisation, and a consumer is left inferring which point the sweep was built around. Inference cannot recover it: where the deltas cover a cross-product the grid is balanced, every point holds each factor value equally often, and every one of them reads as an equally valid base.

## What

`ExploreBuilder.baseConfiguration(FT)` names the grid element the sweep was built around, and `ExploreEmitter` states `mavai-explore-1`'s additive `baseConfiguration` marker on that artefact.

Three deliberate choices:

- **Matched by identity against the declared grid point, never by position.** The emitter reports what the experiment declared, not what happened to be written first.
- **Optional throughout.** A grid that is a plain product of factor values has no base and states none — this is punit's ordinary programmatic explore, and its artefacts are unchanged. Only the declarative surface, which has an authored base, passes one: its grid's first point, the services file's own `configuration:`.
- **Written only as `true`.** A `false` would invite a consumer to read absence as a stated "not the base" when absence means we said nothing.

Naming a base outside the grid is a misuse defect (`IllegalArgumentException`) — it names the grid point the sweep was built around, so it must have been explored.

`./gradlew build` green across all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWJ92fuXBMN29vpAUwcDM