### PR TITLE
The client deadline, the delivery cause, and the trial that judged nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **A language-model service states how long it will be waited for.**
+  The `deadline-ms:` configuration key bounds one exchange — the whole
+  exchange, not merely the connection, since the failure it guards
+  against is a peer that accepts a request and then goes silent on a
+  socket that connected perfectly. Unstated it defaults to 600000 and
+  is recorded as such: the deadline is part of the service's identity,
+  so it is fingerprinted like any covariate and a baseline measured
+  under one deadline does not resolve a test run under another.
+  Previously punit set no timeout at either level and such a peer held
+  a sample open indefinitely.
+
+- **A failed delivery says what kind of failure it was.** Explore and
+  optimize artefacts state `kind` on every failure entry, and a
+  delivery entry's condition is its cause — `unreachable`,
+  `client-deadline`, `peer-timeout`, `server-error`,
+  `unusable-response` — so a configuration whose endpoint was down and
+  one whose answers were bad no longer present identically at a pass
+  rate of zero. The counting rule is untouched: a failed delivery is a
+  failed sample, as before. Authors state a cause from their own
+  bindings through `DeliveryCause`.
+
 - **Token usage reaches the artefact cost blocks.** The declarative
   path now listens for token cost: `ConfiguredService` gains an
   additive token-sink invocation default, the language-model type
@@ -36,17 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   feed cost reporting. Providers, wire shapes, and validation stay
   internal; the module's exports pin moves from exports-nothing to
   exports-exactly-`api`.
-
-### Fixed
-
-- **Measure output names its persisted artefact.** A recording's
-  product is the baseline, not a verdict — every MEASURE run now
-  prints `baseline recorded: <path>` as the artefact lands, closing an
-  honest-output gap (the shape rule: a recording is labelled, renders
-  no composite verdict, and names what it persisted — the first two
-  already held, pinned by a new regression test alongside the fix).
-
-### Added
 
 - **Graduation: the `mavaiMaterialise` task.** For each declared
   contract, emits the equivalent contract as Java source the developer
@@ -92,7 +102,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   conformance corpus mavai-R v0.10.5 — the gate's known-unmet ledger
   is empty again).
 
+- **The declarative-format conformance gate.** punit-decl's test suite
+  now drives the format layer — contract parsing plus the load-time
+  construction walk, and full services-file resolution — over every
+  case of the family's published conformance corpus, fetched from the
+  latest mavai-R release on each build (`fetchPublishedFormats`; local
+  override `-PformatsDir`). The corpus manifest's binding obligations
+  (outcome, and refusal *category*; wording stays punit's own) are
+  asserted case by case, the run diffs its assertions against the full
+  obligation so selective assertion fails the build, and obligations
+  punit does not yet meet sit on a known-unmet ledger asserted
+  inverted — an entry names the directive that retires it, and the
+  ledger only shrinks truthfully.
+
+- **Normative judgement at experiment time.** A measure experiment over
+  a contract that declares normative criteria (`meeting().passRate(...)`)
+  now judges each one against its stipulated threshold using the run's
+  own samples — the Wilson one-sided lower confidence bound at the run's
+  sample count, at the criterion's confidence. The judgement (met /
+  failed / unsupportable-with-feasible-minimum) is rendered in the
+  experiment's console output and recorded per criterion in the baseline
+  file as an additive `normativeJudgement` marker that resolvers and
+  threshold derivation ignore; existing baseline files parse unchanged.
+  Empirical criteria remain unjudged at experiment time. `run()`'s
+  completion semantics are unchanged — it never fails on a failed
+  judgement; the new `assertMeets()` terminal (mutually exclusive with
+  `run()`) performs the same run and persistence, then throws
+  `AssertionFailedError` on a failed judgement and
+  `UnsupportableJudgementException` (a `TestAbortedException` subtype,
+  identifying the cause for listeners and report tooling) on an
+  unsupportable one, with the baseline artefact on disk before any
+  throw.
+- **`PUNIT_BASELINE_DIR` environment variable** for baseline-directory
+  resolution (`BaselineResolver.defaultDir()`), checked between the
+  existing `punit.baseline.dir` system property and the fixed convention
+  path. Closes a gap relative to punit's own documented configuration
+  resolution order (system property → environment variable → default);
+  particularly useful for sentinel deployments in containerized
+  environments, where setting an environment variable is typically more
+  natural than controlling the JVM launch command line.
+
 ### Changed
+
+- **A trial that fails before evaluation counts against every
+  criterion.** A failed delivery — or any other apply-level
+  `Outcome.fail` — judged nothing, and previously reached no
+  criterion's tally at all, so per-criterion pass rates were computed
+  over a denominator that silently excluded them and a run where
+  nothing was delivered emitted an empty `criteria` block that failed
+  schema validation outright. Such a trial is now a failure against
+  every declared criterion, on a `applyFail` axis of its own rather
+  than folded into condition or transform failures that did not
+  happen. Per-criterion rates and verdicts now agree with the
+  aggregate, which already counted these failures. Aligns punit with
+  the family's Python reader.
 
 - **Exploration output is laid out by swept keys.** Each EXPLORE run
   writes its per-configuration artefacts into an experiment-level
@@ -108,22 +171,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   report was left untouched: punit's report module is slated to be
   dropped in favour of the shared `mavai` renderer.)
 
-### Added
+- **Artefact key discipline and the redesigned `failureDistribution`
+  (breaking for exploration and optimization outputs).** The
+  `statistics.failureDistribution` block of `mavai-explore-1` and
+  `mavai-optimize-1` documents is now a *sequence* of
+  `{condition, count}` entries instead of a mapping keyed by
+  free-text check identity: each failed trial is attributed to its
+  first failing condition, so entry counts sum to the enclosing
+  `failures` total, and no mapping key carries unbounded free text.
+  Every mapping key punit emits into these artefacts (postcondition
+  descriptions in `resultProjection`, criterion names, factor names)
+  is now bounded at 256 characters — comfortably under YAML's
+  1,024-character implicit-key limit — with over-long keys truncated
+  to a bounded prefix plus a short content hash so distinct keys
+  stay distinct. Per-input identity remains structural
+  (`inputIndex`); input text appears only in values. The vendored
+  interchange schemas are re-pinned to the mavai-R v0.9.0
+  publication, and the conformance suite now drives a run with a
+  >1,024-character input and over-long condition identities to prove
+  the emitted document parses and validates.
 
-- **The declarative-format conformance gate.** punit-decl's test suite
-  now drives the format layer — contract parsing plus the load-time
-  construction walk, and full services-file resolution — over every
-  case of the family's published conformance corpus, fetched from the
-  latest mavai-R release on each build (`fetchPublishedFormats`; local
-  override `-PformatsDir`). The corpus manifest's binding obligations
-  (outcome, and refusal *category*; wording stays punit's own) are
-  asserted case by case, the run diffs its assertions against the full
-  obligation so selective assertion fails the build, and obligations
-  punit does not yet meet sit on a known-unmet ledger asserted
-  inverted — an entry names the directive that retires it, and the
-  ledger only shrinks truthfully.
+- **Canonical interchange schemas for experiment artefacts (breaking
+  for exploration and optimization outputs).** EXPLORE and OPTIMIZE
+  runs now emit the mavai family's canonical interchange formats —
+  `mavai-explore-1` (one YAML per explored configuration) and
+  `mavai-optimize-1` (one YAML per optimize run) — in place of the
+  punit-private `punit-spec-1` shape those two artefacts carried
+  before. The service identity field is now `serviceContractId`
+  (was `useCaseId`), exploration documents carry the configuration's
+  display name in a new body field `configuration` (the same
+  human-readable stem used for the filename, so consumers never
+  parse filenames), and the per-criterion `statistics.criteria`
+  decomposition is always present. The HTML comparison report
+  readers follow the new field names and schema identities, so
+  reports over newly emitted artefacts work unchanged; documents in
+  the old shape are no longer read. Baseline specs (MEASURE) and
+  verdict XML are untouched — `punit-spec-1` baselines and the spec
+  registry are unaffected. Emitted artefacts are validated in the
+  test suite against the pinned published JSON Schemas
+  (mavai-R release v0.8.6), including the semantic obligations the
+  schemas cannot express (ascending passing-latency vector,
+  floor-gated percentile statement, convergence consistency).
+
+- **Per-criterion matrix transposed in both comparison HTML reports.**
+  The exploration and optimization comparison reports' "Per-criterion
+  comparison" table now lists variants/iterations as rows and criteria
+  as columns (previously the reverse). Bounds the table's column count
+  to the criteria set instead of letting it grow with every
+  variant/iteration, and aligns row identity with the leaderboard
+  table above it.
+- **Comparison-report renderers de-duplicated.** The Explore and
+  Optimize `HtmlWriter`s shared a near-identical `CriterionResult`
+  record and near-identical per-criterion-matrix, latency-cell,
+  cost-cell, termination-cell, pass-rate-cell, number-formatting, and
+  chart-CSS code. `CriterionResult` and these section renderers now
+  live once in a new `org.mavai.punit.report.ComparisonReportHtml`
+  (alongside the existing shared `ReportHtml`); each report's
+  `HtmlWriter` supplies only what's genuinely report-specific. No
+  behavioural change — output is unchanged.
 
 ### Fixed
+
+- **A declarative service type is found from a consuming project.**
+  The `language-model` type is discovered through `ServiceLoader`,
+  which was asked for the *context* classloader's view — correct
+  inside punit's own build, and empty in a consuming project whose
+  test runtime loads punit-decl and punit-lm differently. A first
+  declarative test could resolve `type: language-model` in punit and
+  not in the project that depends on it. Discovery now uses the
+  defining classloader.
+
+- **A declarative project needs no bindings class.** A contract whose
+  every service is declared in `mavai-services.yaml` has nothing to
+  bind, but the loader still required a `MavaiBindings` class to
+  exist and refused when it did not. The bindings artefact is now
+  optional, which is what makes the two-YAML-files-and-a-one-line-body
+  path in the user guide actually reachable.
+
+- **The Wilson lower bound is exactly zero at a zero rate.** At
+  `p̂ = 0` the bound's centre and margin are the same quantity and
+  cancel; binary floating point does not reliably deliver that, and
+  the residue — invisible against any tolerance — turned a derived
+  cutoff of 0 into 1 through `ceil`, demanding one success of a test
+  whose baseline could demand none. Now returned exactly, with a
+  property test sweeping every sample size at three confidences.
+
+- **Measure output names its persisted artefact.** A recording's
+  product is the baseline, not a verdict — every MEASURE run now
+  prints `baseline recorded: <path>` as the artefact lands, closing an
+  honest-output gap (the shape rule: a recording is labelled, renders
+  no composite verdict, and names what it persisted — the first two
+  already held, pinned by a new regression test alongside the fix).
 
 - **An `initial:` overlay restating the baseline is now refused.** The
   conformance gate's first catch: an optimization's `initial:` that
@@ -193,79 +331,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   stays absent: the artefact never claims an identity the author did
   not declare.
 
-### Changed
-
-- **Artefact key discipline and the redesigned `failureDistribution`
-  (breaking for exploration and optimization outputs).** The
-  `statistics.failureDistribution` block of `mavai-explore-1` and
-  `mavai-optimize-1` documents is now a *sequence* of
-  `{condition, count}` entries instead of a mapping keyed by
-  free-text check identity: each failed trial is attributed to its
-  first failing condition, so entry counts sum to the enclosing
-  `failures` total, and no mapping key carries unbounded free text.
-  Every mapping key punit emits into these artefacts (postcondition
-  descriptions in `resultProjection`, criterion names, factor names)
-  is now bounded at 256 characters — comfortably under YAML's
-  1,024-character implicit-key limit — with over-long keys truncated
-  to a bounded prefix plus a short content hash so distinct keys
-  stay distinct. Per-input identity remains structural
-  (`inputIndex`); input text appears only in values. The vendored
-  interchange schemas are re-pinned to the mavai-R v0.9.0
-  publication, and the conformance suite now drives a run with a
-  >1,024-character input and over-long condition identities to prove
-  the emitted document parses and validates.
-
-- **Canonical interchange schemas for experiment artefacts (breaking
-  for exploration and optimization outputs).** EXPLORE and OPTIMIZE
-  runs now emit the mavai family's canonical interchange formats —
-  `mavai-explore-1` (one YAML per explored configuration) and
-  `mavai-optimize-1` (one YAML per optimize run) — in place of the
-  punit-private `punit-spec-1` shape those two artefacts carried
-  before. The service identity field is now `serviceContractId`
-  (was `useCaseId`), exploration documents carry the configuration's
-  display name in a new body field `configuration` (the same
-  human-readable stem used for the filename, so consumers never
-  parse filenames), and the per-criterion `statistics.criteria`
-  decomposition is always present. The HTML comparison report
-  readers follow the new field names and schema identities, so
-  reports over newly emitted artefacts work unchanged; documents in
-  the old shape are no longer read. Baseline specs (MEASURE) and
-  verdict XML are untouched — `punit-spec-1` baselines and the spec
-  registry are unaffected. Emitted artefacts are validated in the
-  test suite against the pinned published JSON Schemas
-  (mavai-R release v0.8.6), including the semantic obligations the
-  schemas cannot express (ascending passing-latency vector,
-  floor-gated percentile statement, convergence consistency).
-
-### Added
-
-- **Normative judgement at experiment time.** A measure experiment over
-  a contract that declares normative criteria (`meeting().passRate(...)`)
-  now judges each one against its stipulated threshold using the run's
-  own samples — the Wilson one-sided lower confidence bound at the run's
-  sample count, at the criterion's confidence. The judgement (met /
-  failed / unsupportable-with-feasible-minimum) is rendered in the
-  experiment's console output and recorded per criterion in the baseline
-  file as an additive `normativeJudgement` marker that resolvers and
-  threshold derivation ignore; existing baseline files parse unchanged.
-  Empirical criteria remain unjudged at experiment time. `run()`'s
-  completion semantics are unchanged — it never fails on a failed
-  judgement; the new `assertMeets()` terminal (mutually exclusive with
-  `run()`) performs the same run and persistence, then throws
-  `AssertionFailedError` on a failed judgement and
-  `UnsupportableJudgementException` (a `TestAbortedException` subtype,
-  identifying the cause for listeners and report tooling) on an
-  unsupportable one, with the baseline artefact on disk before any
-  throw.
-- **`PUNIT_BASELINE_DIR` environment variable** for baseline-directory
-  resolution (`BaselineResolver.defaultDir()`), checked between the
-  existing `punit.baseline.dir` system property and the fixed convention
-  path. Closes a gap relative to punit's own documented configuration
-  resolution order (system property → environment variable → default);
-  particularly useful for sentinel deployments in containerized
-  environments, where setting an environment variable is typically more
-  natural than controlling the JVM launch command line.
-
 ### Documentation
 
 - **Corrected baseline-directory guidance in `SENTINEL-DEPLOYMENT-GUIDE.md`
