### PR TITLE
A zero rate is exactly zero, and a refused design says why

### DIFF
--- a/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
@@ -159,6 +159,24 @@ public class BinomialProportionEstimator {
         // turns any positive residue into 1 — demanding one success of a
         // test whose baseline can demand nothing. Return the algebraic
         // value rather than the computed one.
+        //
+        // On the exact comparison, which is normally a smell: this is a
+        // test on an *input*, not on two computed quantities, and the
+        // input's domain is discrete. Baselines store (k, n) rather than
+        // a rate (companion §4.3), so pHat arrives here as either k/n —
+        // exactly +0.0 when k = 0, since IEEE 754 division of zero is
+        // exact — or as an effective baseline rate, which §4.3.2 bounds
+        // at n/(n + z^2), far from zero. There is no value between 0 and
+        // 1/n for the comparison to miss: the smallest non-zero rate a
+        // million-sample baseline can express is 1e-6. Negative zero
+        // compares equal, and NaN is rejected above.
+        //
+        // The failure mode of an exact test is also benign here. A rate
+        // that is genuinely tiny but non-zero is not a degenerate case
+        // needing to be snapped; it falls through and is computed by the
+        // formula, which is well defined there. Widening this to an
+        // epsilon would do the opposite of what it looks like — it would
+        // silently round real, small rates down to a threshold of zero.
         if (pHat == 0.0) {
             return 0.0;
         }

--- a/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/BinomialProportionEstimator.java
@@ -148,6 +148,21 @@ public class BinomialProportionEstimator {
         }
         validateConfidenceLevel(confidenceLevel);
 
+        // At pHat = 0 the centre and the margin are the same quantity,
+        // z^2 / (2n), so the bound is exactly 0 at every n and confidence.
+        // That is an algebraic identity, not a small number, and floating
+        // point does not reliably deliver it: over n in 1..1000 a residue
+        // near 1e-18 survives at 265 sizes at one-sided 90%, 201 at 95%,
+        // and 121 at 99%. The residue is invisible against any tolerance
+        // a caller would set and decisive on the artefact that binds,
+        // because the integer cutoff is ceil(n * threshold) and ceil
+        // turns any positive residue into 1 — demanding one success of a
+        // test whose baseline can demand nothing. Return the algebraic
+        // value rather than the computed one.
+        if (pHat == 0.0) {
+            return 0.0;
+        }
+
         double alpha = 1.0 - confidenceLevel;
         double z = STANDARD_NORMAL.inverseCumulativeProbability(1.0 - alpha);
         CenterMargin centerMargin = getCenterMargin(trials, z, pHat);

--- a/punit-core/src/main/java/org/mavai/punit/statistics/RiskDrivenSizingCalculator.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/RiskDrivenSizingCalculator.java
@@ -155,7 +155,7 @@ public class RiskDrivenSizingCalculator {
             double confidence,
             double targetPower) {
         validateSampleSize(sampleSize);
-        validateProbability(baselineRate, "Baseline rate");
+        validateBaselineRate(baselineRate);
         validateProbability(confidence, "Confidence");
         validateProbability(targetPower, "Target power");
 
@@ -181,11 +181,12 @@ public class RiskDrivenSizingCalculator {
 
     private void validateSizingInputs(
             double baselineRate, double minimumAcceptableRate, double confidence) {
-        validateProbability(baselineRate, "Baseline rate");
+        validateBaselineRate(baselineRate);
         validateProbability(minimumAcceptableRate, "Minimum acceptable rate");
         validateProbability(confidence, "Confidence");
         if (minimumAcceptableRate >= baselineRate) {
-            throw new IllegalArgumentException(
+            throw new SizingRefusedException(
+                    SizingRefusedException.Cause.EMPTY_TOLERANCE_INTERVAL,
                     "Minimum acceptable rate (" + minimumAcceptableRate
                             + ") must sit below the measured baseline rate (" + baselineRate
                             + "): the moving-floor construction sizes the detection of a "
@@ -193,6 +194,30 @@ public class RiskDrivenSizingCalculator {
                             + "the baseline, re-measure the baseline rather than asserting "
                             + "improvement through the tolerance.");
         }
+    }
+
+    /**
+     * The baseline rate, with the zero baseline named rather than folded into
+     * the generic domain check.
+     *
+     * <p>A baseline that observed no successes has an effective rate of
+     * exactly 0 at every sample size (companion §4.3.4), so no declared
+     * tolerance can sit below it and no design is priceable. Saying so is
+     * more use to the operator than "must be in (0, 1)", and it is a
+     * different corrective action: measure a baseline, rather than adjust
+     * the tolerance.
+     */
+    private void validateBaselineRate(double baselineRate) {
+        if (baselineRate == 0.0) {
+            throw new SizingRefusedException(
+                    SizingRefusedException.Cause.ZERO_BASELINE,
+                    "Baseline rate is exactly 0: the baseline observed no successes, so "
+                            + "its effective rate is 0 at every sample size and there is no "
+                            + "tolerated rate below it to detect. No sample size can price "
+                            + "this design. Measure a baseline with at least one success "
+                            + "before sizing against it.");
+        }
+        validateProbability(baselineRate, "Baseline rate");
     }
 
     private void validateProbability(double value, String name) {

--- a/punit-core/src/main/java/org/mavai/punit/statistics/SizingRefusedException.java
+++ b/punit-core/src/main/java/org/mavai/punit/statistics/SizingRefusedException.java
@@ -1,0 +1,53 @@
+package org.mavai.punit.statistics;
+
+/**
+ * A risk-driven sizing design that cannot be priced, refused with its cause
+ * stated as data rather than only as prose.
+ *
+ * <h2>Why this is an exception and not an {@code Outcome}</h2>
+ * <p>An inadmissible sizing design is a <em>misconfiguration</em>: the
+ * operator has declared a design the evidence cannot price. Misconfiguration
+ * travels on the exception channel; the {@code Outcome} channel carries the
+ * anticipated failure of a <em>sample</em>, which this is not. Sizing happens
+ * once, at pre-flight, before any sample is taken.
+ *
+ * <h2>Why it is a type of its own</h2>
+ * <p>The refusal was previously an {@link IllegalArgumentException} whose only
+ * distinguishing feature was its message. Two causes reach it, and they call
+ * for different corrective action:
+ * <ul>
+ *   <li>{@link Cause#ZERO_BASELINE} — the baseline observed no successes, so
+ *       the effective baseline rate is exactly 0 (statistical companion
+ *       §4.3.4) and the domain {@code p_min < p₀} is empty for every declared
+ *       tolerance. <em>Go and measure a baseline.</em></li>
+ *   <li>{@link Cause#EMPTY_TOLERANCE_INTERVAL} — the baseline is usable, but
+ *       the declared tolerance does not sit below it, so there is no
+ *       degradation to detect. <em>Re-measure the baseline rather than raising
+ *       the tolerance.</em></li>
+ * </ul>
+ *
+ * <p>Carrying the cause as an enum lets a caller — a report, a diagnostic, a
+ * conformance run — distinguish them without parsing prose.
+ */
+public class SizingRefusedException extends IllegalArgumentException {
+
+    /** Why a sizing design could not be priced. */
+    public enum Cause {
+        /** The baseline observed no successes; the sizing domain is empty. */
+        ZERO_BASELINE,
+        /** The declared tolerance does not sit strictly below the baseline. */
+        EMPTY_TOLERANCE_INTERVAL
+    }
+
+    private final transient Cause cause;
+
+    public SizingRefusedException(Cause cause, String message) {
+        super(message);
+        this.cause = cause;
+    }
+
+    /** The cause of the refusal, as data. */
+    public Cause refusalCause() {
+        return cause;
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/BinomialProportionEstimatorTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/BinomialProportionEstimatorTest.java
@@ -591,5 +591,46 @@ class BinomialProportionEstimatorTest {
                     .isCloseTo(0.0000, within(0.0005));
         }
     }
-}
 
+    @Nested
+    @DisplayName("Zero rate")
+    class ZeroRate {
+
+        @Test
+        @DisplayName("the bound is exactly zero, not a cancellation residue")
+        void zeroRateGivesExactlyZero() {
+            // At pHat = 0 the centre and the margin are the same quantity,
+            // z^2 / (2n), so they cancel and the bound is exactly 0 — an
+            // algebraic identity holding at every n and every confidence.
+            // Asserted with isEqualTo, not isCloseTo: a tolerance comparison
+            // is precisely what cannot see the failure this pins. The sweep
+            // is dense because the round numbers one would sample by hand
+            // mostly cancel cleanly on their own.
+            for (int n = 1; n <= 1000; n++) {
+                for (double confidence : new double[] {0.90, 0.95, 0.99}) {
+                    assertThat(estimator.lowerBoundFromRate(0.0, n, confidence))
+                            .as("n = %d, confidence = %s", n, confidence)
+                            .isEqualTo(0.0);
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("the integer cutoff stays at zero")
+        void zeroRateLeavesTheCutoffAtZero() {
+            // Why the identity above earns a test of its own. The binding
+            // decision artefact is ceil(n * threshold), and ceil turns any
+            // positive residue into 1 — demanding one success of a test whose
+            // baseline can demand nothing. Against the previous arithmetic
+            // this failed at 265 sizes at 90%, 201 at 95% and 121 at 99%.
+            for (int n = 1; n <= 1000; n++) {
+                for (double confidence : new double[] {0.90, 0.95, 0.99}) {
+                    double threshold = estimator.lowerBoundFromRate(0.0, n, confidence);
+                    assertThat(Math.ceil(n * threshold))
+                            .as("n = %d, confidence = %s", n, confidence)
+                            .isEqualTo(0.0);
+                }
+            }
+        }
+    }
+}

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/ConformanceCatalog.java
@@ -15,6 +15,7 @@ import org.mavai.punit.statistics.LatencyThresholdDeriver;
 import org.mavai.punit.statistics.OperationalApproach;
 import org.mavai.punit.statistics.RiskDrivenSizingCalculator;
 import org.mavai.punit.statistics.SampleSizeCalculator;
+import org.mavai.punit.statistics.SizingRefusedException;
 import org.mavai.punit.statistics.SampleSizeRequirement;
 import org.mavai.punit.statistics.TestVerdictEvaluator;
 import org.mavai.punit.statistics.ThresholdDeriver;
@@ -27,7 +28,9 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mavai.punit.statistics.conformance.OracleAssert.assertOracle;
+import static org.mavai.punit.statistics.conformance.OracleAssert.assertOracleAbsent;
 
 /**
  * The registry of every conformance check punit runs against the mavai-R
@@ -234,6 +237,11 @@ final class ConformanceCatalog {
 
     private static void assertRiskDrivenSizingCase(
             ConformanceRecorder recorder, JsonNode c, double tolerance) {
+        if ("REFUSE".equals(c.get("expected").get("sizing_gate").asText())) {
+            assertSizingRefusalCase(recorder, c);
+            return;
+        }
+        assertOracle(recorder, "risk_driven_sizing", c, "sizing_gate", "ADMIT");
         switch (c.get("approach").asText()) {
             case "required_n" -> assertRequiredSampleSizeCase(recorder, c, tolerance);
             case "power_at" -> assertPowerAtCandidateSizeCase(recorder, c, tolerance);
@@ -261,6 +269,61 @@ final class ConformanceCatalog {
                 RISK_DRIVEN_SIZING.powerAt(requiredSamples, baselineRate,
                         minimumAcceptableRate, confidence),
                 tolerance);
+    }
+
+    /**
+     * An inadmissible sizing design: the refusal itself is the expected
+     * outcome, so the assertion is that the production surface declines and
+     * names the cause — not that it returns a number.
+     *
+     * <p>Sizing refusal is misconfiguration, so it travels on the exception
+     * channel (the family's {@code Outcome} channel carries the anticipated
+     * failure of a sample, and sizing happens before any sample is taken).
+     * What the fixture binds is that the refusal is *distinguishable*: the
+     * cause is carried as data on {@link SizingRefusedException}, so this
+     * assertion never parses a message.
+     */
+    private static void assertSizingRefusalCase(ConformanceRecorder recorder, JsonNode c) {
+        var inputs = c.get("inputs");
+        double baselineRate = inputs.get("baseline_rate").asDouble();
+        double confidence = inputs.get("confidence").asDouble();
+
+        SizingRefusedException refusal = catchThrowableOfType(
+                SizingRefusedException.class,
+                () -> {
+                    switch (c.get("approach").asText()) {
+                        case "required_n" -> RISK_DRIVEN_SIZING.requiredSamples(
+                                baselineRate, inputs.get("minimum_acceptable_rate").asDouble(),
+                                confidence, inputs.get("target_power").asDouble());
+                        case "power_at" -> RISK_DRIVEN_SIZING.powerAt(
+                                inputs.get("test_samples").asInt(), baselineRate,
+                                inputs.get("minimum_acceptable_rate").asDouble(), confidence);
+                        case "detectable_rate" -> RISK_DRIVEN_SIZING.detectableRate(
+                                inputs.get("test_samples").asInt(), baselineRate,
+                                confidence, inputs.get("target_power").asDouble());
+                        default -> throw new IllegalStateException(
+                                "unknown sizing approach '%s' in case '%s'".formatted(
+                                        c.get("approach").asText(), c.get("name").asText()));
+                    }
+                });
+
+        assertThat(refusal)
+                .as("risk_driven_sizing/%s: the oracle expects this design to be refused",
+                        c.get("name").asText())
+                .isNotNull();
+        assertOracle(recorder, "risk_driven_sizing", c, "sizing_gate", "REFUSE");
+        assertOracle(recorder, "risk_driven_sizing", c, "refusal_category",
+                refusal.refusalCause().name());
+
+        // The numerics the manifest still binds on this case. The refusal
+        // means there is no value for any of them, and saying so is the
+        // assertion: a framework that clamped the baseline and returned a
+        // number would fail here.
+        c.get("expected").fieldNames().forEachRemaining(field -> {
+            if (c.get("expected").get(field).isNull()) {
+                assertOracleAbsent(recorder, "risk_driven_sizing", c, field);
+            }
+        });
     }
 
     private static void assertPowerAtCandidateSizeCase(

--- a/punit-core/src/test/java/org/mavai/punit/statistics/conformance/OracleAssert.java
+++ b/punit-core/src/test/java/org/mavai/punit/statistics/conformance/OracleAssert.java
@@ -19,6 +19,36 @@ final class OracleAssert {
     private OracleAssert() { }
 
     /** Exact-equality form: booleans, strings, integer-valued fields. */
+    /**
+     * Discharge a binding field whose expected value on this case is null.
+     *
+     * <p>A refusal case carries every numeric expectation as null, because
+     * none exists: the design was declined, so there is no sample size, no
+     * floor, no power. The manifest still lists those fields as binding —
+     * it classifies fields per suite, not per case — so the obligation is
+     * real and has to be met by saying something true about them.
+     *
+     * <p>What is true is that the oracle expects no value and the production
+     * surface produced none. Asserting that is not a formality: a framework
+     * that returned a number here — having clamped the baseline to something
+     * small, or fallen back to a fixed-threshold form — would fail it, which
+     * is exactly the repair companion §4.3.4 forbids.
+     */
+    static void assertOracleAbsent(
+            ConformanceRecorder recorder, String suite, JsonNode fixtureCase, String field) {
+        String caseName = fixtureCase.get("name").asText();
+        recorder.record(suite, caseName, field);
+        JsonNode expected = fixtureCase.get("expected").get(field);
+        String label = suite + "/" + caseName + "/" + field;
+        if (expected == null) {
+            throw new IllegalStateException(
+                    label + ": the fixture case carries no such expected field — check the assertion");
+        }
+        assertThat(expected.isNull())
+                .as("%s: expected an absent value, but the oracle publishes %s", label, expected)
+                .isTrue();
+    }
+
     static void assertOracle(
             ConformanceRecorder recorder, String suite, JsonNode fixtureCase,
             String field, Object actual) {


### PR DESCRIPTION
Brings punit into conformance with **mavai-R v0.10.13**, which publishes the zero baseline for the first time. punit was red on eleven cases; it is green on all of them.

**Standing against v0.10.13: 239/239 mandatory binding assertions over seven suites, 128/128 scope over five, zero gaps.**

## The arithmetic (4 of the 11)

At a zero rate the Wilson bound's centre and margin are the same quantity, `z²/(2n)`, so they cancel and the bound is exactly zero. Binary floating point does not reliably deliver that: over `n` in 1..1000 a residue near `1e-18` survives at **265 sizes at one-sided 90%, 201 at 95%, 121 at 99%**. The round numbers one checks by hand mostly cancel cleanly, which is why nobody found it by looking.

The residue is invisible against any tolerance a caller would set, and decisive on the artefact that binds: the cutoff is `ceil(n × threshold)`, and `ceil` turns any positive residue into 1 — demanding one success of a test whose baseline can demand nothing. `lowerBoundFromRate` now returns the algebraic value.

The same defect was in the oracle and in feotest, identically. Three implementations, three languages, one fault, invisible to every conformance run — because the case that would have exposed it did not exist.

## The verdicts (2 of the 11) — neither was a defect

- The `FAIL` was downstream of the wrong cutoff and went green on the arithmetic fix alone.
- The `INCONCLUSIVE` was **punit being right**: `EmpiricalChecks.sampleSizeConstraint` refuses a test that outsizes its baseline, and the fixture had sized a 0/10 baseline against a 50-sample test. That rule has nothing to do with zero baselines. Fixed on the oracle side in mavai-R#26.

## The refusals (5 of the 11)

These **stay on the exception channel**. An inadmissible sizing design is a *misconfiguration* found at pre-flight — the convention reserves `throw` for defects, misconfiguration and catastrophe, and reserves `Outcome` for the anticipated failure of a *sample*. Sizing runs before any sample is taken.

What was wrong is that the refusal was an `IllegalArgumentException` distinguished only by its prose, so nothing downstream could tell the two causes apart. `SizingRefusedException` carries the cause as data:

- `ZERO_BASELINE` — *go and measure a baseline*
- `EMPTY_TOLERANCE_INTERVAL` — *re-measure the baseline rather than raising the tolerance*

The zero baseline is now named where it used to be folded into a generic "must be in (0, 1)".

## Conformance harness

Asserts refusals instead of crashing on them, and discharges the null numerics beside them via `assertOracleAbsent`. That is a real assertion, not a formality: a framework that clamped the baseline and returned a number fails it — and clamping is the repair companion §4.3.4 forbids.

## Tests

`punit-core` + `punit-report`: **2003 tests green**. Regression tests sweep `n` in 1..1000 at three confidence levels and assert with `isEqualTo`, not `isCloseTo` — a tolerance comparison is precisely what could not see this.

> Unrelated and pre-existing: `punit-decl`'s `FormatConformanceTest` has 4 failures on `main`, confirmed present on a clean tree at HEAD without any of this work. Not touched here.