### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-09-07
+
 ### Removed
 
 - **PUnit no longer renders HTML; the family's shared `mavai` tool
@@ -234,23 +236,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   schemas cannot express (ascending passing-latency vector,
   floor-gated percentile statement, convergence consistency).
 
-- **Per-criterion matrix transposed in both comparison HTML reports.**
-  The exploration and optimization comparison reports' "Per-criterion
-  comparison" table now lists variants/iterations as rows and criteria
-  as columns (previously the reverse). Bounds the table's column count
-  to the criteria set instead of letting it grow with every
-  variant/iteration, and aligns row identity with the leaderboard
-  table above it.
-- **Comparison-report renderers de-duplicated.** The Explore and
-  Optimize `HtmlWriter`s shared a near-identical `CriterionResult`
-  record and near-identical per-criterion-matrix, latency-cell,
-  cost-cell, termination-cell, pass-rate-cell, number-formatting, and
-  chart-CSS code. `CriterionResult` and these section renderers now
-  live once in a new `org.mavai.punit.report.ComparisonReportHtml`
-  (alongside the existing shared `ReportHtml`); each report's
-  `HtmlWriter` supplies only what's genuinely report-specific. No
-  behavioural change — output is unchanged.
-
 ### Fixed
 
 - **A declarative service type is found from a consuming project.**
@@ -373,10 +358,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   previously described the convention-default path as "on the classpath"
   — it's a filesystem path relative to the working directory, not a
   classpath resource lookup; corrected in both places.
-
-- Brought the optimize comparison report's description in the user guide
-  (Part 11) in line with the 0.9.3 run-order layout — iterations listed in
-  run order with a **Rank** column, not a score-sorted leaderboard.
 
 ## [0.9.3] - 2026-06-30
 
@@ -1437,7 +1418,8 @@ unit testing of non-deterministic systems.
 - Verbose statistical explanation output
 - Gradle plugin (`org.javai.punit`) for test/experiment task configuration
 
-[Unreleased]: https://github.com/javai-org/punit/compare/v0.7.0-alpha5...HEAD
+[Unreleased]: https://github.com/mavai-org/punit/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/mavai-org/punit/compare/v0.9.3...v0.10.0
 [0.7.0-alpha5]: https://github.com/javai-org/punit/compare/v0.7.0-alpha4...v0.7.0-alpha5
 [0.7.0-alpha4]: https://github.com/javai-org/punit/compare/v0.7.0-alpha3...v0.7.0-alpha4
 [0.7.0-alpha3]: https://github.com/javai-org/punit/compare/v0.7.0-alpha2...v0.7.0-alpha3

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A probabilistic test calls `PUnit.testing(serviceContract).assertPasses()` insid
 
 ```kotlin
 plugins {
-    id("org.mavai.punit") version "0.9.3"
+    id("org.mavai.punit") version "0.10.0"
 }
 
 repositories {
@@ -89,8 +89,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation("org.mavai:punit-core:0.9.3")
-    testImplementation("org.mavai:punit-report:0.9.3")
+    testImplementation("org.mavai:punit-core:0.10.0")
+    testImplementation("org.mavai:punit-report:0.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 ```
@@ -101,13 +101,13 @@ dependencies {
 <dependency>
     <groupId>org.mavai</groupId>
     <artifactId>punit-core</artifactId>
-    <version>0.9.3</version>
+    <version>0.10.0</version>
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>org.mavai</groupId>
     <artifactId>punit-report</artifactId>
-    <version>0.9.3</version>
+    <version>0.10.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -107,11 +107,11 @@ companion where a reader wants the proof.
 ```kotlin
 // build.gradle.kts
 plugins {
-    id("org.mavai.punit") version "0.9.3"
+    id("org.mavai.punit") version "0.10.0"
 }
 
 dependencies {
-    testImplementation("org.mavai:punit-core:0.9.3")
+    testImplementation("org.mavai:punit-core:0.10.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.stdlib.default.dependency=false
-punitVersion=0.10.0-SNAPSHOT
+punitVersion=0.10.0

--- a/punit-gradle-plugin/gradle.properties
+++ b/punit-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-punitVersion=0.10.0-SNAPSHOT
+punitVersion=0.10.0


### PR DESCRIPTION
The release-preparation PR: `punitVersion` leaves SNAPSHOT in both `gradle.properties`, the changelog's Unreleased section becomes `## [0.10.0] - 2026-09-07`, and the README and User Guide pin 0.10.0 in their dependency snippets. This is the bump the release maxims panel keys on.

Three Unreleased notes were dropped rather than carried into the section: the transposed per-criterion matrix, the de-duplicated comparison-report renderers, and the guide paragraph on the optimize report's run-order layout. All three describe code this release removes (the HTML writers left in #285), so a reader moving from 0.9.3 would be told about changes to something that no longer exists.

After merging, the release itself is the guarded `./gradlew release` on `main` (tag, publish to Central, GitHub release from the changelog section, bump to 0.10.1-SNAPSHOT), which needs the owner's GPG key, Central credentials and `gh` session.

The changelog date is today's; if the cut slips, move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cKSnFkFFikid5kseiAHDf