@@ -287,27 +352,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   previously described the convention-default path as "on the classpath"
   — it's a filesystem path relative to the working directory, not a
   classpath resource lookup; corrected in both places.
-
-### Changed
-
-- **Per-criterion matrix transposed in both comparison HTML reports.**
-  The exploration and optimization comparison reports' "Per-criterion
-  comparison" table now lists variants/iterations as rows and criteria
-  as columns (previously the reverse). Bounds the table's column count
-  to the criteria set instead of letting it grow with every
-  variant/iteration, and aligns row identity with the leaderboard
-  table above it.
-- **Comparison-report renderers de-duplicated.** The Explore and
-  Optimize `HtmlWriter`s shared a near-identical `CriterionResult`
-  record and near-identical per-criterion-matrix, latency-cell,
-  cost-cell, termination-cell, pass-rate-cell, number-formatting, and
-  chart-CSS code. `CriterionResult` and these section renderers now
-  live once in a new `org.mavai.punit.report.ComparisonReportHtml`
-  (alongside the existing shared `ReportHtml`); each report's
-  `HtmlWriter` supplies only what's genuinely report-specific. No
-  behavioural change — output is unchanged.
-
-### Documentation
 
 - Brought the optimize comparison report's description in the user guide
   (Part 11) in line with the 0.9.3 run-order layout — iterations listed in

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/CriterionSampleCounts.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/CriterionSampleCounts.java
@@ -20,7 +20,20 @@ import java.util.Objects;
  *       ran.</li>
  * </ul>
  * Both kinds count in the denominator as a non-pass; {@link #fail()}
- * is their sum.
+ * is their sum, together with the third kind below.
+ *
+ * <p>{@link #applyFail()} is the third: a trial that failed at apply —
+ * a failed delivery, or any other {@code Outcome.fail} from the
+ * contract — so that <em>no</em> criterion judged anything. Such a
+ * trial counts as a failure against every declared criterion (owner
+ * ruling, 2026-08-24, adopting the family's Python reader's counting).
+ * It is a bucket of its own rather than a share of
+ * {@link #transformFail()} because the diagnostic axes mean particular
+ * things: a transform/no-value failure is one where a response
+ * <em>arrived</em> and no testable value could be derived from it,
+ * which is a fact about the contract's instrument. An apply failure is
+ * a fact about the service or the transport, and folding the two
+ * would misreport the axis a developer reads first.
  *
  * <p>The denominator is {@link #total()} = {@link #pass()} +
  * {@link #fail()}; the per-criterion observed pass rate is
@@ -37,29 +50,35 @@ import java.util.Objects;
  * @param transformFail count of FAIL samples where the transform
  *                     failed (or produced no value) and the chain
  *                     never ran
+ * @param applyFail    count of samples that failed at apply, before
+ *                     this criterion could judge anything
  */
 public record CriterionSampleCounts(
         String criterionId,
         int pass,
         int conditionFail,
-        int transformFail) {
+        int transformFail,
+        int applyFail) {
 
     public CriterionSampleCounts {
         Objects.requireNonNull(criterionId, "criterionId");
-        if (pass < 0 || conditionFail < 0 || transformFail < 0) {
+        if (pass < 0 || conditionFail < 0 || transformFail < 0 || applyFail < 0) {
             throw new IllegalArgumentException(
                     "counts must be non-negative; got pass=" + pass
                             + ", conditionFail=" + conditionFail
-                            + ", transformFail=" + transformFail);
+                            + ", transformFail=" + transformFail
+                            + ", applyFail=" + applyFail);
         }
     }
 
     /**
-     * Total failing trials — condition failures plus transform /
-     * no-value failures. Both count in the denominator as a non-pass.
+     * Total failing trials — condition failures, transform / no-value
+     * failures, and trials that failed before this criterion could
+     * judge anything. All three count in the denominator as a
+     * non-pass.
      */
     public int fail() {
-        return conditionFail + transformFail;
+        return conditionFail + transformFail + applyFail;
     }
 
     /** Sum of all per-criterion sample outcomes — the denominator. */

--- a/punit-core/src/main/java/org/mavai/punit/api/spec/DeliveryCause.java
+++ b/punit-core/src/main/java/org/mavai/punit/api/spec/DeliveryCause.java
@@ -1,0 +1,95 @@
+package org.mavai.punit.api.spec;
+
+import org.mavai.outcome.Outcome;
+
+/**
+ * Why a delivery failed, from a closed vocabulary.
+ *
+ * <p>A failed <em>delivery</em> — the service unreachable, an error
+ * status, a body carrying nothing to judge — is a failed
+ * <em>sample</em>: counted against every criterion, exactly as it
+ * always has been. This type changes nothing about that count. It
+ * states what <em>kind</em> of failure it was, so a reader can tell a
+ * run in which nothing was measured from a run in which everything was
+ * measured and found wanting. Without it the two are indistinguishable
+ * on every surface punit emits: a configuration whose endpoint was down
+ * and a configuration whose answers were bad both read as a pass rate
+ * of zero.
+ *
+ * <p><strong>No emitter states a cause it cannot know.</strong> The two
+ * timeout senses are separate tokens deliberately.
+ * {@link #CLIENT_DEADLINE} says <em>this framework stopped waiting</em>,
+ * which only a caller holding a deadline of its own may claim;
+ * {@link #PEER_TIMEOUT} says the peer stated that <em>it</em> did. The
+ * same elapsed seconds, two different facts about who gave up — and a
+ * single {@code timeout} token would have been a place for them to be
+ * confused.
+ *
+ * <p>Authors writing their own bindings state a cause through
+ * {@link #fail(String)}, which reserves a failure-id namespace for the
+ * purpose. That namespace is what lets the emitters recognise a
+ * delivery failure without guessing: a contract failure of the author's
+ * own naming is never mistaken for one of these, however it is spelled.
+ *
+ * @see <a href="https://github.com/mavai-org/mavai-R">the family's
+ *      interchange schemas, where this vocabulary is normative</a>
+ */
+public enum DeliveryCause {
+
+    /** No response at all — name resolution, a refused connection. */
+    UNREACHABLE("unreachable"),
+
+    /** This framework's own stated deadline elapsed: it stopped waiting. */
+    CLIENT_DEADLINE("client-deadline"),
+
+    /** The peer stated that it timed out — a different fact from the above. */
+    PEER_TIMEOUT("peer-timeout"),
+
+    /** The service answered that it is failing. */
+    SERVER_ERROR("server-error"),
+
+    /** A delivered body carrying nothing to judge. */
+    UNUSABLE_RESPONSE("unusable-response");
+
+    /**
+     * The reserved failure-id namespace carrying a delivery cause.
+     *
+     * <p>Reserved: an author's own contract failures must not use it.
+     * The emitters read it as the assertion "this trial delivered
+     * nothing", and a false claim there is worse than silence — it
+     * would tell a reader the service was never reached when in truth
+     * it answered and failed a check.
+     */
+    public static final String NAMESPACE = "mavai-delivery";
+
+    private final String token;
+
+    DeliveryCause(String token) {
+        this.token = token;
+    }
+
+    /**
+     * The wire token, as the family's interchange schemas spell it.
+     * This is the delivery entry's identity in an emitted artefact —
+     * bounded and groupable, which a message naming an endpoint is not.
+     */
+    public String token() {
+        return token;
+    }
+
+    /**
+     * A failed delivery on the {@code Outcome} channel: this cause as
+     * the bounded identity, the given message as the text a reader
+     * reads.
+     *
+     * <p>The two are deliberately separate. The message names the
+     * endpoint, the provider, the status — everything needed to
+     * diagnose, and none of it fit to group by or to put in an
+     * artefact's identity field. Shortening the message to make it fit
+     * would trade the diagnostic for the conformance and lose the part
+     * the reader actually needs.
+     */
+    public <T> Outcome<T> fail(String message) {
+        return Outcome.fail(NAMESPACE, token, message);
+    }
+}

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/Engine.java
@@ -374,6 +374,7 @@ public final class Engine {
             int pass = 0;
             int conditionFail = 0;
             int transformFail = 0;
+            int applyFail = 0;
         }
 
         private void recordCriterionSampleOutcomes(ServiceContractOutcome<?, OT> stamped) {
@@ -381,6 +382,11 @@ public final class Engine {
             // failure, synthesised defect outcome) or when this sample's
             // outcome was constructed without per-criterion detail (test
             // fixtures using the back-compat constructor).
+            if (stamped.criterionSampleResults().isEmpty()
+                    && stamped.value() instanceof org.mavai.outcome.Outcome.Fail<OT>) {
+                recordApplyFailure();
+                return;
+            }
             for (var entry : stamped.criterionSampleResults()) {
                 MutableCriterionCounts counts = criterionCounts.computeIfAbsent(
                         entry.criterionId(), k -> new MutableCriterionCounts());
@@ -398,6 +404,22 @@ public final class Engine {
                         }
                     }
                 }
+            }
+        }
+
+        /**
+         * A trial that failed at apply judged nothing, so it reaches
+         * no criterion's tally on its own. It is nonetheless a failure
+         * against every declared criterion — the family's counting
+         * rule, and the reason the aggregate failure count and the
+         * per-criterion denominators agree. Recorded here against the
+         * contract's declarations, since the sample itself carries no
+         * per-criterion detail to record from.
+         */
+        private void recordApplyFailure() {
+            for (var criterion : serviceContract.criteria().asList()) {
+                criterionCounts.computeIfAbsent(criterion.id(),
+                        k -> new MutableCriterionCounts()).applyFail++;
             }
         }
 
@@ -443,7 +465,7 @@ public final class Engine {
             for (var e : criterionCounts.entrySet()) {
                 MutableCriterionCounts c = e.getValue();
                 out.add(new CriterionSampleCounts(
-                        e.getKey(), c.pass, c.conditionFail, c.transformFail));
+                        e.getKey(), c.pass, c.conditionFail, c.transformFail, c.applyFail));
             }
             return List.copyOf(out);
         }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/criteria/PassRate.java
@@ -308,11 +308,21 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
                             auto.criterionId(),
                             summary.successes(),
                             summary.failures(),
-                            auto.transformFail()));
+                            auto.transformFail(),
+                            // Zero, not the criterion's own applyFail:
+                            // run-level failures already include every
+                            // apply failure, so restating them here
+                            // would count them twice in the
+                            // denominator. The axes on this synthetic
+                            // row are not diagnostic anyway — it puts
+                            // every failure in the condition slot.
+                            0));
         }
         if (methodologyCriteria.isEmpty()) {
-            // Run produced no methodology-criterion sample counts
-            // (apply-level-failure run, or a hand-built test fixture).
+            // Run produced no methodology-criterion sample counts (a
+            // hand-built test fixture; an apply-level-failure run now
+            // records against every declared criterion and so no
+            // longer arrives here).
             // Fall back to run-level pass / fail counts. The criterion
             // id is borrowed from the baseline map's lone entry when
             // available (so the lookup below finds it); otherwise the
@@ -328,7 +338,7 @@ public final class PassRate<OT> implements Criterion<OT, PerCriterionPassRateSta
             }
             methodologyCriteria = List.of(
                     new CriterionSampleCounts(
-                            fallbackId, summary.successes(), summary.failures(), 0));
+                            fallbackId, summary.successes(), summary.failures(), 0, 0));
         }
         // Resolve the baseline map up-front (empirical mode only).
         if (isEmpirical()) {

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/FailureDistributions.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/emit/FailureDistributions.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.mavai.outcome.Outcome;
+import org.mavai.punit.api.spec.DeliveryCause;
 import org.mavai.punit.api.spec.Trial;
 
 /**
@@ -27,6 +28,16 @@ import org.mavai.punit.api.spec.Trial;
  * contract-declared descriptions (per-input attribution travels
  * structurally as {@code inputIndex} in the result projection), so
  * entries aggregate by condition alone.
+ *
+ * <p>Each entry also states its {@code kind}: whether these trials
+ * were judged and found wanting, or never delivered a response to
+ * judge. The counting rule is untouched — a failed delivery is a
+ * failed trial exactly as before — but a reader can now tell a
+ * configuration whose endpoint was down from one whose answers were
+ * bad, which on a bare pass rate of zero are the same picture. A
+ * delivery entry's {@code condition} is its cause token from
+ * {@link DeliveryCause}: there is no declared condition to name when
+ * nothing arrived to judge.
  */
 public final class FailureDistributions {
 
@@ -38,20 +49,42 @@ public final class FailureDistributions {
      * all-passing run yields an empty list.
      */
     public static List<Map<String, Object>> fromTrials(List<? extends Trial<?, ?>> trials) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
+        Map<Attribution, Integer> counts = new LinkedHashMap<>();
         for (Trial<?, ?> trial : trials) {
             if (trial.outcome().value() instanceof Outcome.Fail<?> fail) {
-                String condition = EmittedKeys.bound(fail.failure().id().name());
-                counts.merge(condition, 1, Integer::sum);
+                counts.merge(attribute(fail), 1, Integer::sum);
             }
         }
         List<Map<String, Object>> entries = new ArrayList<>(counts.size());
-        for (Map.Entry<String, Integer> e : counts.entrySet()) {
+        for (Map.Entry<Attribution, Integer> e : counts.entrySet()) {
             Map<String, Object> entry = new LinkedHashMap<>();
-            entry.put("condition", e.getKey());
+            entry.put("condition", e.getKey().condition());
+            entry.put("kind", e.getKey().kind());
             entry.put("count", e.getValue());
             entries.add(entry);
         }
         return entries;
     }
+
+    /**
+     * The entry identity: what failed, and what kind of failure it was.
+     *
+     * <p>Recognition is by the reserved failure-id namespace, never by
+     * matching the name against the cause vocabulary. An author is free
+     * to declare a contract condition called {@code server-error}, and
+     * reading it as a transport fact would tell a reader the service
+     * was never reached when in truth it answered and failed a check —
+     * a stated cause that is not merely absent but wrong.
+     */
+    private static Attribution attribute(Outcome.Fail<?> fail) {
+        if (DeliveryCause.NAMESPACE.equals(fail.failure().id().namespace())) {
+            // The cause token is the identity. There is no declared
+            // condition to name when nothing was delivered to judge.
+            return new Attribution(EmittedKeys.bound(fail.failure().id().name()), "delivery");
+        }
+        return new Attribution(EmittedKeys.bound(fail.failure().id().name()), "evaluated");
+    }
+
+    /** One failure-distribution entry's identity, kind included. */
+    private record Attribution(String condition, String kind) { }
 }

--- a/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
+++ b/punit-core/src/main/java/org/mavai/punit/internal/engine/explore/ExploreOutputWriter.java
@@ -227,6 +227,7 @@ public final class ExploreOutputWriter {
             row.put("fail", counts.fail());
             row.put("conditionFail", counts.conditionFail());
             row.put("transformFail", counts.transformFail());
+            row.put("applyFail", counts.applyFail());
             Map<String, Object> standings =
                     standingsByCriterion.get(EmittedKeys.bound(counts.criterionId()));
             if (standings != null) {

--- a/punit-core/src/test/java/org/mavai/punit/api/spec/PerCriterionVerdictsTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/api/spec/PerCriterionVerdictsTest.java
@@ -46,7 +46,7 @@ class PerCriterionVerdictsTest {
         // 90 of 100 passed, threshold 0.80 → 0.90 >= 0.80 → PASS, mirrors legacy.
         PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
                 List.of(legacyPass(0.80)),
-                List.of(new CriterionSampleCounts("only", 90, 10, 0)));
+                List.of(new CriterionSampleCounts("only", 90, 10, 0, 0)));
         assertThat(eval.perCriterionVerdicts()).hasSize(1);
         PerCriterionVerdict row = eval.perCriterionVerdicts().get(0);
         assertThat(row.criterionId()).isEqualTo("only");
@@ -61,7 +61,7 @@ class PerCriterionVerdictsTest {
     void k1IsomorphismFail() {
         PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
                 List.of(legacyPass(0.95)),
-                List.of(new CriterionSampleCounts("only", 80, 20, 0)));
+                List.of(new CriterionSampleCounts("only", 80, 20, 0, 0)));
         assertThat(eval.perCriterionVerdicts().get(0).verdict()).isEqualTo(Verdict.FAIL);
         assertThat(eval.compositeVerdict()).isEqualTo(Verdict.FAIL);
     }
@@ -73,10 +73,39 @@ class PerCriterionVerdictsTest {
         // 100, observed 0.80. Both kinds of fail count as a non-pass.
         PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
                 List.of(legacyPass(0.85)),
-                List.of(new CriterionSampleCounts("crit", 80, 10, 10)));
+                List.of(new CriterionSampleCounts("crit", 80, 10, 10, 0)));
         PerCriterionVerdict row = eval.perCriterionVerdicts().get(0);
         assertThat(row.observed()).isEqualTo(0.80);
         assertThat(row.verdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("apply-failure samples count in the denominator as fails")
+    void applyFailureSamplesCountAsFails() {
+        // 80 PASS, 20 that failed before this criterion judged
+        // anything — a failed delivery, or any other apply-level
+        // failure. Denominator 100, observed 0.80: a trial the service
+        // never answered is a trial this criterion did not pass, which
+        // is what keeps the per-criterion rate honest against the
+        // aggregate.
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.85)),
+                List.of(new CriterionSampleCounts("crit", 80, 0, 0, 20)));
+        PerCriterionVerdict row = eval.perCriterionVerdicts().get(0);
+        assertThat(row.observed()).isEqualTo(0.80);
+        assertThat(row.verdict()).isEqualTo(Verdict.FAIL);
+    }
+
+    @Test
+    @DisplayName("all three failure axes share one denominator")
+    void everyFailureAxisCountsOnce() {
+        // 70 PASS, 10 of each failure kind — denominator 100. The axes
+        // are diagnostic; none of them is exempt from the count, and
+        // none is counted twice.
+        PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
+                List.of(legacyPass(0.60)),
+                List.of(new CriterionSampleCounts("crit", 70, 10, 10, 10)));
+        assertThat(eval.perCriterionVerdicts().get(0).observed()).isEqualTo(0.70);
     }
 
     @Test
@@ -85,8 +114,8 @@ class PerCriterionVerdictsTest {
         PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
                 List.of(legacyInconclusive()),
                 List.of(
-                        new CriterionSampleCounts("a", 100, 0, 0),
-                        new CriterionSampleCounts("b", 100, 0, 0)));
+                        new CriterionSampleCounts("a", 100, 0, 0, 0),
+                        new CriterionSampleCounts("b", 100, 0, 0, 0)));
         assertThat(eval.perCriterionVerdicts())
                 .allMatch(r -> r.verdict() == Verdict.INCONCLUSIVE);
         assertThat(eval.compositeVerdict()).isEqualTo(Verdict.INCONCLUSIVE);
@@ -103,9 +132,9 @@ class PerCriterionVerdictsTest {
         PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
                 List.of(legacyPass(0.85)),
                 List.of(
-                        new CriterionSampleCounts("good-1", 100, 0, 0),
-                        new CriterionSampleCounts("bad", 60, 40, 0),
-                        new CriterionSampleCounts("good-2", 100, 0, 0)));
+                        new CriterionSampleCounts("good-1", 100, 0, 0, 0),
+                        new CriterionSampleCounts("bad", 60, 40, 0, 0),
+                        new CriterionSampleCounts("good-2", 100, 0, 0, 0)));
         List<Verdict> verdicts = eval.perCriterionVerdicts().stream()
                 .map(PerCriterionVerdict::verdict).toList();
         assertThat(verdicts).containsExactly(Verdict.PASS, Verdict.FAIL, Verdict.PASS);
@@ -117,7 +146,7 @@ class PerCriterionVerdictsTest {
     void zeroSampleCriterionInconclusive() {
         PerCriterionEvaluation eval = PerCriterionVerdicts.derive(
                 List.of(legacyPass(0.80)),
-                List.of(new CriterionSampleCounts("empty", 0, 0, 0)));
+                List.of(new CriterionSampleCounts("empty", 0, 0, 0, 0)));
         assertThat(eval.perCriterionVerdicts().get(0).verdict())
                 .isEqualTo(Verdict.INCONCLUSIVE);
     }

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/PostconditionFailureHistogramTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/PostconditionFailureHistogramTest.java
@@ -141,6 +141,19 @@ class PostconditionFailureHistogramTest {
         // No postcondition was evaluated because invoke failed every sample.
         assertThat(summary.failuresByPostcondition()).isEmpty();
         assertThat(summary.failures()).isEqualTo(5);
+
+        // But the criterion still counts them. The postcondition
+        // histogram stays empty because nothing was judged; the
+        // per-criterion tally does not, because a trial the contract
+        // never answered is still a trial that criterion did not pass.
+        // The two say different things and both are needed.
+        assertThat(summary.criterionSampleCounts()).hasSize(1);
+        var counts = summary.criterionSampleCounts().get(0);
+        assertThat(counts.applyFail()).isEqualTo(5);
+        assertThat(counts.conditionFail()).isZero();
+        assertThat(counts.transformFail()).isZero();
+        assertThat(counts.total()).isEqualTo(5);
+        assertThat(counts.observedPassRate()).isZero();
     }
 
     @Test

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
@@ -136,9 +136,69 @@ class InterchangeConformanceTest {
         }
     }
 
+    /**
+     * Never delivers: every trial fails at apply with a stated
+     * delivery cause, as a service whose endpoint is down does.
+     */
+    private static final class UndeliveredContract
+            implements ServiceContract<LlmFactors, String, Integer> {
+        @Override public String id() { return "interchange-undelivered"; }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return DeliveryCause.CLIENT_DEADLINE.fail("stopped waiting after 250ms");
+        }
+        @Override public Criteria<Integer> criteria() {
+            return meeting().<Integer>zeroFailures()
+                    .name("never-reached")
+                    .satisfies("would-have-checked", v -> Outcome.ok());
+        }
+    }
+
     @Nested
     @DisplayName("delivery attribution")
     class DeliveryAttribution {
+
+        @Test
+        @DisplayName("a run that delivered nothing emits a document that opens")
+        void undeliveredRunStatesItsKind() {
+            Map<String, Object> doc = emitExplore(new UndeliveredContract(), 6);
+
+            // The run a reader most needs to open. Before the apply
+            // failure was counted against every declared criterion this
+            // emitted an empty criteria block and failed validation
+            // outright — the total-harness-failure run was the one
+            // producing a malformed artefact.
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> statistics = (Map<String, Object>) doc.get("statistics");
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> entries =
+                    (List<Map<String, Object>>) statistics.get("failureDistribution");
+
+            // Six identically-caused failures are one entry, not six:
+            // the identity is the cause, so the count is readable.
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0))
+                    .containsEntry("kind", "delivery")
+                    .containsEntry("condition", DeliveryCause.CLIENT_DEADLINE.token())
+                    .containsEntry("count", 6);
+            assertThat(((Number) statistics.get("failures")).intValue()).isEqualTo(6);
+
+            // The declared criterion judged nothing and says so: the
+            // apply failures are its whole denominator, on their own
+            // axis rather than folded into a condition or transform
+            // failure that never happened.
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, Object>> criteria =
+                    (Map<String, Map<String, Object>>) statistics.get("criteria");
+            assertThat(criteria).containsOnlyKeys("never-reached");
+            assertThat(criteria.get("never-reached"))
+                    .containsEntry("pass", 0)
+                    .containsEntry("conditionFail", 0)
+                    .containsEntry("transformFail", 0)
+                    .containsEntry("applyFail", 6)
+                    .containsEntry("observedPassRate", 0.0);
+        }
 
         @Test
         @DisplayName("a mixed run separates what was judged from what never arrived")

--- a/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/engine/interchange/InterchangeConformanceTest.java
@@ -19,6 +19,7 @@ import org.mavai.punit.api.Sampling;
 import org.mavai.punit.api.ServiceContract;
 import org.mavai.punit.api.TokenTracker;
 import org.mavai.punit.api.criterion.Criteria;
+import org.mavai.punit.api.spec.DeliveryCause;
 import org.mavai.punit.api.spec.Experiment;
 import org.mavai.punit.api.spec.NextFactor;
 import org.mavai.punit.api.spec.Scorer;
@@ -96,6 +97,152 @@ class InterchangeConformanceTest {
         }
     }
 
+    /**
+     * Delivers on even invocations and not on odd ones — the mixed
+     * run the family's criterion 4 names: some failures judged, some
+     * never delivered, both stated distinctly in one document.
+     */
+    private static final class MixedDeliveryContract
+            implements ServiceContract<LlmFactors, String, Integer> {
+        private final AtomicInteger invocations = new AtomicInteger();
+        @Override public String id() { return "interchange-mixed-delivery"; }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return invocations.getAndIncrement() % 2 == 0
+                    ? Outcome.ok(input.length())
+                    : DeliveryCause.CLIENT_DEADLINE.fail("stopped waiting after 250ms");
+        }
+        @Override public Criteria<Integer> criteria() {
+            return meeting().<Integer>zeroFailures()
+                    .name("judged-when-delivered")
+                    .satisfies("always-fails", v -> Outcome.fail("always-fails", "by design"));
+        }
+    }
+
+    /**
+     * Delivers, and answers badly, under a declared condition whose
+     * name collides with a delivery cause token — the case that
+     * separates recognising a namespace from matching a string.
+     */
+    private static final class CollidingNameContract
+            implements ServiceContract<LlmFactors, String, Integer> {
+        @Override public String id() { return "interchange-colliding"; }
+        @Override public Outcome<Integer> invoke(String input, TokenTracker tracker) {
+            return Outcome.ok(input.length());
+        }
+        @Override public Criteria<Integer> criteria() {
+            return meeting().<Integer>zeroFailures()
+                    .name("author-vocabulary")
+                    .satisfies("server-error", v -> Outcome.fail("server-error", "judged, and bad"));
+        }
+    }
+
+    @Nested
+    @DisplayName("delivery attribution")
+    class DeliveryAttribution {
+
+        @Test
+        @DisplayName("a mixed run separates what was judged from what never arrived")
+        void mixedRunStatesBothKinds() {
+            Map<String, Object> doc = emitExplore(new MixedDeliveryContract(), 6);
+
+            // The schema's conditional binds here and nowhere else in
+            // this suite: kind: delivery obliges condition to be a
+            // deliveryCause token. A run with no delivery entry never
+            // exercises it, which is why this case exists.
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> statistics = (Map<String, Object>) doc.get("statistics");
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> entries =
+                    (List<Map<String, Object>>) statistics.get("failureDistribution");
+
+            // Both kinds, distinctly — the reader can tell which half of
+            // this run is a quality story and which half never happened.
+            assertThat(entries).hasSize(2);
+            assertThat(entries).anySatisfy(entry -> assertThat(entry)
+                    .containsEntry("kind", "delivery")
+                    .containsEntry("condition", DeliveryCause.CLIENT_DEADLINE.token()));
+            assertThat(entries).anySatisfy(entry -> assertThat(entry)
+                    .containsEntry("kind", "evaluated")
+                    .containsEntry("condition", "always-fails"));
+
+            // The counting rule is untouched: every entry's count still
+            // sums to the same failure total it always did.
+            int attributed = entries.stream()
+                    .mapToInt(entry -> ((Number) entry.get("count")).intValue()).sum();
+            assertThat(attributed).isEqualTo(((Number) statistics.get("failures")).intValue());
+
+            // Identically-caused failures aggregate to one entry, not
+            // one per trial: the identity is the cause, so the count is
+            // readable.
+            assertThat(entries).allSatisfy(entry ->
+                    assertThat(((Number) entry.get("count")).intValue()).isGreaterThan(1));
+        }
+
+        @Test
+        @DisplayName("an ordinary failing run states no delivery kind")
+        void judgedRunStatesEvaluated() {
+            Map<String, Object> doc = emitExplore(new FailingContract(), 4);
+
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> statistics = (Map<String, Object>) doc.get("statistics");
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> entries =
+                    (List<Map<String, Object>>) statistics.get("failureDistribution");
+            assertThat(entries).isNotEmpty();
+            assertThat(entries).allSatisfy(entry ->
+                    assertThat(entry).containsEntry("kind", "evaluated"));
+        }
+
+        @Test
+        @DisplayName("a declared condition named like a cause is still evaluated")
+        void authorVocabularyIsNotMistakenForTransport() {
+            Map<String, Object> doc = emitExplore(new CollidingNameContract(), 4);
+
+            assertThat(validate("mavai-explore-1", doc)).isEmpty();
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> statistics = (Map<String, Object>) doc.get("statistics");
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> entries =
+                    (List<Map<String, Object>>) statistics.get("failureDistribution");
+
+            // The author's condition happens to be spelled exactly like
+            // a transport cause. Reading it as one would tell a reader
+            // the service was never reached, when in truth it answered
+            // and failed a check — a stated cause that is wrong, which
+            // is worse than one that is absent.
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0))
+                    .containsEntry("kind", "evaluated")
+                    .containsEntry("condition", "server-error");
+        }
+
+    }
+
+    /** Drives one exploration grid point and returns the emitted document. */
+    private static Map<String, Object> emitExplore(
+            ServiceContract<LlmFactors, String, Integer> contract, int samples) {
+        Sampling<LlmFactors, String, Integer> sampling = Sampling
+                .<LlmFactors, String, Integer>builder()
+                .serviceContractFactory(f -> contract)
+                .inputs("a", "bb")
+                .samples(samples)
+                .build();
+        Experiment experiment = Experiment.exploring(sampling)
+                .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
+                .build();
+        new Engine().run(experiment);
+
+        Map<String, String> sink = new LinkedHashMap<>();
+        ExploreEmitter.emit(experiment, sink::put);
+        assertThat(sink).hasSize(1);
+        return new Yaml().load(sink.values().iterator().next());
+    }
+
     @Nested
     @DisplayName("exploration artefacts")
     class ExplorationArtefacts {
@@ -160,24 +307,6 @@ class InterchangeConformanceTest {
             assertThat(doc).doesNotContainKey("latency");
         }
 
-        private Map<String, Object> emitExplore(
-                ServiceContract<LlmFactors, String, Integer> contract, int samples) {
-            Sampling<LlmFactors, String, Integer> sampling = Sampling
-                    .<LlmFactors, String, Integer>builder()
-                    .serviceContractFactory(f -> contract)
-                    .inputs("a", "bb")
-                    .samples(samples)
-                    .build();
-            Experiment experiment = Experiment.exploring(sampling)
-                    .grid(List.of(new LlmFactors("gpt-4o", 0.3)))
-                    .build();
-            new Engine().run(experiment);
-
-            Map<String, String> sink = new LinkedHashMap<>();
-            ExploreEmitter.emit(experiment, sink::put);
-            assertThat(sink).hasSize(1);
-            return new Yaml().load(sink.values().iterator().next());
-        }
     }
 
     @Nested

--- a/punit-core/src/test/java/org/mavai/punit/internal/reporting/TransparentStatsRendererTest.java
+++ b/punit-core/src/test/java/org/mavai/punit/internal/reporting/TransparentStatsRendererTest.java
@@ -429,13 +429,13 @@ class TransparentStatsRendererTest {
                             new PerCriterionVerdict(
                                     "response-not-empty",
                                     Verdict.PASS,
-                                    new CriterionSampleCounts("response-not-empty", 100, 0, 0),
+                                    new CriterionSampleCounts("response-not-empty", 100, 0, 0, 0),
                                     1.0,
                                     0.85),
                             new PerCriterionVerdict(
                                     "valid-json",
                                     Verdict.PASS,
-                                    new CriterionSampleCounts("valid-json", 90, 5, 5),
+                                    new CriterionSampleCounts("valid-json", 90, 5, 5, 0),
                                     0.90,
                                     0.85)),
                     Verdict.PASS);

--- a/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
+++ b/punit-core/src/test/resources/conformance/interchange/mavai-explore-1.schema.json
@@ -30,7 +30,13 @@
     "configuration": {
       "type": "string",
       "minLength": 1,
-      "description": "The configuration's display name. Cross-document identity for consumers; filenames are never parsed."
+      "description": "The configuration's identity: the string that distinguishes it from its siblings and correlates it across documents. Emitter-derived from the configuration's factor values; filenames are never parsed. Not a display name — a consumer with no configurationName derives something showable from this, which is what a reader saw before configurationName existed."
+    },
+    "configurationName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "The author's name for what this configuration is — the idea under test, stated on the grid entry rather than derived from its values. A consumer that shows a configuration to a reader shows this when present, and falls back to what it derived from `configuration` when absent — never to an empty name. Additive and stated only when authored: absence means the author named nothing. Prose, so bounded and carrying no uniqueness guarantee; it never becomes identity, and two configurations may state the same name and remain two configurations."
     },
     "baseConfiguration": {
       "type": "boolean",
@@ -74,6 +80,18 @@
           "type": "string",
           "minLength": 1,
           "description": "Why the run ended. Consumers flag anything other than COMPLETED."
+        }
+      }
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Informational: how each input the run drove presents itself \u2014 a file input's document name, a text input's bounded excerpt \u2014 for human orientation only. Stated for every input, not only for those that failed: naming some rows and leaving others blank is the asymmetry this block exists to remove. Consumers correlate via inputIndex and must render a document that omits it; nothing here is identity, which stays the inputs fingerprint.",
+      "items": {
+        "type": "object",
+        "required": ["inputIndex", "inputExcerpt"],
+        "properties": {
+          "inputIndex": { "type": "integer", "minimum": 0, "description": "Zero-based index into the inputs list \u2014 the structural input reference, the same one failureDistribution entries carry." },
+          "inputExcerpt": { "type": "string", "maxLength": 256, "description": "Informational bounded excerpt of the input, for human orientation only \u2014 consumers correlate via inputIndex." }
         }
       }
     },
@@ -208,6 +226,11 @@
                 "minimum": 0,
                 "description": "Zero-based structural input reference, as in failureDistribution."
               },
+              "provenance": {
+                "type": "string",
+                "enum": ["criterion", "input"],
+                "description": "Which declaration stated this postcondition: 'criterion' for one the criterion states, asserted of every input; 'input' for one an input's own expected values state, asserted only against that input. Both are postconditions \u2014 they differ in who stated them, and their denominators differ accordingly, which is why a consumer listing them together shows one figure out of six beside another out of twelve with nothing to explain it. Additive and optional: absence means 'criterion', which is what every pre-amendment emission means. A consumer meeting an unknown value reads it as 'criterion' and renders it without comment."
+              },
               "check": {
                 "type": "string",
                 "minLength": 1,
@@ -301,12 +324,41 @@
           "count"
         ],
         "additionalProperties": true,
+        "allOf": [
+          {
+            "$comment": "A delivery entry's condition is drawn from the closed cause vocabulary, never a free-text message: a cause that is not groupable is not countable, and one that is not bounded is not an identity.",
+            "if": {
+              "properties": {
+                "kind": {
+                  "const": "delivery"
+                }
+              },
+              "required": [
+                "kind"
+              ]
+            },
+            "then": {
+              "properties": {
+                "condition": {
+                  "$ref": "#/$defs/deliveryCause"
+                }
+              }
+            }
+          }
+        ],
         "properties": {
           "condition": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
-            "description": "The violating condition's bounded identity, as the contract declares it \u2014 never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex."
+            "description": "The violating condition's bounded identity, as the contract declares it \u2014 never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex. On a delivery-kind entry this is the delivery cause instead, drawn from the closed vocabulary: there is no declared condition to name when nothing was delivered to judge."
+          },
+          "kind": {
+            "enum": [
+              "evaluated",
+              "delivery"
+            ],
+            "description": "Whether these trials were judged and found wanting (evaluated), or never delivered a response to judge (delivery). Absent in pre-amendment emissions \u2014 a consumer renders absence as not stated, never as evaluated. Diagnostic only: a failed delivery is a failed trial on the same counting rule, and this states what kind of failure it was, not how much it counts."
           },
           "count": {
             "type": "integer",
@@ -325,6 +377,17 @@
           }
         }
       }
+    },
+    "deliveryCause": {
+      "enum": [
+        "unreachable",
+        "client-deadline",
+        "peer-timeout",
+        "server-error",
+        "unusable-response"
+      ],
+      "description": "Why a delivery failed, from a closed vocabulary — no emitter states a cause it cannot know. `unreachable`: no response at all (name resolution, refused connection). `client-deadline`: the framework's own stated deadline elapsed — it stopped waiting. `peer-timeout`: the peer stated that it timed out, which is a different fact from the one above and must not be conflated with it. `server-error`: the service answered that it is failing. `unusable-response`: a delivered body carrying nothing to judge.",
+      "$comment": "The two timeout senses are separate tokens deliberately. Before DIR-FAM-TIMEOUT-client-deadline no framework in the family set a deadline, so `we stopped waiting` was unsayable and any observed cut-off was the peer's; a single `timeout` token would have let a later emitter blur the two the moment deadlines arrived."
     },
     "cost": {
       "type": "object",

--- a/punit-core/src/test/resources/conformance/interchange/mavai-optimize-1.schema.json
+++ b/punit-core/src/test/resources/conformance/interchange/mavai-optimize-1.schema.json
@@ -36,6 +36,18 @@
       "format": "date-time",
       "description": "ISO 8601 UTC timestamp of emission."
     },
+    "inputs": {
+      "type": "array",
+      "description": "Informational: how each input the run drove presents itself \u2014 a file input's document name, a text input's bounded excerpt \u2014 for human orientation only. Stated for every input, not only for those that failed: naming some rows and leaving others blank is the asymmetry this block exists to remove. Consumers correlate via inputIndex and must render a document that omits it; nothing here is identity, which stays the inputs fingerprint.",
+      "items": {
+        "type": "object",
+        "required": ["inputIndex", "inputExcerpt"],
+        "properties": {
+          "inputIndex": { "type": "integer", "minimum": 0, "description": "Zero-based index into the inputs list \u2014 the structural input reference, the same one failureDistribution entries carry." },
+          "inputExcerpt": { "type": "string", "maxLength": 256, "description": "Informational bounded excerpt of the input, for human orientation only \u2014 consumers correlate via inputIndex." }
+        }
+      }
+    },
     "iterations": {
       "type": "array",
       "minItems": 1,
@@ -125,12 +137,108 @@
         "observedPassRate": { "type": "number", "minimum": 0, "maximum": 1 },
         "pass": { "type": "integer", "minimum": 0 },
         "fail": { "type": "integer", "minimum": 0 },
-        "failureDistribution": { "$ref": "#/$defs/failureDistribution" }
+        "failureDistribution": { "$ref": "#/$defs/failureDistribution" },
+        "standings": { "$ref": "#/$defs/standings" }
+      }
+    },
+    "standings": {
+      "type": "object",
+      "description": "The criterion's descriptive postcondition standings for this iteration (amendment 2026-07-28) — the identical shape and classification as the exploration schema's standings block, per the identical-statistics-shape rule. Binding when present, additive; counts and the observed fraction only — never a confidence interval, a threshold, or per-check verdict vocabulary.",
+      "required": ["rows"],
+      "additionalProperties": true,
+      "properties": {
+        "optionalSlack": {
+          "type": "string",
+          "pattern": "^[0-9]+%?$",
+          "description": "The criterion's declared optional-check failure budget, verbatim as authored: digits for a count ('2'), digits + % for a percentage ('20%'). Absent iff the contract declares none — absence is distinguishable from '0', the explicit budget of zero."
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "description": "One row per (input, check), in the emitter's stated order.",
+          "items": {
+            "type": "object",
+            "required": ["inputIndex", "check", "optional", "passed", "failed", "skipped", "observedFraction"],
+            "additionalProperties": true,
+            "properties": {
+              "inputIndex": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Zero-based structural input reference, as in failureDistribution."
+              },
+              "provenance": {
+                "type": "string",
+                "enum": ["criterion", "input"],
+                "description": "Which declaration stated this postcondition: 'criterion' for one the criterion states, asserted of every input; 'input' for one an input's own expected values state, asserted only against that input. Both are postconditions \u2014 they differ in who stated them, and their denominators differ accordingly, which is why a consumer listing them together shows one figure out of six beside another out of twelve with nothing to explain it. Additive and optional: absence means 'criterion', which is what every pre-amendment emission means. A consumer meeting an unknown value reads it as 'criterion' and renders it without comment."
+              },
+              "check": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "description": "The check's bounded identity, as the contract declares it — never embedding input or response content."
+              },
+              "optional": {
+                "type": "boolean",
+                "description": "Whether the contract marks this check optional — stated explicitly for every row."
+              },
+              "passed": { "type": "integer", "minimum": 0 },
+              "failed": { "type": "integer", "minimum": 0 },
+              "skipped": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Trials on which the check was not judged because an earlier transform failed."
+              },
+              "observedFraction": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "passed / (passed + failed + skipped), as stated by the emitter."
+              },
+              "path": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "description": "The structural address the check judges, as declared (amendment 2026-07-28, structured rows). Present iff path-addressed; the by-path grouping key — never derived from check."
+              },
+              "form": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "description": "The comparison form's domain name, as the contract format spells it."
+              },
+              "expected": {
+                "type": "string",
+                "maxLength": 256,
+                "description": "Bounded excerpt of the declared operand, for display — never an identity."
+              },
+              "observed": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Obtained-value exemplars, failing exemplars first; distinct excerpts capped by the emitter, counts summing to at most the row's trials.",
+                "items": {
+                  "type": "object",
+                  "required": ["excerpt", "count", "held"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "excerpt": { "type": "string", "maxLength": 256 },
+                    "count": { "type": "integer", "minimum": 1 },
+                    "held": { "type": "boolean" }
+                  }
+                }
+              },
+              "elided": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Trials whose obtained values were not exemplified."
+              }
+            }
+          }
+        }
       }
     },
     "failureDistribution": {
       "type": "array",
-      "description": "A sequence of failure entries aggregated over the run (amendment 2026-07-17: the earlier check-name-keyed mapping is withdrawn — no mapping key may derive from input or response content, per the interchange area's key discipline). Each failed trial is attributed to its first failing condition; the entries' counts sum to the enclosing failures total.",
+      "description": "A sequence of failure entries aggregated over the run (amendment 2026-07-17: the earlier check-name-keyed mapping is withdrawn \u2014 no mapping key may derive from input or response content, per the interchange area's key discipline). Each failed trial is attributed to its first failing condition; the entries' counts sum to the enclosing failures total.",
       "items": {
         "type": "object",
         "required": [
@@ -138,12 +246,41 @@
           "count"
         ],
         "additionalProperties": true,
+        "allOf": [
+          {
+            "$comment": "A delivery entry's condition is drawn from the closed cause vocabulary, never a free-text message: a cause that is not groupable is not countable, and one that is not bounded is not an identity.",
+            "if": {
+              "properties": {
+                "kind": {
+                  "const": "delivery"
+                }
+              },
+              "required": [
+                "kind"
+              ]
+            },
+            "then": {
+              "properties": {
+                "condition": {
+                  "$ref": "#/$defs/deliveryCause"
+                }
+              }
+            }
+          }
+        ],
         "properties": {
           "condition": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
-            "description": "The violating condition's bounded identity, as the contract declares it — never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex."
+            "description": "The violating condition's bounded identity, as the contract declares it \u2014 never embedding input or response content. A per-input condition's identity is the condition name alone; the input travels structurally in inputIndex. On a delivery-kind entry this is the delivery cause instead, drawn from the closed vocabulary: there is no declared condition to name when nothing was delivered to judge."
+          },
+          "kind": {
+            "enum": [
+              "evaluated",
+              "delivery"
+            ],
+            "description": "Whether these trials were judged and found wanting (evaluated), or never delivered a response to judge (delivery). Absent in pre-amendment emissions \u2014 a consumer renders absence as not stated, never as evaluated. Diagnostic only: a failed delivery is a failed trial on the same counting rule, and this states what kind of failure it was, not how much it counts."
           },
           "count": {
             "type": "integer",
@@ -153,15 +290,26 @@
           "inputIndex": {
             "type": "integer",
             "minimum": 0,
-            "description": "Zero-based index into the inputs list, present when the condition is per-input — the structural input reference; the input value itself is never serialised as identity."
+            "description": "Zero-based index into the inputs list, present when the condition is per-input \u2014 the structural input reference; the input value itself is never serialised as identity."
           },
           "inputExcerpt": {
             "type": "string",
             "maxLength": 256,
-            "description": "Informational bounded excerpt of the driving input, for human orientation only — consumers correlate via inputIndex."
+            "description": "Informational bounded excerpt of the driving input, for human orientation only \u2014 consumers correlate via inputIndex."
           }
         }
       }
+    },
+    "deliveryCause": {
+      "enum": [
+        "unreachable",
+        "client-deadline",
+        "peer-timeout",
+        "server-error",
+        "unusable-response"
+      ],
+      "description": "Why a delivery failed, from a closed vocabulary — no emitter states a cause it cannot know. `unreachable`: no response at all (name resolution, refused connection). `client-deadline`: the framework's own stated deadline elapsed — it stopped waiting. `peer-timeout`: the peer stated that it timed out, which is a different fact from the one above and must not be conflated with it. `server-error`: the service answered that it is failing. `unusable-response`: a delivered body carrying nothing to judge.",
+      "$comment": "The two timeout senses are separate tokens deliberately. Before DIR-FAM-TIMEOUT-client-deadline no framework in the family set a deadline, so `we stopped waiting` was unsayable and any observed cut-off was the peer's; a single `timeout` token would have let a later emitter blur the two the moment deadlines arrived."
     },
     "cost": {
       "type": "object",

--- a/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/FormatConformanceTest.java
+++ b/punit-decl/src/test/java/org/mavai/punit/decl/internal/run/FormatConformanceTest.java
@@ -171,6 +171,7 @@ class FormatConformanceTest {
             Map.entry("lm-top-p-range", "`top-p:` must be a number in (0, 1]"),
             Map.entry("lm-prompt-caching-type", "`prompt-caching:` must be a boolean"),
             Map.entry("lm-max-tokens-range", "`max-tokens:` must be a whole number"),
+            Map.entry("lm-deadline-range", "`deadline-ms:` must be a whole number"),
             Map.entry("lm-capabilities-vocabulary", "unknown capability"),
             Map.entry("explorations-empty", "`explorations:` must be a non-empty list"),
             Map.entry("exploration-entry-null-value", "declares no value"),

--- a/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeSet;
@@ -34,6 +36,7 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
     private final String endpoint;
     private final String model;
     private final Map<String, String> headers;
+    private final Duration deadline;
     private final HttpClient client;
 
     private ConfiguredLanguageModel(LmProvider provider, LanguageModelParameters parameters,
@@ -43,7 +46,12 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
         this.endpoint = endpoint;
         this.model = model;
         this.headers = headers;
-        this.client = HttpClient.newHttpClient();
+        this.deadline = Duration.ofMillis(parameters.deadlineMs());
+        // Both levels, because Java separates them and the failure this
+        // guards against connected perfectly and then went silent: a
+        // connect-only deadline satisfies the letter of `deadline-ms:`
+        // and none of its purpose.
+        this.client = HttpClient.newBuilder().connectTimeout(deadline).build();
     }
 
     /**
@@ -82,11 +90,22 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
     public Outcome<org.mavai.punit.lm.api.LmReply> exchange(Object input) {
         String body = Json.write(provider.body().build(parameters, model, input));
         HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(endpoint))
+                .timeout(deadline)
                 .POST(HttpRequest.BodyPublishers.ofString(body));
         headers.forEach(request::header);
         final HttpResponse<String> response;
         try {
             response = client.send(request.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (HttpTimeoutException elapsed) {
+            // The deadline this framework set, elapsed. Stating it as
+            // its own cause is what separates "we stopped waiting" from
+            // "the service is unreachable": both are failed deliveries,
+            // and only one of them is a statement about the service.
+            // HttpConnectTimeoutException arrives here as a subtype —
+            // correctly, since it is the same fact at the other level.
+            return Outcome.fail("service-delivery",
+                    "service did not answer within the " + parameters.deadlineMs()
+                            + "ms deadline at " + endpoint);
         } catch (IOException unreachable) {
             // No response at all — DNS, refused connection, broken pipe:
             // the service did not deliver, a failed sample with its cause.
@@ -151,6 +170,12 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
         // The output ceiling shapes the response as strongly as any
         // sampling parameter, so it is fingerprinted like one.
         entries.put("maxTokens", String.valueOf(parameters.maxTokens()));
+        // Unconditional, unlike the declared-or-absent entries above: a
+        // deadline moves the boundary between a slow delivery and a
+        // failed one, so it is always part of what was measured, and an
+        // unrecorded default is exactly the hidden constant the key
+        // exists to abolish.
+        entries.put("deadlineMs", String.valueOf(parameters.deadlineMs()));
         return entries;
     }
 

--- a/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/ConfiguredLanguageModel.java
@@ -13,6 +13,7 @@ import java.util.TreeSet;
 import org.mavai.outcome.Outcome;
 import org.mavai.punit.decl.ContractConfigurationException;
 import org.mavai.punit.decl.spi.ConfiguredService;
+import org.mavai.punit.api.spec.DeliveryCause;
 import org.mavai.punit.decl.spi.MediaKind;
 import org.mavai.punit.lm.providers.LmProvider;
 import org.mavai.punit.lm.providers.Media;
@@ -30,6 +31,9 @@ import org.mavai.punit.lm.providers.Providers;
  * {@code Outcome} channel with its cause as the reason.
  */
 public final class ConfiguredLanguageModel implements ConfiguredService {
+
+    /** The peer stating that it stopped waiting — not that we did. */
+    private static final int GATEWAY_TIMEOUT = 504;
 
     private final LmProvider provider;
     private final LanguageModelParameters parameters;
@@ -103,13 +107,13 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
             // and only one of them is a statement about the service.
             // HttpConnectTimeoutException arrives here as a subtype —
             // correctly, since it is the same fact at the other level.
-            return Outcome.fail("service-delivery",
+            return DeliveryCause.CLIENT_DEADLINE.fail(
                     "service did not answer within the " + parameters.deadlineMs()
                             + "ms deadline at " + endpoint);
         } catch (IOException unreachable) {
             // No response at all — DNS, refused connection, broken pipe:
             // the service did not deliver, a failed sample with its cause.
-            return Outcome.fail("service-delivery",
+            return DeliveryCause.UNREACHABLE.fail(
                     "service unreachable at " + endpoint + ": " + unreachable.getMessage());
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
@@ -119,11 +123,16 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
         }
         if (response.statusCode() >= 500) {
             // The service answered that it is failing: a failed delivery.
+            // A 504 is the peer stating that *it* timed out waiting on
+            // something further upstream — a different fact from our own
+            // deadline elapsing, and stated as one.
             String detail = Json.excerpt(response.body(), 200);
-            return Outcome.fail("service-delivery",
-                    "service failed to deliver: " + provider.name() + " answered HTTP "
-                            + response.statusCode() + " at " + endpoint
-                            + (detail.isEmpty() ? "" : " — " + detail));
+            DeliveryCause cause = response.statusCode() == GATEWAY_TIMEOUT
+                    ? DeliveryCause.PEER_TIMEOUT
+                    : DeliveryCause.SERVER_ERROR;
+            return cause.fail("service failed to deliver: " + provider.name() + " answered HTTP "
+                    + response.statusCode() + " at " + endpoint
+                    + (detail.isEmpty() ? "" : " — " + detail));
         }
         if (response.statusCode() >= 400) {
             throw new ProviderResponseException(
@@ -134,7 +143,7 @@ public final class ConfiguredLanguageModel implements ConfiguredService {
         try {
             return Outcome.ok(provider.extract().apply(Json.read(response.body(), provider.name())));
         } catch (ServiceDeliveryException undelivered) {
-            return Outcome.fail("service-delivery", undelivered.getMessage());
+            return DeliveryCause.UNUSABLE_RESPONSE.fail(undelivered.getMessage());
         }
     }
 

--- a/punit-lm/src/main/java/org/mavai/punit/lm/LanguageModelParameters.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/LanguageModelParameters.java
@@ -7,9 +7,9 @@ import java.util.Set;
  * One language-model service configuration: its complete covariate
  * values, validated and resolved from a definition's
  * {@code configuration:} record. {@code null} means undeclared;
- * {@code maxTokens} is always resolved (the format-normative default
- * when unstated) because a silent, provider-chosen ceiling would make
- * the same file mean different populations.
+ * {@code maxTokens} and {@code deadlineMs} are always resolved (their
+ * defaults when unstated) because a silent, reader-chosen value would
+ * make the same file mean different populations.
  */
 public record LanguageModelParameters(
         String systemPrompt,
@@ -21,10 +21,33 @@ public record LanguageModelParameters(
         String thinking,
         Boolean promptCaching,
         Map<String, Object> responseSchema,
-        int maxTokens) {
+        int maxTokens,
+        int deadlineMs) {
 
     /** The output-token ceiling when {@code max-tokens:} is unstated — format-normative. */
     public static final int DEFAULT_MAX_TOKENS = 4096;
+
+    /**
+     * How long this reader waits for one response before recording a
+     * failed delivery, when {@code deadline-ms:} is unstated: ten
+     * minutes.
+     *
+     * <p>Unlike {@link #DEFAULT_MAX_TOKENS} this value is not
+     * format-normative — the services format requires every reader to
+     * state a finite default and forbids an unbounded wait, but leaves
+     * the number to each reader's judgement about its own transport.
+     * punit's judgement is to match the family's Python reader rather
+     * than to exercise that latitude: the two invoke the same services,
+     * often from the same authored file, and since the deadline is part
+     * of the service's identity a divergent default would let one file
+     * name two populations depending on which reader opened it.
+     *
+     * <p>Ten minutes is generous by design. The largest configurations
+     * in family use are slowest to first byte, and a deadline that
+     * manufactures failed deliveries is worse than the hang it replaced
+     * — it converts a visible stall into an invisible bias.
+     */
+    public static final int DEFAULT_DEADLINE_MS = 600_000;
 
     /** The largest ceiling the non-streaming adapters carry without risking a timeout. */
     public static final int MAX_TOKENS_CEILING = 16000;
@@ -38,16 +61,16 @@ public record LanguageModelParameters(
 
     LanguageModelParameters withoutResponseSchema() {
         return new LanguageModelParameters(systemPrompt, provider, capabilities, model,
-                temperature, topP, thinking, promptCaching, null, maxTokens);
+                temperature, topP, thinking, promptCaching, null, maxTokens, deadlineMs);
     }
 
     LanguageModelParameters withoutPromptCaching() {
         return new LanguageModelParameters(systemPrompt, provider, capabilities, model,
-                temperature, topP, thinking, null, responseSchema, maxTokens);
+                temperature, topP, thinking, null, responseSchema, maxTokens, deadlineMs);
     }
 
     LanguageModelParameters withoutThinking() {
         return new LanguageModelParameters(systemPrompt, provider, capabilities, model,
-                temperature, topP, null, promptCaching, responseSchema, maxTokens);
+                temperature, topP, null, promptCaching, responseSchema, maxTokens, deadlineMs);
     }
 }

--- a/punit-lm/src/main/java/org/mavai/punit/lm/ParameterValidation.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/ParameterValidation.java
@@ -17,7 +17,8 @@ final class ParameterValidation {
 
     private static final Set<String> CONFIGURATION_KEYS = Set.of(
             "system-prompt", "provider", "capabilities", "model", "temperature",
-            "top-p", "thinking", "prompt-caching", "response-schema", "max-tokens");
+            "top-p", "thinking", "prompt-caching", "response-schema", "max-tokens",
+            "deadline-ms");
 
     private static final List<String> THINKING_VALUES = List.of("adaptive", "none");
 
@@ -46,6 +47,7 @@ final class ParameterValidation {
         Boolean promptCaching = promptCaching(serviceName, configuration);
         Map<String, Object> responseSchema = responseSchema(serviceName, configuration);
         int maxTokens = maxTokens(serviceName, configuration);
+        int deadlineMs = deadlineMs(serviceName, configuration);
         if ("adaptive".equals(thinking)
                 && maxTokens <= LanguageModelParameters.THINKING_MIN_MAX_TOKENS) {
             throw fail(serviceName, "`max-tokens: " + maxTokens + "` is too small for "
@@ -56,7 +58,7 @@ final class ParameterValidation {
                     + "nothing. Raise the ceiling or set `thinking: none`.");
         }
         return new LanguageModelParameters(systemPrompt, providerName, capabilities, model,
-                temperature, topP, thinking, promptCaching, responseSchema, maxTokens);
+                temperature, topP, thinking, promptCaching, responseSchema, maxTokens, deadlineMs);
     }
 
     private static String systemPrompt(String serviceName, Map<String, Object> configuration) {
@@ -173,6 +175,28 @@ final class ParameterValidation {
                     + LanguageModelParameters.DEFAULT_MAX_TOKENS + " and is recorded as such.");
         }
         return ceiling;
+    }
+
+    /**
+     * The declared wait, in whole milliseconds, or the recorded
+     * default. Zero has no meaning here: an unbounded wait is what this
+     * key exists to abolish, so the format gives it no spelling.
+     */
+    private static int deadlineMs(String serviceName, Map<String, Object> configuration) {
+        Object value = configuration.get("deadline-ms");
+        if (value == null) {
+            return LanguageModelParameters.DEFAULT_DEADLINE_MS;
+        }
+        if (value instanceof Boolean || !(value instanceof Integer deadline) || deadline < 1) {
+            throw fail(serviceName, "`deadline-ms:` must be a whole number of milliseconds "
+                    + "greater than zero — how long this framework waits for one response "
+                    + "before recording a failed delivery. It bounds the whole exchange, not "
+                    + "just the connection. Unstated, it defaults to "
+                    + LanguageModelParameters.DEFAULT_DEADLINE_MS + " and is recorded as such; "
+                    + "it is part of the service's identity, so a baseline measured under one "
+                    + "deadline does not resolve a test run under another.");
+        }
+        return deadline;
     }
 
     private static String string(

--- a/punit-lm/src/main/java/org/mavai/punit/lm/PromptEngineer.java
+++ b/punit-lm/src/main/java/org/mavai/punit/lm/PromptEngineer.java
@@ -145,7 +145,8 @@ public final class PromptEngineer implements StepperProvider {
                     identity -> ConfiguredLanguageModel.of("prompt-engineer (meta)",
                             new LanguageModelParameters(systemPrompt, metaProvider, null,
                                     metaModel, temperature, null, null, null, null,
-                                    LanguageModelParameters.DEFAULT_MAX_TOKENS)));
+                                    LanguageModelParameters.DEFAULT_MAX_TOKENS,
+                                    LanguageModelParameters.DEFAULT_DEADLINE_MS)));
             System.out.println("[PUNIT] note: prompt-engineer meta model: provider "
                     + (metaProvider == null ? "openai-compatible" : metaProvider) + ", model "
                     + (metaModel == null ? "(environment default)" : metaModel)

--- a/punit-lm/src/test/java/org/mavai/punit/lm/ClientDeadlineTest.java
+++ b/punit-lm/src/test/java/org/mavai/punit/lm/ClientDeadlineTest.java
@@ -1,0 +1,176 @@
+package org.mavai.punit.lm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mavai.outcome.Outcome;
+import org.mavai.punit.decl.ContractConfigurationException;
+import org.mavai.punit.decl.spi.ConfiguredService;
+import org.mavai.punit.decl.spi.ServiceType;
+
+/**
+ * The wait this reader owns: how long it holds a sample open before
+ * recording a failed delivery, what it states when that wait elapses,
+ * and why the resolved value is always part of what was measured.
+ */
+@DisplayName("the client deadline")
+class ClientDeadlineTest {
+
+    private final ServiceType type = new LanguageModelServiceType();
+    private StubLlm stub;
+
+    @BeforeEach
+    void start() {
+        stub = StubLlm.start();
+        System.setProperty("mavai.llm.endpoint", stub.endpoint());
+        System.setProperty("mavai.llm.api-key", "test-key");
+    }
+
+    @AfterEach
+    void stop() {
+        stub.close();
+        System.clearProperty("mavai.llm.endpoint");
+        System.clearProperty("mavai.llm.api-key");
+    }
+
+    private ConfiguredService service(Object... pairs) {
+        Map<String, Object> configuration = new LinkedHashMap<>();
+        configuration.put("system-prompt", "You answer politely.");
+        configuration.put("model", "test-model");
+        for (int i = 0; i < pairs.length; i += 2) {
+            configuration.put((String) pairs[i], pairs[i + 1]);
+        }
+        return type.configure("svc", configuration);
+    }
+
+    @Nested
+    @DisplayName("a peer that accepts and then goes silent")
+    class Stalling {
+
+        @Test
+        @DisplayName("is abandoned at the deadline, not waited on indefinitely")
+        void abandonedAtTheDeadline() {
+            stub.stalling();
+            ConfiguredService service = service("deadline-ms", 250);
+
+            long before = System.nanoTime();
+            Outcome<String> outcome = service.invoke("hello");
+            Duration waited = Duration.ofNanos(System.nanoTime() - before);
+
+            assertThat(outcome).isInstanceOf(Outcome.Fail.class);
+            // The socket connects perfectly and the stub holds it for
+            // thirty seconds. Returning inside five proves the deadline
+            // bounded the response and not merely the connection — the
+            // whole point of the key, and the one property a
+            // connect-only timeout would fail while passing every other
+            // assertion here.
+            assertThat(waited).isLessThan(Duration.ofSeconds(5));
+        }
+
+        @Test
+        @DisplayName("is stated as this framework's own wait elapsing")
+        void statedAsOurOwnWait() {
+            stub.stalling();
+
+            Outcome<String> outcome = service("deadline-ms", 250).invoke("hello");
+
+            // Not "unreachable": the endpoint answered the connection.
+            // Conflating the two would attribute to the service a fact
+            // about this framework's patience.
+            assertThat(((Outcome.Fail<String>) outcome).failure().message())
+                    .contains("did not answer within the 250ms deadline")
+                    .doesNotContain("unreachable");
+        }
+
+        @Test
+        @DisplayName("is a failed sample, not an aborted run")
+        void isAFailedSample() {
+            stub.stalling();
+
+            // The delivery taxonomy is untouched: a peer that stops
+            // answering is evidence about the service, counted, not a
+            // defect that stops everything.
+            assertThat(service("deadline-ms", 250).invoke("hello"))
+                    .isInstanceOf(Outcome.Fail.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("the resolved wait")
+    class Resolved {
+
+        @Test
+        @DisplayName("is recorded even when the author never wrote it")
+        void recordedWhenDefaulted() {
+            assertThat(service().configurationCovariates())
+                    .containsEntry("deadlineMs",
+                            String.valueOf(LanguageModelParameters.DEFAULT_DEADLINE_MS));
+        }
+
+        @Test
+        @DisplayName("is recorded as declared when the author wrote it")
+        void recordedWhenDeclared() {
+            assertThat(service("deadline-ms", 90_000).configurationCovariates())
+                    .containsEntry("deadlineMs", "90000");
+        }
+
+        @Test
+        @DisplayName("distinguishes two otherwise identical services")
+        void distinguishesIdenticalServices() {
+            // Identity, not decoration: a shorter wait converts slow
+            // deliveries into failed ones, so these two configurations
+            // sample different populations and must not share a
+            // fingerprint. This is what makes a baseline measured under
+            // one deadline refuse a test run under another.
+            assertThat(service("deadline-ms", 30_000).configurationCovariates())
+                    .isNotEqualTo(service("deadline-ms", 60_000).configurationCovariates());
+        }
+    }
+
+    @Nested
+    @DisplayName("refusals")
+    class Refusals {
+
+        @Test
+        @DisplayName("zero is not a spelling for waiting forever")
+        void zeroRefused() {
+            assertThatThrownBy(() -> service("deadline-ms", 0))
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("`deadline-ms:` must be a whole number")
+                    .hasMessageContaining(
+                            String.valueOf(LanguageModelParameters.DEFAULT_DEADLINE_MS));
+        }
+
+        @Test
+        @DisplayName("a negative wait is refused")
+        void negativeRefused() {
+            assertThatThrownBy(() -> service("deadline-ms", -1))
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("`deadline-ms:` must be a whole number");
+        }
+
+        @Test
+        @DisplayName("a fractional wait is refused")
+        void fractionalRefused() {
+            assertThatThrownBy(() -> service("deadline-ms", 1.5))
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("`deadline-ms:` must be a whole number");
+        }
+
+        @Test
+        @DisplayName("a boolean is refused")
+        void booleanRefused() {
+            assertThatThrownBy(() -> service("deadline-ms", true))
+                    .isInstanceOf(ContractConfigurationException.class)
+                    .hasMessageContaining("`deadline-ms:` must be a whole number");
+        }
+    }
+}

--- a/punit-lm/src/test/java/org/mavai/punit/lm/StubLlm.java
+++ b/punit-lm/src/test/java/org/mavai/punit/lm/StubLlm.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A local endpoint standing in for a vendor: replays a canned response
@@ -21,11 +23,16 @@ final class StubLlm implements AutoCloseable {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    /** Long enough that a deadline measured in tens of ms strikes first. */
+    private static final long STALL_MILLIS = 30_000;
+
     private final HttpServer server;
     private final List<JsonNode> requestBodies = new ArrayList<>();
     private final List<Map<String, List<String>>> requestHeaders = new ArrayList<>();
     private volatile int status = 200;
     private volatile String response = "{}";
+    private volatile boolean stall;
+    private final CountDownLatch closed = new CountDownLatch(1);
 
     private StubLlm(HttpServer server) {
         this.server = server;
@@ -40,6 +47,21 @@ final class StubLlm implements AutoCloseable {
                 synchronized (stub) {
                     stub.requestBodies.add(MAPPER.readTree(request));
                     stub.requestHeaders.add(exchange.getRequestHeaders());
+                }
+                if (stub.stall) {
+                    // Accepted, and then silent: the shape of the field
+                    // failure — a connected socket with nothing coming
+                    // back, which a connect-only deadline never catches.
+                    // The latch is held until close(), so the silence
+                    // outlasts any deadline under test without the
+                    // handler thread outliving the test that started it.
+                    try {
+                        stub.closed.await(STALL_MILLIS, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
+                    exchange.close();
+                    return;
                 }
                 byte[] body = stub.response.getBytes(StandardCharsets.UTF_8);
                 exchange.sendResponseHeaders(stub.status, body.length);
@@ -57,6 +79,12 @@ final class StubLlm implements AutoCloseable {
     /** The stub's URL, for {@code mavai.llm.endpoint}. */
     String endpoint() {
         return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+    }
+
+    /** Accept the request, then never answer. */
+    StubLlm stalling() {
+        this.stall = true;
+        return this;
     }
 
     StubLlm respond(int status, String body) {
@@ -103,6 +131,7 @@ final class StubLlm implements AutoCloseable {
 
     @Override
     public void close() {
+        closed.countDown();
         server.stop(0);
     }
 }


### PR DESCRIPTION
punit-decl has been red on `main` since **2026-08-09**, on four conformance cases with one cause, and no punit commit between the last green run and now. mavai-R shipped `deadline-ms` into the services corpus and punit did not follow. Since punit-decl resolves `releases/latest` at build time, the ratchet worked exactly as designed and nobody was looking at it.

This closes that, and the arc it belongs to. Implements `DIR-PU-TIMEOUT-client-deadline` and `DIR-PU-DELIVERY-failure-visibility` — the punit derivations the family directives have listed as following since 2026-08-07.

## The deadline (`b7cd8d47`)

`punit-lm` built its `HttpClient` with the no-argument factory and its request with no timeout, so a peer that accepted the POST and then went silent held the sample open forever. Both levels are set now from one declared `deadline-ms:` — both, because the failure that provoked the family directive connected perfectly and then waited on the status line, which a connect-only deadline never sees.

**The catch splits before it widens.** `HttpTimeoutException` extends `IOException`, so the existing branch would have swallowed every timeout into wording that says `service unreachable at {endpoint}` — asserting a fact about the service to describe a fact about our own patience. Splitting in the same commit that sets the deadline is the point: adding the deadline first would have manufactured a false cause rather than merely failing to state a true one.

The default is **600000**, matching baseltest rather than punit's own 30-second webhook precedent. Not an independent transport judgement — the two readers invoke the same services from the same authored file, and the deadline is identity, so a divergent default would let one file name two populations depending on which reader opened it. The resolved value is recorded unconditionally, unlike the declared-or-absent covariates around it.

## The delivery cause (`71df499d`)

All four delivery branches shared the failure name `service-delivery`, so every cause collapsed into one entry naming no cause at all. Explore and optimize artefacts now state `kind` on every failure entry, and a delivery entry's condition is its cause token.

The cause travels as the **failure-id namespace**, not by matching the name against the vocabulary. An author may declare a condition called `server-error`, and reading it as transport would tell a reader the service was never reached when in truth it answered and failed a check — a stated cause that is wrong, which is worse than one that is absent. There is a conformance case for that collision.

Also re-vendors the interchange schemas, **pinned at mavai-R v0.9.0 while the oracle is at v0.10.13**. The stale copies had `additionalProperties: true` and no `deliveryCause`, so they accepted the new `kind` field without checking one value of it — conformant against a schema that could not read what it emitted. Verified against the published `interchange-v0.10.13.zip` asset rather than the working tree, byte-for-byte.

## The trial that judged nothing (`48682933`)

Driving a fully-undelivered run found a live defect on `main`: an apply-level failure reached no criterion's tally, so such a run emitted an empty `statistics.criteria` and **failed schema validation outright**. The total-harness-failure run was the one producing a document a reader could not load.

Fixing it needed the denominator ruling `archived/DIR-DECISION-RULE-CONFORMANCE-family` finding 2 recorded as wanted in July. **Owner ruling, 2026-08-24: adopt baseltest's counting** — an apply-level failure counts as a failure against every declared criterion.

`applyFail` is its own axis rather than a share of `transformFail`: transform/no-value means a response *arrived* and no testable value could be derived, a fact about the instrument; an apply failure is a fact about the service. Folding them would have made the artefact validate while misreporting the axis a developer reads first.

Smaller in effect than feared: `PassRate` already fell back to run-level counts on an apply-level run, so its verdict counted these all along. What diverged was the per-criterion rows. No existing test changed its expectation.

## Oracle alignment

All three feeds at **v0.10.13**: statistical fixtures and the formats corpus resolve `releases/latest` per build; the interchange schemas are vendored and diffed against the published asset.

One gap recorded and not closed: the asset carries `mavai-baseline-1.schema.json` and punit vendors only two schemas — but punit's baselines declare `punit-baseline-3`, a local format. That is `DIR-FAM-BASELINE-interchange-standard`, blocked on five owner rulings, not an oversight here.

## Changelog

Consolidated three `Added` groups, two `Changed` and two `Documentation` into one of each — this text becomes the release body verbatim. Added entries for #271 and #272, which had none and are the two fixes a first declarative test walks into.

The heading stays `[Unreleased]`; retitling it to `0.10.0` is the release-prep act and belongs with the version bump.

## Verification

`./gradlew clean build` green, including ArchUnit, statistics isolation, and the requirement-code isolation guard. The four `FormatConformanceTest` cases are green by punit knowing the key, not by excusing it.

The stall test is the one that matters: it drives a socket that accepts and then goes silent, which is the only assertion here a connect-only deadline would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmLrE9NtmR31un2SDgg3b3